### PR TITLE
ci: gate SBOM+attest on build-cli-linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -432,7 +432,10 @@ jobs:
   sbom-binaries:
     name: SBOM+attest (${{ matrix.artifact-name }})
     runs-on: ubuntu-latest
-    needs: [determine-version, build, build-go-macos]
+    # build-cli-linux produces the wendy-cli-linux-* archives; without it in
+    # needs, those matrix entries race the upload and fail with "Artifact not
+    # found".
+    needs: [determine-version, build, build-cli-linux, build-go-macos]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
`sbom-binaries` attests `wendy-cli-linux-amd64` and `wendy-cli-linux-arm64`, but those archives come from the `build-cli-linux` job, which was missing from the job's `needs`. Those two matrix legs were free to start once `build` and `build-go-macos` finished, racing the linux CLI upload.

Observed in [run 30224630671](https://github.com/wendylabsinc/WendyOS/actions/runs/30224630671):

| event | time |
|---|---|
| `wendy-cli-linux-amd64` build starts | 23:09:23 |
| `SBOM+attest (wendy-cli-linux-amd64)` starts | 23:10:20 |
| download fails — `Artifact not found` | 23:10:31 |
| archive artifact finalized | 23:10:42 |

The artifact was present in the run all along (11 MB); the job simply looked 11s too early. The arm64 leg passed only because that build is faster, so this flaps rather than failing every time. Since `release` needs `sbom-binaries`, the race also skips the release job.

Fix is one line: add `build-cli-linux` to `needs`. `package-linux` already declares it, which is why packaging was unaffected.

Checked all seven `sbom-binaries` matrix entries against the job that uploads each archive — `build` (agent linux + cli windows), `build-cli-linux` (cli linux), `build-go-macos` (cli darwin) — all now covered by `needs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CXZwcAfT2sCqn3YsbAC5z
