### PR TITLE
docs: restore Swift E2E specification prose

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLoginTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLoginTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy auth login'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays browser and API-key login modes without opening a browser. */
+    /**
+     Displays usage for `wendy auth login`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +29,12 @@ struct `'wendy auth login'` {
         }
     }
 
+    /**
+     Without `--api-key`, starts the Wendy Cloud browser login flow,
+     receives the callback token, generates client credentials, and
+     stores the resulting session in the CLI configuration. Success
+     output gives concise next-step guidance and stderr stays empty.
+     */
     @Test(
         .disabled(
             "WDY-1949: browser login needs a protected callback/token/PKI fixture and injectable browser; real browsers and personal cloud auth are prohibited."
@@ -32,6 +44,11 @@ struct `'wendy auth login'` {
         // TODO: enable with protected browser and auth fixtures (WDY-1949).
     }
 
+    /**
+     With `--api-key`, authenticates against the selected cloud gRPC or
+     local pki-core endpoint using the provided bearer token. The token
+     is not echoed to stdout, stderr, command records, or saved config.
+     */
     @Test(
         .disabled(
             "WDY-1949: API-key login needs an ephemeral protected pki-core endpoint with recorder redaction; production or personal keys cannot be used."
@@ -41,6 +58,11 @@ struct `'wendy auth login'` {
         // TODO: enable with protected PKI and secret-redaction fixtures (WDY-1949).
     }
 
+    /**
+     `--cloud` and `--cloud-grpc` bind the login to a specific Wendy
+     Cloud environment. The stored session records enough endpoint
+     identity for later commands to choose the same environment.
+     */
     @Test(
         .disabled(
             "WDY-1949: endpoint selection needs multiple protected cloud/PKI fixtures so stored identity can be verified without production auth."
@@ -50,6 +72,11 @@ struct `'wendy auth login'` {
         // TODO: enable with protected multi-cloud fixtures (WDY-1949).
     }
 
+    /**
+     Cancelling or timing out the browser callback reports a login
+     failure, exits non-zero, and leaves prior authentication state
+     unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1949: cancellation and timeout require controllable browser callback process state rather than opening a real browser."
@@ -59,6 +86,11 @@ struct `'wendy auth login'` {
         // TODO: enable with the protected browser callback fixture (WDY-1949).
     }
 
+    /**
+     A successful login for a cloud that already has stored credentials
+     replaces the old credentials atomically while preserving sessions
+     for other clouds.
+     */
     @Test(
         .disabled(
             "WDY-1949: atomic session replacement needs protected certificate issuance for two cloud identities without personal auth state."
@@ -68,7 +100,12 @@ struct `'wendy auth login'` {
         // TODO: enable with protected multi-session auth fixtures (WDY-1949).
     }
 
-    /** Malformed config fails before browser or network activity and remains unchanged. */
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test
     func `reports invalid CLI configuration before acting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -96,7 +133,13 @@ struct `'wendy auth login'` {
         }
     }
 
-    /** API-key mode requires a local/cloud gRPC endpoint before network access. */
+    /**
+     Requires the API endpoint needed to exchange an API key for a Wendy auth
+     session.
+
+     Missing endpoint configuration fails locally without writing partial
+     credentials.
+     */
     @Test
     func `requires an endpoint for API key login`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -109,7 +152,12 @@ struct `'wendy auth login'` {
         }
     }
 
-    /** Unknown flags fail before browser or network access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects unknown flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -122,6 +170,12 @@ struct `'wendy auth login'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy auth login' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLogoutTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthLogoutTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy auth logout'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays logout usage without reading or changing config. */
+    /**
+     Displays usage for `wendy auth logout`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,7 +26,11 @@ struct `'wendy auth logout'` {
         }
     }
 
-    /** Removes a sole stored session while preserving unrelated known config fields. */
+    /**
+     Deletes stored Wendy Cloud credentials for the selected session and
+     prints a concise confirmation. Other configuration keys and cached
+     project files remain intact.
+     */
     @Test
     func `removes the active auth session`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -54,6 +64,10 @@ struct `'wendy auth logout'` {
         }
     }
 
+    /**
+     With no stored auth session, reports that the user is logged out and
+     exits successfully without creating configuration files.
+     */
     @Test(
         .disabled(
             "WDY-1947: already-logged-out logout creates/rewrites config and claims credentials were removed instead of remaining a non-mutating no-op."
@@ -63,6 +77,10 @@ struct `'wendy auth logout'` {
         // TODO: enable when logged-out logout does not create state (WDY-1947).
     }
 
+    /**
+     When more than one auth session exists, targets the active or
+     explicitly selected cloud and leaves unrelated sessions available.
+     */
     @Test(
         .disabled(
             "WDY-1947: logout always clears every auth entry and has no active/explicit session selector, so unrelated cloud sessions cannot be preserved."
@@ -72,6 +90,11 @@ struct `'wendy auth logout'` {
         // TODO: enable when logout is session-aware (WDY-1947).
     }
 
+    /**
+     With `--json`, emits one JSON object describing whether credentials
+     were removed. JSON mode emits no human confirmation text and no
+     stderr on success.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy auth logout --json' ignores JSON mode and prints a human confirmation."
@@ -81,7 +104,12 @@ struct `'wendy auth logout'` {
         // TODO: enable when auth logout implements global --json (WDY-1909).
     }
 
-    /** Malformed config fails without mutation. */
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test
     func `reports invalid CLI configuration before acting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -107,7 +135,12 @@ struct `'wendy auth logout'` {
         }
     }
 
-    /** Unknown flags fail before config mutation. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -125,6 +158,12 @@ struct `'wendy auth logout'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy auth logout' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthRefreshCertsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthRefreshCertsTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy auth refresh-certs'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays certificate-refresh usage without loading or contacting auth state. */
+    /**
+     Displays usage for `wendy auth refresh-certs`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +25,12 @@ struct `'wendy auth refresh-certs'` {
         }
     }
 
+    /**
+     Uses an existing auth session to generate a new key pair and CSR,
+     obtains fresh client certificates, and atomically replaces the old
+     certificate material. Success output identifies the refreshed
+     session without printing secrets.
+     */
     @Test(
         .disabled(
             "WDY-1949: certificate refresh success needs a protected PKI/cloud endpoint with ephemeral stored credentials; personal sessions are prohibited."
@@ -28,7 +40,11 @@ struct `'wendy auth refresh-certs'` {
         // TODO: enable with the protected PKI/cloud fixture (WDY-1949).
     }
 
-    /** Missing auth fails locally without generating keys or creating config. */
+    /**
+     When no login session is available, reports that authentication is
+     required. No key pair, CSR, certificate, or partial configuration
+     update is written.
+     */
     @Test
     func `reports missing auth session without creating credentials`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -46,6 +62,11 @@ struct `'wendy auth refresh-certs'` {
         }
     }
 
+    /**
+     Network, authorization, or certificate issuance failures leave the
+     previous working credentials in place and report the failing stage
+     on stderr.
+     */
     @Test(
         .disabled(
             "WDY-1949: issuance/network/authorization failure preservation needs a controllable protected PKI endpoint and known prior certificates."
@@ -55,6 +76,11 @@ struct `'wendy auth refresh-certs'` {
         // TODO: enable with protected PKI failure modes (WDY-1949).
     }
 
+    /**
+     With `--json`, emits one JSON object with the cloud identity and
+     certificate validity metadata. Secret key material never appears in
+     stdout, stderr, or command records.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy auth refresh-certs --json' ignores JSON mode; WDY-1949 tracks the protected fixture required for refresh metadata."
@@ -64,7 +90,12 @@ struct `'wendy auth refresh-certs'` {
         // TODO: enable when refresh implements JSON and has protected fixtures (WDY-1909, WDY-1949).
     }
 
-    /** Malformed config fails locally and remains unchanged. */
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test
     func `reports invalid CLI configuration before acting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -90,7 +121,12 @@ struct `'wendy auth refresh-certs'` {
         }
     }
 
-    /** Unknown flags fail before config or PKI access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -103,6 +139,12 @@ struct `'wendy auth refresh-certs'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy auth refresh-certs' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyAuthStatusTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy auth status'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays local auth-status usage without reading credentials. */
+    /**
+     Displays usage for `wendy auth status`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,7 +25,11 @@ struct `'wendy auth status'` {
         }
     }
 
-    /** Reports logged-out state locally without creating a config file. */
+    /**
+     With no stored credentials, reports that the user is not logged in,
+     exits successfully, emits no stderr, and does not create config
+     files.
+     */
     @Test
     func `prints logged-out status without contacting the cloud`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -37,7 +47,11 @@ struct `'wendy auth status'` {
         }
     }
 
-    /** Prints non-secret endpoint, user, and organization metadata from local config. */
+    /**
+     With a stored session, reports the cloud identity and account or
+     organization summary available locally. Secrets and private key
+     material are never printed.
+     */
     @Test
     func `prints logged-in status from stored credentials`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -63,6 +77,11 @@ struct `'wendy auth status'` {
         }
     }
 
+    /**
+     Expired, malformed, or incomplete credentials produce an actionable
+     status that distinguishes local credential problems from cloud
+     connectivity problems.
+     */
     @Test(
         .disabled(
             "WDY-1948: auth status does not consistently classify malformed/incomplete certificate material; malformed PEM can be silently ignored."
@@ -72,6 +91,11 @@ struct `'wendy auth status'` {
         // TODO: enable when local credential states are explicit and actionable (WDY-1948).
     }
 
+    /**
+     With `--json`, emits one JSON object containing login state, cloud
+     endpoint identity, and certificate validity fields. JSON mode emits
+     no prompt text and no stderr on success.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy auth status --json' ignores JSON mode and prints human status; WDY-1948 tracks missing structured credential validity states."
@@ -81,7 +105,12 @@ struct `'wendy auth status'` {
         // TODO: enable when auth status implements structured JSON (WDY-1909, WDY-1948).
     }
 
-    /** Malformed CLI config fails locally and remains unchanged. */
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test
     func `reports invalid CLI configuration before acting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -107,7 +136,12 @@ struct `'wendy auth status'` {
         }
     }
 
-    /** Unknown flags fail before config access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -120,6 +154,12 @@ struct `'wendy auth status'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy auth status' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy build'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays builder selection usage without inspecting the project or toolchains. */
+    /**
+     Displays usage for `wendy build`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +29,12 @@ struct `'wendy build'` {
         }
     }
 
+    /**
+     Reads `wendy.json` and project markers from the current directory,
+     selects the build strategy, and produces a container image for the
+     target WendyOS architecture. Success output names the image and build
+     type.
+     */
     @Test(
         .disabled(
             "WDY-1950: successful builds need pinned sample projects, builders/toolchains, image namespaces, and cleanup rather than ambient runner installations."
@@ -32,6 +44,11 @@ struct `'wendy build'` {
         // TODO: enable with isolated build fixtures (WDY-1950).
     }
 
+    /**
+     When Docker, Swift, or Python markers coexist, `--build-type` selects
+     the intended builder. The chosen strategy is reflected in output and no
+     other builder mutates the project.
+     */
     @Test(
         .disabled(
             "WDY-1950: overlapping-marker strategy coverage needs maintained Docker/Swift/Python fixtures and controlled builder availability."
@@ -41,7 +58,12 @@ struct `'wendy build'` {
         // TODO: enable with overlapping project fixtures (WDY-1950).
     }
 
-    /** A directory with no supported project marker fails without creating artifacts. */
+    /**
+     Reports that the working directory is not a Wendy project when required
+     project configuration is absent.
+
+     The command fails before invoking a builder or producing build artifacts.
+     */
     @Test
     func `reports missing project configuration`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -58,7 +80,12 @@ struct `'wendy build'` {
         }
     }
 
-    /** Invalid builder and mutually exclusive builder options fail before toolchain access. */
+    /**
+     Validates the requested builder against the command's supported builder
+     choices.
+
+     Invalid values fail before project compilation or remote builder access.
+     */
     @Test
     func `validates builder selection locally`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -78,6 +105,11 @@ struct `'wendy build'` {
         }
     }
 
+    /**
+     With `--json`, emits one JSON object describing the selected builder,
+     image reference, target architecture, cache usage, and build result.
+     Progress logs stay out of stdout JSON.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy build' does not implement global --json; WDY-1950 tracks the isolated successful build fixture needed for metadata."
@@ -87,7 +119,12 @@ struct `'wendy build'` {
         // TODO: enable when build implements JSON and has isolated fixtures (WDY-1909, WDY-1950).
     }
 
-    /** Unknown flags fail before project or toolchain access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -100,6 +137,12 @@ struct `'wendy build'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy build' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device apps list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device apps list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device apps list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device apps list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device apps list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device apps list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device apps list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays deployed applications with names, images, status, restart policy,
+     and relevant ports. An empty device reports an empty successful list.
+     */
     @Test(
         .disabled(
             "WDY-1952: human application inventory needs seeded cloud tunnel and managed-agent container state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device apps list'` {
     )
     func `lists deployed applications`() async throws {}
 
+    /**
+     With `--json`, emits application objects with stable field names and value
+     types. JSON mode emits no table formatting and no stderr on success.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON application schema needs seeded cloud tunnel and managed-agent container state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device apps list'` {
     )
     func `prints JSON application inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device apps list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device apps list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsRemoveTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device apps remove'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device apps remove`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -26,6 +33,11 @@ struct `'wendy cloud device apps remove'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target removal needs isolated auth, tunnel, and seeded managed-agent application state."
@@ -33,6 +45,11 @@ struct `'wendy cloud device apps remove'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -40,6 +57,11 @@ struct `'wendy cloud device apps remove'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -54,6 +76,11 @@ struct `'wendy cloud device apps remove'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
@@ -61,6 +88,11 @@ struct `'wendy cloud device apps remove'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes the named application only after confirmation or `--force`.
+     Success output identifies the removed app and any optional cleanup
+     performed.
+     */
     @Test(
         .disabled(
             "WDY-1952: confirmation and successful removal need seeded cloud tunnel and managed-agent application state."
@@ -68,6 +100,11 @@ struct `'wendy cloud device apps remove'` {
     )
     func `removes an application after confirmation`() async throws {}
 
+    /**
+     `--cleanup` removes the container image and `--delete-volumes` removes
+     persistent volumes only for the named app. Omitted cleanup flags leave
+     those resources intact.
+     */
     @Test(
         .disabled(
             "WDY-1952: cleanup isolation needs seeded application, image, and persistent-volume state behind a cloud tunnel."
@@ -75,6 +112,10 @@ struct `'wendy cloud device apps remove'` {
     )
     func `honors cleanup and volume deletion flags`() async throws {}
 
+    /**
+     An app name that is not deployed produces a failure diagnostic and does
+     not remove images, volumes, or other apps.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-application behavior needs seeded neighboring cloud-managed application and resource state."
@@ -82,6 +123,12 @@ struct `'wendy cloud device apps remove'` {
     )
     func `reports unknown applications without deleting resources`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -93,6 +140,12 @@ struct `'wendy cloud device apps remove'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStartTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStartTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device apps start'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device apps start`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -25,6 +32,11 @@ struct `'wendy cloud device apps start'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target startup needs isolated auth, tunnel, and seeded managed-agent application state."
@@ -32,6 +44,11 @@ struct `'wendy cloud device apps start'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -39,6 +56,11 @@ struct `'wendy cloud device apps start'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -53,6 +75,11 @@ struct `'wendy cloud device apps start'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
@@ -60,6 +87,11 @@ struct `'wendy cloud device apps start'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Starts the named deployed application and streams container output until
+     the app exits or the user cancels. Startup failure is reported as command
+     failure.
+     */
     @Test(
         .disabled(
             "WDY-1952: startup and streamed output need seeded cloud-managed application/container state plus process control."
@@ -67,6 +99,10 @@ struct `'wendy cloud device apps start'` {
     )
     func `starts an application and streams output`() async throws {}
 
+    /**
+     `--detach` starts the app and returns after start-up status is known
+     without streaming logs.
+     */
     @Test(
         .disabled(
             "WDY-1952: detached startup needs seeded cloud tunnel and managed-agent application/container state."
@@ -74,6 +110,10 @@ struct `'wendy cloud device apps start'` {
     )
     func `starts detached when requested`() async throws {}
 
+    /**
+     A missing app name or unknown deployed app produces a usage or not-found
+     diagnostic and no new container is created.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-application behavior needs seeded cloud-managed application/container state."
@@ -81,6 +121,12 @@ struct `'wendy cloud device apps start'` {
     )
     func `reports unknown applications without creating containers`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -92,6 +138,12 @@ struct `'wendy cloud device apps start'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStopTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAppsStopTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device apps stop'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device apps stop`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -24,6 +31,11 @@ struct `'wendy cloud device apps stop'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target stop needs isolated auth, tunnel, and seeded managed-agent application state."
@@ -31,6 +43,11 @@ struct `'wendy cloud device apps stop'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -38,6 +55,11 @@ struct `'wendy cloud device apps stop'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -52,6 +74,11 @@ struct `'wendy cloud device apps stop'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel, connection, and incompatible-RPC failures need controllable seeded cloud and managed-agent responses."
@@ -59,6 +86,10 @@ struct `'wendy cloud device apps stop'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Stops the named application and prints a concise confirmation after the
+     agent reports it stopped.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful stop needs seeded running cloud-managed application/container state."
@@ -66,6 +97,10 @@ struct `'wendy cloud device apps stop'` {
     )
     func `stops a running application`() async throws {}
 
+    /**
+     An already stopped app produces a clear no-op or not-running result
+     without affecting other applications.
+     */
     @Test(
         .disabled(
             "WDY-1952: stopped-app idempotence needs seeded stopped cloud-managed application/container state."
@@ -73,6 +108,10 @@ struct `'wendy cloud device apps stop'` {
     )
     func `handles already stopped applications predictably`() async throws {}
 
+    /**
+     Unknown app names fail without stopping containers that have similar
+     names.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-app isolation needs seeded neighboring cloud-managed application/container state."
@@ -80,6 +119,12 @@ struct `'wendy cloud device apps stop'` {
     )
     func `reports unknown applications without side effects`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -91,6 +136,12 @@ struct `'wendy cloud device apps stop'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device audio list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device audio list`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device audio list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device audio list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device audio list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device audio list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device audio list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays input and output audio devices with ids, names, channel counts,
+     sample rates, and default markers when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human audio inventory needs seeded cloud tunnel and managed-agent audio state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device audio list'` {
     )
     func `lists audio devices`() async throws {}
 
+    /**
+     With `--json`, emits audio device objects with stable id, direction,
+     default, channel, and sample-rate fields.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON audio schema needs seeded cloud tunnel and managed-agent audio state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device audio list'` {
     )
     func `prints JSON audio device inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device audio list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device audio list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListenTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioListenTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device audio listen'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device audio listen`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud device audio listen'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target listening needs a seeded managed agent and simulated audio capability without physical hardware."
@@ -29,6 +41,11 @@ struct `'wendy cloud device audio listen'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -36,6 +53,11 @@ struct `'wendy cloud device audio listen'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -49,6 +71,11 @@ struct `'wendy cloud device audio listen'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -56,6 +83,11 @@ struct `'wendy cloud device audio listen'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams audio from the selected microphone using the requested device id,
+     channel count, and sample rate. The stream continues until cancelled or
+     the device ends it.
+     */
     @Test(
         .disabled(
             "WDY-1952: microphone streaming needs seeded managed-agent audio frames without physical hardware."
@@ -63,6 +95,10 @@ struct `'wendy cloud device audio listen'` {
     )
     func `streams microphone audio`() async throws {}
 
+    /**
+     `--stdout` writes raw PCM bytes to stdout and sends diagnostics to stderr
+     so piping to another process is safe.
+     */
     @Test(
         .disabled(
             "WDY-1952: raw PCM routing needs seeded managed-agent audio frames and stream process control."
@@ -70,6 +106,10 @@ struct `'wendy cloud device audio listen'` {
     )
     func `writes raw PCM to stdout when requested`() async throws {}
 
+    /**
+     Invalid ids, channel counts, or sample rates fail before a stream is
+     opened.
+     */
     @Test(
         .disabled(
             "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
@@ -77,6 +117,12 @@ struct `'wendy cloud device audio listen'` {
     )
     func `validates audio parameters before streaming`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -88,6 +134,12 @@ struct `'wendy cloud device audio listen'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device audio listen' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioMonitorTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioMonitorTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device audio monitor'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device audio monitor`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy cloud device audio monitor'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target monitoring needs a seeded managed agent and simulated audio capability without physical hardware."
@@ -27,6 +39,11 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -34,6 +51,11 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -46,6 +68,11 @@ struct `'wendy cloud device audio monitor'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -53,6 +80,10 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays a live VU meter for the selected audio input at the requested
+     update rate and keeps diagnostics separate from the terminal UI.
+     */
     @Test(
         .disabled(
             "WDY-1952: VU rendering needs seeded managed-agent level frames plus controlled terminal output."
@@ -60,6 +91,10 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `renders live audio levels`() async throws {}
 
+    /**
+     Invalid device ids or update rates fail before a monitoring stream is
+     opened.
+     */
     @Test(
         .disabled(
             "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
@@ -67,6 +102,10 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `validates monitor parameters before streaming`() async throws {}
 
+    /**
+     Cancelling the monitor closes the remote stream and restores terminal
+     output without modifying device settings.
+     */
     @Test(
         .disabled(
             "WDY-1952: cancellation cleanup needs seeded streaming RPC state and harness process control."
@@ -74,6 +113,12 @@ struct `'wendy cloud device audio monitor'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -85,6 +130,12 @@ struct `'wendy cloud device audio monitor'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device audio monitor' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceAudioSetDefaultTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device audio set-default'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device audio set-default`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy cloud device audio set-default'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target mutation needs seeded managed-agent audio state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy cloud device audio set-default'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -33,6 +50,11 @@ struct `'wendy cloud device audio set-default'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -46,6 +68,11 @@ struct `'wendy cloud device audio set-default'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -53,6 +80,10 @@ struct `'wendy cloud device audio set-default'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Sets the selected audio device id as the device default and prints a
+     concise confirmation with the chosen id or name.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful default selection needs seeded managed-agent audio device state."
@@ -60,6 +91,10 @@ struct `'wendy cloud device audio set-default'` {
     )
     func `sets the default audio device`() async throws {}
 
+    /**
+     Missing or invalid `--id` values produce a usage diagnostic before
+     contacting or mutating audio settings.
+     */
     @Test
     func `requires an audio device id`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -71,6 +106,10 @@ struct `'wendy cloud device audio set-default'` {
         }
     }
 
+    /**
+     If the agent rejects the id or does not support default audio selection,
+     the previous default remains active.
+     */
     @Test(
         .disabled(
             "WDY-1952: rejection and previous-default preservation need seeded managed-agent audio state."
@@ -78,6 +117,12 @@ struct `'wendy cloud device audio set-default'` {
     )
     func `reports unsupported devices without changing defaults`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -89,6 +134,12 @@ struct `'wendy cloud device audio set-default'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device audio set-default' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device bluetooth connect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device bluetooth connect`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud device bluetooth connect'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target connection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -29,6 +41,11 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -36,6 +53,11 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -50,6 +72,11 @@ struct `'wendy cloud device bluetooth connect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -57,6 +84,10 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Connects to the requested peripheral address and applies pair and trust
+     options. Success output identifies the connected address.
+     */
     @Test(
         .disabled(
             "WDY-1952: pair/trust/connect behavior needs simulated managed-agent Bluetooth state without physical radios."
@@ -64,6 +95,10 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `connects to a Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic before a
+     Bluetooth operation starts.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -75,6 +110,12 @@ struct `'wendy cloud device bluetooth connect'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -82,6 +123,10 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     Pairing, trust, or connection failures report the failed stage and do not
+     claim the peripheral is connected.
+     */
     @Test(
         .disabled(
             "WDY-1952: staged pair/trust/connect failures need controllable simulated managed-agent Bluetooth responses."
@@ -89,6 +134,12 @@ struct `'wendy cloud device bluetooth connect'` {
     )
     func `reports pairing failures without trusting the device`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -101,6 +152,12 @@ struct `'wendy cloud device bluetooth connect'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device bluetooth disconnect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device bluetooth disconnect`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud device bluetooth disconnect'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target disconnection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -29,6 +41,11 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -36,6 +53,11 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -50,6 +72,11 @@ struct `'wendy cloud device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -57,6 +84,10 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Disconnects the requested peripheral address and prints a concise
+     confirmation after the agent reports it disconnected.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful disconnection needs simulated managed-agent Bluetooth connection state."
@@ -64,6 +95,10 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `disconnects a Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
+     operation.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -75,6 +110,12 @@ struct `'wendy cloud device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -82,6 +123,10 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     A peripheral that is not connected produces a clear no-op or not-connected
+     result without affecting pairing state.
+     */
     @Test(
         .disabled(
             "WDY-1952: already-disconnected semantics need simulated managed-agent Bluetooth state."
@@ -89,6 +134,12 @@ struct `'wendy cloud device bluetooth disconnect'` {
     )
     func `handles already disconnected peripherals predictably`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -101,6 +152,12 @@ struct `'wendy cloud device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device bluetooth forget'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device bluetooth forget`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy cloud device bluetooth forget'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target forget needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -27,6 +39,11 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -34,6 +51,11 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device bluetooth forget'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -55,6 +82,10 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes pairing and trust state for the requested peripheral address
+     without changing unrelated peripherals.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful forget needs simulated managed-agent pairing/trust state without physical radios."
@@ -62,6 +93,10 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `forgets a paired Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
+     operation.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -73,6 +108,12 @@ struct `'wendy cloud device bluetooth forget'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -80,6 +121,10 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     Forgetting an address unknown to the device reports a not-found result and
+     preserves other pairings.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-address isolation needs seeded neighboring managed-agent pairing state."
@@ -87,6 +132,12 @@ struct `'wendy cloud device bluetooth forget'` {
     )
     func `reports unknown peripherals without changing known devices`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -99,6 +150,12 @@ struct `'wendy cloud device bluetooth forget'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device bluetooth list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device bluetooth list`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device bluetooth list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device bluetooth list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device bluetooth list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device bluetooth list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -55,6 +82,10 @@ struct `'wendy cloud device bluetooth list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays discoverable Bluetooth peripherals with address, name, paired,
+     trusted, and connected status when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: Bluetooth scans need seeded cloud tunnel and simulated managed-agent peripheral state."
@@ -62,6 +93,10 @@ struct `'wendy cloud device bluetooth list'` {
     )
     func `scans for Bluetooth peripherals`() async throws {}
 
+    /**
+     With `--json`, emits peripheral objects with stable address and status
+     fields. An empty scan is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON Bluetooth schema needs seeded cloud tunnel and simulated managed-agent peripheral state."
@@ -69,6 +104,12 @@ struct `'wendy cloud device bluetooth list'` {
     )
     func `prints JSON Bluetooth inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -80,6 +121,12 @@ struct `'wendy cloud device bluetooth list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device bluetooth list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBtListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBtListTests.swift
@@ -6,6 +6,13 @@ import WendyE2ETesting
 struct `'wendy cloud device bt list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays the canonical Bluetooth-list help when invoked through the legacy
+     `bt list` alias.
+
+     The output identifies the current command interface and exits successfully
+     without contacting a device.
+     */
     @Test
     func `prints canonical Bluetooth list help through the bt alias`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,13 @@ struct `'wendy cloud device bt list'` {
         }
     }
 
+    /**
+     Routes the cloud `bt list` compatibility command to the canonical Bluetooth
+     list implementation.
+
+     Selection, output, failure, and JSON behavior remain consistent with the
+     canonical command.
+     */
     @Test(
         .disabled(
             "WDY-1952: cloud-routed alias equivalence needs seeded tunnel/auth and simulated managed-agent Bluetooth state."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device camera list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device camera list`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device camera list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device camera list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device camera list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device camera list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device camera list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays cameras with ids, names, supported formats, resolutions, and
+     frame rates when the agent reports them.
+     */
     @Test(
         .disabled(
             "WDY-1952: human camera inventory needs seeded cloud tunnel and managed-agent camera state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device camera list'` {
     )
     func `lists cameras`() async throws {}
 
+    /**
+     With `--json`, emits camera objects and capability arrays with stable
+     field names. No cameras is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON camera schema needs seeded cloud tunnel and managed-agent camera state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device camera list'` {
     )
     func `prints JSON camera inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device camera list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device camera list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraViewTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceCameraViewTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device camera view'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device camera view`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +30,11 @@ struct `'wendy cloud device camera view'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target viewing needs a seeded managed agent and simulated camera capability without physical hardware."
@@ -30,6 +42,11 @@ struct `'wendy cloud device camera view'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -37,6 +54,11 @@ struct `'wendy cloud device camera view'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -50,6 +72,11 @@ struct `'wendy cloud device camera view'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -57,6 +84,10 @@ struct `'wendy cloud device camera view'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams video from the selected camera using the requested dimensions and
+     frame rate. Interactive mode opens a viewer when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: camera playback needs seeded encoded frames plus controlled local viewer dependencies."
@@ -64,6 +95,10 @@ struct `'wendy cloud device camera view'` {
     )
     func `streams camera video`() async throws {}
 
+    /**
+     `--stdout` writes the encoded video stream to stdout and keeps diagnostics
+     on stderr for safe piping.
+     */
     @Test(
         .disabled(
             "WDY-1952: encoded stdout routing needs seeded frames and bounded stream process control."
@@ -71,6 +106,10 @@ struct `'wendy cloud device camera view'` {
     )
     func `writes encoded video to stdout when requested`() async throws {}
 
+    /**
+     Invalid camera ids, dimensions, or frame rates fail before a remote camera
+     stream is opened.
+     */
     @Test(
         .disabled(
             "WDY-1958: semantic camera dimensions and frame rates are not validated locally before target connection/RPC."
@@ -78,6 +117,10 @@ struct `'wendy cloud device camera view'` {
     )
     func `validates camera parameters before streaming`() async throws {}
 
+    /**
+     Cancelling the viewer closes the remote stream and local viewer process
+     without changing camera settings.
+     */
     @Test(
         .disabled(
             "WDY-1952: viewer cancellation cleanup needs seeded streaming RPC state and harness process control."
@@ -85,6 +128,12 @@ struct `'wendy cloud device camera view'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -96,6 +145,12 @@ struct `'wendy cloud device camera view'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device camera view' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceDashboardTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceDashboardTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device dashboard'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device dashboard`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device dashboard'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target dashboard startup needs a seeded managed agent with telemetry state."
@@ -28,6 +40,11 @@ struct `'wendy cloud device dashboard'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device dashboard'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device dashboard'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -55,6 +82,11 @@ struct `'wendy cloud device dashboard'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays live metrics and logs for the selected device, optionally
+     filtered to an application. The dashboard is informational and does not
+     mutate device state.
+     */
     @Test(
         .disabled(
             "WDY-1952: live dashboard rendering needs seeded metrics/log streams and scripted terminal control."
@@ -62,6 +94,10 @@ struct `'wendy cloud device dashboard'` {
     )
     func `shows a live device dashboard`() async throws {}
 
+    /**
+     Without an interactive terminal, reports that the live dashboard requires
+     a terminal or suggests machine-readable alternatives.
+     */
     @Test(
         .disabled(
             "WDY-1952: terminal capability behavior needs a seeded target plus controlled TTY/non-TTY execution."
@@ -69,6 +105,10 @@ struct `'wendy cloud device dashboard'` {
     )
     func `reports non-interactive dashboard limitations`() async throws {}
 
+    /**
+     Cancelling the dashboard closes log and metric streams and restores
+     terminal output.
+     */
     @Test(
         .disabled(
             "WDY-1952: dashboard cancellation cleanup needs seeded streams and harness process control."
@@ -76,6 +116,12 @@ struct `'wendy cloud device dashboard'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -87,6 +133,12 @@ struct `'wendy cloud device dashboard'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device dashboard' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceEnrollTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceEnrollTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device enroll'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device enroll`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device enroll'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit-target enrollment needs isolated auth, PKI/cloud, and disposable provisioning fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device enroll'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device enroll'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -49,6 +71,11 @@ struct `'wendy cloud device enroll'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1949: connection and incompatible-RPC failures need disposable provisioning and auth fixtures."
@@ -56,6 +83,10 @@ struct `'wendy cloud device enroll'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Uses the stored auth session to create an enrollment token and provisions
+     the device with mTLS credentials and an optional name.
+     */
     @Test(
         .disabled(
             "WDY-1949: successful enrollment needs isolated auth, token issuance, certificate, and disposable device fixtures."
@@ -63,6 +94,10 @@ struct `'wendy cloud device enroll'` {
     )
     func `enrolls the selected device with Wendy Cloud`() async throws {}
 
+    /**
+     Token creation, certificate issuance, or device provisioning failures
+     leave previous device credentials usable and report the failing stage.
+     */
     @Test(
         .disabled(
             "WDY-1949: partial-failure rollback needs controllable token, certificate, and provisioning failure fixtures."
@@ -70,6 +105,10 @@ struct `'wendy cloud device enroll'` {
     )
     func `does not leave partial credentials on enrollment failure`() async throws {}
 
+    /**
+     With `--json`, emits enrollment status and certificate metadata without
+     printing tokens or private keys.
+     */
     @Test(
         .disabled(
             "WDY-1949: JSON enrollment metadata needs isolated successful PKI/cloud and device fixtures."
@@ -77,6 +116,12 @@ struct `'wendy cloud device enroll'` {
     )
     func `prints JSON enrollment metadata`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -88,6 +133,12 @@ struct `'wendy cloud device enroll'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device enroll' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceHardwareListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceHardwareListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device hardware list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device hardware list`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device hardware list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device hardware list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device hardware list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device hardware list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device hardware list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays hardware capabilities such as GPU, audio, camera, storage, and
+     buses with ids and user-facing labels.
+     */
     @Test(
         .disabled(
             "WDY-1952: hardware inventory needs seeded cloud tunnel and managed-agent capability state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device hardware list'` {
     )
     func `lists hardware capabilities`() async throws {}
 
+    /**
+     `--category` restricts output to matching capabilities. Unknown categories
+     produce an empty successful result or clear validation diagnostic.
+     */
     @Test(
         .disabled(
             "WDY-1952: category filtering needs seeded multi-category managed-agent capability state."
@@ -68,6 +103,10 @@ struct `'wendy cloud device hardware list'` {
     )
     func `filters by category`() async throws {}
 
+    /**
+     With `--json`, emits hardware objects grouped or labeled by category with
+     stable field names.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON hardware schema needs seeded cloud tunnel and managed-agent capability state."
@@ -75,6 +114,12 @@ struct `'wendy cloud device hardware list'` {
     )
     func `prints JSON hardware inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -86,6 +131,12 @@ struct `'wendy cloud device hardware list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device hardware list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceLogsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceLogsTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device logs'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device logs`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud device logs'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target log streaming needs a seeded managed agent with telemetry state."
@@ -29,6 +41,11 @@ struct `'wendy cloud device logs'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -36,6 +53,11 @@ struct `'wendy cloud device logs'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device logs'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -55,6 +82,10 @@ struct `'wendy cloud device logs'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams logs from the selected device and applies app, service, level, and
+     severity filters before presenting entries.
+     */
     @Test(
         .disabled(
             "WDY-1952: filtered log streaming needs seeded managed-agent container and telemetry records."
@@ -62,6 +93,10 @@ struct `'wendy cloud device logs'` {
     )
     func `streams device logs`() async throws {}
 
+    /**
+     With `--json`, emits newline-delimited or array-wrapped structured log
+     entries suitable for automation, without table formatting.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON log framing needs seeded managed-agent telemetry records and bounded stream control."
@@ -69,6 +104,10 @@ struct `'wendy cloud device logs'` {
     )
     func `prints structured log entries in JSON mode`() async throws {}
 
+    /**
+     Cancelling log streaming closes the remote stream without changing app or
+     device state.
+     */
     @Test(
         .disabled(
             "WDY-1952: log cancellation cleanup needs a seeded stream and harness process control."
@@ -76,6 +115,12 @@ struct `'wendy cloud device logs'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -87,6 +132,12 @@ struct `'wendy cloud device logs'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDevicePsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDevicePsTests.swift
@@ -6,6 +6,12 @@ import WendyE2ETesting
 struct `'wendy cloud device ps'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays help for the cloud `ps` compatibility alias.
+
+     The output directs users to the canonical application-list behavior and
+     exits without authentication or device access.
+     */
     @Test
     func `prints cloud device ps alias help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +28,13 @@ struct `'wendy cloud device ps'` {
         }
     }
 
+    /**
+     Routes the cloud `ps` compatibility command to the canonical application-list
+     implementation.
+
+     Device selection, output, and failure behavior remain consistent with the
+     canonical command.
+     */
     @Test(
         .disabled(
             "WDY-1952: cloud-routed alias equivalence needs seeded tunnel/auth and managed-agent application state."
@@ -29,6 +42,12 @@ struct `'wendy cloud device ps'` {
     )
     func `aliases cloud device apps list`() async throws {}
 
+    /**
+     Keeps machine-readable application-list output on stdout when the cloud `ps`
+     alias is used with `--json`.
+
+     Diagnostics remain on stderr so automation can parse stdout independently.
+     */
     @Test(
         .disabled(
             "WDY-1952: cloud-routed JSON schema equivalence needs seeded tunnel/auth and managed-agent application state."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetDefaultTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy cloud device set-default'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays positional hostname usage without auth, discovery, or config access. */
+    /**
+     Displays usage for `wendy cloud device set-default`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -25,6 +31,11 @@ struct `'wendy cloud device set-default'` {
         }
     }
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1943: omitted-hostname selection enters physical discovery/picker flow; deterministic non-interactive behavior needs injected discovery fixtures."
@@ -34,7 +45,12 @@ struct `'wendy cloud device set-default'` {
         // TODO: enable with deterministic picker/discovery fixtures (WDY-1943).
     }
 
-    /** Stores an offline hostname locally; cloud reachability pinning remains best-effort. */
+    /**
+     Saves an explicit default-device hostname in local Wendy configuration.
+
+     The local preference is updated even when cloud authentication and remote
+     reachability are unavailable.
+     */
     @Test
     func `saves the default device hostname without cloud authentication`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -52,7 +68,13 @@ struct `'wendy cloud device set-default'` {
         }
     }
 
-    /** Preserves unrelated known config while changing only the default hostname. */
+    /**
+     Changes only the default-device setting while preserving other recognized
+     Wendy configuration values.
+
+     Analytics preferences, update metadata, and completion settings retain their
+     existing values after the mutation.
+     */
     @Test
     func `preserves unrelated known configuration keys`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -85,6 +107,13 @@ struct `'wendy cloud device set-default'` {
         }
     }
 
+    /**
+     Preserves unrecognized top-level configuration values while changing the
+     default-device setting.
+
+     This allows newer or third-party settings to survive a mutation performed by
+     the current CLI.
+     */
     @Test(
         .disabled(
             "WDY-1940: typed config load/save discards unknown top-level keys during default-device mutation."
@@ -94,6 +123,12 @@ struct `'wendy cloud device set-default'` {
         // TODO: enable when config mutations round-trip unknown keys (WDY-1940).
     }
 
+    /**
+     Requires an explicit hostname to contain a nonempty device address.
+
+     Empty or whitespace-only values fail validation without changing the saved
+     default device.
+     */
     @Test(
         .disabled(
             "WDY-1953: an explicit empty hostname is accepted, saved as an empty default, and reported as success instead of failing validation."
@@ -103,7 +138,12 @@ struct `'wendy cloud device set-default'` {
         // TODO: enable when empty/whitespace hostnames are rejected (WDY-1953).
     }
 
-    /** Too many positional arguments and unknown flags fail before config mutation. */
+    /**
+     Accepts only the documented arguments and flags for `wendy cloud device
+     set-default`. Extra positional arguments or unknown flags produce a
+     usage diagnostic on stderr, return a failure status, emit no success
+     output, and leave existing state unchanged.
+     */
     @Test
     func `rejects undocumented arguments and flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetupTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceSetupTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device setup'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device setup`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -18,6 +25,11 @@ struct `'wendy cloud device setup'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target setup needs seeded provisioning, auth, WiFi, and version state."
@@ -25,6 +37,11 @@ struct `'wendy cloud device setup'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -32,6 +49,11 @@ struct `'wendy cloud device setup'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -44,6 +66,11 @@ struct `'wendy cloud device setup'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -51,6 +78,11 @@ struct `'wendy cloud device setup'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Guides the user through device naming, cloud enrollment, and WiFi
+     configuration for a new device, explaining each side effect before
+     applying it.
+     */
     @Test(
         .disabled(
             "WDY-1952: the setup wizard needs seeded provisioning/auth/WiFi state plus scripted PTY interaction."
@@ -58,6 +90,10 @@ struct `'wendy cloud device setup'` {
     )
     func `walks through new device setup`() async throws {}
 
+    /**
+     Existing auth sessions, device names, or WiFi configuration are detected
+     and not repeated unless the user chooses to change them.
+     */
     @Test(
         .disabled(
             "WDY-1952: setup resume behavior needs seeded partially configured device and auth state."
@@ -65,6 +101,10 @@ struct `'wendy cloud device setup'` {
     )
     func `uses existing state to skip completed setup steps`() async throws {}
 
+    /**
+     Cancelling the setup flow stops at the current step and avoids applying
+     later enrollment or WiFi changes.
+     */
     @Test(
         .disabled(
             "WDY-1952: setup cancellation needs seeded state and harness process control across wizard stages."
@@ -72,6 +112,12 @@ struct `'wendy cloud device setup'` {
     )
     func `cancels without continuing later setup`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -83,6 +129,12 @@ struct `'wendy cloud device setup'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device setup' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceTelemetryStreamTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceTelemetryStreamTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device telemetry-stream'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device telemetry-stream`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -25,6 +32,11 @@ struct `'wendy cloud device telemetry-stream'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target telemetry needs a seeded managed agent with logs, metrics, and traces."
@@ -32,6 +44,11 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -39,6 +56,11 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -52,6 +74,11 @@ struct `'wendy cloud device telemetry-stream'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -59,6 +86,11 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams selected logs, metrics, and traces as JSON lines with stable
+     envelope fields and timestamps. The stream continues until cancelled or
+     the device closes it.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSONL framing needs seeded logs, metrics, and traces plus bounded stream control."
@@ -66,6 +98,10 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `streams telemetry as JSONL`() async throws {}
 
+    /**
+     App, service, logs, metrics, and traces filters constrain the stream
+     before entries are emitted to stdout.
+     */
     @Test(
         .disabled(
             "WDY-1952: telemetry filtering needs seeded neighboring app/service records across all signal types."
@@ -73,6 +109,10 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `applies telemetry filters`() async throws {}
 
+    /**
+     Cancelling the stream closes the remote telemetry subscription and emits
+     no malformed trailing JSON.
+     */
     @Test(
         .disabled(
             "WDY-1952: telemetry cancellation cleanup needs seeded streams and harness process control."
@@ -80,6 +120,12 @@ struct `'wendy cloud device telemetry-stream'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -91,6 +137,12 @@ struct `'wendy cloud device telemetry-stream'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device telemetry-stream' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUnsetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUnsetDefaultTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy cloud device unset-default'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays local clear-default usage without reading config or selecting a device. */
+    /**
+     Displays usage for `wendy cloud device unset-default`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,7 +29,10 @@ struct `'wendy cloud device unset-default'` {
         }
     }
 
-    /** Clears only the saved default and preserves unrelated known config. */
+    /**
+     Removes the saved default device from CLI configuration and prints a
+     concise confirmation. Other configuration keys remain intact.
+     */
     @Test
     func `clears the saved default device`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -57,6 +66,10 @@ struct `'wendy cloud device unset-default'` {
         }
     }
 
+    /**
+     With no saved default device, reports a no-op success and avoids creating
+     unrelated configuration state.
+     */
     @Test(
         .disabled(
             "WDY-1953: with no saved default, unset-default creates/rewrites config and reports a clear instead of remaining a non-mutating no-op."
@@ -66,7 +79,12 @@ struct `'wendy cloud device unset-default'` {
         // TODO: enable when no-default unset is non-mutating (WDY-1953).
     }
 
-    /** Unknown flags fail before config mutation. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -83,6 +101,12 @@ struct `'wendy cloud device unset-default'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device unset-default' silently accepts extra positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUpdateTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device update'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device update`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud device update'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target update needs a disposable seeded agent and isolated release/artifact fixtures."
@@ -29,6 +41,11 @@ struct `'wendy cloud device update'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -36,6 +53,11 @@ struct `'wendy cloud device update'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device update'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need a disposable seeded agent with controllable responses."
@@ -55,6 +82,10 @@ struct `'wendy cloud device update'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Downloads the selected agent release, verifies it, uploads it to the
+     device, and reports the installed version after update.
+     */
     @Test(
         .disabled(
             "WDY-1952: release update needs isolated downloads and a disposable agent restart/reconnect target."
@@ -62,6 +93,10 @@ struct `'wendy cloud device update'` {
     )
     func `updates the device agent from the latest release`() async throws {}
 
+    /**
+     `--binary` skips release download and uploads the provided local agent
+     binary after validating that it is readable.
+     */
     @Test(
         .disabled(
             "WDY-1952: local binary upload needs an architecture fixture and disposable agent restart/reconnect target."
@@ -69,9 +104,17 @@ struct `'wendy cloud device update'` {
     )
     func `uploads a local binary when requested`() async throws {}
 
+    /**
+     `--nightly` selects a prerelease agent build and reports that prerelease
+     channel in output.
+     */
     @Test(.disabled("WDY-1952: nightly selection needs isolated release and OS manifest fixtures."))
     func `uses nightly releases when requested`() async throws {}
 
+    /**
+     Download, verification, upload, or restart failures report the failing
+     stage and do not claim the update completed.
+     */
     @Test(
         .disabled(
             "WDY-1952: failure preservation needs controllable download/upload/restart stages on a disposable agent."
@@ -79,6 +122,12 @@ struct `'wendy cloud device update'` {
     )
     func `preserves the running agent on failed update`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -90,6 +139,12 @@ struct `'wendy cloud device update'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device update' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVersionTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVersionTests.swift
@@ -6,6 +6,12 @@ import WendyE2ETesting
 struct `'wendy cloud device version'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Keeps the deprecated cloud `version` alias out of parent command discovery
+     while preserving direct help for compatibility.
+
+     Direct help identifies the canonical cloud device information command.
+     */
     @Test
     func `is hidden from parent help while direct help mirrors cloud device info`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -32,6 +38,12 @@ struct `'wendy cloud device version'` {
         }
     }
 
+    /**
+     Routes the deprecated cloud `version` command to cloud device information.
+
+     Successful output includes a deprecation notice that directs users to the
+     canonical command.
+     */
     @Test(
         .disabled(
             "WDY-1952: cloud-routed info equivalence and deprecation output need seeded tunnel/auth and managed-agent metadata."
@@ -39,6 +51,12 @@ struct `'wendy cloud device version'` {
     )
     func `aliases cloud device info with a deprecation notice`() async throws {}
 
+    /**
+     Keeps machine-readable command results on stdout when `--json` is requested.
+
+     Deprecation notices and diagnostics remain on stderr so automation can parse
+     stdout independently.
+     */
     @Test(
         .disabled(
             "WDY-1952: cloud-routed JSON compatibility needs seeded tunnel/auth and managed-agent metadata."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device volumes list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device volumes list`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device volumes list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device volumes list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device volumes list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device volumes list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device volumes list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays persistent volumes with names, paths, sizes, owning applications,
+     and usage metadata when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: volume inventory needs seeded cloud tunnel and managed-agent storage state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device volumes list'` {
     )
     func `lists persistent volumes`() async throws {}
 
+    /**
+     With `--json`, emits volume objects with stable name, path, size, and
+     owner fields. No volumes is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON volume schema needs seeded cloud tunnel and managed-agent storage state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device volumes list'` {
     )
     func `prints JSON volume inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device volumes list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device volumes list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceVolumesRemoveTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device volumes remove'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device volumes remove`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy cloud device volumes remove'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target removal needs seeded managed-agent persistent-volume state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -33,6 +50,11 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device volumes remove'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes the named volume only after confirmation or `--force`. Success
+     output identifies the removed volume.
+     */
     @Test(
         .disabled(
             "WDY-1952: confirmation and successful removal need seeded managed-agent persistent-volume state."
@@ -61,6 +92,12 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `removes a persistent volume after confirmation`() async throws {}
 
+    /**
+     Prompts for a volume when its name is omitted in an interactive session.
+
+     The selected volume is passed to the removal flow; cancellation leaves
+     device storage unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: omitted names intentionally open a device-backed volume picker and need seeded list results."
@@ -68,6 +105,10 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `selects a missing volume name interactively`() async throws {}
 
+    /**
+     An unknown volume name fails without deleting similarly named volumes or
+     application containers.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-volume isolation needs seeded neighboring volume and application state."
@@ -75,6 +116,12 @@ struct `'wendy cloud device volumes remove'` {
     )
     func `reports unknown volumes without deleting data`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -86,6 +133,12 @@ struct `'wendy cloud device volumes remove'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiConnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi connect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi connect`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy cloud device wifi connect'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target connection needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -27,6 +39,11 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -34,6 +51,11 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -48,6 +70,11 @@ struct `'wendy cloud device wifi connect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -55,6 +82,10 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Connects the device to the requested SSID using the supplied password when
+     needed and reports the resulting connection status.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful connection needs simulated managed-agent WiFi association state without physical radios."
@@ -62,6 +93,11 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `connects to a WiFi network`() async throws {}
 
+    /**
+     For secured networks without `--password`, prompts in an interactive
+     terminal without echoing the secret. Non-interactive mode reports that a
+     password is required.
+     */
     @Test(
         .disabled(
             "WDY-1952: password prompting and redaction need a scripted PTY plus simulated secured-network state."
@@ -69,6 +105,13 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `prompts for missing password only in interactive mode`() async throws {}
 
+    /**
+     Prompts for a WiFi network when its SSID is omitted in an interactive
+     session.
+
+     The selected network is passed to the connection flow; cancellation leaves
+     device networking unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: omitted SSID intentionally opens a device-backed network picker and needs simulated scan results."
@@ -76,6 +119,10 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `selects a missing SSID interactively`() async throws {}
 
+    /**
+     Authentication or association failures report the error and do not replace
+     existing working network credentials.
+     */
     @Test(
         .disabled(
             "WDY-1952: failed-credential preservation needs seeded neighboring managed-agent network profiles."
@@ -83,6 +130,12 @@ struct `'wendy cloud device wifi connect'` {
     )
     func `does not save failed credentials`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -94,6 +147,12 @@ struct `'wendy cloud device wifi connect'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi connect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiDisconnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi disconnect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi disconnect`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -18,6 +25,11 @@ struct `'wendy cloud device wifi disconnect'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target disconnection needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -25,6 +37,11 @@ struct `'wendy cloud device wifi disconnect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -32,6 +49,11 @@ struct `'wendy cloud device wifi disconnect'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -45,6 +67,11 @@ struct `'wendy cloud device wifi disconnect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -52,6 +79,10 @@ struct `'wendy cloud device wifi disconnect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Disconnects the active WiFi connection and reports the resulting
+     disconnected state.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful disconnection needs simulated managed-agent WiFi connection state."
@@ -59,6 +90,10 @@ struct `'wendy cloud device wifi disconnect'` {
     )
     func `disconnects from the current WiFi network`() async throws {}
 
+    /**
+     A device with no active WiFi connection reports a no-op or already-
+     disconnected result without changing saved networks.
+     */
     @Test(
         .disabled(
             "WDY-1952: already-disconnected semantics need simulated managed-agent WiFi state."
@@ -66,6 +101,12 @@ struct `'wendy cloud device wifi disconnect'` {
     )
     func `handles already disconnected devices predictably`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -77,6 +118,12 @@ struct `'wendy cloud device wifi disconnect'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi disconnect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiForgetTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi forget'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi forget`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy cloud device wifi forget'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target forget needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -26,6 +38,11 @@ struct `'wendy cloud device wifi forget'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -33,6 +50,11 @@ struct `'wendy cloud device wifi forget'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -46,6 +68,11 @@ struct `'wendy cloud device wifi forget'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -53,11 +80,18 @@ struct `'wendy cloud device wifi forget'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes saved credentials for the requested SSID without affecting other
+     known networks or current nonmatching connections.
+     */
     @Test(
         .disabled("WDY-1952: successful forget needs simulated managed-agent saved-network state.")
     )
     func `forgets a known WiFi network`() async throws {}
 
+    /**
+     Missing `--ssid` produces a usage diagnostic and no WiFi operation.
+     */
     @Test
     func `requires an SSID`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -69,6 +103,10 @@ struct `'wendy cloud device wifi forget'` {
         }
     }
 
+    /**
+     Forgetting an SSID that is not saved reports a clear result and leaves all
+     known networks unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-network isolation needs seeded neighboring managed-agent network profiles."
@@ -76,6 +114,12 @@ struct `'wendy cloud device wifi forget'` {
     )
     func `reports unknown networks without changing saved credentials`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -87,6 +131,12 @@ struct `'wendy cloud device wifi forget'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi forget' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device wifi list'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device wifi list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device wifi list'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device wifi list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device wifi list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays scanned WiFi networks with SSID, signal strength, security, saved
+     status, and current connection markers when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: WiFi scans need seeded cloud tunnel and simulated managed-agent network state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device wifi list'` {
     )
     func `lists available WiFi networks`() async throws {}
 
+    /**
+     With `--json`, emits WiFi network objects with stable SSID, signal,
+     security, saved, and connected fields.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON WiFi schema needs seeded cloud tunnel and simulated managed-agent network state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device wifi list'` {
     )
     func `prints JSON WiFi scan results`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device wifi list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi list' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiRankTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiRankTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi rank'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi rank`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device wifi rank'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: explicit cloud-target ranking needs seeded managed-agent saved-network state without physical radios."
@@ -28,6 +40,11 @@ struct `'wendy cloud device wifi rank'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device wifi rank'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -49,6 +71,11 @@ struct `'wendy cloud device wifi rank'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -56,6 +83,10 @@ struct `'wendy cloud device wifi rank'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     `--ssid` with `--priority` updates one saved network's autoconnect
+     priority and leaves other priorities unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: single-network ranking needs seeded neighboring managed-agent priority state."
@@ -63,6 +94,10 @@ struct `'wendy cloud device wifi rank'` {
     )
     func `sets priority for a single known network`() async throws {}
 
+    /**
+     `--order` assigns priorities to the listed SSIDs from highest to lowest
+     while preserving unlisted known networks.
+     */
     @Test(
         .disabled(
             "WDY-1952: bulk ranking needs seeded listed/unlisted managed-agent priority state."
@@ -70,6 +105,10 @@ struct `'wendy cloud device wifi rank'` {
     )
     func `bulk reorders known networks`() async throws {}
 
+    /**
+     Supplying incomplete or conflicting ranking flags produces a usage
+     diagnostic before WiFi settings are changed.
+     */
     @Test
     func `validates mutually exclusive ranking modes`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -94,6 +133,12 @@ struct `'wendy cloud device wifi rank'` {
         }
     }
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -105,6 +150,12 @@ struct `'wendy cloud device wifi rank'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi rank' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceWifiStatusTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud device wifi status'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud device wifi status`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud device wifi status'` {
         }
     }
 
+    /**
+     `--device` selects the cloud device and skips local discovery and pickers.
+     The command does not read or change the saved default device when an
+     explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit cloud-device selection needs isolated auth and tunnel fixtures."
@@ -28,6 +40,11 @@ struct `'wendy cloud device wifi status'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1949: missing cloud-device selection can only be observed after injecting valid isolated auth."
@@ -35,6 +52,11 @@ struct `'wendy cloud device wifi status'` {
     )
     func `reports missing device selection in non-interactive mode`() async throws {}
 
+    /**
+     Cloud-routed device commands validate the selected Wendy Cloud auth
+     session before connecting to the broker. Missing or ambiguous auth fails
+     before device state changes.
+     */
     @Test
     func `requires cloud authentication before opening a tunnel`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +69,11 @@ struct `'wendy cloud device wifi status'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: tunnel and incompatible-RPC failures need seeded cloud and managed-agent responses."
@@ -54,6 +81,10 @@ struct `'wendy cloud device wifi status'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Reports whether WiFi is connected, the active SSID, signal quality, IP
+     details, and known-network state when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human WiFi status needs seeded cloud tunnel and simulated connected/disconnected state."
@@ -61,6 +92,10 @@ struct `'wendy cloud device wifi status'` {
     )
     func `prints current WiFi status`() async throws {}
 
+    /**
+     With `--json`, emits one JSON object with connection state and nullable
+     fields for disconnected devices.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON WiFi status needs seeded cloud tunnel and simulated connected/disconnected state."
@@ -68,6 +103,12 @@ struct `'wendy cloud device wifi status'` {
     )
     func `prints JSON WiFi status`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy cloud device wifi status'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud device wifi status' silently accepts positional arguments because the mirrored leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDiscoverTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud discover'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud discover`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy cloud discover'` {
         }
     }
 
+    /**
+     Uses the stored Wendy Cloud auth session to list enrolled devices
+     with names, online status, and connection metadata. Success output
+     is a finite list and emits no stderr.
+     */
     @Test(
         .disabled(
             "WDY-1949: enrolled-device discovery needs isolated cloud auth and seeded asset inventory."
@@ -28,6 +40,11 @@ struct `'wendy cloud discover'` {
     )
     func `lists enrolled cloud devices`() async throws {}
 
+    /**
+     `--all` includes offline devices and marks their state clearly.
+     Without `--all`, the default listing focuses on currently usable
+     devices.
+     */
     @Test(
         .disabled(
             "WDY-1949: offline-device filtering needs isolated cloud auth and seeded online/offline asset inventory."
@@ -35,6 +52,10 @@ struct `'wendy cloud discover'` {
     )
     func `includes offline devices when requested`() async throws {}
 
+    /**
+     With no auth session, reports that login is required and performs no
+     cloud discovery request.
+     */
     @Test
     func `reports missing auth before contacting discovery services`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,6 +68,10 @@ struct `'wendy cloud discover'` {
         }
     }
 
+    /**
+     With `--json`, emits device objects with stable id, name, status,
+     and endpoint fields. JSON mode emits no table formatting.
+     */
     @Test(
         .disabled(
             "WDY-1949: JSON cloud discovery schema needs isolated auth and seeded asset inventory."
@@ -54,6 +79,12 @@ struct `'wendy cloud discover'` {
     )
     func `prints JSON cloud discovery results for automation`() async throws {}
 
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test
     func `reports invalid CLI configuration before acting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +110,12 @@ struct `'wendy cloud discover'` {
         }
     }
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -91,6 +128,12 @@ struct `'wendy cloud discover'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud discover' silently accepts positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudEnrollDeviceTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudEnrollDeviceTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud enroll-device'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud enroll-device`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy cloud enroll-device'` {
         }
     }
 
+    /**
+     Creates an enrollment token with the stored cloud auth session and
+     provisions the selected device with mTLS credentials. Output
+     matches the device enrollment flow apart from the command name.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1952: alias parity needs isolated PKI auth and a disposable seeded device provisioning target."
@@ -29,6 +41,11 @@ struct `'wendy cloud enroll-device'` {
     )
     func `acts as the cloud alias for device enrollment`() async throws {}
 
+    /**
+     `--cloud-grpc` selects the cloud or pki-core endpoint when more
+     than one auth session exists. Sessions for other endpoints remain
+     untouched.
+     */
     @Test(
         .disabled(
             "WDY-1949: endpoint selection needs multiple isolated cloud/PKI auth sessions and token issuance fixtures."
@@ -36,6 +53,11 @@ struct `'wendy cloud enroll-device'` {
     )
     func `uses the requested cloud endpoint`() async throws {}
 
+    /**
+     Authentication failures, token creation failures, and device
+     connection failures leave the device and local credential store in
+     their previous state.
+     */
     @Test(
         .disabled(
             "WDY-1959: cloud enroll-device connects to and may inspect WiFi on the local device before resolving auth; WDY-1949 tracks isolated failure fixtures."
@@ -43,6 +65,10 @@ struct `'wendy cloud enroll-device'` {
     )
     func `reports missing auth or unreachable devices without partial enrollment`() async throws {}
 
+    /**
+     With `--json`, emits cloud, device, certificate, and enrollment
+     status fields without printing token or private key material.
+     */
     @Test(
         .disabled(
             "WDY-1949: JSON enrollment output needs isolated successful PKI/cloud and disposable device fixtures."
@@ -50,6 +76,12 @@ struct `'wendy cloud enroll-device'` {
     )
     func `prints JSON enrollment result for automation`() async throws {}
 
+    /**
+     Reads the Wendy CLI configuration before performing work that depends on
+     user state. Malformed configuration is reported as a configuration error,
+     no prompts open, no network connection is attempted, and the original file
+     remains byte-for-byte unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1959: invalid auth configuration is not read until after local device connection and optional WiFi inspection."
@@ -57,6 +89,12 @@ struct `'wendy cloud enroll-device'` {
     )
     func `reports invalid CLI configuration before acting`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -69,6 +107,12 @@ struct `'wendy cloud enroll-device'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud enroll-device' silently accepts positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy cloud run'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy cloud run`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +30,12 @@ struct `'wendy cloud run'` {
         }
     }
 
+    /**
+     Reads the project configuration, builds the application image,
+     deploys it through the Wendy Cloud tunnel broker, and starts the
+     container. Success output makes the running app and target device
+     clear.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: cloud build/deploy/start needs isolated projects, builders, auth, tunnels, images, and a disposable managed-agent target."
@@ -30,6 +43,11 @@ struct `'wendy cloud run'` {
     )
     func `builds, deploys, and starts the current project`() async throws {}
 
+    /**
+     `--deploy` creates or updates the container on the target device and
+     leaves it stopped. The command exits successfully after deployment and
+     prints no live log stream.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: stopped cloud deployment needs an isolated project and disposable managed-agent container state."
@@ -37,6 +55,10 @@ struct `'wendy cloud run'` {
     )
     func `deploys without starting when requested`() async throws {}
 
+    /**
+     `--detach` starts the application and returns after start-up status is
+     known. Output includes the app name and how to view logs later.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: detached cloud startup needs an isolated built app and disposable managed-agent target."
@@ -44,6 +66,11 @@ struct `'wendy cloud run'` {
     )
     func `detaches after starting when requested`() async throws {}
 
+    /**
+     `--user-args` preserves argument boundaries and forwards the provided
+     values to the started application without interpreting secrets or shell
+     metacharacters locally.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: user-argument boundaries need an argv-reporting fixture app deployed through an isolated cloud tunnel."
@@ -51,6 +78,11 @@ struct `'wendy cloud run'` {
     )
     func `passes user arguments to the container`() async throws {}
 
+    /**
+     `--prefix` selects the project directory and `--device` names the cloud
+     device and skips the picker. The command does not read unrelated
+     `wendy.json` files or open interactive device selection.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: explicit project/device success needs isolated project, auth, tunnel, and managed-target fixtures."
@@ -58,6 +90,11 @@ struct `'wendy cloud run'` {
     )
     func `uses explicit project and device selection`() async throws {}
 
+    /**
+     Requires a valid Wendy Cloud auth session before opening the tunnel.
+     Missing or ambiguous sessions produce an auth diagnostic without
+     building, deploying, or contacting a device.
+     */
     @Test
     func `uses cloud authentication before connecting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +107,11 @@ struct `'wendy cloud run'` {
         }
     }
 
+    /**
+     Build failures, invalid project configuration, unreachable devices, or
+     deployment errors return a failure status. Partial remote resources are
+     either cleaned up or identified clearly for manual cleanup.
+     */
     @Test(
         .disabled(
             "WDY-1949/WDY-1950: build/deployment failure cleanup needs controllable builder, tunnel, and managed-agent failure modes."
@@ -77,6 +119,10 @@ struct `'wendy cloud run'` {
     )
     func `reports build or deployment failure without claiming success`() async throws {}
 
+    /**
+     With `--json`, emits structured build, deploy, start, and app metadata.
+     Progress and streamed container logs do not corrupt stdout JSON.
+     */
     @Test(
         .disabled(
             "WDY-1909/WDY-1949/WDY-1950: cloud run lacks complete JSON results and needs isolated deployment fixtures to verify stream separation."
@@ -84,6 +130,12 @@ struct `'wendy cloud run'` {
     )
     func `prints JSON run metadata for automation`() async throws {}
 
+    /**
+     Rejects a project prefix that does not resolve to an existing directory.
+
+     Local path validation fails before cloud authentication, build, deployment,
+     or tunnel setup.
+     */
     @Test
     func `rejects a missing project prefix before cloud access`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -97,6 +149,12 @@ struct `'wendy cloud run'` {
         }
     }
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -109,6 +167,12 @@ struct `'wendy cloud run'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy cloud run' silently accepts positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudTunnelTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudTunnelTests.swift
@@ -16,7 +16,7 @@ struct `'wendy cloud tunnel'` {
         // AI: Review the full help output as CLI documentation for a networking
         // command. Flag confusing port-mapping wording, missing safety cues,
         // duplicated global flags, or formatting that would make setup hard.
-        try await self.scenario.run { cli, _ in
+        try await self.scenario.run(authenticated: false) { cli, _ in
             try await cli.sh("wendy cloud tunnel --help") { result in
                 let stdout = result.stdout
 
@@ -72,7 +72,7 @@ struct `'wendy cloud tunnel'` {
      */
     @Test
     func `rejects invalid port mappings before listening`() async throws {
-        try await self.scenario.run { cli, _ in
+        try await self.scenario.run(authenticated: false) { cli, _ in
             try await cli.sh("wendy cloud tunnel notaport") { result in
                 let stderr = result.stderr
 

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device apps list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device apps list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device apps list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target inventory needs seeded managed-agent application state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device apps list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device apps list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device apps list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays deployed applications with names, images, status, restart policy,
+     and relevant ports. An empty device reports an empty successful list.
+     */
     @Test(
         .disabled(
             "WDY-1952: human application inventory needs seeded empty/populated managed-agent container state."
@@ -52,6 +78,10 @@ struct `'wendy device apps list'` {
     )
     func `lists deployed applications`() async throws {}
 
+    /**
+     With `--json`, emits application objects with stable field names and value
+     types. JSON mode emits no table formatting and no stderr on success.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON application schema needs seeded empty/populated managed-agent container state."
@@ -59,6 +89,12 @@ struct `'wendy device apps list'` {
     )
     func `prints JSON application inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device apps list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device apps list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsRemoveTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device apps remove'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device apps remove`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy device apps remove'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target removal needs seeded managed-agent application state without a physical device."
@@ -28,6 +40,11 @@ struct `'wendy device apps remove'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -40,6 +57,11 @@ struct `'wendy device apps remove'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -47,6 +69,11 @@ struct `'wendy device apps remove'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes the named application only after confirmation or `--force`.
+     Success output identifies the removed app and any optional cleanup
+     performed.
+     */
     @Test(
         .disabled(
             "WDY-1952: confirmation and successful removal need seeded managed-agent application state."
@@ -54,6 +81,11 @@ struct `'wendy device apps remove'` {
     )
     func `removes an application after confirmation`() async throws {}
 
+    /**
+     `--cleanup` removes the container image and `--delete-volumes` removes
+     persistent volumes only for the named app. Omitted cleanup flags leave
+     those resources intact.
+     */
     @Test(
         .disabled(
             "WDY-1952: cleanup isolation needs seeded application, image, and persistent-volume state."
@@ -61,6 +93,10 @@ struct `'wendy device apps remove'` {
     )
     func `honors cleanup and volume deletion flags`() async throws {}
 
+    /**
+     An app name that is not deployed produces a failure diagnostic and does
+     not remove images, volumes, or other apps.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-application behavior needs seeded neighboring application and resource state."
@@ -68,6 +104,12 @@ struct `'wendy device apps remove'` {
     )
     func `reports unknown applications without deleting resources`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +121,12 @@ struct `'wendy device apps remove'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStartTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStartTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device apps start'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device apps start`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device apps start'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target startup needs seeded managed-agent application state without a physical device."
@@ -27,6 +39,11 @@ struct `'wendy device apps start'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -39,6 +56,11 @@ struct `'wendy device apps start'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -46,6 +68,11 @@ struct `'wendy device apps start'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Starts the named deployed application and streams container output until
+     the app exits or the user cancels. Startup failure is reported as command
+     failure.
+     */
     @Test(
         .disabled(
             "WDY-1952: startup and streamed output need seeded managed-agent application/container state plus process control."
@@ -53,6 +80,10 @@ struct `'wendy device apps start'` {
     )
     func `starts an application and streams output`() async throws {}
 
+    /**
+     `--detach` starts the app and returns after start-up status is known
+     without streaming logs.
+     */
     @Test(
         .disabled(
             "WDY-1952: detached startup needs seeded managed-agent application/container state."
@@ -60,6 +91,10 @@ struct `'wendy device apps start'` {
     )
     func `starts detached when requested`() async throws {}
 
+    /**
+     A missing app name or unknown deployed app produces a usage or not-found
+     diagnostic and no new container is created.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-application behavior needs seeded managed-agent application/container state."
@@ -67,6 +102,12 @@ struct `'wendy device apps start'` {
     )
     func `reports unknown applications without creating containers`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -78,6 +119,12 @@ struct `'wendy device apps start'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStopTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAppsStopTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device apps stop'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device apps stop`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device apps stop'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target stop needs seeded managed-agent application state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device apps stop'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device apps stop'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device apps stop'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Stops the named application and prints a concise confirmation after the
+     agent reports it stopped.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful stop needs seeded running managed-agent application/container state."
@@ -52,6 +78,10 @@ struct `'wendy device apps stop'` {
     )
     func `stops a running application`() async throws {}
 
+    /**
+     An already stopped app produces a clear no-op or not-running result
+     without affecting other applications.
+     */
     @Test(
         .disabled(
             "WDY-1952: stopped-app idempotence needs seeded stopped managed-agent application/container state."
@@ -59,6 +89,10 @@ struct `'wendy device apps stop'` {
     )
     func `handles already stopped applications predictably`() async throws {}
 
+    /**
+     Unknown app names fail without stopping containers that have similar
+     names.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-app isolation needs seeded neighboring managed-agent application/container state."
@@ -66,6 +100,12 @@ struct `'wendy device apps stop'` {
     )
     func `reports unknown applications without side effects`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -77,6 +117,12 @@ struct `'wendy device apps stop'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device audio list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device audio list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device audio list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target inventory needs seeded managed-agent audio state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device audio list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device audio list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device audio list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays input and output audio devices with ids, names, channel counts,
+     sample rates, and default markers when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human audio inventory needs seeded managed-agent audio hardware/capability state."
@@ -52,6 +78,10 @@ struct `'wendy device audio list'` {
     )
     func `lists audio devices`() async throws {}
 
+    /**
+     With `--json`, emits audio device objects with stable id, direction,
+     default, channel, and sample-rate fields.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON audio schema needs seeded managed-agent audio hardware/capability state."
@@ -59,6 +89,12 @@ struct `'wendy device audio list'` {
     )
     func `prints JSON audio device inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device audio list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device audio list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListenTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioListenTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device audio listen'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device audio listen`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy device audio listen'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target listening needs a seeded managed agent and simulated audio capability without physical hardware."
@@ -29,6 +41,11 @@ struct `'wendy device audio listen'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -41,6 +58,11 @@ struct `'wendy device audio listen'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -48,6 +70,11 @@ struct `'wendy device audio listen'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams audio from the selected microphone using the requested device id,
+     channel count, and sample rate. The stream continues until cancelled or
+     the device ends it.
+     */
     @Test(
         .disabled(
             "WDY-1952: microphone streaming needs seeded managed-agent audio frames without physical hardware."
@@ -55,6 +82,10 @@ struct `'wendy device audio listen'` {
     )
     func `streams microphone audio`() async throws {}
 
+    /**
+     `--stdout` writes raw PCM bytes to stdout and sends diagnostics to stderr
+     so piping to another process is safe.
+     */
     @Test(
         .disabled(
             "WDY-1952: raw PCM routing needs seeded managed-agent audio frames and stream process control."
@@ -62,6 +93,10 @@ struct `'wendy device audio listen'` {
     )
     func `writes raw PCM to stdout when requested`() async throws {}
 
+    /**
+     Invalid ids, channel counts, or sample rates fail before a stream is
+     opened.
+     */
     @Test(
         .disabled(
             "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
@@ -69,6 +104,12 @@ struct `'wendy device audio listen'` {
     )
     func `validates audio parameters before streaming`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -80,6 +121,12 @@ struct `'wendy device audio listen'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device audio listen' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioMonitorTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioMonitorTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device audio monitor'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device audio monitor`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device audio monitor'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target monitoring needs a seeded managed agent and simulated audio capability without physical hardware."
@@ -27,6 +39,11 @@ struct `'wendy device audio monitor'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -39,6 +56,11 @@ struct `'wendy device audio monitor'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -46,6 +68,10 @@ struct `'wendy device audio monitor'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays a live VU meter for the selected audio input at the requested
+     update rate and keeps diagnostics separate from the terminal UI.
+     */
     @Test(
         .disabled(
             "WDY-1952: VU rendering needs seeded managed-agent level frames plus controlled terminal output."
@@ -53,6 +79,10 @@ struct `'wendy device audio monitor'` {
     )
     func `renders live audio levels`() async throws {}
 
+    /**
+     Invalid device ids or update rates fail before a monitoring stream is
+     opened.
+     */
     @Test(
         .disabled(
             "WDY-1956: semantic audio parameter ranges are not validated locally before target connection/RPC."
@@ -60,6 +90,10 @@ struct `'wendy device audio monitor'` {
     )
     func `validates monitor parameters before streaming`() async throws {}
 
+    /**
+     Cancelling the monitor closes the remote stream and restores terminal
+     output without modifying device settings.
+     */
     @Test(
         .disabled(
             "WDY-1952: cancellation cleanup needs seeded streaming RPC state and harness process control."
@@ -67,6 +101,12 @@ struct `'wendy device audio monitor'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -78,6 +118,12 @@ struct `'wendy device audio monitor'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device audio monitor' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceAudioSetDefaultTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device audio set-default'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device audio set-default`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device audio set-default'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target mutation needs seeded managed-agent audio state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device audio set-default'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device audio set-default'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device audio set-default'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Sets the selected audio device id as the device default and prints a
+     concise confirmation with the chosen id or name.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful default selection needs seeded managed-agent audio device state."
@@ -52,6 +78,10 @@ struct `'wendy device audio set-default'` {
     )
     func `sets the default audio device`() async throws {}
 
+    /**
+     Missing or invalid `--id` values produce a usage diagnostic before
+     contacting or mutating audio settings.
+     */
     @Test
     func `requires an audio device id`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -63,6 +93,10 @@ struct `'wendy device audio set-default'` {
         }
     }
 
+    /**
+     If the agent rejects the id or does not support default audio selection,
+     the previous default remains active.
+     */
     @Test(
         .disabled(
             "WDY-1952: rejection and previous-default preservation need seeded managed-agent audio state."
@@ -70,6 +104,12 @@ struct `'wendy device audio set-default'` {
     )
     func `reports unsupported devices without changing defaults`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -81,6 +121,12 @@ struct `'wendy device audio set-default'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device audio set-default' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device bluetooth connect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device bluetooth connect`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device bluetooth connect'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target connection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -27,6 +39,11 @@ struct `'wendy device bluetooth connect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -39,6 +56,11 @@ struct `'wendy device bluetooth connect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -46,6 +68,10 @@ struct `'wendy device bluetooth connect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Connects to the requested peripheral address and applies pair and trust
+     options. Success output identifies the connected address.
+     */
     @Test(
         .disabled(
             "WDY-1952: pair/trust/connect behavior needs simulated managed-agent Bluetooth state without physical radios."
@@ -53,6 +79,10 @@ struct `'wendy device bluetooth connect'` {
     )
     func `connects to a Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic before a
+     Bluetooth operation starts.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -64,6 +94,12 @@ struct `'wendy device bluetooth connect'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -71,6 +107,10 @@ struct `'wendy device bluetooth connect'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     Pairing, trust, or connection failures report the failed stage and do not
+     claim the peripheral is connected.
+     */
     @Test(
         .disabled(
             "WDY-1952: staged pair/trust/connect failures need controllable simulated managed-agent Bluetooth responses."
@@ -78,6 +118,12 @@ struct `'wendy device bluetooth connect'` {
     )
     func `reports pairing failures without trusting the device`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -89,6 +135,12 @@ struct `'wendy device bluetooth connect'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device bluetooth disconnect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device bluetooth disconnect`. The output
+     includes the command synopsis, local flags, inherited global flags,
+     and concise descriptions. Help exits successfully, writes to stdout,
+     emits no stderr, and leaves configuration, cache, project, cloud, and
+     device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device bluetooth disconnect'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target disconnection needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -27,6 +39,11 @@ struct `'wendy device bluetooth disconnect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -40,6 +57,11 @@ struct `'wendy device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -47,6 +69,10 @@ struct `'wendy device bluetooth disconnect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Disconnects the requested peripheral address and prints a concise
+     confirmation after the agent reports it disconnected.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful disconnection needs simulated managed-agent Bluetooth connection state."
@@ -54,6 +80,10 @@ struct `'wendy device bluetooth disconnect'` {
     )
     func `disconnects a Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
+     operation.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -65,6 +95,12 @@ struct `'wendy device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -72,6 +108,10 @@ struct `'wendy device bluetooth disconnect'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     A peripheral that is not connected produces a clear no-op or not-connected
+     result without affecting pairing state.
+     */
     @Test(
         .disabled(
             "WDY-1952: already-disconnected semantics need simulated managed-agent Bluetooth state."
@@ -79,6 +119,12 @@ struct `'wendy device bluetooth disconnect'` {
     )
     func `handles already disconnected peripherals predictably`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -91,6 +137,12 @@ struct `'wendy device bluetooth disconnect'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device bluetooth forget'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device bluetooth forget`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -18,6 +25,11 @@ struct `'wendy device bluetooth forget'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target forget needs a seeded managed agent and simulated Bluetooth capability without physical hardware."
@@ -25,6 +37,11 @@ struct `'wendy device bluetooth forget'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -37,6 +54,11 @@ struct `'wendy device bluetooth forget'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -44,6 +66,10 @@ struct `'wendy device bluetooth forget'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes pairing and trust state for the requested peripheral address
+     without changing unrelated peripherals.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful forget needs simulated managed-agent pairing/trust state without physical radios."
@@ -51,6 +77,10 @@ struct `'wendy device bluetooth forget'` {
     )
     func `forgets a paired Bluetooth peripheral`() async throws {}
 
+    /**
+     Missing or malformed addresses produce a usage diagnostic and no Bluetooth
+     operation.
+     */
     @Test
     func `requires a peripheral address`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -62,6 +92,12 @@ struct `'wendy device bluetooth forget'` {
         }
     }
 
+    /**
+     Rejects peripheral addresses that do not use the documented Bluetooth
+     address format.
+
+     Validation fails before connecting to a device or changing Bluetooth state.
+     */
     @Test(
         .disabled(
             "WDY-1957: malformed Bluetooth addresses are forwarded to target resolution/RPC without local validation."
@@ -69,6 +105,10 @@ struct `'wendy device bluetooth forget'` {
     )
     func `rejects malformed peripheral addresses`() async throws {}
 
+    /**
+     Forgetting an address unknown to the device reports a not-found result and
+     preserves other pairings.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-address isolation needs seeded neighboring managed-agent pairing state."
@@ -76,6 +116,12 @@ struct `'wendy device bluetooth forget'` {
     )
     func `reports unknown peripherals without changing known devices`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -87,6 +133,12 @@ struct `'wendy device bluetooth forget'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device bluetooth list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device bluetooth list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device bluetooth list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target scans need a seeded managed agent and simulated Bluetooth capability without physical peripherals."
@@ -26,6 +38,11 @@ struct `'wendy device bluetooth list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device bluetooth list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device bluetooth list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays discoverable Bluetooth peripherals with address, name, paired,
+     trusted, and connected status when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human Bluetooth inventory needs simulated peripheral state without scanning physical radios."
@@ -52,6 +78,10 @@ struct `'wendy device bluetooth list'` {
     )
     func `scans for Bluetooth peripherals`() async throws {}
 
+    /**
+     With `--json`, emits peripheral objects with stable address and status
+     fields. An empty scan is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON Bluetooth schema needs simulated empty/populated peripheral state without physical radios."
@@ -59,6 +89,12 @@ struct `'wendy device bluetooth list'` {
     )
     func `prints JSON Bluetooth inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device bluetooth list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device bluetooth list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBtListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBtListTests.swift
@@ -6,7 +6,11 @@ import WendyE2ETesting
 struct `'wendy device bt list'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Resolves `bt` to the canonical Bluetooth list command and option surface. */
+    /**
+     Resolves through the `bt` alias and displays the same help as `wendy device
+     bluetooth list`, including inherited device/global flags and validation
+     behavior.
+     */
     @Test
     func `prints '... bluetooth list help' through the 'bt' alias`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +27,11 @@ struct `'wendy device bt list'` {
         }
     }
 
+    /**
+     Lists Bluetooth peripherals using the same output contract as `wendy device
+     bluetooth list`. The alias does not change target selection, JSON output,
+     or error diagnostics.
+     */
     @Test(
         .disabled(
             "WDY-1952: canonical/alias peripheral inventory equivalence needs seeded managed-agent Bluetooth responses without physical hardware."
@@ -32,7 +41,12 @@ struct `'wendy device bt list'` {
         // TODO: enable with seeded managed-agent Bluetooth fixtures (WDY-1952).
     }
 
-    /** Missing target fails before scanning or prompting. */
+    /**
+     Reports that no device target was supplied without starting device discovery.
+
+     Non-interactive invocation fails cleanly and leaves saved selection and device
+     state unchanged.
+     */
     @Test
     func `reports missing device without scanning`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device camera list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device camera list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device camera list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target inventory needs seeded managed-agent camera state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device camera list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device camera list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device camera list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays cameras with ids, names, supported formats, resolutions, and
+     frame rates when the agent reports them.
+     */
     @Test(
         .disabled(
             "WDY-1952: human camera inventory needs seeded managed-agent camera hardware/capability state."
@@ -52,6 +78,10 @@ struct `'wendy device camera list'` {
     )
     func `lists cameras`() async throws {}
 
+    /**
+     With `--json`, emits camera objects and capability arrays with stable
+     field names. No cameras is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON camera schema needs seeded managed-agent camera hardware/capability state."
@@ -59,6 +89,12 @@ struct `'wendy device camera list'` {
     )
     func `prints JSON camera inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device camera list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device camera list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraViewTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceCameraViewTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device camera view'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device camera view`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,6 +30,11 @@ struct `'wendy device camera view'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target viewing needs a seeded managed agent and simulated camera capability without physical hardware."
@@ -30,6 +42,11 @@ struct `'wendy device camera view'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -42,6 +59,11 @@ struct `'wendy device camera view'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -49,6 +71,10 @@ struct `'wendy device camera view'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams video from the selected camera using the requested dimensions and
+     frame rate. Interactive mode opens a viewer when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: camera playback needs seeded encoded frames plus controlled local viewer dependencies."
@@ -56,6 +82,10 @@ struct `'wendy device camera view'` {
     )
     func `streams camera video`() async throws {}
 
+    /**
+     `--stdout` writes the encoded video stream to stdout and keeps diagnostics
+     on stderr for safe piping.
+     */
     @Test(
         .disabled(
             "WDY-1952: encoded stdout routing needs seeded frames and bounded stream process control."
@@ -63,6 +93,10 @@ struct `'wendy device camera view'` {
     )
     func `writes encoded video to stdout when requested`() async throws {}
 
+    /**
+     Invalid camera ids, dimensions, or frame rates fail before a remote camera
+     stream is opened.
+     */
     @Test(
         .disabled(
             "WDY-1958: semantic camera dimensions and frame rates are not validated locally before target connection/RPC."
@@ -70,6 +104,10 @@ struct `'wendy device camera view'` {
     )
     func `validates camera parameters before streaming`() async throws {}
 
+    /**
+     Cancelling the viewer closes the remote stream and local viewer process
+     without changing camera settings.
+     */
     @Test(
         .disabled(
             "WDY-1952: viewer cancellation cleanup needs seeded streaming RPC state and harness process control."
@@ -77,6 +115,12 @@ struct `'wendy device camera view'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -88,6 +132,12 @@ struct `'wendy device camera view'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device camera view' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceDashboardTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceDashboardTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device dashboard'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device dashboard`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy device dashboard'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target dashboard startup needs a seeded managed agent with telemetry state."
@@ -28,6 +40,11 @@ struct `'wendy device dashboard'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -40,6 +57,11 @@ struct `'wendy device dashboard'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -47,6 +69,11 @@ struct `'wendy device dashboard'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays live metrics and logs for the selected device, optionally
+     filtered to an application. The dashboard is informational and does not
+     mutate device state.
+     */
     @Test(
         .disabled(
             "WDY-1952: live dashboard rendering needs seeded metrics/log streams and scripted terminal control."
@@ -54,6 +81,10 @@ struct `'wendy device dashboard'` {
     )
     func `shows a live device dashboard`() async throws {}
 
+    /**
+     Without an interactive terminal, reports that the live dashboard requires
+     a terminal or suggests machine-readable alternatives.
+     */
     @Test(
         .disabled(
             "WDY-1952: terminal capability behavior needs a seeded target plus controlled TTY/non-TTY execution."
@@ -61,6 +92,10 @@ struct `'wendy device dashboard'` {
     )
     func `reports non-interactive dashboard limitations`() async throws {}
 
+    /**
+     Cancelling the dashboard closes log and metric streams and restores
+     terminal output.
+     */
     @Test(
         .disabled(
             "WDY-1952: dashboard cancellation cleanup needs seeded streams and harness process control."
@@ -68,6 +103,12 @@ struct `'wendy device dashboard'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +120,12 @@ struct `'wendy device dashboard'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device dashboard' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceEnrollTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceEnrollTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device enroll'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device enroll`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy device enroll'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1949: explicit-target enrollment needs isolated auth, PKI/cloud, and disposable provisioning fixtures."
@@ -28,6 +40,11 @@ struct `'wendy device enroll'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -40,6 +57,11 @@ struct `'wendy device enroll'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1949: connection and incompatible-RPC failures need disposable provisioning and auth fixtures."
@@ -47,6 +69,10 @@ struct `'wendy device enroll'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Uses the stored auth session to create an enrollment token and provisions
+     the device with mTLS credentials and an optional name.
+     */
     @Test(
         .disabled(
             "WDY-1949: successful enrollment needs isolated auth, token issuance, certificate, and disposable device fixtures."
@@ -54,6 +80,10 @@ struct `'wendy device enroll'` {
     )
     func `enrolls the selected device with Wendy Cloud`() async throws {}
 
+    /**
+     Without a usable auth session, reports that login is required and performs
+     no device provisioning.
+     */
     @Test(
         .disabled(
             "WDY-1959: auth is currently resolved only after target connection and optional WiFi inspection."
@@ -61,6 +91,10 @@ struct `'wendy device enroll'` {
     )
     func `reports missing auth before touching the device`() async throws {}
 
+    /**
+     Token creation, certificate issuance, or device provisioning failures
+     leave previous device credentials usable and report the failing stage.
+     */
     @Test(
         .disabled(
             "WDY-1949: partial-failure rollback needs controllable token, certificate, and provisioning failure fixtures."
@@ -68,6 +102,10 @@ struct `'wendy device enroll'` {
     )
     func `does not leave partial credentials on enrollment failure`() async throws {}
 
+    /**
+     With `--json`, emits enrollment status and certificate metadata without
+     printing tokens or private keys.
+     */
     @Test(
         .disabled(
             "WDY-1949: JSON enrollment metadata needs isolated successful PKI/cloud and device fixtures."
@@ -75,6 +113,12 @@ struct `'wendy device enroll'` {
     )
     func `prints JSON enrollment metadata`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -86,6 +130,12 @@ struct `'wendy device enroll'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device enroll' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceHardwareListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceHardwareListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device hardware list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device hardware list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device hardware list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target inventory needs seeded managed-agent hardware state without a physical device."
@@ -27,6 +39,11 @@ struct `'wendy device hardware list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -39,6 +56,11 @@ struct `'wendy device hardware list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -46,11 +68,19 @@ struct `'wendy device hardware list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays hardware capabilities such as GPU, audio, camera, storage, and
+     buses with ids and user-facing labels.
+     */
     @Test(
         .disabled("WDY-1952: human hardware inventory needs seeded managed-agent capability state.")
     )
     func `lists hardware capabilities`() async throws {}
 
+    /**
+     `--category` restricts output to matching capabilities. Unknown categories
+     produce an empty successful result or clear validation diagnostic.
+     */
     @Test(
         .disabled(
             "WDY-1952: category filtering needs seeded multi-category managed-agent capability state."
@@ -58,9 +88,19 @@ struct `'wendy device hardware list'` {
     )
     func `filters by category`() async throws {}
 
+    /**
+     With `--json`, emits hardware objects grouped or labeled by category with
+     stable field names.
+     */
     @Test(.disabled("WDY-1952: JSON hardware schema needs seeded managed-agent capability state."))
     func `prints JSON hardware inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -72,6 +112,12 @@ struct `'wendy device hardware list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device hardware list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceLogsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceLogsTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device logs'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device logs`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy device logs'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target log streaming needs a seeded managed agent with telemetry state."
@@ -29,6 +41,11 @@ struct `'wendy device logs'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -41,6 +58,11 @@ struct `'wendy device logs'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -48,6 +70,10 @@ struct `'wendy device logs'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams logs from the selected device and applies app, service, level, and
+     severity filters before presenting entries.
+     */
     @Test(
         .disabled(
             "WDY-1952: filtered log streaming needs seeded managed-agent container and telemetry records."
@@ -55,6 +81,10 @@ struct `'wendy device logs'` {
     )
     func `streams device logs`() async throws {}
 
+    /**
+     With `--json`, emits newline-delimited or array-wrapped structured log
+     entries suitable for automation, without table formatting.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON log framing needs seeded managed-agent telemetry records and bounded stream control."
@@ -62,6 +92,10 @@ struct `'wendy device logs'` {
     )
     func `prints structured log entries in JSON mode`() async throws {}
 
+    /**
+     Cancelling log streaming closes the remote stream without changing app or
+     device state.
+     */
     @Test(
         .disabled(
             "WDY-1952: log cancellation cleanup needs a seeded stream and harness process control."
@@ -69,6 +103,12 @@ struct `'wendy device logs'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -80,6 +120,12 @@ struct `'wendy device logs'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDevicePsTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDevicePsTests.swift
@@ -6,7 +6,11 @@ import WendyE2ETesting
 struct `'wendy device ps'` {
     let scenario = CLIAndAgentScenario()
 
-    /** The hidden alias remains directly invocable and identifies its canonical command. */
+    /**
+     Displays usage for `wendy device ps`. The output identifies the command as
+     an alias for `wendy device apps list`, lists the same inherited global
+     flags, exits successfully, and emits no stderr.
+     */
     @Test
     func `prints '... device ps' alias help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -26,6 +30,11 @@ struct `'wendy device ps'` {
         }
     }
 
+    /**
+     Produces the same human-readable application inventory as `wendy device
+     apps list`, including empty-device output and table formatting. The alias
+     does not introduce additional prompts or state changes.
+     */
     @Test(
         .disabled(
             "WDY-1952: human inventory equivalence needs seeded managed-agent application state without a physical device."
@@ -35,6 +44,10 @@ struct `'wendy device ps'` {
         // TODO: enable with seeded managed-agent app fixtures (WDY-1952).
     }
 
+    /**
+     With `--json`, emits the same application inventory schema as `wendy device
+     apps list` and keeps stdout machine-readable for automation.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON inventory schema equivalence needs seeded managed-agent application state without a physical device."
@@ -44,7 +57,11 @@ struct `'wendy device ps'` {
         // TODO: enable with seeded managed-agent app fixtures (WDY-1952).
     }
 
-    /** Missing target fails before prompts or alias-specific output. */
+    /**
+     Reports that no device target was supplied in a non-interactive session.
+
+     The command emits no picker prompt and performs no device operation.
+     */
     @Test
     func `reports missing device without prompting`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetDefaultTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy device set-default'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays positional hostname usage without discovery or config access. */
+    /**
+     Displays usage for `wendy device set-default`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +26,11 @@ struct `'wendy device set-default'` {
         }
     }
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test(
         .disabled(
             "WDY-1943: omitted-hostname selection enters physical discovery/picker flow; deterministic non-interactive behavior needs injected discovery fixtures."
@@ -29,7 +40,11 @@ struct `'wendy device set-default'` {
         // TODO: enable with deterministic picker/discovery fixtures (WDY-1943).
     }
 
-    /** Stores an offline hostname locally; reachability pinning remains best-effort. */
+    /**
+     Writes the provided hostname as the CLI default device and prints a
+     concise confirmation. Future device commands use this value when no
+     explicit device is supplied.
+     */
     @Test
     func `saves the default device hostname`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -47,7 +62,13 @@ struct `'wendy device set-default'` {
         }
     }
 
-    /** Preserves unrelated known config while changing only the default hostname. */
+    /**
+     Changes only the default-device setting while preserving other recognized
+     Wendy configuration values.
+
+     Analytics preferences, update metadata, and completion settings retain their
+     existing values after the mutation.
+     */
     @Test
     func `preserves unrelated known configuration keys`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -80,6 +101,13 @@ struct `'wendy device set-default'` {
         }
     }
 
+    /**
+     Preserves unrecognized top-level configuration values while changing the
+     default-device setting.
+
+     This allows newer or third-party settings to survive a mutation performed by
+     the current CLI.
+     */
     @Test(
         .disabled(
             "WDY-1940: typed config load/save discards unknown top-level keys during default-device mutation."
@@ -89,6 +117,12 @@ struct `'wendy device set-default'` {
         // TODO: enable when config mutations round-trip unknown keys (WDY-1940).
     }
 
+    /**
+     Requires an explicit hostname to contain a nonempty device address.
+
+     Empty or whitespace-only values fail validation without changing the saved
+     default device.
+     */
     @Test(
         .disabled(
             "WDY-1953: an explicit empty hostname is accepted, saved as an empty default, and reported as success instead of failing validation."
@@ -98,7 +132,12 @@ struct `'wendy device set-default'` {
         // TODO: enable when empty/whitespace hostnames are rejected (WDY-1953).
     }
 
-    /** Too many positional arguments and unknown flags fail before config mutation. */
+    /**
+     Accepts only the documented arguments and flags for `wendy device set-
+     default`. Extra positional arguments or unknown flags produce a usage
+     diagnostic on stderr, return a failure status, emit no success output,
+     and leave existing state unchanged.
+     */
     @Test
     func `rejects undocumented arguments and flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetupTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceSetupTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device setup'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device setup`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -18,6 +25,11 @@ struct `'wendy device setup'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target setup needs seeded provisioning, auth, WiFi, and version state."
@@ -25,6 +37,11 @@ struct `'wendy device setup'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -37,6 +54,11 @@ struct `'wendy device setup'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -44,6 +66,11 @@ struct `'wendy device setup'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Guides the user through device naming, cloud enrollment, and WiFi
+     configuration for a new device, explaining each side effect before
+     applying it.
+     */
     @Test(
         .disabled(
             "WDY-1952: the setup wizard needs seeded provisioning/auth/WiFi state plus scripted PTY interaction."
@@ -51,6 +78,10 @@ struct `'wendy device setup'` {
     )
     func `walks through new device setup`() async throws {}
 
+    /**
+     Existing auth sessions, device names, or WiFi configuration are detected
+     and not repeated unless the user chooses to change them.
+     */
     @Test(
         .disabled(
             "WDY-1952: setup resume behavior needs seeded partially configured device and auth state."
@@ -58,6 +89,10 @@ struct `'wendy device setup'` {
     )
     func `uses existing state to skip completed setup steps`() async throws {}
 
+    /**
+     Cancelling the setup flow stops at the current step and avoids applying
+     later enrollment or WiFi changes.
+     */
     @Test(
         .disabled(
             "WDY-1952: setup cancellation needs seeded state and harness process control across wizard stages."
@@ -65,6 +100,12 @@ struct `'wendy device setup'` {
     )
     func `cancels without continuing later setup`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -76,6 +117,12 @@ struct `'wendy device setup'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device setup' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceTelemetryStreamTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceTelemetryStreamTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device telemetry-stream'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device telemetry-stream`. The output includes
+     the command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -25,6 +32,11 @@ struct `'wendy device telemetry-stream'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target telemetry needs a seeded managed agent with logs, metrics, and traces."
@@ -32,6 +44,11 @@ struct `'wendy device telemetry-stream'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -44,6 +61,11 @@ struct `'wendy device telemetry-stream'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -51,6 +73,11 @@ struct `'wendy device telemetry-stream'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Streams selected logs, metrics, and traces as JSON lines with stable
+     envelope fields and timestamps. The stream continues until cancelled or
+     the device closes it.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSONL framing needs seeded logs, metrics, and traces plus bounded stream control."
@@ -58,6 +85,10 @@ struct `'wendy device telemetry-stream'` {
     )
     func `streams telemetry as JSONL`() async throws {}
 
+    /**
+     App, service, logs, metrics, and traces filters constrain the stream
+     before entries are emitted to stdout.
+     */
     @Test(
         .disabled(
             "WDY-1952: telemetry filtering needs seeded neighboring app/service records across all signal types."
@@ -65,6 +96,10 @@ struct `'wendy device telemetry-stream'` {
     )
     func `applies telemetry filters`() async throws {}
 
+    /**
+     Cancelling the stream closes the remote telemetry subscription and emits
+     no malformed trailing JSON.
+     */
     @Test(
         .disabled(
             "WDY-1952: telemetry cancellation cleanup needs seeded streams and harness process control."
@@ -72,6 +107,12 @@ struct `'wendy device telemetry-stream'` {
     )
     func `shuts down cleanly on cancellation`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -83,6 +124,12 @@ struct `'wendy device telemetry-stream'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device telemetry-stream' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUnsetDefaultTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUnsetDefaultTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy device unset-default'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays local clear-default usage without reading config or selecting a device. */
+    /**
+     Displays usage for `wendy device unset-default`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,7 +26,10 @@ struct `'wendy device unset-default'` {
         }
     }
 
-    /** Clears only the saved default and preserves unrelated known config. */
+    /**
+     Removes the saved default device from CLI configuration and prints a
+     concise confirmation. Other configuration keys remain intact.
+     */
     @Test
     func `clears the saved default device`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -54,6 +63,10 @@ struct `'wendy device unset-default'` {
         }
     }
 
+    /**
+     With no saved default device, reports a no-op success and avoids creating
+     unrelated configuration state.
+     */
     @Test(
         .disabled(
             "WDY-1953: with no saved default, unset-default creates/rewrites config and reports a clear instead of remaining a non-mutating no-op."
@@ -63,7 +76,12 @@ struct `'wendy device unset-default'` {
         // TODO: enable when no-default unset is non-mutating (WDY-1953).
     }
 
-    /** Unknown flags fail before config mutation. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -80,6 +98,12 @@ struct `'wendy device unset-default'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device unset-default' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device update'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device update`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,6 +29,11 @@ struct `'wendy device update'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target update needs a disposable seeded agent and isolated release/artifact fixtures."
@@ -29,6 +41,11 @@ struct `'wendy device update'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -41,6 +58,11 @@ struct `'wendy device update'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need a disposable seeded agent with controllable responses."
@@ -48,6 +70,10 @@ struct `'wendy device update'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Downloads the selected agent release, verifies it, uploads it to the
+     device, and reports the installed version after update.
+     */
     @Test(
         .disabled(
             "WDY-1952: release update needs isolated downloads and a disposable agent restart/reconnect target."
@@ -55,6 +81,10 @@ struct `'wendy device update'` {
     )
     func `updates the device agent from the latest release`() async throws {}
 
+    /**
+     `--binary` skips release download and uploads the provided local agent
+     binary after validating that it is readable.
+     */
     @Test(
         .disabled(
             "WDY-1952: local binary upload needs an architecture fixture and disposable agent restart/reconnect target."
@@ -62,9 +92,17 @@ struct `'wendy device update'` {
     )
     func `uploads a local binary when requested`() async throws {}
 
+    /**
+     `--nightly` selects a prerelease agent build and reports that prerelease
+     channel in output.
+     */
     @Test(.disabled("WDY-1952: nightly selection needs isolated release and OS manifest fixtures."))
     func `uses nightly releases when requested`() async throws {}
 
+    /**
+     Download, verification, upload, or restart failures report the failing
+     stage and do not claim the update completed.
+     */
     @Test(
         .disabled(
             "WDY-1952: failure preservation needs controllable download/upload/restart stages on a disposable agent."
@@ -72,6 +110,12 @@ struct `'wendy device update'` {
     )
     func `preserves the running agent on failed update`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -83,6 +127,12 @@ struct `'wendy device update'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device update' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVersionTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVersionTests.swift
@@ -6,7 +6,12 @@ import WendyE2ETesting
 struct `'wendy device version'` {
     let scenario = CLIAndAgentScenario()
 
-    /** The hidden alias stays absent from parent help while direct help mirrors `device info`. */
+    /**
+     The hidden command remains directly invocable for older scripts, but
+     `wendy device --help` does not advertise it. Direct help preserves the
+     `wendy device info` option surface for users who still discover the legacy
+     command explicitly.
+     */
     @Test
     func `is hidden from parent help while direct help mirrors '... device info'`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -29,6 +34,9 @@ struct `'wendy device version'` {
         }
     }
 
+    /**
+     In human-readable mode, the deprecated command reports the same device information as `wendy device info` and directs users to the replacement command.
+     */
     @Test(
         .disabled(
             "WDY-1952: human alias equivalence and deprecation output need a seeded managed-agent info response without a physical device."
@@ -38,7 +46,9 @@ struct `'wendy device version'` {
         // TODO: enable with the seeded managed-agent fixture (WDY-1952).
     }
 
-    /** JSON mode fails cleanly before deprecation text when no target is selected. */
+    /**
+     With `--json`, deprecation guidance stays out of stdout and stderr so existing scripts can continue parsing the response.
+     */
     @Test
     func `'--json' keeps JSON output clean`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device volumes list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device volumes list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device volumes list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target inventory needs seeded managed-agent volume state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device volumes list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device volumes list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device volumes list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays persistent volumes with names, paths, sizes, owning applications,
+     and usage metadata when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human volume inventory needs seeded empty/populated managed-agent storage state."
@@ -52,6 +78,10 @@ struct `'wendy device volumes list'` {
     )
     func `lists persistent volumes`() async throws {}
 
+    /**
+     With `--json`, emits volume objects with stable name, path, size, and
+     owner fields. No volumes is a successful empty result.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON volume schema needs seeded empty/populated managed-agent storage state."
@@ -59,6 +89,12 @@ struct `'wendy device volumes list'` {
     )
     func `prints JSON volume inventory`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device volumes list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device volumes list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesRemoveTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceVolumesRemoveTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device volumes remove'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device volumes remove`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device volumes remove'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target removal needs seeded managed-agent persistent-volume state without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device volumes remove'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device volumes remove'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device volumes remove'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes the named volume only after confirmation or `--force`. Success
+     output identifies the removed volume.
+     */
     @Test(
         .disabled(
             "WDY-1952: confirmation and successful removal need seeded managed-agent persistent-volume state."
@@ -52,6 +78,12 @@ struct `'wendy device volumes remove'` {
     )
     func `removes a persistent volume after confirmation`() async throws {}
 
+    /**
+     Prompts for a volume when its name is omitted in an interactive session.
+
+     The selected volume is passed to the removal flow; cancellation leaves
+     device storage unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: omitted names intentionally open a device-backed volume picker and need seeded list results."
@@ -59,6 +91,10 @@ struct `'wendy device volumes remove'` {
     )
     func `selects a missing volume name interactively`() async throws {}
 
+    /**
+     An unknown volume name fails without deleting similarly named volumes or
+     application containers.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-volume isolation needs seeded neighboring volume and application state."
@@ -66,6 +102,12 @@ struct `'wendy device volumes remove'` {
     )
     func `reports unknown volumes without deleting data`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -77,6 +119,12 @@ struct `'wendy device volumes remove'` {
         }
     }
 
+    /**
+     Rejects more positional arguments than the command's documented interface
+     accepts.
+
+     Validation fails before the requested cloud or device operation begins.
+     */
     @Test
     func `rejects extra positional arguments`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiConnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi connect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi connect`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +27,11 @@ struct `'wendy device wifi connect'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target connection needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -27,6 +39,11 @@ struct `'wendy device wifi connect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -40,6 +57,11 @@ struct `'wendy device wifi connect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -47,6 +69,10 @@ struct `'wendy device wifi connect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Connects the device to the requested SSID using the supplied password when
+     needed and reports the resulting connection status.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful connection needs simulated managed-agent WiFi association state without physical radios."
@@ -54,6 +80,11 @@ struct `'wendy device wifi connect'` {
     )
     func `connects to a WiFi network`() async throws {}
 
+    /**
+     For secured networks without `--password`, prompts in an interactive
+     terminal without echoing the secret. Non-interactive mode reports that a
+     password is required.
+     */
     @Test(
         .disabled(
             "WDY-1952: password prompting and redaction need a scripted PTY plus simulated secured-network state."
@@ -61,6 +92,13 @@ struct `'wendy device wifi connect'` {
     )
     func `prompts for missing password only in interactive mode`() async throws {}
 
+    /**
+     Prompts for a WiFi network when its SSID is omitted in an interactive
+     session.
+
+     The selected network is passed to the connection flow; cancellation leaves
+     device networking unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: omitted SSID intentionally opens a device-backed network picker and needs simulated scan results."
@@ -68,6 +106,10 @@ struct `'wendy device wifi connect'` {
     )
     func `selects a missing SSID interactively`() async throws {}
 
+    /**
+     Authentication or association failures report the error and do not replace
+     existing working network credentials.
+     */
     @Test(
         .disabled(
             "WDY-1952: failed-credential preservation needs seeded neighboring managed-agent network profiles."
@@ -75,6 +117,12 @@ struct `'wendy device wifi connect'` {
     )
     func `does not save failed credentials`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -86,6 +134,12 @@ struct `'wendy device wifi connect'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi connect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiDisconnectTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi disconnect'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi disconnect`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -18,6 +25,11 @@ struct `'wendy device wifi disconnect'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target disconnection needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -25,6 +37,11 @@ struct `'wendy device wifi disconnect'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -37,6 +54,11 @@ struct `'wendy device wifi disconnect'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -44,6 +66,10 @@ struct `'wendy device wifi disconnect'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Disconnects the active WiFi connection and reports the resulting
+     disconnected state.
+     */
     @Test(
         .disabled(
             "WDY-1952: successful disconnection needs simulated managed-agent WiFi connection state."
@@ -51,6 +77,10 @@ struct `'wendy device wifi disconnect'` {
     )
     func `disconnects from the current WiFi network`() async throws {}
 
+    /**
+     A device with no active WiFi connection reports a no-op or already-
+     disconnected result without changing saved networks.
+     */
     @Test(
         .disabled(
             "WDY-1952: already-disconnected semantics need simulated managed-agent WiFi state."
@@ -58,6 +88,12 @@ struct `'wendy device wifi disconnect'` {
     )
     func `handles already disconnected devices predictably`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -69,6 +105,12 @@ struct `'wendy device wifi disconnect'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi disconnect' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiForgetTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi forget'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi forget`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device wifi forget'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target forget needs a seeded managed agent and simulated WiFi capability without physical radios."
@@ -26,6 +38,11 @@ struct `'wendy device wifi forget'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device wifi forget'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,11 +67,18 @@ struct `'wendy device wifi forget'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Removes saved credentials for the requested SSID without affecting other
+     known networks or current nonmatching connections.
+     */
     @Test(
         .disabled("WDY-1952: successful forget needs simulated managed-agent saved-network state.")
     )
     func `forgets a known WiFi network`() async throws {}
 
+    /**
+     Missing `--ssid` produces a usage diagnostic and no WiFi operation.
+     */
     @Test
     func `requires an SSID`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -61,6 +90,10 @@ struct `'wendy device wifi forget'` {
         }
     }
 
+    /**
+     Forgetting an SSID that is not saved reports a clear result and leaves all
+     known networks unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: unknown-network isolation needs seeded neighboring managed-agent network profiles."
@@ -68,6 +101,12 @@ struct `'wendy device wifi forget'` {
     )
     func `reports unknown networks without changing saved credentials`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -79,6 +118,12 @@ struct `'wendy device wifi forget'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi forget' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiListTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiListTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi list'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi list`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device wifi list'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target scans need a seeded managed agent and simulated WiFi capability without physical radios."
@@ -26,6 +38,11 @@ struct `'wendy device wifi list'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device wifi list'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device wifi list'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Displays scanned WiFi networks with SSID, signal strength, security, saved
+     status, and current connection markers when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human WiFi inventory needs simulated network state without scanning physical radios."
@@ -52,6 +78,10 @@ struct `'wendy device wifi list'` {
     )
     func `lists available WiFi networks`() async throws {}
 
+    /**
+     With `--json`, emits WiFi network objects with stable SSID, signal,
+     security, saved, and connected fields.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON WiFi schema needs simulated empty/populated network state without physical radios."
@@ -59,6 +89,12 @@ struct `'wendy device wifi list'` {
     )
     func `prints JSON WiFi scan results`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device wifi list'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi list' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiRankTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiRankTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi rank'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi rank`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -21,6 +28,11 @@ struct `'wendy device wifi rank'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target ranking needs seeded managed-agent saved-network state without physical radios."
@@ -28,6 +40,11 @@ struct `'wendy device wifi rank'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -41,6 +58,11 @@ struct `'wendy device wifi rank'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -48,6 +70,10 @@ struct `'wendy device wifi rank'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     `--ssid` with `--priority` updates one saved network's autoconnect
+     priority and leaves other priorities unchanged.
+     */
     @Test(
         .disabled(
             "WDY-1952: single-network ranking needs seeded neighboring managed-agent priority state."
@@ -55,6 +81,10 @@ struct `'wendy device wifi rank'` {
     )
     func `sets priority for a single known network`() async throws {}
 
+    /**
+     `--order` assigns priorities to the listed SSIDs from highest to lowest
+     while preserving unlisted known networks.
+     */
     @Test(
         .disabled(
             "WDY-1952: bulk ranking needs seeded listed/unlisted managed-agent priority state."
@@ -62,6 +92,10 @@ struct `'wendy device wifi rank'` {
     )
     func `bulk reorders known networks`() async throws {}
 
+    /**
+     Supplying incomplete or conflicting ranking flags produces a usage
+     diagnostic before WiFi settings are changed.
+     */
     @Test
     func `validates mutually exclusive ranking modes`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -84,6 +118,12 @@ struct `'wendy device wifi rank'` {
         }
     }
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -95,6 +135,12 @@ struct `'wendy device wifi rank'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi rank' silently accepts positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiStatusTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceWifiStatusTests.swift
@@ -5,6 +5,13 @@ import WendyE2ETesting
 struct `'wendy device wifi status'` {
     let scenario = CLIAndAgentScenario()
 
+    /**
+     Displays usage for `wendy device wifi status`. The output includes the
+     command synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -19,6 +26,11 @@ struct `'wendy device wifi status'` {
         }
     }
 
+    /**
+     `--device` selects the target device hostname and skips discovery and
+     pickers. The command does not read or change the saved default device when
+     an explicit target is supplied.
+     */
     @Test(
         .disabled(
             "WDY-1952: explicit-target status needs a seeded managed agent and simulated WiFi capability without a physical device."
@@ -26,6 +38,11 @@ struct `'wendy device wifi status'` {
     )
     func `uses explicit device selection without prompting`() async throws {}
 
+    /**
+     Without an explicit or configured device in a non-interactive context,
+     reports that a device selection is required, emits no prompt escape
+     sequences, and performs no device operation.
+     */
     @Test
     func `reports missing device selection in non-interactive mode`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -38,6 +55,11 @@ struct `'wendy device wifi status'` {
         }
     }
 
+    /**
+     Connection failures, timeouts, and incompatible agent responses produce
+     stderr diagnostics and a failure status. Output does not claim that the
+     operation succeeded.
+     */
     @Test(
         .disabled(
             "WDY-1952: connection and incompatible-RPC failures need controllable seeded managed-agent responses."
@@ -45,6 +67,10 @@ struct `'wendy device wifi status'` {
     )
     func `reports unreachable devices without partial success`() async throws {}
 
+    /**
+     Reports whether WiFi is connected, the active SSID, signal quality, IP
+     details, and known-network state when available.
+     */
     @Test(
         .disabled(
             "WDY-1952: human WiFi status needs simulated connected/disconnected managed-agent network state."
@@ -52,6 +78,10 @@ struct `'wendy device wifi status'` {
     )
     func `prints current WiFi status`() async throws {}
 
+    /**
+     With `--json`, emits one JSON object with connection state and nullable
+     fields for disconnected devices.
+     */
     @Test(
         .disabled(
             "WDY-1952: JSON WiFi status needs simulated connected/disconnected managed-agent network state."
@@ -59,6 +89,12 @@ struct `'wendy device wifi status'` {
     )
     func `prints JSON WiFi status`() async throws {}
 
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -70,6 +106,12 @@ struct `'wendy device wifi status'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy device wifi status' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsDownloadTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsDownloadTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy os download'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays image-download usage and cache controls without fetching a manifest. */
+    /**
+     Displays usage for `wendy os download`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -22,7 +28,11 @@ struct `'wendy os download'` {
         }
     }
 
-    /** Downloads and verifies a pinned image into an isolated OS cache. */
+    /**
+     Downloads the requested WendyOS image version, verifies the artifact,
+     and stores it in the OS cache for later installation. Success
+     output includes device type, version, cache path, and size.
+     */
     @Test(
         .disabled(
             "WDY-1944: deterministic download success requires a pinned local manifest/artifact server and checksum fixture rather than the mutable public catalog."
@@ -32,7 +42,11 @@ struct `'wendy os download'` {
         // TODO: enable with the protected OS artifact fixture (WDY-1944).
     }
 
-    /** Reuses a verified cached image unless overwrite is explicitly requested. */
+    /**
+     When the requested image already exists and verifies successfully,
+     uses the cached artifact. `--overwrite` replaces it after a
+     successful new download.
+     */
     @Test(
         .disabled(
             "WDY-1944: cache-hit and overwrite coverage requires a pinned manifest plus known artifact/checksum bytes."
@@ -42,7 +56,11 @@ struct `'wendy os download'` {
         // TODO: enable with the protected OS artifact fixture (WDY-1944).
     }
 
-    /** Download and verification failures preserve an existing cached artifact. */
+    /**
+     Unknown versions, unavailable manifests, network failures, or failed
+     verification leave existing cached artifacts untouched and report a
+     failure on stderr.
+     */
     @Test(
         .disabled(
             "WDY-1944: unavailable-version, network-failure, and checksum-failure paths need a controllable local manifest/artifact server."
@@ -52,7 +70,10 @@ struct `'wendy os download'` {
         // TODO: enable with failure modes from the protected OS artifact fixture (WDY-1944).
     }
 
-    /** Emits structured version, path, checksum, size, and cache-hit metadata. */
+    /**
+     With `--json`, emits one JSON object containing version, device type,
+     artifact path, checksum, byte count, and cache-hit status.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy os download' does not implement global --json; WDY-1944 tracks the deterministic artifact fixture needed to exercise a successful result."
@@ -62,7 +83,12 @@ struct `'wendy os download'` {
         // TODO: enable when download implements JSON and has a pinned fixture (WDY-1909, WDY-1944).
     }
 
-    /** Unknown flags fail before manifest or cache access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -75,7 +101,12 @@ struct `'wendy os download'` {
         }
     }
 
-    /** Extra positional arguments are rejected before manifest or cache access. */
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy os download' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsInstallTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsInstallTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy os install'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays install modes, destructive safeguards, and preseed flags without listing drives. */
+    /**
+     Displays usage for `wendy os install`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -24,7 +30,11 @@ struct `'wendy os install'` {
         }
     }
 
-    /** Writes a selected image only to a protected disposable drive after confirmation. */
+    /**
+     Writes the selected WendyOS image or firmware to the target drive
+     after the user confirms the destructive operation. Output reports
+     progress and final device preparation status.
+     */
     @Test(
         .disabled(
             "WDY-1944: install success requires a disposable virtual block device and pinned image fixture with safeguards against host disks."
@@ -34,7 +44,11 @@ struct `'wendy os install'` {
         // TODO: enable with the protected virtual-drive fixture (WDY-1944).
     }
 
-    /** Runs image-plus-drive mode without prompts while retaining drive safety checks. */
+    /**
+     When image path, drive id, and `--force` are provided, skips
+     interactive pickers and confirmation prompts while preserving the
+     same safety checks for drive identity.
+     */
     @Test(
         .disabled(
             "WDY-1944: non-interactive flashing still requires a disposable virtual drive; physical runner disks must remain unavailable to E2E."
@@ -44,7 +58,11 @@ struct `'wendy os install'` {
         // TODO: enable with the protected virtual-drive fixture (WDY-1944).
     }
 
-    /** Refuses protected internal drives unless the dedicated consent flag is present. */
+    /**
+     Internal or non-removable drives are protected. Non-interactive
+     installs require the dedicated overwrite flag before any bytes are
+     written.
+     */
     @Test(
         .disabled(
             "WDY-1944: internal-drive safety needs a synthetic inventory and disposable target; it cannot be asserted against a runner's real disks."
@@ -54,7 +72,11 @@ struct `'wendy os install'` {
         // TODO: enable with the protected virtual-drive inventory (WDY-1944).
     }
 
-    /** Validates and writes WiFi/device identity into a disposable image before flashing. */
+    /**
+     WiFi flags and device-name flags are written into first-boot
+     configuration for the image. Invalid WiFi definitions fail before
+     the target drive is modified.
+     */
     @Test(
         .disabled(
             "WDY-1944: first-boot preseed verification requires a pinned image that can be mounted and inspected without touching a physical drive."
@@ -64,7 +86,11 @@ struct `'wendy os install'` {
         // TODO: enable with the protected image and virtual-drive fixture (WDY-1944).
     }
 
-    /** Pre-enrollment uses a dedicated protected cloud session and disposable image. */
+    /**
+     `--pre-enroll` uses the stored auth session to add enrollment data
+     to the image. Missing or expired auth fails before writing the
+     drive.
+     */
     @Test(
         .disabled(
             "WDY-1944: pre-enrollment needs protected auth, a pinned image, and a disposable drive fixture; personal auth and physical disks are prohibited."
@@ -74,7 +100,10 @@ struct `'wendy os install'` {
         // TODO: enable with protected cloud and OS install fixtures (WDY-1944).
     }
 
-    /** Emits one JSON result without progress text corrupting stdout. */
+    /**
+     With `--json`, emits structured drive, image, version, and outcome
+     metadata. Progress output does not corrupt stdout JSON.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy os install' does not implement global --json; WDY-1944 tracks the protected fixture needed for a successful install."
@@ -120,7 +149,12 @@ struct `'wendy os install'` {
         }
     }
 
-    /** Unknown flags fail before image or drive access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects unknown flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsListDrivesTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsListDrivesTests.swift
@@ -6,7 +6,13 @@ import WendyE2ETesting
 struct `'wendy os list-drives'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays drive-listing usage and flags without enumerating disks. */
+    /**
+     Displays usage for `wendy os list-drives`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -82,7 +88,12 @@ struct `'wendy os list-drives'` {
         // TODO: enable when structured drive safety metadata is available (WDY-1946).
     }
 
-    /** Unknown flags fail before disk enumeration. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -95,7 +106,12 @@ struct `'wendy os list-drives'` {
         }
     }
 
-    /** Extra positional arguments are rejected before disk enumeration. */
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy os list-drives' silently accepts extra positional arguments because the leaf command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyOsUpdateTests.swift
@@ -5,7 +5,13 @@ import WendyE2ETesting
 struct `'wendy os update'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays local, remote, nightly, and PR update modes without connecting to a device. */
+    /**
+     Displays usage for `wendy os update`. The output includes the command
+     synopsis, local flags, inherited global flags, and concise
+     descriptions. Help exits successfully, writes to stdout, emits no
+     stderr, and leaves configuration, cache, project, cloud, and device
+     state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -23,7 +29,11 @@ struct `'wendy os update'` {
         }
     }
 
-    /** Serves a pinned local Mender artifact to a hosted update-capable WendyOS target. */
+    /**
+     Serves the provided Mender artifact to the selected device and
+     requests an OS update. Success output identifies the artifact and
+     device update status.
+     */
     @Test(
         .disabled(
             "WDY-1944: local-artifact OTA success requires a hosted update-capable WendyOS fixture and pinned Mender artifact."
@@ -33,7 +43,10 @@ struct `'wendy os update'` {
         // TODO: enable with the protected hosted OTA fixture (WDY-1944).
     }
 
-    /** Validates a remote artifact URL locally before contacting the target device. */
+    /**
+     `--artifact-url` instructs the device to fetch a remote artifact
+     directly. The URL is validated before the update request is sent.
+     */
     @Test(
         .disabled(
             "WDY-1945: --artifact-url is not validated until after device connection and version RPCs, so malformed URLs cannot fail locally as specified."
@@ -43,7 +56,10 @@ struct `'wendy os update'` {
         // TODO: enable when URL validation precedes device access (WDY-1945).
     }
 
-    /** Resolves pinned nightly artifacts and applies them to a hosted OTA target. */
+    /**
+     `--nightly` selects the latest prerelease OS and agent artifacts
+     from the manifest and reports the chosen versions before updating.
+     */
     @Test(
         .disabled(
             "WDY-1944: nightly resolution and update success need a pinned manifest plus hosted update-capable WendyOS fixture."
@@ -53,7 +69,10 @@ struct `'wendy os update'` {
         // TODO: enable with protected manifest and OTA fixtures (WDY-1944).
     }
 
-    /** Cleans up a temporary local artifact server when the hosted target is unreachable. */
+    /**
+     If the target device cannot be reached, the command stops any
+     temporary local artifact server and exits with a clear diagnostic.
+     */
     @Test(
         .disabled(
             "WDY-1944: cleanup observation needs a controllable hosted OTA target and local artifact-server fixture rather than a physical device."
@@ -63,7 +82,10 @@ struct `'wendy os update'` {
         // TODO: enable with protected OTA and artifact-server fixtures (WDY-1944).
     }
 
-    /** Emits structured device, artifact, version, and request-status metadata. */
+    /**
+     With `--json`, emits one JSON object containing device, artifact,
+     version, and update request status fields.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy os update' does not implement global --json; WDY-1944 tracks the hosted fixture needed for update metadata."
@@ -73,7 +95,12 @@ struct `'wendy os update'` {
         // TODO: enable when update implements JSON and has a hosted fixture (WDY-1909, WDY-1944).
     }
 
-    /** Rejects conflicting artifact sources before device access. */
+    /**
+     Rejects requests that specify more than one operating-system artifact source.
+
+     Source validation fails before downloading, contacting update services, or
+     changing a device.
+     */
     @Test
     func `rejects conflicting artifact sources locally`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -92,7 +119,12 @@ struct `'wendy os update'` {
         }
     }
 
-    /** Rejects too many positional arguments and unknown flags before device access. */
+    /**
+     Accepts only the documented arguments and flags for `wendy os update`.
+     Extra positional arguments or unknown flags produce a usage diagnostic
+     on stderr, return a failure status, emit no success output, and leave
+     existing state unchanged.
+     */
     @Test
     func `rejects undocumented arguments and flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyRunTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyRunTests.swift
@@ -5,7 +5,12 @@ import WendyE2ETesting
 struct `'wendy run'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays build, deploy, target, and log-stream controls without resolving a device. */
+    /**
+     Displays usage for `wendy run`. The output includes the command synopsis,
+     local flags, inherited global flags, and concise descriptions. Help exits
+     successfully, writes to stdout, emits no stderr, and leaves configuration,
+     cache, project, cloud, and device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -25,6 +30,12 @@ struct `'wendy run'` {
         }
     }
 
+    /**
+     Reads the project configuration, builds the application image,
+     deploys it over the selected direct device connection, and starts the
+     container. Success output makes the running app and target device
+     clear.
+     */
     @Test(
         .disabled(
             "WDY-1950: end-to-end build/deploy/start needs pinned sample projects, isolated image namespaces, and a disposable managed-agent target."
@@ -34,6 +45,11 @@ struct `'wendy run'` {
         // TODO: enable with isolated build and managed-deploy fixtures (WDY-1950).
     }
 
+    /**
+     `--deploy` creates or updates the container on the target device and
+     leaves it stopped. The command exits successfully after deployment and
+     prints no live log stream.
+     */
     @Test(
         .disabled(
             "WDY-1950: stopped deployment state needs a disposable managed agent with observable container lifecycle and cleanup."
@@ -43,6 +59,10 @@ struct `'wendy run'` {
         // TODO: enable with the managed-deploy fixture (WDY-1950).
     }
 
+    /**
+     `--detach` starts the application and returns after start-up status is
+     known. Output includes the app name and how to view logs later.
+     */
     @Test(
         .disabled(
             "WDY-1950: detach success and follow-up log guidance need an isolated built app and disposable managed-agent target."
@@ -52,6 +72,11 @@ struct `'wendy run'` {
         // TODO: enable with isolated build and managed-deploy fixtures (WDY-1950).
     }
 
+    /**
+     `--user-args` preserves argument boundaries and forwards the provided
+     values to the started application without interpreting secrets or shell
+     metacharacters locally.
+     */
     @Test(
         .disabled(
             "WDY-1950: user-argument boundary verification needs a fixture app that reports received argv from a disposable managed target."
@@ -61,6 +86,11 @@ struct `'wendy run'` {
         // TODO: enable with an argv-reporting app fixture (WDY-1950).
     }
 
+    /**
+     `--prefix` selects the project directory and `--device` selects the target
+     device and skips the picker. The command does not read unrelated
+     `wendy.json` files or open interactive device selection.
+     */
     @Test(
         .disabled(
             "WDY-1950: explicit prefix/device success needs isolated projects and a disposable managed target without physical device selection."
@@ -70,6 +100,11 @@ struct `'wendy run'` {
         // TODO: enable with isolated project and managed-target fixtures (WDY-1950).
     }
 
+    /**
+     Build failures, invalid project configuration, unreachable devices, or
+     deployment errors return a failure status. Partial remote resources are
+     either cleaned up or identified clearly for manual cleanup.
+     */
     @Test(
         .disabled(
             "WDY-1950: build/deploy failure cleanup needs controllable builder and managed-agent failure modes with observable remote resources."
@@ -79,6 +114,10 @@ struct `'wendy run'` {
         // TODO: enable with isolated build/deploy failure fixtures (WDY-1950).
     }
 
+    /**
+     With `--json`, emits structured build, deploy, start, and app metadata.
+     Progress and streamed container logs do not corrupt stdout JSON.
+     */
     @Test(
         .disabled(
             "WDY-1909: 'wendy run' does not implement a complete global --json result; WDY-1950 tracks the isolated deployment fixture needed to verify log separation."
@@ -88,7 +127,12 @@ struct `'wendy run'` {
         // TODO: enable when run JSON and managed-deploy fixtures exist (WDY-1909, WDY-1950).
     }
 
-    /** Invalid local prefix and chunking options fail before device selection or build work. */
+    /**
+     Validates local run options before selecting or contacting a target device.
+
+     Invalid option combinations fail without discovery, build, deployment, or
+     device state changes.
+     */
     @Test
     func `validates local options before selecting a device`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -107,7 +151,12 @@ struct `'wendy run'` {
         }
     }
 
-    /** Missing device selection fails without building or creating project artifacts. */
+    /**
+     Reports a missing device target before starting a project build.
+
+     Non-interactive failure leaves build artifacts, deployments, and device state
+     unchanged.
+     */
     @Test
     func `reports missing target before building`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -120,7 +169,12 @@ struct `'wendy run'` {
         }
     }
 
-    /** Unknown flags fail before project, build, or device access. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects unknown flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -133,6 +187,12 @@ struct `'wendy run'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy run' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyTourTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyTourTests.swift
@@ -5,7 +5,12 @@ import WendyE2ETesting
 struct `'wendy tour'` {
     let scenario = CLIAndAgentScenario()
 
-    /** Displays guided-tour usage without starting terminal UI. */
+    /**
+     Displays usage for `wendy tour`. The output includes the command synopsis,
+     local flags, inherited global flags, and concise descriptions. Help exits
+     successfully, writes to stdout, emits no stderr, and leaves configuration,
+     cache, project, cloud, and device state untouched.
+     */
     @Test
     func `prints command help`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -20,6 +25,11 @@ struct `'wendy tour'` {
         }
     }
 
+    /**
+     Presents the new-user tour as an interactive sequence covering auth,
+     project setup, device discovery, and deployment choices. Each step
+     explains what happens before performing side effects.
+     */
     @Test(
         .disabled(
             "WDY-1951: the multi-step Bubble Tea tour needs scripted PTY screen synchronization plus isolated auth, project, discovery, install, MCP, and deployment fixtures."
@@ -29,6 +39,10 @@ struct `'wendy tour'` {
         // TODO: enable with the scripted isolated tour fixture (WDY-1951).
     }
 
+    /**
+     Existing auth sessions, projects, or configured devices are detected
+     and presented as completed rather than repeated unnecessarily.
+     */
     @Test(
         .disabled(
             "WDY-1951: completed-step coverage needs a scripted PTY and isolated fixture state for every downstream tour integration."
@@ -38,6 +52,10 @@ struct `'wendy tour'` {
         // TODO: enable with the scripted isolated tour fixture (WDY-1951).
     }
 
+    /**
+     Cancelling the tour stops at the current step, preserves state already
+     confirmed by the user, and avoids starting later steps.
+     */
     @Test(
         .disabled(
             "WDY-1951: cancellation checkpoints need PTY process control and observable isolated side effects to prove later steps did not run."
@@ -47,7 +65,10 @@ struct `'wendy tour'` {
         // TODO: enable with scripted cancellation control (WDY-1951).
     }
 
-    /** Non-interactive invocation fails promptly with terminal guidance instead of blocking. */
+    /**
+     Without an interactive terminal, reports that the tour requires a
+     terminal and exits with guidance instead of blocking for input.
+     */
     @Test
     func `runs safely in non-interactive contexts`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -59,7 +80,12 @@ struct `'wendy tour'` {
         }
     }
 
-    /** Unknown flags fail before terminal detection or tour side effects. */
+    /**
+     Rejects flags that are not part of the command's documented interface.
+
+     The command reports a usage error on stderr and does not perform the
+     requested operation.
+     */
     @Test
     func `rejects undocumented flags`() async throws {
         try await self.scenario.run(authenticated: false) { cli, _ in
@@ -72,6 +98,12 @@ struct `'wendy tour'` {
         }
     }
 
+    /**
+     Rejects positional arguments because this command is entirely flag-driven.
+
+     The command reports a usage error instead of treating undocumented input as
+     a valid request.
+     */
     @Test(
         .disabled(
             "WDY-1934: 'wendy tour' silently accepts extra positional arguments because the command has no cobra.NoArgs validator."


### PR DESCRIPTION
> **In plain terms:** No CLI behavior change — the E2E cleanup accidentally removed the written behavioral contracts that power Wendy’s test reference and review reports. This restores that documentation everywhere and removes an unnecessary login dependency from two local tunnel checks.

## Summary

- Restore concise specification prose immediately before every Swift E2E `@Test`, including intentionally disabled infrastructure contracts.
- Recover 526 original contracts and document 179 newly added or renamed tests; all 925 tests now have attached specification prose.
- Run cloud tunnel help and malformed-port validation without installing an authentication fixture.
- Keep the existing executable/disabled classifications, tracking issues, and zero-`SPEC STUB` result unchanged.

## Stack

- Stacked on #1492.
- Test-only documentation and scenario configuration; no product, helper, harness, cloud, PKI, tunnel, or device changes.

## Tests

- `make format`
- `swift run swift-e2e-testing reference --format html --output ../Build/Reference Tests/WendyE2ETests`
  - Generated the complete 109-suite HTML reference successfully.
- Specification audit: 925 tests, 0 missing documentation blocks.
- `bash swift/Scripts/E2ETest.sh --output-dir Build/e2e --filter "WendyCloudTunnelTests"`
  - `Test run with 6 tests in 1 suite passed` (3 executed, 3 intentionally skipped).
- `git diff --check`
