### PR TITLE
fix(deps): remediate screencast npm audit findings

### DIFF
--- a/screencast/package-lock.json
+++ b/screencast/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "screencast",
       "devDependencies": {
         "@slidev/cli": "52.16.0",
         "@slidev/theme-default": "0.25.0"
@@ -6135,9 +6136,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -7138,9 +7139,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7551,9 +7552,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {

--- a/screencast/package.json
+++ b/screencast/package.json
@@ -13,6 +13,6 @@
     "@slidev/theme-default": "0.25.0"
   },
   "overrides": {
-    "dompurify": "3.4.11"
+    "dompurify": "3.4.12"
   }
 }


### PR DESCRIPTION
> **In plain terms:** Any change touching the screencast tooling currently fails CI, because three security advisories were published against dependency versions pinned in its lock file — even though nothing in the repository changed. This updates those three dependencies to their patched releases so screencast work can pass CI again. Dev-tooling only; nothing here ships in the product.

## Summary
- Bump the `dompurify` override to the patched 3.4.12 — the previous remediation pin from #1345 has since had its own advisory (GHSA-c2j3-45gr-mqc4) published against it.
- Refresh the two transitive pins with in-range patched releases: `js-yaml` 4.3.0 (GHSA-52cp-r559-cp3m, high) and `linkify-it` 5.0.2 (GHSA-v245-v573-v5vm, high).
- No direct dependency or code changes; the diff is the override bump plus the corresponding lock-file entries.

## Tests
- `npm ci --ignore-scripts` — clean install from the regenerated lock file.
- `npm audit --audit-level=high` — 0 vulnerabilities (the workflow's hard gate).
- `scripts/audit-npm.mjs` — policy gate accepts with zero findings at all levels.
- `bash scripts/check.sh` — all screencast checks pass.
