### PR TITLE
fix(mcp): wrap list tool results in object envelopes (WDY-2001)

### DIFF
--- a/go/internal/cli/mcp/results.go
+++ b/go/internal/cli/mcp/results.go
@@ -15,7 +15,37 @@ func okResult(v any) *mcpgo.CallToolResult {
 	if err != nil {
 		return errResultf(errCodeInternal, "marshaling result: %s", err.Error())
 	}
+	// MCP requires structuredContent to be a JSON object. Wrap anything that is
+	// not one (array, scalar, null) rather than emitting a result conformant
+	// clients reject outright. Recurses at most once: a map[string]any always
+	// marshals to an object. Prefer okList at call sites — it gives the payload
+	// a meaningful key instead of the generic one used here.
+	if len(b) == 0 || b[0] != '{' {
+		return okResult(map[string]any{"result": v})
+	}
 	return mcpgo.NewToolResultStructured(v, string(b))
+}
+
+// okList wraps a list payload under key in an object envelope. MCP requires
+// structuredContent to be a JSON object, so returning a bare array makes
+// conformant clients reject the whole result. A nil slice is normalized to []
+// so the key is always present.
+func okList[T any](key string, items []T) *mcpgo.CallToolResult {
+	return okResult(map[string]any{key: listOrEmpty(items)})
+}
+
+// okListBounded is okList with okResultBounded's byte ceiling on the payload.
+func okListBounded[T any](key string, items []T, maxBytes int) *mcpgo.CallToolResult {
+	return okResultBounded(map[string]any{key: listOrEmpty(items)}, maxBytes)
+}
+
+// listOrEmpty returns items, substituting an empty slice for nil so it
+// marshals as [] rather than null.
+func listOrEmpty[T any](items []T) []T {
+	if items == nil {
+		return []T{}
+	}
+	return items
 }
 
 // okText returns a plain-text success result (for simple confirmations).
@@ -42,7 +72,8 @@ func okResultBounded(v any, maxBytes int) *mcpgo.CallToolResult {
 		eb, _ := json.MarshalIndent(env, "", "  ")
 		return mcpgo.NewToolResultStructured(env, string(eb))
 	}
-	return mcpgo.NewToolResultStructured(v, string(b))
+	// Delegate so the under-budget path gets okResult's object guard too.
+	return okResult(v)
 }
 
 // okTextBounded returns a plain-text success result like okText, but clamps s

--- a/go/internal/cli/mcp/results_test.go
+++ b/go/internal/cli/mcp/results_test.go
@@ -24,6 +24,71 @@ func TestOkResult_HasStructuredAndJSONText(t *testing.T) {
 	}
 }
 
+// MCP requires structuredContent to be a JSON object. A bare array made every
+// list-shaped tool fail client-side schema validation (WDY-2001), so okResult
+// wraps any non-object payload rather than emitting one.
+func TestOkResult_WrapsNonObjectPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		v    any
+	}{
+		{"slice", []map[string]any{{"a": 1}}},
+		{"empty slice", []map[string]any{}},
+		{"nil slice", []map[string]any(nil)},
+		{"scalar", "hello"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := okResult(tc.v)
+			if _, ok := r.StructuredContent.(map[string]any); !ok {
+				t.Fatalf("structuredContent must be an object, got %T", r.StructuredContent)
+			}
+			text := toolResultText(t, r)
+			if text[0] != '{' {
+				t.Errorf("text fallback must be a JSON object, got %s", text)
+			}
+		})
+	}
+}
+
+func TestOkList_WrapsUnderKeyAndNormalizesNil(t *testing.T) {
+	r := okList("devices", []map[string]any(nil))
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object structured content, got %T", r.StructuredContent)
+	}
+	// The key must be present with an empty list, not absent and not null —
+	// agents branch on it without a nil check.
+	var env map[string][]map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, r)), &env); err != nil {
+		t.Fatalf("text fallback is not valid JSON: %v", err)
+	}
+	rows, ok := env["devices"]
+	if !ok {
+		t.Fatal("envelope is missing the devices key")
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected empty list, got %v", rows)
+	}
+	if _, ok := sc["devices"]; !ok {
+		t.Error("structuredContent is missing the devices key")
+	}
+}
+
+func TestOkListBounded_TruncationEnvelopeSurvives(t *testing.T) {
+	big := make([]string, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		big = append(big, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	}
+	r := okListBounded("batches", big, 200)
+	sc, ok := r.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected truncation envelope map, got %T", r.StructuredContent)
+	}
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
 func TestOkResultBounded_TruncatesOversize(t *testing.T) {
 	big := make([]string, 0, 1000)
 	for i := 0; i < 1000; i++ {

--- a/go/internal/cli/mcp/server_helpers_test.go
+++ b/go/internal/cli/mcp/server_helpers_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -26,6 +27,37 @@ func toolResultText(t *testing.T, result *mcpgo.CallToolResult) string {
 		t.Fatalf("expected TextContent, got %T", result.Content[0])
 	}
 	return tc.Text
+}
+
+// structuredMap asserts the result carries an object structuredContent, which
+// MCP requires — a bare array makes conformant clients reject the whole result.
+func structuredMap(t *testing.T, result *mcpgo.CallToolResult) map[string]any {
+	t.Helper()
+	if result.StructuredContent == nil {
+		t.Fatal("result should carry structuredContent")
+	}
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent must be a JSON object, got %T", result.StructuredContent)
+	}
+	return sc
+}
+
+// listPayload decodes the JSON text fallback and returns the rows stored under
+// key, asserting the payload is an object envelope rather than a bare array.
+func listPayload(t *testing.T, result *mcpgo.CallToolResult, key string) []map[string]any {
+	t.Helper()
+	structuredMap(t, result)
+	var env map[string][]map[string]any
+	text := toolResultText(t, result)
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("text fallback is not a JSON object: %v (got %s)", err, text)
+	}
+	rows, ok := env[key]
+	if !ok {
+		t.Fatalf("envelope is missing key %q (got %s)", key, text)
+	}
+	return rows
 }
 
 // callTool invokes a registered tool handler by name. Used in tests only.

--- a/go/internal/cli/mcp/tools_bluetooth.go
+++ b/go/internal/cli/mcp/tools_bluetooth.go
@@ -101,10 +101,7 @@ func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolR
 	for _, d := range seen {
 		devices = append(devices, d)
 	}
-	if devices == nil {
-		devices = []map[string]any{}
-	}
-	return okResult(devices), nil
+	return okList("devices", devices), nil
 }
 
 func (s *mcpServer) handleBluetoothConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -247,7 +247,7 @@ func (s *mcpServer) handleCloudDiscover(ctx context.Context, req mcpgo.CallToolR
 	for _, a := range assets {
 		out = append(out, cloudAssetToMap(a))
 	}
-	return okResult(out), nil
+	return okList("devices", out), nil
 }
 
 func (s *mcpServer) handleCloudConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_cloud_test.go
+++ b/go/internal/cli/mcp/tools_cloud_test.go
@@ -2,12 +2,10 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"strings"
 	"testing"
 
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	"google.golang.org/grpc"
@@ -71,11 +69,7 @@ func TestCloudDiscover_ReturnsConfiguredCloudDevices(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var devices []map[string]any
-	if err := json.Unmarshal([]byte(text), &devices); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	devices := listPayload(t, result, "devices")
 	if len(devices) != 1 {
 		t.Fatalf("len(devices) = %d, want 1", len(devices))
 	}
@@ -119,8 +113,8 @@ func TestCloudDiscover_HasStructuredContent(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if result.StructuredContent == nil {
-		t.Fatal("cloud_discover should return structuredContent")
+	if _, ok := structuredMap(t, result)["devices"]; !ok {
+		t.Error("cloud_discover envelope is missing the devices key")
 	}
 }
 

--- a/go/internal/cli/mcp/tools_container.go
+++ b/go/internal/cli/mcp/tools_container.go
@@ -131,10 +131,7 @@ func (s *mcpServer) handleContainerList(ctx context.Context, _ mcpgo.CallToolReq
 		}
 		containers = append(containers, entry)
 	}
-	if containers == nil {
-		containers = []map[string]any{}
-	}
-	return okResult(containers), nil
+	return okList("containers", containers), nil
 }
 
 func (s *mcpServer) handleContainerStart(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -237,10 +234,7 @@ func (s *mcpServer) handleContainerStats(ctx context.Context, _ mcpgo.CallToolRe
 			"storage_bytes": cs.GetStorageBytes(),
 		})
 	}
-	if stats == nil {
-		stats = []map[string]any{}
-	}
-	return okResult(stats), nil
+	return okList("stats", stats), nil
 }
 
 func (s *mcpServer) handleContainerAttach(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_container_test.go
+++ b/go/internal/cli/mcp/tools_container_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"strings"
 	"testing"
@@ -177,11 +176,7 @@ func TestContainerList_ReturnsJSON(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var containers []map[string]any
-	if err := json.Unmarshal([]byte(text), &containers); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	containers := listPayload(t, result, "containers")
 	if len(containers) != 1 {
 		t.Fatalf("expected 1 container, got %d", len(containers))
 	}
@@ -256,11 +251,7 @@ func TestContainerStats_ReturnsJSON(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var stats []map[string]any
-	if err := json.Unmarshal([]byte(text), &stats); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	stats := listPayload(t, result, "stats")
 	if len(stats) != 1 {
 		t.Fatalf("expected 1 stat, got %d", len(stats))
 	}

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -98,10 +98,7 @@ func (s *mcpServer) handleDeviceList(ctx context.Context, req mcpgo.CallToolRequ
 		}
 	}
 
-	if len(devices) == 0 {
-		devices = []map[string]any{}
-	}
-	return okResult(devices), nil
+	return okList("devices", devices), nil
 }
 
 func (s *mcpServer) handleDeviceConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_device_test.go
+++ b/go/internal/cli/mcp/tools_device_test.go
@@ -116,11 +116,7 @@ func TestDeviceList_ReturnsConfiguredDevices(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result")
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var devices []map[string]any
-	if err := json.Unmarshal([]byte(text), &devices); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	devices := listPayload(t, result, "devices")
 	if len(devices) == 0 {
 		t.Fatal("expected at least one device")
 	}
@@ -140,10 +136,7 @@ func TestDeviceList_SourceFieldOnConfigEntries(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result")
 	}
-	var devices []map[string]any
-	if err := json.Unmarshal([]byte(toolResultText(t, result)), &devices); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	devices := listPayload(t, result, "devices")
 	for _, d := range devices {
 		if d["source"] != "config" {
 			t.Errorf("expected source=config, got %v (device: %v)", d["source"], d)
@@ -167,10 +160,7 @@ func TestDeviceList_ScanTrue_IncludesScanResults(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result")
 	}
-	var devices []map[string]any
-	if err := json.Unmarshal([]byte(toolResultText(t, result)), &devices); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
+	devices := listPayload(t, result, "devices")
 	if len(devices) != 1 {
 		t.Fatalf("expected 1 device, got %d", len(devices))
 	}

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -66,7 +66,10 @@ stopped containers.
 ## Result shape & error codes
 
 Tools that return data include a machine-readable structuredContent object
-alongside human-readable text. Errors include an error_code you can branch
+alongside human-readable text. List-shaped tools nest their rows under a
+single key — devices (device_list, cloud_discover, bluetooth_scan),
+containers, stats, capabilities, networks (wifi_list, wifi_known_networks),
+batches (telemetry_*) — never as a bare array. Errors include an error_code you can branch
 on — e.g. NOT_CONNECTED, DEVICE_UNREACHABLE, ENTITLEMENT_DENIED,
 INVALID_ARGUMENT, NOT_FOUND, MULTIPLE_SESSIONS, UNSUPPORTED, TIMEOUT,
 INTERNAL. Tool annotations mark read-only vs destructive vs mutating

--- a/go/internal/cli/mcp/tools_hardware.go
+++ b/go/internal/cli/mcp/tools_hardware.go
@@ -45,8 +45,5 @@ func (s *mcpServer) handleHardwareCapabilities(ctx context.Context, req mcpgo.Ca
 		}
 		caps = append(caps, entry)
 	}
-	if caps == nil {
-		caps = []map[string]any{}
-	}
-	return okResult(caps), nil
+	return okList("capabilities", caps), nil
 }

--- a/go/internal/cli/mcp/tools_hardware_provisioning_test.go
+++ b/go/internal/cli/mcp/tools_hardware_provisioning_test.go
@@ -105,11 +105,7 @@ func TestHardwareCapabilities_ReturnsList(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var caps []map[string]any
-	if err := json.Unmarshal([]byte(text), &caps); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	caps := listPayload(t, result, "capabilities")
 	if len(caps) != 1 {
 		t.Fatalf("expected 1 capability, got %d", len(caps))
 	}
@@ -138,8 +134,8 @@ func TestHardwareCapabilities_HasStructuredContent(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if result.StructuredContent == nil {
-		t.Fatal("hardware_capabilities should return structuredContent")
+	if _, ok := structuredMap(t, result)["capabilities"]; !ok {
+		t.Error("hardware_capabilities envelope is missing the capabilities key")
 	}
 }
 
@@ -156,9 +152,10 @@ func TestHardwareCapabilities_EmptyList(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	if text != "[]" {
-		t.Errorf("expected empty JSON array, got %q", text)
+	// An empty result must still be an object envelope with the key present,
+	// not a bare [] — conformant clients reject a non-object structuredContent.
+	if caps := listPayload(t, result, "capabilities"); len(caps) != 0 {
+		t.Errorf("expected no capabilities, got %v", caps)
 	}
 }
 

--- a/go/internal/cli/mcp/tools_telemetry.go
+++ b/go/internal/cli/mcp/tools_telemetry.go
@@ -149,7 +149,7 @@ func (s *mcpServer) handleTelemetryLogs(ctx context.Context, req mcpgo.CallToolR
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
+	return okListBounded("batches", result, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -183,7 +183,7 @@ func (s *mcpServer) handleTelemetryMetrics(ctx context.Context, req mcpgo.CallTo
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
+	return okListBounded("batches", result, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -217,5 +217,5 @@ func (s *mcpServer) handleTelemetryTraces(ctx context.Context, req mcpgo.CallToo
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
-	return okResultBounded(result, intParam(req, "max_bytes", 100000)), nil
+	return okListBounded("batches", result, intParam(req, "max_bytes", 100000)), nil
 }

--- a/go/internal/cli/mcp/tools_telemetry_test.go
+++ b/go/internal/cli/mcp/tools_telemetry_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -98,13 +97,8 @@ func TestTelemetryLogs_ReturnsJSON(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	if len(text) == 0 {
-		t.Fatal("expected non-empty result")
-	}
-	// Should be a JSON array
-	if text[0] != '[' {
-		t.Errorf("expected JSON array, got: %s", text)
+	if batches := listPayload(t, result, "batches"); len(batches) != 1 {
+		t.Errorf("expected 1 batch, got %d", len(batches))
 	}
 }
 
@@ -125,12 +119,12 @@ func TestTelemetryLogs_HasStructuredContent(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if result.StructuredContent == nil {
-		t.Fatal("telemetry_logs should return structuredContent")
+	if _, ok := structuredMap(t, result)["batches"]; !ok {
+		t.Error("telemetry_logs envelope is missing the batches key")
 	}
 }
 
-func TestTelemetryLogs_EmptyReturnsEmptyArray(t *testing.T) {
+func TestTelemetryLogs_EmptyReturnsEmptyList(t *testing.T) {
 	fake := &fakeTelemetryServer{}
 	conn := startFakeTelemetryServer(t, fake)
 	srv := New(&config.Config{}, nil)
@@ -143,9 +137,10 @@ func TestTelemetryLogs_EmptyReturnsEmptyArray(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	if text != "[]" {
-		t.Errorf("text = %q, want []", text)
+	// An empty stream must still be an object envelope with the key present,
+	// not a bare [] — conformant clients reject a non-object structuredContent.
+	if batches := listPayload(t, result, "batches"); len(batches) != 0 {
+		t.Errorf("expected no batches, got %v", batches)
 	}
 }
 
@@ -166,9 +161,8 @@ func TestTelemetryMetrics_ReturnsJSON(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	if text[0] != '[' {
-		t.Errorf("expected JSON array, got: %s", text)
+	if batches := listPayload(t, result, "batches"); len(batches) != 1 {
+		t.Errorf("expected 1 batch, got %d", len(batches))
 	}
 }
 
@@ -189,8 +183,7 @@ func TestTelemetryTraces_ReturnsJSON(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	if text[0] != '[' {
-		t.Errorf("expected JSON array, got: %s", text)
+	if batches := listPayload(t, result, "batches"); len(batches) != 1 {
+		t.Errorf("expected 1 batch, got %d", len(batches))
 	}
 }

--- a/go/internal/cli/mcp/tools_wifi.go
+++ b/go/internal/cli/mcp/tools_wifi.go
@@ -76,10 +76,7 @@ func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest)
 			"priority":     n.GetPriority(),
 		})
 	}
-	if networks == nil {
-		networks = []map[string]any{}
-	}
-	return okResult(networks), nil
+	return okList("networks", networks), nil
 }
 
 func (s *mcpServer) handleWiFiConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -156,8 +153,5 @@ func (s *mcpServer) handleWiFiKnownNetworks(ctx context.Context, _ mcpgo.CallToo
 			"security": n.GetSecurity().String(),
 		})
 	}
-	if networks == nil {
-		networks = []map[string]any{}
-	}
-	return okResult(networks), nil
+	return okList("networks", networks), nil
 }

--- a/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
+++ b/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
@@ -120,11 +120,7 @@ func TestWiFiList_ReturnsNetworks(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var networks []map[string]any
-	if err := json.Unmarshal([]byte(text), &networks); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	networks := listPayload(t, result, "networks")
 	if len(networks) != 1 {
 		t.Fatalf("expected 1 network, got %d", len(networks))
 	}
@@ -150,8 +146,8 @@ func TestWiFiList_HasStructuredContent(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if result.StructuredContent == nil {
-		t.Fatal("wifi_list should return structuredContent")
+	if _, ok := structuredMap(t, result)["networks"]; !ok {
+		t.Error("wifi_list envelope is missing the networks key")
 	}
 }
 
@@ -247,11 +243,7 @@ func TestWiFiKnownNetworks_ReturnsNetworks(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var networks []map[string]any
-	if err := json.Unmarshal([]byte(text), &networks); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	networks := listPayload(t, result, "networks")
 	if len(networks) != 1 || networks[0]["ssid"] != "HomeNet" {
 		t.Errorf("unexpected networks: %v", networks)
 	}
@@ -285,11 +277,7 @@ func TestBluetoothScan_ReturnsPeripherals(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	text := result.Content[0].(mcpgo.TextContent).Text
-	var devices []map[string]any
-	if err := json.Unmarshal([]byte(text), &devices); err != nil {
-		t.Fatalf("invalid JSON: %v\ntext: %s", err, text)
-	}
+	devices := listPayload(t, result, "devices")
 	if len(devices) != 1 {
 		t.Fatalf("expected 1 device, got %d", len(devices))
 	}
@@ -315,8 +303,8 @@ func TestBluetoothScan_HasStructuredContent(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if result.StructuredContent == nil {
-		t.Fatal("bluetooth_scan should return structuredContent")
+	if _, ok := structuredMap(t, result)["devices"]; !ok {
+		t.Error("bluetooth_scan envelope is missing the devices key")
 	}
 }
 


### PR DESCRIPTION
## Problem

The MCP spec requires `structuredContent` to be a JSON **object**, but `wendy mcp serve` returned a top-level JSON **array** from every list-shaped tool. Spec-conformant clients reject the entire result:

```
MCP server "wendy" returned a malformed result that failed schema validation:
[{"expected":"record","code":"invalid_type","path":["structuredContent"],
  "message":"Invalid input: expected record, received array"}]
```

`okResult()`/`okResultBounded()` passed payloads straight into `mcpgo.NewToolResultStructured`, which is a pure pass-through, so any call site handing it a Go slice produced a bare array. Because every handler normalized `nil` to an empty slice, the tools failed **even with zero results** — a total outage of all 11 tools, not an edge case. The only workaround was shelling out to the `wendy` CLI.

## Fix

- **`results.go`** — new `okList`/`okListBounded` generic helpers that nest rows under a named key and normalize `nil` → `[]`, plus a guard inside `okResult` that wraps any non-object payload so a future call site can't reintroduce the bug.
- **All 11 handlers** now use those helpers, with keys `devices` / `containers` / `stats` / `capabilities` / `networks` / `batches`. This also deleted seven copy-pasted `if x == nil { x = []map[string]any{} }` blocks.
- **Guide text** documents the envelope convention so agents know where to look.

| Tool | Envelope key |
| -- | -- |
| `device_list`, `cloud_discover`, `bluetooth_scan` | `devices` |
| `container_list` | `containers` |
| `container_stats` | `stats` |
| `hardware_capabilities` | `capabilities` |
| `wifi_list`, `wifi_known_networks` | `networks` |
| `telemetry_logs` / `_metrics` / `_traces` | `batches` |

Map-returning tools (`wendy_status`, `device_info`, `wifi_status`, `provisioning_*`, `os_update*`, `cloud_enroll_device`, `cloud_tunnel`) were already object-shaped and are untouched.

## Tests

The five `*_HasStructuredContent` tests only asserted non-nil, which is why this shipped — they're tightened to assert object shape plus the expected key, via a shared `structuredMap`/`listPayload` helper. Added `results_test.go` coverage for the `okResult` guard, `okList` nil-normalization, and the `okListBounded` truncation envelope.

## Verification

- `go test ./go/internal/cli/...` — all 17 packages pass. `gofmt -l go/` and `go vet` clean.
- **End-to-end against a live Jetson Orin Nano** (WendyOS-0.18.1, agent 2026.07.20-035949), driving the real stdio server over JSON-RPC. Same driver, both binaries:

| | shipped `wendy` | this branch |
| -- | -- | -- |
| all 11 tools | `structuredContent` is an **array** | **object** with the expected key |

  Live sample from the patched binary: `hardware_capabilities` → 28 rows, `wifi_list` → 9 rows, `container_list` → 1 row, `telemetry_logs` → 2 batches. `bluetooth_scan` and `telemetry_traces` returned 0 rows, exercising the empty case that also used to fail.
- Swept all 16 device-independent tools: zero non-object `structuredContent`.

## Notes

- This **changes the tool result shape** for these 11 tools. No in-repo consumer parses them, and the current shape is unusable by conformant clients, so there's nothing working to preserve.
- Two corrections to the issue: there are **no `outputSchema` declarations** anywhere in the repo, so that caveat doesn't apply; and the `tools_cloud_test.go:141` "inconsistent test" is a misattribution — that line is inside `TestCloud_MultipleSessions_Code`, which asserts on an *error* result, and error results were already maps.
- Follow-up worth considering: declaring `outputSchema` on these tools so clients can validate shape up front. Additive and independent of this fix.

Fixes WDY-2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S59TTzzHYGEB8cwnVBaXYm