### PR TITLE
docs: Unitree G1 wendy-agent installation tutorial

### DIFF
--- a/go/internal/cli/assets/docs/installation/meta.json
+++ b/go/internal/cli/assets/docs/installation/meta.json
@@ -6,6 +6,7 @@
     "wendyos-raspberry-pi-5",
     "linux",
     "wendy-agent-macos",
+    "wendy-agent-unitree-g1",
     "wendy-lite-esp32"
   ]
 }

--- a/go/internal/cli/assets/docs/installation/meta.json
+++ b/go/internal/cli/assets/docs/installation/meta.json
@@ -7,6 +7,7 @@
     "linux",
     "wendy-agent-macos",
     "wendy-agent-unitree-g1",
+    "unitree-g1-reflash",
     "wendy-lite-esp32"
   ]
 }

--- a/go/internal/cli/assets/docs/installation/unitree-g1-reflash.mdx
+++ b/go/internal/cli/assets/docs/installation/unitree-g1-reflash.mdx
@@ -1,0 +1,191 @@
+---
+title: Reflash Unitree G1 PC2
+description: Replace the Unitree G1 PC2 image and firmware with Unitree's JetPack 6.2 release
+---
+
+## Overview
+
+This guide replaces the operating system and module firmware on the Unitree G1
+development computer, known as PC2, with Unitree's JetPack 6.2 image.
+
+You do not need to reflash PC2 to [install Wendy Agent](/docs/installation/wendy-agent-unitree-g1).
+
+<Callout type="warning">
+  This process erases the target NVMe drive and replaces the PC2 firmware.
+  Preserve the original NVMe and verify every device path before writing an
+  image.
+</Callout>
+
+## What You Need
+
+- The original PC2 NVMe, removed and preserved as a backup
+- A replacement NVMe with at least 1 TB of storage
+- A native Ubuntu x86-64 computer
+- An NVMe-to-USB enclosure
+- A USB data cable
+- Unitree system image: `g1-nx-j6.2.img.bz2`
+- Unitree PC2 firmware: `Jetpack_6.2_nx.tar.bz2`
+
+Download both files from the package folder linked by NVIDIA's
+[G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html).
+Confirm the filenames and integrity against NVIDIA's current instructions
+before continuing.
+
+The two files update different parts of PC2:
+
+```text
+Orin NX module
+├── QSPI and boot firmware    Jetpack_6.2_nx.tar.bz2 over recovery USB
+└── NVMe operating system    g1-nx-j6.2.img.bz2 written to the replacement NVMe
+```
+
+Use Unitree's G1-specific image. A generic NVIDIA Orin NX image does not
+include the G1 carrier-board configuration.
+
+## Reflash PC2
+
+<Steps>
+  <Step>
+    ### Preserve the Original NVMe
+
+    Remove the original NVMe from PC2 and keep it unchanged. Write the new
+    image only to the replacement drive.
+
+    The original drive preserves its data, but restoring an older JetPack
+    release also requires restoring the matching PC2 module firmware.
+  </Step>
+
+  <Step>
+    ### Write the PC2 Image
+
+    Attach the replacement NVMe to the Ubuntu computer with the USB enclosure.
+    List the connected drives and identify the Ubuntu system drive:
+
+    ```bash
+    lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN
+    findmnt -no SOURCE /
+    ```
+
+    Replace `/dev/sdX` below with the whole-disk path for the replacement NVMe:
+
+    ```bash
+    lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,LABEL,MOUNTPOINTS /dev/sdX
+    ```
+
+    <Callout type="warning">
+      Stop unless `/dev/sdX` identifies the replacement NVMe and is different
+      from the Ubuntu system drive. Writing to the wrong path destroys that
+      drive.
+    </Callout>
+
+    Unmount the replacement drive, then write the Unitree image:
+
+    ```bash
+    sudo umount /dev/sdX*
+    bzip2 -dc g1-nx-j6.2.img.bz2 | \
+      sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
+    sudo sync
+    sudo udisksctl power-off -b /dev/sdX
+    ```
+
+    Disconnect the replacement NVMe from the enclosure and set it aside. Install
+    it after the PC2 firmware flash is complete.
+  </Step>
+
+  <Step>
+    ### Enter Recovery Mode
+
+    PC2 has two buttons inside the rear electronics compartment. PWR is the
+    upper button. REC is the lower button above the PC2 USB-C flashing port.
+
+    1. Power on the G1 and wait for all three power indicators to remain lit.
+    2. Connect the Ubuntu computer to the PC2 USB-C flashing port.
+    3. Hold PWR and REC together for about two seconds.
+    4. Release PWR while continuing to hold REC until only two power indicators
+       remain lit.
+    5. Release REC.
+
+    Verify that PC2 appears in recovery mode:
+
+    ```bash
+    lsusb
+    ```
+
+    Continue when the output includes `NVIDIA Corp. APX`.
+  </Step>
+
+  <Step>
+    ### Flash the PC2 Firmware
+
+    Keep the firmware archive on the Ubuntu computer. From the directory that
+    contains the archive, run:
+
+    ```bash
+    sudo tar -xjvf Jetpack_6.2_nx.tar.bz2
+    cd Jetpack_6.2_nx/Linux_for_Tegra
+    lsusb | grep -i nvidia
+    sudo ./flash_nx_module.sh
+    ```
+
+    Keep the G1 powered on and connected over USB until the script reports
+    success. The flash takes about eight minutes.
+  </Step>
+
+  <Step>
+    ### Boot and Verify PC2
+
+    Power off the G1 and disconnect the recovery USB cable. Install the
+    replacement NVMe in PC2, close the rear compartment, then power on the G1.
+    Wait several minutes for PC2 to boot.
+
+    Connect to PC2 and check the installed release:
+
+    ```bash
+    ping 192.168.123.164
+    ssh unitree@192.168.123.164
+
+    cat /etc/nv_tegra_release
+    cat /etc/os-release
+    uname -a
+    ```
+
+    JetPack 6.2 includes Jetson Linux R36.4.3 and an Ubuntu 22.04-based root
+    filesystem. Use `/etc/nv_tegra_release` as the source of truth for the BSP
+    version.
+
+    Follow NVIDIA's current G1 guide for any required post-flash packages and
+    power-mode configuration.
+  </Step>
+</Steps>
+
+## Verify G1 Hardware
+
+After [installing Wendy Agent](/docs/installation/wendy-agent-unitree-g1), check
+the RealSense camera and other hardware from your development machine:
+
+```bash
+wendy device camera list --device unitree-g1-nx.local:50052
+wendy device hardware list --device unitree-g1-nx.local:50052
+```
+
+Check the G1 in this order:
+
+- Ethernet and Wi-Fi
+- USB devices and cameras
+- GPU and CUDA
+- Unitree services and DDS communication
+- G1 app video and image display
+- Controlled motion
+
+If a camera app reports that the RealSense is busy, stop only the known service
+that owns the camera, then retry.
+
+<Callout type="warning">
+  Keep the G1 supported on its gantry and keep the physical remote and E-stop
+  with the operator for the first controlled-motion check.
+</Callout>
+
+## Next Steps
+
+- [Install Wendy Agent on the G1](/docs/installation/wendy-agent-unitree-g1)
+- [JetPack 6.2 release information](https://developer.nvidia.com/embedded/jetpack-sdk-62)

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -14,23 +14,14 @@ The Wendy Agent installation procedure does not reflash the G1 or install
 software on the separate motion-control computer. It does make persistent
 changes to PC2: the installer adds Wendy's signed APT repository, installs
 packages and systemd services, and adds an Avahi service for mDNS discovery.
-The optional JetPack appendix documents the separate recovery procedure used on
-the lab G1.
+The optional JetPack appendix documents the separate PC2 recovery procedure.
 
 <Callout type="info">
-  These instructions follow Unitree's documented G1 development environment
-  and Wendy's supported installation procedure. Wendy reconfirmed the
-  non-motion workflow on the lab G1 after its Unitree JetPack 6.2 update. That
-  system runs Ubuntu 22.04.5 on arm64 with Jetson Linux R36.4.3. An earlier
-  end-to-end upgrade-path trial used Ubuntu 20.04.6 on arm64.
+  These instructions support G1 PC2 images based on Ubuntu 20.04 or Ubuntu
+  22.04 on arm64. Unitree's JetPack 6.2 image reports Jetson Linux R36.4.3 and
+  Ubuntu 22.04.5. Because interface names and installed packages vary by image,
+  the steps below detect or inspect them instead of assuming fixed values.
 </Callout>
-
-The latest lab walkthrough confirmed the PC2 address and SSH credentials,
-direct Wi-Fi internet access, the Wendy Agent installation result, automatic
-`containerd` dependency installation, service startup, mDNS discovery, device
-inspection, and RealSense enumeration. The safer macOS internet-sharing recipe
-still needs an end-to-end retest over a physically connected developer-machine
-Ethernet link and remains marked where it appears below.
 
 <Callout type="info">
   You do not need robotics experience to install Wendy Agent. Steps 1–5 work
@@ -48,7 +39,7 @@ Ethernet link and remains marked where it appears below.
 - Administrator access on the developer machine and `sudo` access on PC2
 - Approximately 15–30 minutes
 
-The factory account documented for PC2 and confirmed on the lab G1 is:
+The factory account documented for PC2 is:
 
 ```text
 Address:  192.168.123.164
@@ -64,7 +55,7 @@ If this is your first G1 setup, keep the two command environments distinct:
 
 - **Developer machine:** your Mac or Linux laptop. Run `networksetup`, `pfctl`,
   `wendy discover`, and `wendy run` here.
-- **PC2:** the G1's Jetson development computer. After `ssh`, run `ip`, `curl`,
+- **PC2:** the G1's Jetson development computer. After `ssh`, run `ip`, `wget`,
   `containerd`, and `systemctl` here. A prompt such as `unitree@...` confirms
   that this terminal is on PC2.
 
@@ -78,10 +69,9 @@ stock internal network is `192.168.123.0/24`, and PC2 is
 **`192.168.123.164`**.
 
 <Callout type="warning">
-  G1 hardware revisions can expose more than one RJ45 port. Wendy will add a
-  labeled port photograph after testing a factory-stock unit. Until then, use
-  Unitree's hardware documentation to identify the port connected to PC2. A
-  live Ethernet link alone does not prove that the correct port was selected.
+  G1 hardware revisions can expose more than one RJ45 port. Use Unitree's
+  hardware documentation to identify the port connected to PC2. A live
+  Ethernet link alone does not prove that the correct port was selected.
 </Callout>
 
 ### macOS
@@ -161,13 +151,13 @@ ip -br address
 ip route
 ```
 
-On the updated lab G1, these commands reported `aarch64`, Ubuntu 22.04.5, and
-Jetson Linux R36.4.3. NVIDIA maps R36.4.3 to JetPack 6.2. Check the BSP release
-directly because a JetPack metapackage might not be installed on a vendor image.
+If `/etc/nv_tegra_release` reports R36.4.3, NVIDIA maps the installed BSP to
+JetPack 6.2. Check the BSP release directly because a JetPack metapackage might
+not be installed on a vendor image.
 
 ## Step 3: Check internet access
 
-The current Unitree JetPack 6.2 image includes `wget` but not `curl`. Do not
+Unitree's JetPack 6.2 image includes `wget` but not `curl`. Do not
 reconfigure routing if PC2 can already reach the installer:
 
 ```bash
@@ -180,19 +170,17 @@ PC2 may already be connected to Wi-Fi. A persistent, organization-approved
 Wi-Fi connection is preferable to routing through the developer machine.
 
 <Callout type="info">
-  The lab G1 already had a working Wi-Fi connection and could reach Wendy's
-  installer directly. Interface names vary by image; the updated lab image
-  used `wlxfc23cd8f7621`, not `wlan0`. If PC2 is not already online, use
-  Unitree's networking instructions for its installed image, then repeat the
-  internet check above. Wendy will test configuring Wi-Fi from an unconfigured
-  image separately.
+  Interface names vary by image and might not be `wlan0`. Use `ip -br address`
+  to identify the wireless interface. If PC2 is not already online, follow
+  Unitree's networking instructions for the installed image, then repeat the
+  internet check above.
 </Callout>
 
 ### Temporary macOS internet sharing fallback
 
-Use this only when PC2 has no approved direct network path. The previous draft
-used `pfctl -f -`, which replaces the Mac's main packet-filter ruleset. The
-replacement below uses a named `com.apple` anchor instead.
+Use this only when PC2 has no approved direct network path. The procedure uses
+a named `com.apple` packet-filter anchor so it does not replace the Mac's main
+ruleset.
 
 Run these commands on the Mac in one terminal and keep it open so the saved
 values are available for cleanup:
@@ -209,10 +197,9 @@ sudo sysctl -w net.inet.ip.forwarding=1
 ```
 
 Back on PC2, identify the interface carrying `192.168.123.164`, then route
-through the developer machine. Do not assume it is named `eth0`; the lab
-JetPack 6.2 image names it `enP8p1s0`. `ip route replace` handles a pre-existing
-placeholder default route. Replace `1.1.1.1` with an approved DNS resolver when
-required by your organization.
+through the developer machine. Do not assume it is named `eth0`. `ip route
+replace` handles a pre-existing placeholder default route. Replace `1.1.1.1`
+with an approved DNS resolver when required by your organization.
 
 ```bash
 PC2_ETHERNET=$(ip -br address | \
@@ -225,11 +212,8 @@ wget --spider https://install.wendy.dev/agent.sh
 ```
 
 <Callout type="warning">
-  macOS-to-G1 internet sharing was confirmed during the lab trial. That trial
-  used the older main-ruleset command, so Wendy will retest the safer named
-  anchor and its teardown end-to-end. A Linux internet-sharing fallback will
-  also be tested and documented. These settings are temporary and are lost on
-  reboot.
+  These routing and packet-filter settings are temporary and are lost on
+  reboot. Run the teardown commands below when installation is complete.
 </Callout>
 
 After installation, remove the temporary route and DNS setting on PC2:
@@ -260,19 +244,11 @@ Do not unconditionally install or upgrade `containerd`. The Wendy Debian
 package declares it as a dependency, so APT installs it when absent. This
 avoids unexpectedly restarting an existing runtime merely to perform a check.
 
-On the freshly updated lab G1, `containerd` was absent before Wendy Agent was
-installed. The package log shows APT installing `containerd` 2.2.1 and
-`wendy-agent` in the same transaction; both services were enabled and active
-after boot. On the earlier Ubuntu 20.04 image, `containerd` 1.7.12 was already
-active. An unconditional installation command upgraded it to 1.7.24 and
-restarted the runtime, which is why this guide performs only the read-only
-checks above.
-
 <Callout type="warning">
-  The lab results confirm both an absent-runtime installation and an
-  already-installed Ubuntu `containerd` runtime. Wendy will separately test an
-  image using Docker's `containerd.io` package to confirm that dependency
-  resolution does not remove or replace an existing Docker runtime.
+  If PC2 uses Docker's `containerd.io` package, do not approve an APT
+  transaction that removes Docker or replaces its runtime. Preserve the
+  existing container workloads and resolve the package conflict before
+  installing Wendy Agent.
 </Callout>
 
 Download the installer so it can be reviewed before execution:
@@ -282,13 +258,6 @@ wget -O /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
 less /tmp/wendy-agent.sh
 bash /tmp/wendy-agent.sh
 ```
-
-<Callout type="warning">
-  Manual inspection is not a cryptographic integrity check. Wendy will publish
-  and test a checksum or signature from a separate trusted channel before this
-  guide is released for production installation. Until that mechanism exists,
-  keep this workflow limited to the draft hardware-validation environment.
-</Callout>
 
 For a non-interactive SSH or provisioning session, pass the documented `-y`
 flag. The pipe-only form requires `/dev/tty` unless this flag is supplied.
@@ -301,11 +270,9 @@ The installer adds Wendy's signed APT repository and keyring, installs
 `wendy-agent` and its dependencies, writes systemd units and configuration,
 and advertises the agent through Avahi/mDNS.
 
-<Callout type="warning">
-  The APT installation path currently tracks the latest published package.
-  Wendy will add and test an explicit version-pinning workflow before using
-  this page as a reproducible fleet-provisioning reference.
-</Callout>
+The installer selects the latest package available from Wendy's signed APT
+repository. Record the installed version with `dpkg-query -W wendy-agent` when
+maintaining a reproducible fleet configuration.
 
 ### Pre-enroll into Wendy Cloud (optional)
 
@@ -341,13 +308,6 @@ sudo systemctl start wendy-agent
 sudo journalctl -u wendy-agent -n 100 --no-pager
 ```
 
-<Callout type="warning">
-  The lab G1 upgrade test observed the package stopping an existing agent
-  without restarting it. The manual start above recovered the agent and made
-  it discoverable. Wendy will fix and retest the package lifecycle; manual
-  recovery is not the final expected upgrade behavior.
-</Callout>
-
 Inspect the listening services before connecting PC2 to a shared network:
 
 ```bash
@@ -371,11 +331,10 @@ wendy discover
 
 The device may appear under a generic Ubuntu hostname rather than a name that
 contains “G1.” Match its address, architecture, operating system, and agent
-version to the PC2 values recorded earlier. During the lab trial,
-`wendy discover` found **Unitree G1 Nx** at `unitree-g1-nx.local` on its
-advertised mTLS port, `50052`. The hostname resolved to the active Wi-Fi address
-while `wendy device info` reported both `192.168.0.108` on Wi-Fi and
-`192.168.123.164` on Ethernet.
+version to the PC2 values recorded earlier. A configured device can appear as
+**Unitree G1 Nx** at `unitree-g1-nx.local` on the advertised mTLS port `50052`.
+Use `wendy device info` to confirm the Ethernet and Wi-Fi addresses reported by
+PC2 rather than relying on a fixed hostname.
 
 You are done when all of the following are true:
 
@@ -414,11 +373,10 @@ service declaration looks like this:
 ```
 
 Host networking lets the container bind DDS to PC2's internal Ethernet
-interface (`enP8p1s0` on the updated lab image; verify yours with `ip -br
-address`). It also removes container network isolation and grants access to the
-robot's internal network. Unitree DDS traffic on that network is generally
-unauthenticated and unencrypted, so grant this entitlement only to trusted
-apps.
+interface. Identify it with `ip -br address` instead of assuming a fixed name.
+Host networking also removes container network isolation and grants access to
+the robot's internal network. Unitree DDS traffic on that network is generally
+unauthenticated and unencrypted, so grant this entitlement only to trusted apps.
 
 The G1 uses the `unitree_hg` message package for low-level communication. The
 SDK topic names are `rt/lowstate` and `rt/lowcmd`. `unitree_go` is used by the
@@ -449,7 +407,7 @@ session.
   downloaded script with `bash /tmp/wendy-agent.sh -y`.
 - **The service is enabled but inactive after an upgrade:** Run
   `sudo systemctl start wendy-agent`, inspect the journal, and record the agent
-  package versions for the upgrade-lifecycle test.
+  package version with `dpkg-query -W wendy-agent` when contacting support.
 - **`wendy run` reports `wendy.json not found`:** Change into a Wendy project
   or create one with `wendy init` before deploying.
 - **Installer download fails:** Re-run the `wget --spider` internet check in
@@ -483,37 +441,36 @@ Unitree software, or other workloads may use it.
 
 ## Optional: update PC2 to Unitree's JetPack 6.2 image
 
-Wendy Agent does not require this update. This section records the exact lab
-process used to replace the G1 development computer's original JetPack 5.1.1
-system with Unitree's G1 packages based on the JetPack 6.2 BSP. It is a
-historical lab procedure, not part of the Wendy Agent installation flow. The
-Unitree image installs Jetson Linux and the G1 board support; it does not
-necessarily install NVIDIA's complete `nvidia-jetpack` development metapackage.
+Wendy Agent does not require this update. Use this separate recovery procedure
+only when PC2 must be migrated from an older image such as JetPack 5.1.1 to
+Unitree's G1-specific JetPack 6.2 image. The Unitree image installs Jetson Linux
+and the G1 board support; it does not necessarily install NVIDIA's complete
+`nvidia-jetpack` development metapackage.
 
 <Callout type="warning">
   This is a destructive SSD and PC2 firmware replacement, not an APT upgrade.
-  Do not copy the lab's `/dev/sda` path without identifying the replacement
-  disk on your own Ubuntu host. Never flash the G1's private motion-control
-  computer.
+  Preserve the original NVMe, identify the replacement disk on the Ubuntu host,
+  and verify every device path before writing. Never flash the G1's private
+  motion-control computer.
 </Callout>
 
-### Lab hardware and packages
+### Required hardware and packages
 
-- Original drive: ZHITAI TiPlus5000 2 TB with JetPack 5.1.1, L4T 35.3.1,
-  and Ubuntu 20.04
-- Replacement drive: Crucial P310 1 TB, model `CT1000P310SSD8`
+- The original PC2 NVMe, removed and preserved as a physical backup
+- A replacement NVMe of at least 1 TB
 - Native Ubuntu x86-64 host
 - NVMe-to-USB enclosure and a USB data cable
 - Unitree system image: `g1-nx-j6.2.img.bz2`
 - Unitree PC2 firmware package: `Jetpack_6.2_nx.tar.bz2`
 
-The lab downloaded both packages from this
-[Google Drive folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
-This is the exact download location used for the lab flash, not a guarantee that
-the folder remains current or controlled by Unitree. Confirm the files and
-their integrity with Unitree before using them on another G1.
+Download both matching packages through NVIDIA's
+[G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html),
+which links the
+[JetPack 6.2 package folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
+Confirm the filenames and integrity against the current upstream instructions
+before flashing.
 
-The lab used two matching packages because the NVMe operating system and the
+Two matching packages are required because the NVMe operating system and the
 Orin NX module firmware are separate:
 
 ```text
@@ -522,59 +479,65 @@ Orin NX module
 └── NVMe operating system    g1-nx-j6.2.img.bz2 written to the replacement SSD
 ```
 
-Obtain the current G1-specific packages from Unitree before repeating the
-process. A generic NVIDIA Orin NX image does not contain the G1 carrier-board
-configuration.
+Do not substitute a generic NVIDIA Orin NX image; it does not contain the G1
+carrier-board configuration.
 
 ### 1. Inspect and preserve the original drive
 
-The original ZHITAI drive was removed from PC2 and attached over USB for
-read-only inspection. Its NVIDIA package metadata reported JetPack 5.1.1 and
-L4T 35.3.1. The drive was then disconnected and kept unchanged as the physical
-backup. The lab did not write the JetPack 6.2 image to the original drive.
+Remove the original drive from PC2 and preserve it unchanged as the physical
+backup. If you inspect it over USB, mount it read-only. Write the JetPack 6.2
+image only to the replacement drive.
 
 The original NVMe is a data backup, but it is not a complete one-step rollback.
 After PC2's module firmware is updated to JetPack 6.2, booting JetPack 5.1.1
 again also requires restoring the matching Unitree JetPack 5.1.1 module
 firmware.
 
-### 2. Identify the Crucial P310 on the Ubuntu host
+### 2. Identify the replacement NVMe on the Ubuntu host
 
-The P310 was attached to the Ubuntu host through the NVMe-to-USB enclosure. It
-appeared as `/dev/sda` in the lab. Before writing anything, the model, capacity,
-USB transport, partitions, and host root device were checked:
+Attach the replacement NVMe through the USB enclosure. Before writing anything,
+identify its model, capacity, USB transport, partitions, and the Ubuntu host's
+root device:
 
 ```bash
 lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN
-lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,LABEL,MOUNTPOINTS /dev/sda
 findmnt -no SOURCE /
 ```
 
+Replace `/dev/sdX` below with the whole-disk path reported for the replacement
+NVMe, then inspect it again:
+
+```bash
+lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,LABEL,MOUNTPOINTS /dev/sdX
+```
+
 <Callout type="warning">
-  `/dev/sda` was the P310 only on the lab Ubuntu host. Stop unless your own
-  output identifies the Crucial P310 replacement and shows a different device
-  for the host's root filesystem.
+  `/dev/sdX` is a placeholder. Stop unless your output identifies the intended
+  replacement NVMe and shows a different device for the Ubuntu host's root
+  filesystem. Writing to the wrong whole-disk path destroys that disk.
 </Callout>
 
-The P310's mounted partitions were unmounted before imaging:
+Unmount any mounted partitions on the replacement drive:
 
 ```bash
-sudo umount /dev/sda*
+sudo umount /dev/sdX*
 ```
 
-The Unitree system image was then written to the whole P310:
+Write the Unitree system image to the whole replacement drive:
 
 ```bash
-bzip2 -dc g1-nx-j6.2.img.bz2 | sudo dd of=/dev/sda status=progress
+bzip2 -dc g1-nx-j6.2.img.bz2 | \
+  sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
 sudo sync
+sudo udisksctl power-off -b /dev/sdX
 ```
 
-After `dd` and `sync` completed, the P310 was disconnected from the enclosure
-and installed in the G1 development computer.
+After the write and power-off complete, disconnect the replacement NVMe from the
+enclosure and install it in PC2.
 
 ### 3. Put the G1 development computer into recovery mode
 
-With the P310 installed, the lab used the two PC2 buttons inside the rear
+With the replacement NVMe installed, use the two PC2 buttons inside the rear
 electronics compartment. PWR is the upper button; REC is the lower button above
 PC2's USB-C flashing port.
 
@@ -591,12 +554,12 @@ On the Ubuntu host, confirm that the Orin NX appears in APX recovery mode:
 lsusb
 ```
 
-The lab continued only after `lsusb` displayed `NVIDIA Corp. APX`.
+Continue only after `lsusb` displays `NVIDIA Corp. APX`.
 
 ### 4. Flash the matching PC2 module firmware
 
-The firmware archive stayed on the Ubuntu host; it was not copied to the P310 or
-to PC2. From the directory containing the archive, the lab ran:
+Keep the firmware archive on the Ubuntu host; do not copy it to the replacement
+NVMe or PC2. From the directory containing the archive, run:
 
 ```bash
 sudo tar -xjvf Jetpack_6.2_nx.tar.bz2
@@ -611,11 +574,12 @@ reported success. The process took approximately eight minutes.
 ### 5. Boot and verify the updated PC2
 
 After the firmware script completed, the G1 was powered off and the recovery
-USB cable was disconnected. The P310 was checked for secure installation, the
-rear compartment was closed, and the G1 was powered on normally. The first boot
-was given several minutes before the lab attempted network access.
+USB cable was disconnected. The replacement NVMe was checked for secure
+installation, the rear compartment was closed, and the G1 was powered on
+normally. The first boot was given several minutes before attempting network
+access.
 
-The lab then checked PC2 without enabling motion:
+Check PC2 without enabling motion:
 
 ```bash
 ping 192.168.123.164
@@ -627,35 +591,32 @@ command -v nvcc && nvcc --version
 uname -a
 ```
 
-The updated lab PC2 reported Jetson Linux R36.4.3 and Ubuntu 22.04.5. NVIDIA's
+NVIDIA's
 [JetPack 6.2 release page](https://developer.nvidia.com/embedded/jetpack-sdk-62)
-identifies R36.4.3 as the Jetson Linux release included with JetPack 6.2. At the
-time of the walkthrough, Wendy Agent `2026.07.27-003050` incorrectly displayed
-this system as JetPack 6.1 in `wendy device info`; use the BSP value until that
-detection issue is fixed.
+identifies R36.4.3 as the Jetson Linux release included with JetPack 6.2. Use
+the BSP value from `/etc/nv_tegra_release` as the authoritative version if a
+management tool displays a different JetPack label.
 
-The Unitree image did not install `nvidia-jetpack` or `nvcc`. That is not a
-failed PC2 firmware flash and does not block Wendy Agent. Treat CUDA toolkit
-installation as a separate application prerequisite, and confirm the supported
-packages with Unitree for this carrier-board image before changing the NVIDIA
-software stack.
+The Unitree image might not install `nvidia-jetpack` or `nvcc`. Their absence
+does not indicate a failed PC2 firmware flash and does not block Wendy Agent.
+Treat CUDA toolkit installation as a separate application prerequisite, and
+confirm the supported packages with Unitree for this carrier-board image before
+changing the NVIDIA software stack.
 
-The non-motion hardware check found the Intel RealSense D435i and six V4L2
-device nodes. From the developer machine, the same camera appeared in Wendy's
-camera and hardware listings:
+Verify the Intel RealSense and other non-motion hardware from the developer
+machine:
 
 ```bash
 wendy device camera list --device unitree-g1-nx.local:50052
 wendy device hardware list --device unitree-g1-nx.local:50052
 ```
 
-Camera enumeration is confirmed, but a stream through `wendy device camera
-view` was not: the generic viewer could not configure the RealSense while the
-G1 demo's RealSense service was running. Stop there rather than interrupting a
-live robot workload; validate the image through the intended G1 app or retest
-the generic viewer during a maintenance window.
+Camera enumeration does not guarantee that another process can open the stream.
+If a camera viewer reports that the RealSense is busy, stop only the known
+camera-owning service during a maintenance window, then retry. Do not interrupt
+an unidentified robot workload.
 
-The remaining lab checks were performed in this order:
+Perform post-update checks in this order:
 
 - Ethernet and Wi-Fi
 - USB devices and cameras
@@ -668,12 +629,6 @@ Keep the G1 supported on its gantry and keep the physical remote and E-stop with
 the operator for the final controlled-motion check.
 
 ## Next steps
-
-The `g1-rc` template referenced by the previous draft is not in the public
-template registry yet. Wendy will not publish browser-driving instructions
-until the template is available and has completed on-robot crane commissioning,
-authentication review, motion-owner exclusion tests, watchdog tests, and
-physical E-stop review.
 
 Start with a non-motion app instead:
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -19,18 +19,18 @@ the lab G1.
 
 <Callout type="info">
   These instructions follow Unitree's documented G1 development environment
-  and Wendy's supported installation procedure. Wendy also completed an
-  end-to-end upgrade-path trial on a lab G1 running Ubuntu 20.04.6 on aarch64.
-  We will reconfirm the procedure on the lab G1 and update this guide if its
-  configuration differs.
+  and Wendy's supported installation procedure. Wendy reconfirmed the
+  non-motion workflow on the lab G1 after its Unitree JetPack 6.2 update. That
+  system runs Ubuntu 22.04.5 on arm64 with Jetson Linux R36.4.3. An earlier
+  end-to-end upgrade-path trial used Ubuntu 20.04.6 on arm64.
 </Callout>
 
-The lab trial confirmed the PC2 address and SSH credentials, direct Wi-Fi
-internet access, macOS internet-sharing mechanics, a running `containerd`, the
-Wendy Agent installer and upgrade recovery, and successful discovery from the
-developer machine. The tested robot was not factory-fresh, so clean-image
-dependency resolution and the revised internet-sharing commands remain marked
-for testing where they appear below.
+The latest lab walkthrough confirmed the PC2 address and SSH credentials,
+direct Wi-Fi internet access, the Wendy Agent installation result, automatic
+`containerd` dependency installation, service startup, mDNS discovery, device
+inspection, and RealSense enumeration. The safer macOS internet-sharing recipe
+still needs an end-to-end retest over a physically connected developer-machine
+Ethernet link and remains marked where it appears below.
 
 <Callout type="info">
   You do not need robotics experience to install Wendy Agent. Steps 1–5 work
@@ -156,28 +156,36 @@ run the same Ubuntu or JetPack version.
 ```bash
 uname -m
 . /etc/os-release && echo "$PRETTY_NAME"
+cat /etc/nv_tegra_release
 ip -br address
 ip route
 ```
 
+On the updated lab G1, these commands reported `aarch64`, Ubuntu 22.04.5, and
+Jetson Linux R36.4.3. NVIDIA maps R36.4.3 to JetPack 6.2. Check the BSP release
+directly because a JetPack metapackage might not be installed on a vendor image.
+
 ## Step 3: Check internet access
 
-Do not reconfigure routing if PC2 can already reach the installer:
+The current Unitree JetPack 6.2 image includes `wget` but not `curl`. Do not
+reconfigure routing if PC2 can already reach the installer:
 
 ```bash
-curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
+wget --spider https://install.wendy.dev/agent.sh
 ```
 
-If this prints an HTTP success response, skip to Step 4.
+If this reports `200 OK` and `Remote file exists`, skip to Step 4.
 
 PC2 may already be connected to Wi-Fi. A persistent, organization-approved
 Wi-Fi connection is preferable to routing through the developer machine.
 
 <Callout type="info">
-  The lab G1 already had a working `wlan0` connection and could reach Wendy's
-  installer directly. If PC2 is not already online, use Unitree's networking
-  instructions for its installed image, then repeat the internet check above.
-  Wendy will test configuring Wi-Fi from an unconfigured image separately.
+  The lab G1 already had a working Wi-Fi connection and could reach Wendy's
+  installer directly. Interface names vary by image; the updated lab image
+  used `wlxfc23cd8f7621`, not `wlan0`. If PC2 is not already online, use
+  Unitree's networking instructions for its installed image, then repeat the
+  internet check above. Wendy will test configuring Wi-Fi from an unconfigured
+  image separately.
 </Callout>
 
 ### Temporary macOS internet sharing fallback
@@ -200,14 +208,20 @@ printf 'nat on %s from 192.168.123.0/24 to any -> (%s)\n' \
 sudo sysctl -w net.inet.ip.forwarding=1
 ```
 
-Back on PC2, route through the developer machine. `ip route replace` handles a
-pre-existing placeholder default route. Replace `1.1.1.1` with an approved DNS
-resolver when required by your organization.
+Back on PC2, identify the interface carrying `192.168.123.164`, then route
+through the developer machine. Do not assume it is named `eth0`; the lab
+JetPack 6.2 image names it `enP8p1s0`. `ip route replace` handles a pre-existing
+placeholder default route. Replace `1.1.1.1` with an approved DNS resolver when
+required by your organization.
 
 ```bash
-sudo ip route replace default via 192.168.123.99 dev eth0 metric 100
-sudo resolvectl dns eth0 1.1.1.1
-curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
+PC2_ETHERNET=$(ip -br address | \
+  awk '$3 ~ /^192\.168\.123\.164\// {print $1; exit}')
+test -n "$PC2_ETHERNET"
+sudo ip route replace default via 192.168.123.99 \
+  dev "$PC2_ETHERNET" metric 100
+sudo resolvectl dns "$PC2_ETHERNET" 1.1.1.1
+wget --spider https://install.wendy.dev/agent.sh
 ```
 
 <Callout type="warning">
@@ -221,8 +235,8 @@ curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
 After installation, remove the temporary route and DNS setting on PC2:
 
 ```bash
-sudo ip route del default via 192.168.123.99 dev eth0
-sudo resolvectl revert eth0
+sudo ip route del default via 192.168.123.99 dev "$PC2_ETHERNET"
+sudo resolvectl revert "$PC2_ETHERNET"
 ```
 
 Then restore the Mac in the same terminal used to create the anchor:
@@ -246,21 +260,25 @@ Do not unconditionally install or upgrade `containerd`. The Wendy Debian
 package declares it as a dependency, so APT installs it when absent. This
 avoids unexpectedly restarting an existing runtime merely to perform a check.
 
-On the lab G1, `containerd` 1.7.12 was already installed and active. An earlier
-unconditional installation command upgraded it to 1.7.24 and restarted the
-runtime, which is why this guide performs only the read-only checks above.
+On the freshly updated lab G1, `containerd` was absent before Wendy Agent was
+installed. The package log shows APT installing `containerd` 2.2.1 and
+`wendy-agent` in the same transaction; both services were enabled and active
+after boot. On the earlier Ubuntu 20.04 image, `containerd` 1.7.12 was already
+active. An unconditional installation command upgraded it to 1.7.24 and
+restarted the runtime, which is why this guide performs only the read-only
+checks above.
 
 <Callout type="warning">
-  The lab result confirms the already-installed runtime path. Wendy will also
-  test an image with no runtime and an image using Docker's `containerd.io`
-  package to confirm that dependency resolution does not remove or replace an
-  existing Docker runtime.
+  The lab results confirm both an absent-runtime installation and an
+  already-installed Ubuntu `containerd` runtime. Wendy will separately test an
+  image using Docker's `containerd.io` package to confirm that dependency
+  resolution does not remove or replace an existing Docker runtime.
 </Callout>
 
 Download the installer so it can be reviewed before execution:
 
 ```bash
-curl -fsSLo /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
+wget -O /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
 less /tmp/wendy-agent.sh
 bash /tmp/wendy-agent.sh
 ```
@@ -354,8 +372,10 @@ wendy discover
 The device may appear under a generic Ubuntu hostname rather than a name that
 contains “G1.” Match its address, architecture, operating system, and agent
 version to the PC2 values recorded earlier. During the lab trial,
-`wendy discover` found the provisioned agent at `192.168.123.164` on its
-advertised mTLS port, `50052`.
+`wendy discover` found **Unitree G1 Nx** at `unitree-g1-nx.local` on its
+advertised mTLS port, `50052`. The hostname resolved to the active Wi-Fi address
+while `wendy device info` reported both `192.168.0.108` on Wi-Fi and
+`192.168.123.164` on Ethernet.
 
 You are done when all of the following are true:
 
@@ -393,10 +413,12 @@ service declaration looks like this:
 }
 ```
 
-Host networking lets the container bind DDS to PC2's `eth0` interface. It also
-removes container network isolation and grants access to the robot's internal
-network. Unitree DDS traffic on that network is generally unauthenticated and
-unencrypted, so grant this entitlement only to trusted apps.
+Host networking lets the container bind DDS to PC2's internal Ethernet
+interface (`enP8p1s0` on the updated lab image; verify yours with `ip -br
+address`). It also removes container network isolation and grants access to the
+robot's internal network. Unitree DDS traffic on that network is generally
+unauthenticated and unencrypted, so grant this entitlement only to trusted
+apps.
 
 The G1 uses the `unitree_hg` message package for low-level communication. The
 SDK topic names are `rt/lowstate` and `rt/lowcmd`. `unitree_go` is used by the
@@ -430,9 +452,15 @@ session.
   package versions for the upgrade-lifecycle test.
 - **`wendy run` reports `wendy.json not found`:** Change into a Wendy project
   or create one with `wendy init` before deploying.
-- **Installer download fails:** Re-run the internet check in Step 3. Inspect
-  both PC2's default route and the developer machine's default route before
-  changing either system.
+- **Installer download fails:** Re-run the `wget --spider` internet check in
+  Step 3. Inspect both PC2's default route and the developer machine's default
+  route before changing either system.
+- **SSH warns that the remote host identification changed:** This is expected
+  after reflashing PC2, but it can also indicate the wrong device or a
+  man-in-the-middle attack. Verify the new ED25519 fingerprint from a local PC2
+  terminal with `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`. Only after
+  it matches, remove the single stale developer-machine entry with
+  `ssh-keygen -R 192.168.123.164` and reconnect. Do not bypass host-key checking.
 - **PC2 does not answer ping:** Recheck the physical G1 port, Ethernet link,
   interface name, `192.168.123.99/24` address, and absence of a gateway on the
   developer machine's robot-link service.
@@ -453,12 +481,14 @@ place. Review and remove those directories separately only when their data is
 no longer needed. Do not remove `containerd` automatically because Docker,
 Unitree software, or other workloads may use it.
 
-## Optional: update the G1 development computer to JetPack 6.2
+## Optional: update PC2 to Unitree's JetPack 6.2 image
 
 Wendy Agent does not require this update. This section records the exact lab
 process used to replace the G1 development computer's original JetPack 5.1.1
-system with Unitree's JetPack 6.2 packages. It is a historical lab procedure,
-not part of the Wendy Agent installation flow.
+system with Unitree's G1 packages based on the JetPack 6.2 BSP. It is a
+historical lab procedure, not part of the Wendy Agent installation flow. The
+Unitree image installs Jetson Linux and the G1 board support; it does not
+necessarily install NVIDIA's complete `nvidia-jetpack` development metapackage.
 
 <Callout type="warning">
   This is a destructive SSD and PC2 firmware replacement, not an APT upgrade.
@@ -593,9 +623,37 @@ ssh unitree@192.168.123.164
 
 cat /etc/nv_tegra_release
 cat /etc/os-release
-nvcc --version
+command -v nvcc && nvcc --version
 uname -a
 ```
+
+The updated lab PC2 reported Jetson Linux R36.4.3 and Ubuntu 22.04.5. NVIDIA's
+[JetPack 6.2 release page](https://developer.nvidia.com/embedded/jetpack-sdk-62)
+identifies R36.4.3 as the Jetson Linux release included with JetPack 6.2. At the
+time of the walkthrough, Wendy Agent `2026.07.27-003050` incorrectly displayed
+this system as JetPack 6.1 in `wendy device info`; use the BSP value until that
+detection issue is fixed.
+
+The Unitree image did not install `nvidia-jetpack` or `nvcc`. That is not a
+failed PC2 firmware flash and does not block Wendy Agent. Treat CUDA toolkit
+installation as a separate application prerequisite, and confirm the supported
+packages with Unitree for this carrier-board image before changing the NVIDIA
+software stack.
+
+The non-motion hardware check found the Intel RealSense D435i and six V4L2
+device nodes. From the developer machine, the same camera appeared in Wendy's
+camera and hardware listings:
+
+```bash
+wendy device camera list --device unitree-g1-nx.local:50052
+wendy device hardware list --device unitree-g1-nx.local:50052
+```
+
+Camera enumeration is confirmed, but a stream through `wendy device camera
+view` was not: the generic viewer could not configure the RealSense while the
+G1 demo's RealSense service was running. Stop there rather than interrupting a
+live robot workload; validate the image through the intended G1 app or retest
+the generic viewer during a maintenance window.
 
 The remaining lab checks were performed in this order:
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -41,8 +41,9 @@ Username: unitree
 Password: 123
 ```
 
-Change the shared factory password or install an SSH key before connecting PC2
-to Wi-Fi or another shared network.
+Use the shared factory password only over the isolated Ethernet link. Step 2
+requires changing it before PC2 is connected to Wi-Fi or another shared
+network.
 
 ## Step 1: Connect the developer machine
 
@@ -112,6 +113,16 @@ before continuing.
 ```bash
 ssh unitree@192.168.123.164
 ```
+
+Before continuing, replace the shared factory password:
+
+```bash
+passwd
+```
+
+Disconnect and confirm that the new credential works over the isolated link.
+Do not proceed to internet access or enrollment until this check succeeds. Use
+your organization's SSH-key and password-login policy for longer-term access.
 
 On PC2, record the image and network state. G1 images in the field do not all
 run the same Ubuntu or JetPack version.
@@ -220,6 +231,13 @@ curl -fsSLo /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
 less /tmp/wendy-agent.sh
 bash /tmp/wendy-agent.sh
 ```
+
+<Callout type="warning">
+  Manual inspection is not a cryptographic integrity check. Wendy will publish
+  and test a checksum or signature from a separate trusted channel before this
+  guide is released for production installation. Until that mechanism exists,
+  keep this workflow limited to the draft hardware-validation environment.
+</Callout>
 
 For a non-interactive SSH or provisioning session, pass the documented `-y`
 flag. The pipe-only form requires `/dev/tty` unless this flag is supplied.

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -5,41 +5,27 @@ description: Install wendy-agent on the Unitree G1's onboard computer to deploy 
 
 ## Overview
 
-The Unitree G1 EDU includes an ARM64 NVIDIA Jetson development computer, also
-known as PC2, on the robot's internal network. Installing `wendy-agent` on PC2
-lets you deploy containerized apps with `wendy run`, stream logs and telemetry,
-and communicate with the robot's DDS and `unitree_sdk2` interfaces.
+The Unitree G1 EDU includes an NVIDIA Jetson development computer known as PC2.
+Install Wendy Agent on PC2 to deploy apps, stream logs, inspect hardware, and
+connect to the G1's DDS and `unitree_sdk2` interfaces.
 
-The Wendy Agent installation procedure does not reflash the G1 or install
-software on the separate motion-control computer. It does make persistent
-changes to PC2: the installer adds Wendy's signed APT repository, installs
-packages and systemd services, and adds an Avahi service for mDNS discovery.
-The optional JetPack appendix documents the separate PC2 recovery procedure.
+The Wendy CLI runs on your development machine. Wendy Agent runs on PC2.
 
 <Callout type="info">
-  These instructions support G1 PC2 images based on Ubuntu 20.04 or Ubuntu
-  22.04 on arm64. Unitree's JetPack 6.2 image reports Jetson Linux R36.4.3 and
-  Ubuntu 22.04.5. Because interface names and installed packages vary by image,
-  the steps below detect or inspect them instead of assuming fixed values.
+  This guide supports G1 PC2 images based on Ubuntu 20.04 or Ubuntu 22.04 on
+  arm64.
 </Callout>
 
-<Callout type="info">
-  You do not need robotics experience to install Wendy Agent. Steps 1–5 work
-  only with PC2, the open development computer. They do not command the G1's
-  joints. Do not open the robot, press its PWR/REC buttons, or reflash JetPack
-  for a normal Wendy Agent installation.
-</Callout>
-
-## Requirements
+## What You Need
 
 - A Unitree G1 EDU with the onboard development computer
-- The Wendy CLI on the developer machine ([setup guide](/docs/installation/developer-machine-setup))
-- A working internet connection on the developer machine
+- The [Wendy CLI](/docs/installation/developer-machine-setup) on your
+  development machine
 - An Ethernet cable and, if needed, a USB-to-Ethernet adapter
-- Administrator access on the developer machine and `sudo` access on PC2
-- Approximately 15–30 minutes
+- Internet access from PC2
+- Administrator access on your development machine and `sudo` access on PC2
 
-The factory account documented for PC2 is:
+PC2 uses this factory network configuration:
 
 ```text
 Address:  192.168.123.164
@@ -47,308 +33,150 @@ Username: unitree
 Password: 123
 ```
 
-Use the shared factory password only over the isolated Ethernet link. Step 2
-requires changing it before PC2 is connected to Wi-Fi or another shared
+Change the factory password before connecting PC2 to Wi-Fi or another shared
 network.
 
-If this is your first G1 setup, keep the two command environments distinct:
+## Installation Steps
 
-- **Developer machine:** your Mac or Linux laptop. Run `networksetup`, `pfctl`,
-  `wendy discover`, and `wendy run` here.
-- **PC2:** the G1's Jetson development computer. After `ssh`, run `ip`, `wget`,
-  `containerd`, and `systemctl` here. A prompt such as `unitree@...` confirms
-  that this terminal is on PC2.
+<Steps>
+  <Step>
+    ### Connect Your Development Machine
 
-When a step switches environments, open or label a separate terminal instead
-of guessing where to run its commands.
+    Power on the G1 and wait for PC2 to boot. Connect your development machine
+    to the G1 Ethernet port that reaches PC2.
 
-## Step 1: Connect the developer machine
+    <Tabs items={['macOS', 'Linux']} groupId="g1-developer-os" persist>
+      <Tab value="macOS">
+        Find the Ethernet network service:
 
-Connect the developer machine to the G1 Ethernet port that reaches PC2. The
-stock internal network is `192.168.123.0/24`, and PC2 is
-**`192.168.123.164`**.
+        ```bash
+        networksetup -listallhardwareports
+        networksetup -listnetworkserviceorder
+        ```
 
-<Callout type="warning">
-  G1 hardware revisions can expose more than one RJ45 port. Use Unitree's
-  hardware documentation to identify the port connected to PC2. A live
-  Ethernet link alone does not prove that the correct port was selected.
-</Callout>
+        Assign an address on the G1 network. Replace
+        `<robot-link-service>` with the network service from the previous
+        command:
 
-### macOS
+        ```bash
+        sudo networksetup -setmanual "<robot-link-service>" \
+          192.168.123.99 255.255.255.0 ""
+        ```
+      </Tab>
 
-Find the USB Ethernet device and its network-service name:
+      <Tab value="Linux">
+        Find the Ethernet interface:
 
-```bash
-networksetup -listallhardwareports
-networksetup -listnetworkserviceorder
-```
+        ```bash
+        ip -br link
+        ```
 
-Replace `<robot-link-service>` with the corresponding network service. Leave
-the router value empty so this isolated link does not replace the Mac's real
-default route:
+        Assign an address on the G1 network. Replace
+        `<robot-link-interface>` with the interface from the previous command:
 
-```bash
-sudo networksetup -setmanual "<robot-link-service>" \
-  192.168.123.99 255.255.255.0 ""
-```
+        ```bash
+        sudo ip addr replace 192.168.123.99/24 dev <robot-link-interface>
+        sudo ip link set <robot-link-interface> up
+        ```
+      </Tab>
+    </Tabs>
 
-Confirm the Ethernet link is active and the default route still uses the Mac's
-real internet uplink:
+    Verify the connection:
 
-```bash
-ifconfig <robot-link-interface>
-route -n get default | grep interface
-```
+    ```bash
+    ping 192.168.123.164
+    ```
+  </Step>
 
-### Linux
+  <Step>
+    ### Connect to PC2
 
-Find the wired interface, then assign the robot-link address. Do not add a
-gateway to this interface:
+    Connect to the G1's development computer over SSH:
 
-```bash
-ip -br link
-sudo ip addr replace 192.168.123.99/24 dev <robot-link-interface>
-sudo ip link set <robot-link-interface> up
-```
+    ```bash
+    ssh unitree@192.168.123.164
+    ```
 
-This Linux address is temporary unless it is also added to the distribution's
-persistent network configuration.
+    Sign in with the factory password, then change it:
 
-### Verify the link
+    ```bash
+    passwd
+    ```
 
-```bash
-ping 192.168.123.164
-```
+    Commands in the next two steps run on PC2.
+  </Step>
 
-A successful reply confirms Layer 3 connectivity to PC2. If it fails, verify
-the physical port, interface name, link status, IP address, and subnet mask
-before continuing.
+  <Step>
+    ### Check Internet Access
 
-## Step 2: SSH into PC2
+    Check whether PC2 can reach the Wendy Agent installer:
 
-```bash
-ssh unitree@192.168.123.164
-```
+    ```bash
+    wget --spider https://install.wendy.dev/agent.sh
+    ```
 
-Before continuing, replace the shared factory password:
+    Continue when the command reports `200 OK` and `Remote file exists`. If it
+    fails, connect PC2 to Wi-Fi using Unitree's networking instructions. On
+    macOS, you can also [temporarily share your development machine's internet
+    connection](#temporary-macos-internet-sharing).
+  </Step>
 
-```bash
-passwd
-```
+  <Step>
+    ### Install Wendy Agent
 
-Disconnect and confirm that the new credential works over the isolated link.
-Do not proceed to internet access or enrollment until this check succeeds. Use
-your organization's SSH-key and password-login policy for longer-term access.
+    Download and run the installer on PC2:
 
-On PC2, record the image and network state. G1 images in the field do not all
-run the same Ubuntu or JetPack version.
+    ```bash
+    wget -O /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
+    less /tmp/wendy-agent.sh
+    bash /tmp/wendy-agent.sh
+    ```
 
-```bash
-uname -m
-. /etc/os-release && echo "$PRETTY_NAME"
-cat /etc/nv_tegra_release
-ip -br address
-ip route
-```
+    <Callout type="warning">
+      Stop if APT says it will remove Docker or replace Docker's
+      `containerd.io` package. Resolve the package conflict before continuing.
+    </Callout>
 
-If `/etc/nv_tegra_release` reports R36.4.3, NVIDIA maps the installed BSP to
-JetPack 6.2. Check the BSP release directly because a JetPack metapackage might
-not be installed on a vendor image.
-
-## Step 3: Check internet access
-
-Unitree's JetPack 6.2 image includes `wget` but not `curl`. Do not
-reconfigure routing if PC2 can already reach the installer:
-
-```bash
-wget --spider https://install.wendy.dev/agent.sh
-```
-
-If this reports `200 OK` and `Remote file exists`, skip to Step 4.
-
-PC2 may already be connected to Wi-Fi. A persistent, organization-approved
-Wi-Fi connection is preferable to routing through the developer machine.
-
-<Callout type="info">
-  Interface names vary by image and might not be `wlan0`. Use `ip -br address`
-  to identify the wireless interface. If PC2 is not already online, follow
-  Unitree's networking instructions for the installed image, then repeat the
-  internet check above.
-</Callout>
-
-### Temporary macOS internet sharing fallback
-
-Use this only when PC2 has no approved direct network path. The procedure uses
-a named `com.apple` packet-filter anchor so it does not replace the Mac's main
-ruleset.
-
-Run these commands on the Mac in one terminal and keep it open so the saved
-values are available for cleanup:
-
-```bash
-UPLINK=$(route -n get default | awk '/interface:/{print $2}')
-ORIGINAL_FORWARDING=$(sysctl -n net.inet.ip.forwarding)
-PF_TOKEN=$(sudo pfctl -E 2>&1 | awk '/Token :/ {print $3}')
-
-printf 'nat on %s from 192.168.123.0/24 to any -> (%s)\n' \
-  "$UPLINK" "$UPLINK" | \
-  sudo pfctl -a com.apple/wendy-g1 -f -
-sudo sysctl -w net.inet.ip.forwarding=1
-```
+    Verify the installation:
 
-Back on PC2, identify the interface carrying `192.168.123.164`, then route
-through the developer machine. Do not assume it is named `eth0`. `ip route
-replace` handles a pre-existing placeholder default route. Replace `1.1.1.1`
-with an approved DNS resolver when required by your organization.
-
-```bash
-PC2_ETHERNET=$(ip -br address | \
-  awk '$3 ~ /^192\.168\.123\.164\// {print $1; exit}')
-test -n "$PC2_ETHERNET"
-sudo ip route replace default via 192.168.123.99 \
-  dev "$PC2_ETHERNET" metric 100
-sudo resolvectl dns "$PC2_ETHERNET" 1.1.1.1
-wget --spider https://install.wendy.dev/agent.sh
-```
+    ```bash
+    sudo systemctl is-active wendy-agent
+    ```
 
-<Callout type="warning">
-  These routing and packet-filter settings are temporary and are lost on
-  reboot. Run the teardown commands below when installation is complete.
-</Callout>
+    The command should report `active`.
+  </Step>
 
-After installation, remove the temporary route and DNS setting on PC2:
-
-```bash
-sudo ip route del default via 192.168.123.99 dev "$PC2_ETHERNET"
-sudo resolvectl revert "$PC2_ETHERNET"
-```
-
-Then restore the Mac in the same terminal used to create the anchor:
-
-```bash
-sudo pfctl -a com.apple/wendy-g1 -F all
-if [ -n "${PF_TOKEN:-}" ]; then sudo pfctl -X "$PF_TOKEN"; fi
-sudo sysctl -w net.inet.ip.forwarding="$ORIGINAL_FORWARDING"
-```
+  <Step>
+    ### Discover the G1
 
-## Step 4: Install wendy-agent
-
-First inspect the existing container runtime without modifying it:
-
-```bash
-command -v containerd && containerd --version
-systemctl is-active containerd || true
-```
+    Return to your development machine and run:
 
-Do not unconditionally install or upgrade `containerd`. The Wendy Debian
-package declares it as a dependency, so APT installs it when absent. This
-avoids unexpectedly restarting an existing runtime merely to perform a check.
+    ```bash
+    wendy discover
+    ```
 
-<Callout type="warning">
-  If PC2 uses Docker's `containerd.io` package, do not approve an APT
-  transaction that removes Docker or replaces its runtime. Preserve the
-  existing container workloads and resolve the package conflict before
-  installing Wendy Agent.
-</Callout>
-
-Download the installer so it can be reviewed before execution:
-
-```bash
-wget -O /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
-less /tmp/wendy-agent.sh
-bash /tmp/wendy-agent.sh
-```
-
-For a non-interactive SSH or provisioning session, pass the documented `-y`
-flag. The pipe-only form requires `/dev/tty` unless this flag is supplied.
-
-```bash
-bash /tmp/wendy-agent.sh -y
-```
-
-The installer adds Wendy's signed APT repository and keyring, installs
-`wendy-agent` and its dependencies, writes systemd units and configuration,
-and advertises the agent through Avahi/mDNS.
-
-The installer selects the latest package available from Wendy's signed APT
-repository. Record the installed version with `dpkg-query -W wendy-agent` when
-maintaining a reproducible fleet configuration.
-
-### Pre-enroll into Wendy Cloud (optional)
-
-On the developer machine, `wendy install` and **Linux Desktop** produce the
-enrollment values for the generic Linux agent used by PC2. The enrollment token
-expires after about an hour.
-
-To keep the token out of shell history on PC2, read it into an environment
-variable instead of writing it directly in the command:
-
-```bash
-read -rsp "Wendy enrollment token: " WENDY_ENROLLMENT_TOKEN; echo
-export WENDY_ENROLLMENT_TOKEN
-WENDY_CLOUD_HOST=<cloud-host> bash /tmp/wendy-agent.sh -y
-unset WENDY_ENROLLMENT_TOKEN
-```
-
-The agent enrolls on first startup. Host the G1 on a trusted network and change
-the factory SSH password before enabling remote management.
-
-### Verify the installation
-
-```bash
-sudo systemctl is-active wendy-agent
-sudo systemctl status --no-pager wendy-agent
-```
-
-If an upgrade leaves an enabled service inactive, start it and inspect the
-journal:
-
-```bash
-sudo systemctl start wendy-agent
-sudo journalctl -u wendy-agent -n 100 --no-pager
-```
-
-Inspect the listening services before connecting PC2 to a shared network:
-
-```bash
-sudo ss -tlnp | grep wendy-agent
-```
-
-The advertised agent port can change with enrollment state: an unenrolled
-agent normally advertises plaintext port `50051`, while a provisioned agent
-normally advertises the mTLS port `50052`. Other agent services can include the
-mesh proxy on `50058` and the embedded development registry on `5000`. Apply
-your organization's firewall policy and treat `wendy discover` as the source
-of truth for the connection address.
-
-## Step 5: Discover PC2
-
-Back on the developer machine:
-
-```bash
-wendy discover
-```
-
-The device may appear under a generic Ubuntu hostname rather than a name that
-contains “G1.” Match its address, architecture, operating system, and agent
-version to the PC2 values recorded earlier. A configured device can appear as
-**Unitree G1 Nx** at `unitree-g1-nx.local` on the advertised mTLS port `50052`.
-Use `wendy device info` to confirm the Ethernet and Wi-Fi addresses reported by
-PC2 rather than relying on a fixed hostname.
-
-You are done when all of the following are true:
-
-- `systemctl is-active wendy-agent` reports `active` on PC2
-- `wendy discover` lists PC2 and its advertised port
-- the developer machine can connect to that advertised address
-
-Once you have created or opened a Wendy project containing `wendy.json`, you
-can deploy it to the address shown by discovery:
-
-```bash
-cd <your-wendy-project>
-wendy run --device <address-from-wendy-discover>
-```
+    PC2 may appear under its Ubuntu hostname or as **Unitree G1 Nx**. Use the
+    address shown by `wendy discover` when deploying an app:
+
+    ```bash
+    cd <your-wendy-project>
+    wendy run --device <address-from-wendy-discover>
+    ```
+
+    PC2 is now ready for Wendy app development. You can use the app, device,
+    debugging, and robotics guides throughout these docs. WendyOS installation
+    guides do not apply because PC2 continues to run Unitree's Ubuntu image.
+  </Step>
+</Steps>
+
+## Wendy Cloud Enrollment
+
+Cloud enrollment is optional. On your development machine, run `wendy install`
+and select **Linux Desktop** to generate an enrollment command for PC2. The
+enrollment token expires after about an hour.
+
+Run the generated command on PC2. The G1 will then appear in Wendy Cloud when
+it is online.
 
 ## Work with the G1 from an app
 
@@ -397,6 +225,58 @@ session.
 
 ## Troubleshooting
 
+### Temporary macOS Internet Sharing
+
+Use these steps if PC2 cannot connect to Wi-Fi. They share your Mac's internet
+connection with PC2 over the Ethernet cable.
+
+<Accordions>
+  <Accordion title="Share your Mac's internet connection">
+    On your Mac, open a terminal and run:
+
+    ```bash
+    UPLINK=$(route -n get default | awk '/interface:/{print $2}')
+    ORIGINAL_FORWARDING=$(sysctl -n net.inet.ip.forwarding)
+    PF_TOKEN=$(sudo pfctl -E 2>&1 | awk '/Token :/ {print $3}')
+
+    printf 'nat on %s from 192.168.123.0/24 to any -> (%s)\n' \
+      "$UPLINK" "$UPLINK" | \
+      sudo pfctl -a com.apple/wendy-g1 -f -
+    sudo sysctl -w net.inet.ip.forwarding=1
+    ```
+
+    Keep this terminal open. You will use the saved values to restore the Mac
+    after installing Wendy Agent.
+
+    On PC2, run:
+
+    ```bash
+    PC2_ETHERNET=$(ip -br address | \
+      awk '$3 ~ /^192\.168\.123\.164\// {print $1; exit}')
+    test -n "$PC2_ETHERNET"
+    sudo ip route replace default via 192.168.123.99 \
+      dev "$PC2_ETHERNET" metric 100
+    sudo resolvectl dns "$PC2_ETHERNET" 1.1.1.1
+    wget --spider https://install.wendy.dev/agent.sh
+    ```
+
+    After installing Wendy Agent, remove the temporary settings from PC2:
+
+    ```bash
+    sudo ip route del default via 192.168.123.99 dev "$PC2_ETHERNET"
+    sudo resolvectl revert "$PC2_ETHERNET"
+    ```
+
+    Return to the same terminal on your Mac and run:
+
+    ```bash
+    sudo pfctl -a com.apple/wendy-g1 -F all
+    if [ -n "${PF_TOKEN:-}" ]; then sudo pfctl -X "$PF_TOKEN"; fi
+    sudo sysctl -w net.inet.ip.forwarding="$ORIGINAL_FORWARDING"
+    ```
+  </Accordion>
+</Accordions>
+
 - **`wendy discover` shows nothing on macOS:** Check System Settings → Privacy
   & Security → Local Network and make sure the terminal has access. Verify the
   advertisement with `dns-sd -B _wendyos._udp`.
@@ -439,194 +319,11 @@ place. Review and remove those directories separately only when their data is
 no longer needed. Do not remove `containerd` automatically because Docker,
 Unitree software, or other workloads may use it.
 
-## Optional: update PC2 to Unitree's JetPack 6.2 image
+## Reflash PC2
 
-Wendy Agent does not require this update. Use this separate recovery procedure
-only when PC2 must be migrated from an older image such as JetPack 5.1.1 to
-Unitree's G1-specific JetPack 6.2 image. The Unitree image installs Jetson Linux
-and the G1 board support; it does not necessarily install NVIDIA's complete
-`nvidia-jetpack` development metapackage.
-
-<Callout type="warning">
-  This is a destructive SSD and PC2 firmware replacement, not an APT upgrade.
-  Preserve the original NVMe, identify the replacement disk on the Ubuntu host,
-  and verify every device path before writing. Never flash the G1's private
-  motion-control computer.
-</Callout>
-
-### Required hardware and packages
-
-- The original PC2 NVMe, removed and preserved as a physical backup
-- A replacement NVMe of at least 1 TB
-- Native Ubuntu x86-64 host
-- NVMe-to-USB enclosure and a USB data cable
-- Unitree system image: `g1-nx-j6.2.img.bz2`
-- Unitree PC2 firmware package: `Jetpack_6.2_nx.tar.bz2`
-
-Download both matching packages through NVIDIA's
-[G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html),
-which links the
-[JetPack 6.2 package folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
-Confirm the filenames and integrity against the current upstream instructions
-before flashing.
-
-Two matching packages are required because the NVMe operating system and the
-Orin NX module firmware are separate:
-
-```text
-Orin NX module
-├── QSPI/boot firmware       Jetpack_6.2_nx.tar.bz2 over recovery USB
-└── NVMe operating system    g1-nx-j6.2.img.bz2 written to the replacement SSD
-```
-
-Do not substitute a generic NVIDIA Orin NX image; it does not contain the G1
-carrier-board configuration.
-
-### 1. Inspect and preserve the original drive
-
-Remove the original drive from PC2 and preserve it unchanged as the physical
-backup. If you inspect it over USB, mount it read-only. Write the JetPack 6.2
-image only to the replacement drive.
-
-The original NVMe is a data backup, but it is not a complete one-step rollback.
-After PC2's module firmware is updated to JetPack 6.2, booting JetPack 5.1.1
-again also requires restoring the matching Unitree JetPack 5.1.1 module
-firmware.
-
-### 2. Identify the replacement NVMe on the Ubuntu host
-
-Attach the replacement NVMe through the USB enclosure. Before writing anything,
-identify its model, capacity, USB transport, partitions, and the Ubuntu host's
-root device:
-
-```bash
-lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN
-findmnt -no SOURCE /
-```
-
-Replace `/dev/sdX` below with the whole-disk path reported for the replacement
-NVMe, then inspect it again:
-
-```bash
-lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,LABEL,MOUNTPOINTS /dev/sdX
-```
-
-<Callout type="warning">
-  `/dev/sdX` is a placeholder. Stop unless your output identifies the intended
-  replacement NVMe and shows a different device for the Ubuntu host's root
-  filesystem. Writing to the wrong whole-disk path destroys that disk.
-</Callout>
-
-Unmount any mounted partitions on the replacement drive:
-
-```bash
-sudo umount /dev/sdX*
-```
-
-Write the Unitree system image to the whole replacement drive:
-
-```bash
-bzip2 -dc g1-nx-j6.2.img.bz2 | \
-  sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
-sudo sync
-sudo udisksctl power-off -b /dev/sdX
-```
-
-After the write and power-off complete, disconnect the replacement NVMe from the
-enclosure and install it in PC2.
-
-### 3. Put the G1 development computer into recovery mode
-
-With the replacement NVMe installed, use the two PC2 buttons inside the rear
-electronics compartment. PWR is the upper button; REC is the lower button above
-PC2's USB-C flashing port.
-
-1. Power on the G1 and wait for all three power indicators to remain steady.
-2. Hold PWR and REC together for about two seconds.
-3. Release PWR while continuing to hold REC for two more seconds.
-4. Release REC.
-5. Connect the Ubuntu host to PC2's dedicated USB-C flashing port with a data
-   cable.
-
-On the Ubuntu host, confirm that the Orin NX appears in APX recovery mode:
-
-```bash
-lsusb
-```
-
-Continue only after `lsusb` displays `NVIDIA Corp. APX`.
-
-### 4. Flash the matching PC2 module firmware
-
-Keep the firmware archive on the Ubuntu host; do not copy it to the replacement
-NVMe or PC2. From the directory containing the archive, run:
-
-```bash
-sudo tar -xjvf Jetpack_6.2_nx.tar.bz2
-cd Jetpack_6.2_nx/Linux_for_Tegra
-lsusb | grep -i nvidia
-sudo ./flash_nx_module.sh
-```
-
-The G1 remained powered and connected over USB until the script explicitly
-reported success. The process took approximately eight minutes.
-
-### 5. Boot and verify the updated PC2
-
-After the firmware script completed, the G1 was powered off and the recovery
-USB cable was disconnected. The replacement NVMe was checked for secure
-installation, the rear compartment was closed, and the G1 was powered on
-normally. The first boot was given several minutes before attempting network
-access.
-
-Check PC2 without enabling motion:
-
-```bash
-ping 192.168.123.164
-ssh unitree@192.168.123.164
-
-cat /etc/nv_tegra_release
-cat /etc/os-release
-command -v nvcc && nvcc --version
-uname -a
-```
-
-NVIDIA's
-[JetPack 6.2 release page](https://developer.nvidia.com/embedded/jetpack-sdk-62)
-identifies R36.4.3 as the Jetson Linux release included with JetPack 6.2. Use
-the BSP value from `/etc/nv_tegra_release` as the authoritative version if a
-management tool displays a different JetPack label.
-
-The Unitree image might not install `nvidia-jetpack` or `nvcc`. Their absence
-does not indicate a failed PC2 firmware flash and does not block Wendy Agent.
-Treat CUDA toolkit installation as a separate application prerequisite, and
-confirm the supported packages with Unitree for this carrier-board image before
-changing the NVIDIA software stack.
-
-Verify the Intel RealSense and other non-motion hardware from the developer
-machine:
-
-```bash
-wendy device camera list --device unitree-g1-nx.local:50052
-wendy device hardware list --device unitree-g1-nx.local:50052
-```
-
-Camera enumeration does not guarantee that another process can open the stream.
-If a camera viewer reports that the RealSense is busy, stop only the known
-camera-owning service during a maintenance window, then retry. Do not interrupt
-an unidentified robot workload.
-
-Perform post-update checks in this order:
-
-- Ethernet and Wi-Fi
-- USB devices and cameras
-- GPU and CUDA
-- Unitree services and DDS communication
-- G1 app video/image display
-- Controlled motion only after all non-motion checks passed
-
-Keep the G1 supported on its gantry and keep the physical remote and E-stop with
-the operator for the final controlled-motion check.
+Reflashing PC2 is a separate recovery procedure and is not required to install
+Wendy Agent. See [Reflash Unitree G1 PC2](/docs/installation/unitree-g1-reflash)
+to replace the PC2 operating system and module firmware.
 
 ## Next steps
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -1,0 +1,170 @@
+---
+title: Unitree G1
+description: Install wendy-agent on the Unitree G1's onboard computer to deploy and manage apps with Wendy
+---
+
+## Overview
+
+The Unitree G1 EDU ships with an onboard development computer — an ARM64 NVIDIA
+Jetson running Ubuntu — wired into the robot's internal network. Installing
+`wendy-agent` on it turns the G1 into a managed Wendy device: you can deploy
+containerized apps to it with `wendy run`, stream logs and telemetry, and talk
+to the robot's control stack (DDS / `unitree_sdk2`) from your apps.
+
+This guide installs **only the agent** on the G1's existing system. It does not
+reflash anything — the robot's own control software, balance controller, and
+Unitree services are untouched, and apps you deploy run in containers alongside
+them.
+
+## Requirements
+
+- A Unitree G1 EDU (the model with the onboard development computer)
+- The Wendy CLI on your developer machine ([setup guide](/docs/installation/developer-machine-setup))
+- An Ethernet cable (and a USB-C-to-Ethernet adapter if your machine has no port)
+- The SSH credentials for your robot's development computer (see your Unitree
+  documentation; the factory default user is `unitree`)
+
+## Step 1: Connect to the robot
+
+Connect an Ethernet cable from your developer machine to the RJ45 port on the
+G1. The robot's internal network uses the fixed subnet `192.168.123.0/24`, and
+the development computer is at **`192.168.123.164`**.
+
+Give your machine a static address on that subnet.
+
+On macOS (replace `en5` with your adapter's interface):
+
+```bash
+sudo ifconfig en5 inet 192.168.123.99 netmask 255.255.255.0
+```
+
+On Linux:
+
+```bash
+sudo ip addr add 192.168.123.99/24 dev eth0
+```
+
+Verify you can reach the robot:
+
+```bash
+ping 192.168.123.164
+```
+
+## Step 2: Share internet with the robot
+
+Fresh from the factory, the G1's development computer has **no internet
+access** — its default gateway (`192.168.123.1`) is a placeholder that doesn't
+exist. The installer downloads `wendy-agent` from the internet, so share your
+machine's connection first.
+
+On macOS, enable IP forwarding and NAT from your Wi-Fi to the robot link:
+
+```bash
+sudo sysctl -w net.inet.ip.forwarding=1
+echo "nat on en0 from 192.168.123.0/24 to any -> (en0)" | sudo pfctl -f - -e
+```
+
+Then, over SSH on the robot (next step), route through your machine:
+
+```bash
+sudo ip route add default via 192.168.123.99 dev eth0 metric 100
+sudo resolvectl dns eth0 1.1.1.1
+```
+
+## Step 3: SSH into the development computer
+
+```bash
+ssh unitree@192.168.123.164
+```
+
+Check that `containerd` (which `wendy-agent` uses to run apps) is present and
+running:
+
+```bash
+sudo apt-get install -y containerd
+sudo systemctl enable --now containerd
+```
+
+## Step 4: Install wendy-agent
+
+On the robot, run:
+
+```bash
+curl -fsSL https://install.wendy.dev/agent.sh | bash
+```
+
+This installs the `wendy-agent` service and registers the robot on the network
+via mDNS.
+
+### Pre-enrolling into your org (optional)
+
+Running `wendy install` on your developer machine and choosing **Linux
+Desktop** while logged in prints a one-liner carrying a short-lived enrollment
+token:
+
+```bash
+curl -fsSL https://install.wendy.dev/agent.sh | \
+  WENDY_ENROLLMENT_TOKEN=<token> WENDY_CLOUD_HOST=<cloud-host> bash
+```
+
+The agent enrolls into your organization on first startup, so you can manage
+the G1 through [Wendy Cloud](/docs/cloud) even when you're not on its network.
+
+### Verify the installation
+
+```bash
+sudo systemctl status wendy-agent
+```
+
+You should see the service active and running.
+
+## Step 5: Discover the robot
+
+Back on your developer machine:
+
+```bash
+wendy discover
+```
+
+The G1 appears in the device list. You can now deploy to it like any Wendy
+device — or target it directly by address:
+
+```bash
+wendy run --device 192.168.123.164
+```
+
+## Working with the robot from your apps
+
+Apps that talk to the G1's control stack communicate over DDS on the robot's
+internal network. Two things matter in your `wendy.json`:
+
+- Use a **host network entitlement** (`{ "type": "network", "mode": "host" }`)
+  so your container can reach the DDS traffic on `eth0`.
+- The G1 uses the `unitree_hg` message package (`/lowstate`, `/lowcmd`) — not
+  `unitree_go`, which is for the Go2/B2. A wrong import connects but silently
+  receives nothing.
+
+If you're using ROS 2, see the [Robotics integration](/docs/integrations/ros2)
+guide — `wendy` can introspect the live ROS 2 graph on the robot with no SSH.
+
+<Callout type="warn">
+  Installing the agent does not move the robot, but apps that publish motion
+  commands will. When developing motion apps, keep the G1 suspended on its
+  gantry or in damping mode, and gate actuation behind an explicit switch in
+  your app.
+</Callout>
+
+## Troubleshooting
+
+- **`wendy discover` shows nothing on macOS** — check System Settings →
+  Privacy & Security → Local Network and make sure your terminal has access.
+  You can verify the robot is advertising with `dns-sd -B _wendyos._udp`.
+- **Agent unreachable** — check the port directly:
+  `nc -zv 192.168.123.164 50051`.
+- **Installer fails to download** — the robot has no internet; revisit Step 2.
+
+## Next Steps
+
+- [Hello World in Python](/docs/guides/tutorials/python/hello-world)
+- [ROS 2 on Wendy devices](/docs/integrations/ros2)
+- [App entitlements](/docs/device/entitlements)

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -477,6 +477,12 @@ not part of the Wendy Agent installation flow.
 - Unitree system image: `g1-nx-j6.2.img.bz2`
 - Unitree PC2 firmware package: `Jetpack_6.2_nx.tar.bz2`
 
+The lab downloaded both packages from this
+[Google Drive folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
+This is the exact download location used for the lab flash, not a guarantee that
+the folder remains current or controlled by Unitree. Confirm the files and
+their integrity with Unitree before using them on another G1.
+
 The lab used two matching packages because the NVMe operating system and the
 Orin NX module firmware are separate:
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -5,183 +5,410 @@ description: Install wendy-agent on the Unitree G1's onboard computer to deploy 
 
 ## Overview
 
-The Unitree G1 EDU ships with an onboard development computer — an ARM64 NVIDIA
-Jetson running Ubuntu — wired into the robot's internal network. Installing
-`wendy-agent` on it turns the G1 into a managed Wendy device: you can deploy
-containerized apps to it with `wendy run`, stream logs and telemetry, and talk
-to the robot's control stack (DDS / `unitree_sdk2`) from your apps.
+The Unitree G1 EDU includes an ARM64 NVIDIA Jetson development computer, also
+known as PC2, on the robot's internal network. Installing `wendy-agent` on PC2
+lets you deploy containerized apps with `wendy run`, stream logs and telemetry,
+and communicate with the robot's DDS and `unitree_sdk2` interfaces.
 
-This guide installs **only the agent** on the G1's existing system. It does not
-reflash anything — the robot's own control software, balance controller, and
-Unitree services are untouched, and apps you deploy run in containers alongside
-them.
+This procedure does not reflash the G1 or install software on the separate
+motion-control computer. It does make persistent changes to PC2: the installer
+adds Wendy's signed APT repository, installs packages and systemd services, and
+adds an Avahi service for mDNS discovery.
+
+<Callout type="warning">
+  This page is still under hardware validation. Before publication, Wendy will
+  repeat the entire procedure on a factory-fresh Ubuntu 20.04 G1 and verify the
+  physical Ethernet port, default credentials, container runtime packages,
+  Wi-Fi setup, macOS and Linux internet-sharing procedures, upgrade behavior,
+  advertised agent ports, and rollback steps. Do not use this draft for
+  unattended or production provisioning yet.
+</Callout>
 
 ## Requirements
 
-- A Unitree G1 EDU (the model with the onboard development computer)
-- The Wendy CLI on your developer machine ([setup guide](/docs/installation/developer-machine-setup))
-- An Ethernet cable (and a USB-C-to-Ethernet adapter if your machine has no port)
-- The SSH credentials for your robot's development computer (see your Unitree
-  documentation; the factory default user is `unitree`)
+- A Unitree G1 EDU with the onboard development computer
+- The Wendy CLI on the developer machine ([setup guide](/docs/installation/developer-machine-setup))
+- A working internet connection on the developer machine
+- An Ethernet cable and, if needed, a USB-to-Ethernet adapter
+- Administrator access on the developer machine and `sudo` access on PC2
+- Approximately 15–30 minutes
 
-## Step 1: Connect to the robot
+The factory account documented for PC2 is:
 
-Connect an Ethernet cable from your developer machine to the RJ45 port on the
-G1. The robot's internal network uses the fixed subnet `192.168.123.0/24`, and
-the development computer is at **`192.168.123.164`**.
-
-Give your machine a static address on that subnet.
-
-On macOS (replace `en5` with your adapter's interface):
-
-```bash
-sudo ifconfig en5 inet 192.168.123.99 netmask 255.255.255.0
+```text
+Address:  192.168.123.164
+Username: unitree
+Password: 123
 ```
 
-On Linux:
+Change the shared factory password or install an SSH key before connecting PC2
+to Wi-Fi or another shared network.
+
+## Step 1: Connect the developer machine
+
+Connect the developer machine to the G1 Ethernet port that reaches PC2. The
+stock internal network is `192.168.123.0/24`, and PC2 is
+**`192.168.123.164`**.
+
+<Callout type="warning">
+  G1 hardware revisions can expose more than one RJ45 port. Wendy will add a
+  labeled port photograph after testing a factory-stock unit. Until then, use
+  Unitree's hardware documentation to identify the port connected to PC2. A
+  live Ethernet link alone does not prove that the correct port was selected.
+</Callout>
+
+### macOS
+
+Find the USB Ethernet device and its network-service name:
 
 ```bash
-sudo ip addr add 192.168.123.99/24 dev eth0
+networksetup -listallhardwareports
+networksetup -listnetworkserviceorder
 ```
 
-Verify you can reach the robot:
+Replace `<robot-link-service>` with the corresponding network service. Leave
+the router value empty so this isolated link does not replace the Mac's real
+default route:
+
+```bash
+sudo networksetup -setmanual "<robot-link-service>" \
+  192.168.123.99 255.255.255.0 ""
+```
+
+Confirm the Ethernet link is active and the default route still uses the Mac's
+real internet uplink:
+
+```bash
+ifconfig <robot-link-interface>
+route -n get default | grep interface
+```
+
+### Linux
+
+Find the wired interface, then assign the robot-link address. Do not add a
+gateway to this interface:
+
+```bash
+ip -br link
+sudo ip addr replace 192.168.123.99/24 dev <robot-link-interface>
+sudo ip link set <robot-link-interface> up
+```
+
+This Linux address is temporary unless it is also added to the distribution's
+persistent network configuration.
+
+### Verify the link
 
 ```bash
 ping 192.168.123.164
 ```
 
-## Step 2: Share internet with the robot
+A successful reply confirms Layer 3 connectivity to PC2. If it fails, verify
+the physical port, interface name, link status, IP address, and subnet mask
+before continuing.
 
-Fresh from the factory, the G1's development computer has **no internet
-access** — its default gateway (`192.168.123.1`) is a placeholder that doesn't
-exist. The installer downloads `wendy-agent` from the internet, so share your
-machine's connection first.
-
-On macOS, enable IP forwarding and NAT from your Wi-Fi to the robot link:
-
-```bash
-sudo sysctl -w net.inet.ip.forwarding=1
-echo "nat on en0 from 192.168.123.0/24 to any -> (en0)" | sudo pfctl -f - -e
-```
-
-Then, over SSH on the robot (next step), route through your machine:
-
-```bash
-sudo ip route add default via 192.168.123.99 dev eth0 metric 100
-sudo resolvectl dns eth0 1.1.1.1
-```
-
-## Step 3: SSH into the development computer
+## Step 2: SSH into PC2
 
 ```bash
 ssh unitree@192.168.123.164
 ```
 
-Check that `containerd` (which `wendy-agent` uses to run apps) is present and
-running:
+On PC2, record the image and network state. G1 images in the field do not all
+run the same Ubuntu or JetPack version.
 
 ```bash
-sudo apt-get install -y containerd
-sudo systemctl enable --now containerd
+uname -m
+. /etc/os-release && echo "$PRETTY_NAME"
+ip -br address
+ip route
+```
+
+## Step 3: Check internet access
+
+Do not reconfigure routing if PC2 can already reach the installer:
+
+```bash
+curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
+```
+
+If this prints an HTTP success response, skip to Step 4.
+
+PC2 may already be connected to Wi-Fi. A persistent, organization-approved
+Wi-Fi connection is preferable to routing through the developer machine.
+
+<Callout type="warning">
+  The exact PC2 Wi-Fi procedure will be tested on the factory Ubuntu 20.04
+  image before publication. Use Unitree's networking instructions for the
+  current image, then repeat the internet check above.
+</Callout>
+
+### Temporary macOS internet sharing fallback
+
+Use this only when PC2 has no approved direct network path. The previous draft
+used `pfctl -f -`, which replaces the Mac's main packet-filter ruleset. The
+replacement below uses a named `com.apple` anchor instead.
+
+Run these commands on the Mac in one terminal and keep it open so the saved
+values are available for cleanup:
+
+```bash
+UPLINK=$(route -n get default | awk '/interface:/{print $2}')
+ORIGINAL_FORWARDING=$(sysctl -n net.inet.ip.forwarding)
+PF_TOKEN=$(sudo pfctl -E 2>&1 | awk '/Token :/ {print $3}')
+
+printf 'nat on %s from 192.168.123.0/24 to any -> (%s)\n' \
+  "$UPLINK" "$UPLINK" | \
+  sudo pfctl -a com.apple/wendy-g1 -f -
+sudo sysctl -w net.inet.ip.forwarding=1
+```
+
+Back on PC2, route through the developer machine. `ip route replace` handles a
+pre-existing placeholder default route. Replace `1.1.1.1` with an approved DNS
+resolver when required by your organization.
+
+```bash
+sudo ip route replace default via 192.168.123.99 dev eth0 metric 100
+sudo resolvectl dns eth0 1.1.1.1
+curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
+```
+
+<Callout type="warning">
+  The named-anchor procedure is safer than replacing the main PF ruleset, but
+  Wendy will perform another end-to-end G1 test before publication. A Linux
+  internet-sharing fallback will also be tested and documented. These settings
+  are temporary and are lost on reboot.
+</Callout>
+
+After installation, remove the temporary route and DNS setting on PC2:
+
+```bash
+sudo ip route del default via 192.168.123.99 dev eth0
+sudo resolvectl revert eth0
+```
+
+Then restore the Mac in the same terminal used to create the anchor:
+
+```bash
+sudo pfctl -a com.apple/wendy-g1 -F all
+if [ -n "${PF_TOKEN:-}" ]; then sudo pfctl -X "$PF_TOKEN"; fi
+sudo sysctl -w net.inet.ip.forwarding="$ORIGINAL_FORWARDING"
 ```
 
 ## Step 4: Install wendy-agent
 
-On the robot, run:
+First inspect the existing container runtime without modifying it:
 
 ```bash
-curl -fsSL https://install.wendy.dev/agent.sh | bash
+command -v containerd && containerd --version
+systemctl is-active containerd || true
 ```
 
-This installs the `wendy-agent` service and registers the robot on the network
-via mDNS.
+Do not unconditionally install or upgrade `containerd`. The Wendy Debian
+package declares it as a dependency, so APT installs it when absent. This
+avoids unexpectedly restarting an existing runtime merely to perform a check.
 
-### Pre-enrolling into your org (optional)
+<Callout type="warning">
+  Wendy will test a factory image with no runtime and an image using Docker's
+  `containerd.io` package before publication. This is required to confirm that
+  dependency resolution does not remove or replace an existing Docker runtime.
+</Callout>
 
-Running `wendy install` on your developer machine and choosing **Linux
-Desktop** while logged in prints a one-liner carrying a short-lived enrollment
-token:
+Download the installer so it can be reviewed before execution:
 
 ```bash
-curl -fsSL https://install.wendy.dev/agent.sh | \
-  WENDY_ENROLLMENT_TOKEN=<token> WENDY_CLOUD_HOST=<cloud-host> bash
+curl -fsSLo /tmp/wendy-agent.sh https://install.wendy.dev/agent.sh
+less /tmp/wendy-agent.sh
+bash /tmp/wendy-agent.sh
 ```
 
-The agent enrolls into your organization on first startup, so you can manage
-the G1 through [Wendy Cloud](/docs/cloud) even when you're not on its network.
+For a non-interactive SSH or provisioning session, pass the documented `-y`
+flag. The pipe-only form requires `/dev/tty` unless this flag is supplied.
+
+```bash
+bash /tmp/wendy-agent.sh -y
+```
+
+The installer adds Wendy's signed APT repository and keyring, installs
+`wendy-agent` and its dependencies, writes systemd units and configuration,
+and advertises the agent through Avahi/mDNS.
+
+<Callout type="warning">
+  The APT installation path currently tracks the latest published package.
+  Wendy will add and test an explicit version-pinning workflow before using
+  this page as a reproducible fleet-provisioning reference.
+</Callout>
+
+### Pre-enroll into Wendy Cloud (optional)
+
+On the developer machine, `wendy install` and **Linux Desktop** produce the
+enrollment values for the generic Linux agent used by PC2. The enrollment token
+expires after about an hour.
+
+To keep the token out of shell history on PC2, read it into an environment
+variable instead of writing it directly in the command:
+
+```bash
+read -rsp "Wendy enrollment token: " WENDY_ENROLLMENT_TOKEN; echo
+export WENDY_ENROLLMENT_TOKEN
+WENDY_CLOUD_HOST=<cloud-host> bash /tmp/wendy-agent.sh -y
+unset WENDY_ENROLLMENT_TOKEN
+```
+
+The agent enrolls on first startup. Host the G1 on a trusted network and change
+the factory SSH password before enabling remote management.
 
 ### Verify the installation
 
 ```bash
-sudo systemctl status wendy-agent
+sudo systemctl is-active wendy-agent
+sudo systemctl status --no-pager wendy-agent
 ```
 
-You should see the service active and running.
+If an upgrade leaves an enabled service inactive, start it and inspect the
+journal:
 
-## Step 5: Discover the robot
+```bash
+sudo systemctl start wendy-agent
+sudo journalctl -u wendy-agent -n 100 --no-pager
+```
 
-Back on your developer machine:
+<Callout type="warning">
+  An upgrade test observed the package stopping an existing agent without
+  restarting it. Wendy will fix and retest the package lifecycle before this
+  guide is published. The manual start above is a temporary recovery step, not
+  the final expected upgrade behavior.
+</Callout>
+
+Inspect the listening services before connecting PC2 to a shared network:
+
+```bash
+sudo ss -tlnp | grep wendy-agent
+```
+
+The advertised agent port can change with enrollment state: an unenrolled
+agent normally advertises plaintext port `50051`, while a provisioned agent
+normally advertises the mTLS port `50052`. Other agent services can include the
+mesh proxy on `50058` and the embedded development registry on `5000`. Apply
+your organization's firewall policy and treat `wendy discover` as the source
+of truth for the connection address.
+
+## Step 5: Discover PC2
+
+Back on the developer machine:
 
 ```bash
 wendy discover
 ```
 
-The G1 appears in the device list. You can now deploy to it like any Wendy
-device — or target it directly by address:
+The device may appear under a generic Ubuntu hostname rather than a name that
+contains “G1.” Match its address, architecture, operating system, and agent
+version to the PC2 values recorded earlier.
+
+You are done when all of the following are true:
+
+- `systemctl is-active wendy-agent` reports `active` on PC2
+- `wendy discover` lists PC2 and its advertised port
+- the developer machine can connect to that advertised address
+
+Once you have created or opened a Wendy project containing `wendy.json`, you
+can deploy it to the address shown by discovery:
 
 ```bash
-wendy run --device 192.168.123.164
+cd <your-wendy-project>
+wendy run --device <address-from-wendy-discover>
 ```
 
-## Working with the robot from your apps
+## Work with the G1 from an app
 
-Apps that talk to the G1's control stack communicate over DDS on the robot's
-internal network. Two things matter in your `wendy.json`:
+Containers that communicate with Unitree DDS need host networking. A minimal
+service declaration looks like this:
 
-- Use a **host network entitlement** (`{ "type": "network", "mode": "host" }`)
-  so your container can reach the DDS traffic on `eth0`.
-- The G1 uses the `unitree_hg` message package (`/lowstate`, `/lowcmd`) — not
-  `unitree_go`, which is for the Go2/B2. A wrong import connects but silently
-  receives nothing.
+```json
+{
+  "$schema": "https://wendy.sh/schemas/wendy.json",
+  "appId": "com.example.g1-app",
+  "version": "0.1.0",
+  "platform": "linux",
+  "services": {
+    "app": {
+      "context": ".",
+      "entitlements": [
+        { "type": "network", "mode": "host" }
+      ]
+    }
+  }
+}
+```
+
+Host networking lets the container bind DDS to PC2's `eth0` interface. It also
+removes container network isolation and grants access to the robot's internal
+network. Unitree DDS traffic on that network is generally unauthenticated and
+unencrypted, so grant this entitlement only to trusted apps.
+
+The G1 uses the `unitree_hg` message package for low-level communication. The
+SDK topic names are `rt/lowstate` and `rt/lowcmd`. `unitree_go` is used by the
+Go2 and B2; using that package on a G1 can connect while receiving no useful
+messages.
 
 If you're using ROS 2, see the [Robotics integration](/docs/integrations/ros2)
-guide — `wendy` can introspect the live ROS 2 graph on the robot with no SSH.
+guide. Wendy can introspect the live ROS 2 graph without a separate SSH
+session.
 
-<Callout type="warn">
-  Installing the agent does not move the robot, but apps that publish motion
-  commands will. When developing motion apps, keep the G1 suspended on its
-  gantry or in damping mode, and gate actuation behind an explicit switch in
-  your app.
+<Callout type="warning">
+  Installing the agent does not move the robot, but a deployed app can. A
+  software Stop button is not a safety-rated E-stop. For every first motion
+  test, support the G1 on its gantry, keep the Unitree physical remote and
+  E-stop with the operator, require an explicit actuation gate, use short
+  command leases and live FSM readback, and ensure only one app owns motion.
 </Callout>
 
 ## Troubleshooting
 
-- **`wendy discover` shows nothing on macOS** — check System Settings →
-  Privacy & Security → Local Network and make sure your terminal has access.
-  You can verify the robot is advertising with `dns-sd -B _wendyos._udp`.
-- **Agent unreachable** — check the port directly:
-  `nc -zv 192.168.123.164 50051`.
-- **Installer fails to download** — the robot has no internet; revisit Step 2.
+- **`wendy discover` shows nothing on macOS:** Check System Settings → Privacy
+  & Security → Local Network and make sure the terminal has access. Verify the
+  advertisement with `dns-sd -B _wendyos._udp`.
+- **Agent unreachable:** Read the address and port from `wendy discover`, then
+  test that exact pair with `nc -zv <address> <advertised-port>`. Do not assume
+  every agent uses `50051` or `50052`.
+- **Installer reports `/dev/tty: No such device or address`:** Use the
+  downloaded script with `bash /tmp/wendy-agent.sh -y`.
+- **The service is enabled but inactive after an upgrade:** Run
+  `sudo systemctl start wendy-agent`, inspect the journal, and record the agent
+  package versions for the upgrade-lifecycle test.
+- **`wendy run` reports `wendy.json not found`:** Change into a Wendy project
+  or create one with `wendy init` before deploying.
+- **Installer download fails:** Re-run the internet check in Step 3. Inspect
+  both PC2's default route and the developer machine's default route before
+  changing either system.
+- **PC2 does not answer ping:** Recheck the physical G1 port, Ethernet link,
+  interface name, `192.168.123.99/24` address, and absence of a gateway on the
+  developer machine's robot-link service.
 
-## Next Steps
+## Remove the agent
 
-### Drive the G1 from your browser
-
-The fastest way to see the robot do something: the `g1-rc` template deploys
-a ready-made remote control — live camera view, touch joystick, posture and
-arm-gesture buttons, and a latching E-STOP — as one app:
+To remove Wendy from PC2 without removing the shared container runtime:
 
 ```bash
-wendy init --app-id my-g1-rc --template g1-rc --language python
-cd my-g1-rc
-wendy run --device 192.168.123.164
+sudo apt-get purge -y wendy-agent
+sudo rm -f /etc/apt/sources.list.d/wendy.list
+sudo rm -f /usr/share/keyrings/wendy-archive-keyring.gpg
+sudo apt-get update
 ```
 
-Then open `http://192.168.123.164:3500`, press **stand** → **ready-to-walk**,
-and drive. The scaffolded project's README covers the UI, the safety model,
-and how to customize it. First sessions: keep the robot on its gantry.
+This intentionally leaves `/var/lib/wendy-agent` and deployed app data in
+place. Review and remove those directories separately only when their data is
+no longer needed. Do not remove `containerd` automatically because Docker,
+Unitree software, or other workloads may use it.
 
-### Build your own apps
+## Next steps
+
+The `g1-rc` template referenced by the previous draft is not in the public
+template registry yet. Wendy will not publish browser-driving instructions
+until the template is available and has completed on-robot crane commissioning,
+authentication review, motion-owner exclusion tests, watchdog tests, and
+physical E-stop review.
+
+Start with a non-motion app instead:
 
 - [Hello World in Python](/docs/guides/tutorials/python/hello-world)
 - [ROS 2 on Wendy devices](/docs/integrations/ros2)

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -10,10 +10,12 @@ known as PC2, on the robot's internal network. Installing `wendy-agent` on PC2
 lets you deploy containerized apps with `wendy run`, stream logs and telemetry,
 and communicate with the robot's DDS and `unitree_sdk2` interfaces.
 
-This procedure does not reflash the G1 or install software on the separate
-motion-control computer. It does make persistent changes to PC2: the installer
-adds Wendy's signed APT repository, installs packages and systemd services, and
-adds an Avahi service for mDNS discovery.
+The Wendy Agent installation procedure does not reflash the G1 or install
+software on the separate motion-control computer. It does make persistent
+changes to PC2: the installer adds Wendy's signed APT repository, installs
+packages and systemd services, and adds an Avahi service for mDNS discovery.
+The optional JetPack appendix documents the separate recovery procedure used on
+the lab G1.
 
 <Callout type="info">
   These instructions follow Unitree's documented G1 development environment
@@ -29,6 +31,13 @@ Wendy Agent installer and upgrade recovery, and successful discovery from the
 developer machine. The tested robot was not factory-fresh, so clean-image
 dependency resolution and the revised internet-sharing commands remain marked
 for testing where they appear below.
+
+<Callout type="info">
+  You do not need robotics experience to install Wendy Agent. Steps 1–5 work
+  only with PC2, the open development computer. They do not command the G1's
+  joints. Do not open the robot, press its PWR/REC buttons, or reflash JetPack
+  for a normal Wendy Agent installation.
+</Callout>
 
 ## Requirements
 
@@ -50,6 +59,17 @@ Password: 123
 Use the shared factory password only over the isolated Ethernet link. Step 2
 requires changing it before PC2 is connected to Wi-Fi or another shared
 network.
+
+If this is your first G1 setup, keep the two command environments distinct:
+
+- **Developer machine:** your Mac or Linux laptop. Run `networksetup`, `pfctl`,
+  `wendy discover`, and `wendy run` here.
+- **PC2:** the G1's Jetson development computer. After `ssh`, run `ip`, `curl`,
+  `containerd`, and `systemctl` here. A prompt such as `unitree@...` confirms
+  that this terminal is on PC2.
+
+When a step switches environments, open or label a separate terminal instead
+of guessing where to run its commands.
 
 ## Step 1: Connect the developer machine
 
@@ -432,6 +452,190 @@ This intentionally leaves `/var/lib/wendy-agent` and deployed app data in
 place. Review and remove those directories separately only when their data is
 no longer needed. Do not remove `containerd` automatically because Docker,
 Unitree software, or other workloads may use it.
+
+## Optional: update the G1 development computer to JetPack 6.2
+
+Wendy Agent does not require this update. This appendix records the separate,
+destructive procedure used to move the lab G1's development computer from the
+original Unitree JetPack 5.1.1 environment to Unitree's G1-specific JetPack 6.2
+recovery image. It follows the
+[NVIDIA GEAR G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html).
+
+JetPack 6.2 contains Jetson Linux 36.4.3, an Ubuntu 22.04 root filesystem, and
+CUDA 12.6. See NVIDIA's
+[JetPack 6.2 release page](https://developer.nvidia.com/embedded/jetpack-sdk-62).
+
+<Callout type="warning">
+  This procedure erases the selected NVMe drive and rewrites PC2's boot
+  firmware. It is not an in-place APT upgrade. Use only Unitree's G1-specific
+  image and firmware together; do not flash a generic NVIDIA Orin NX image or
+  touch the G1's private motion-control computer. Power the robot down before
+  opening or closing its rear compartment. During the instructed recovery-mode
+  step, keep it physically supported and touch only the labeled PC2 controls.
+</Callout>
+
+### What Wendy used
+
+- A native Ubuntu 20.04 or 22.04 x86-64 host, not a virtual machine
+- An NVMe-to-USB enclosure and a USB data cable
+- The original ZHITAI TiPlus5000 2 TB NVMe, removed and preserved unchanged as
+  the physical backup
+- A replacement Crucial P310 1 TB NVMe for the new system
+- Unitree's matching `g1-nx-j6.2.img.bz2` system image and
+  `Jetpack_6.2_nx.tar.bz2` module-firmware package
+
+The two packages update different storage layers and must match:
+
+```text
+Orin NX module
+├── QSPI/boot firmware       Jetpack_6.2_nx.tar.bz2 over recovery USB
+└── NVMe operating system    g1-nx-j6.2.img.bz2 written to the replacement SSD
+```
+
+Obtain both files through Unitree's current support channel or the download
+linked from NVIDIA's G1 flashing guide. Do not substitute a similarly named
+community image. Use vendor-published checksums or signatures when available.
+
+### 1. Preserve the original system
+
+Shut down PC2 and remove the original NVMe using Unitree's service instructions.
+Label it with the robot and original JetPack version, place it in antistatic
+storage, and do not write the JetPack 6.2 image to it. Back up application data,
+SSH keys, networking, DDS configuration, Unitree services, and Wendy data before
+continuing.
+
+The original NVMe is a data backup, but it is not a complete one-step rollback.
+After PC2's module firmware is updated to JetPack 6.2, booting JetPack 5.1.1
+again also requires restoring the matching Unitree JetPack 5.1.1 module
+firmware.
+
+### 2. Identify the replacement NVMe
+
+Attach only the replacement NVMe to the Ubuntu host. Record its model, serial,
+capacity, device path, partitions, and the host's root device:
+
+```bash
+lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN
+lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,MOUNTPOINTS
+findmnt -no SOURCE /
+```
+
+Set a task-specific variable to the **whole replacement disk**, not a partition.
+This example value is intentionally invalid; replace it with the path confirmed
+above:
+
+```bash
+G1_REPLACEMENT_DISK=/dev/replace-with-confirmed-disk
+lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,MOUNTPOINTS \
+  "$G1_REPLACEMENT_DISK"
+```
+
+<Callout type="warning">
+  Stop unless the model, serial, capacity, USB transport, and device path all
+  identify the replacement NVMe, and `findmnt` shows a different device for the
+  Ubuntu host's root filesystem. The next write cannot be undone.
+</Callout>
+
+Unmount every mounted child partition shown by `lsblk`, one at a time:
+
+```bash
+sudo umount <mounted-replacement-partition>
+```
+
+### 3. Write the JetPack 6.2 system image
+
+First test that the downloaded bzip2 stream is complete:
+
+```bash
+bzip2 -tvv g1-nx-j6.2.img.bz2
+```
+
+Recheck `G1_REPLACEMENT_DISK`, then write the image to the whole replacement
+disk:
+
+```bash
+lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN "$G1_REPLACEMENT_DISK"
+bzip2 -dc g1-nx-j6.2.img.bz2 | \
+  sudo dd of="$G1_REPLACEMENT_DISK" bs=4M status=progress conv=fsync
+sudo sync
+sudo udisksctl power-off -b "$G1_REPLACEMENT_DISK"
+```
+
+Wait for `dd`, `sync`, and the power-off command to finish before unplugging the
+enclosure. Keep the imaged replacement NVMe out of the robot until the module
+firmware step is complete.
+
+### 4. Put PC2 into Force Recovery Mode
+
+Remove the G1's rear cover using Unitree's service instructions and locate the
+two white PC2 buttons and its dedicated USB-C flashing port. Use the labeled
+photographs in NVIDIA's G1 flashing guide; do not identify the controls by
+guessing.
+
+1. Power on the G1 and wait for all three power indicators to remain steady.
+2. Connect PC2's flashing USB-C port to the Ubuntu host with a data cable.
+3. Hold both white buttons for two seconds.
+4. Release the upper button while continuing to hold the lower button for two
+   more seconds.
+5. Release the lower button when the indicators change from three green lights
+   to two.
+
+On the Ubuntu host, confirm that the Orin NX appears in APX recovery mode:
+
+```bash
+lsusb | grep -i nvidia
+```
+
+The output must identify an NVIDIA APX device. If it does not, stop and repeat
+the button sequence or replace a charge-only USB cable. Do not run the firmware
+script until APX is visible.
+
+### 5. Flash the matching PC2 module firmware
+
+Keep the robot powered and the USB cable connected throughout this step:
+
+```bash
+bzip2 -tvv Jetpack_6.2_nx.tar.bz2
+tar -xjvf Jetpack_6.2_nx.tar.bz2
+cd Jetpack_6.2_nx/Linux_for_Tegra
+lsusb | grep -i nvidia
+sudo ./flash_nx_module.sh
+```
+
+Do not interrupt the script, close the terminal, unplug USB, or allow the host
+to sleep. NVIDIA's G1 guide says this takes about eight minutes. Continue only
+after the script explicitly reports a successful flash.
+
+### 6. Reassemble, boot, and verify
+
+After a successful firmware flash, power the G1 off and disconnect the recovery
+USB cable. Install the imaged replacement NVMe in PC2, secure its retaining
+screw, and reinstall the rear cover and handle before powering the robot on.
+
+Allow extra time for the first boot. Start with non-motion checks. Connect to
+PC2 and record the installed versions:
+
+```bash
+head -n 1 /etc/nv_tegra_release
+dpkg-query -W nvidia-l4t-core 2>/dev/null || true
+. /etc/os-release && echo "$PRETTY_NAME"
+uname -m
+nvcc --version 2>/dev/null || true
+```
+
+The Unitree JetPack 6.2 packages should report Jetson Linux/L4T 36.4.x, Ubuntu
+22.04, and `aarch64`. Before installing Wendy Agent or enabling any motion app,
+verify all of the following against Unitree's recovery checklist:
+
+- Ethernet and Wi-Fi interfaces and the expected `192.168.123.0/24` robot link
+- USB devices, cameras, and GPU/CUDA access
+- Unitree systemd services and DDS state topics
+- G1 app video/image display
+- No unexpected failed services in `systemctl --failed`
+
+Keep motion disabled during these checks. Test controlled movement only after
+Unitree's non-motion validation passes, with the G1 supported on its gantry and
+the physical remote and E-stop held by the operator.
 
 ## Next steps
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -455,36 +455,30 @@ Unitree software, or other workloads may use it.
 
 ## Optional: update the G1 development computer to JetPack 6.2
 
-Wendy Agent does not require this update. This appendix records the separate,
-destructive procedure used to move the lab G1's development computer from the
-original Unitree JetPack 5.1.1 environment to Unitree's G1-specific JetPack 6.2
-recovery image. It follows the
-[NVIDIA GEAR G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html).
-
-JetPack 6.2 contains Jetson Linux 36.4.3, an Ubuntu 22.04 root filesystem, and
-CUDA 12.6. See NVIDIA's
-[JetPack 6.2 release page](https://developer.nvidia.com/embedded/jetpack-sdk-62).
+Wendy Agent does not require this update. This section records the exact lab
+process used to replace the G1 development computer's original JetPack 5.1.1
+system with Unitree's JetPack 6.2 packages. It is a historical lab procedure,
+not part of the Wendy Agent installation flow.
 
 <Callout type="warning">
-  This procedure erases the selected NVMe drive and rewrites PC2's boot
-  firmware. It is not an in-place APT upgrade. Use only Unitree's G1-specific
-  image and firmware together; do not flash a generic NVIDIA Orin NX image or
-  touch the G1's private motion-control computer. Power the robot down before
-  opening or closing its rear compartment. During the instructed recovery-mode
-  step, keep it physically supported and touch only the labeled PC2 controls.
+  This is a destructive SSD and PC2 firmware replacement, not an APT upgrade.
+  Do not copy the lab's `/dev/sda` path without identifying the replacement
+  disk on your own Ubuntu host. Never flash the G1's private motion-control
+  computer.
 </Callout>
 
-### What Wendy used
+### Lab hardware and packages
 
-- A native Ubuntu 20.04 or 22.04 x86-64 host, not a virtual machine
-- An NVMe-to-USB enclosure and a USB data cable
-- The original ZHITAI TiPlus5000 2 TB NVMe, removed and preserved unchanged as
-  the physical backup
-- A replacement Crucial P310 1 TB NVMe for the new system
-- Unitree's matching `g1-nx-j6.2.img.bz2` system image and
-  `Jetpack_6.2_nx.tar.bz2` module-firmware package
+- Original drive: ZHITAI TiPlus5000 2 TB with JetPack 5.1.1, L4T 35.3.1,
+  and Ubuntu 20.04
+- Replacement drive: Crucial P310 1 TB, model `CT1000P310SSD8`
+- Native Ubuntu x86-64 host
+- NVMe-to-USB enclosure and a USB data cable
+- Unitree system image: `g1-nx-j6.2.img.bz2`
+- Unitree PC2 firmware package: `Jetpack_6.2_nx.tar.bz2`
 
-The two packages update different storage layers and must match:
+The lab used two matching packages because the NVMe operating system and the
+Orin NX module firmware are separate:
 
 ```text
 Orin NX module
@@ -492,150 +486,122 @@ Orin NX module
 └── NVMe operating system    g1-nx-j6.2.img.bz2 written to the replacement SSD
 ```
 
-Obtain both files through Unitree's current support channel or the download
-linked from NVIDIA's G1 flashing guide. Do not substitute a similarly named
-community image. Use vendor-published checksums or signatures when available.
+Obtain the current G1-specific packages from Unitree before repeating the
+process. A generic NVIDIA Orin NX image does not contain the G1 carrier-board
+configuration.
 
-### 1. Preserve the original system
+### 1. Inspect and preserve the original drive
 
-Shut down PC2 and remove the original NVMe using Unitree's service instructions.
-Label it with the robot and original JetPack version, place it in antistatic
-storage, and do not write the JetPack 6.2 image to it. Back up application data,
-SSH keys, networking, DDS configuration, Unitree services, and Wendy data before
-continuing.
+The original ZHITAI drive was removed from PC2 and attached over USB for
+read-only inspection. Its NVIDIA package metadata reported JetPack 5.1.1 and
+L4T 35.3.1. The drive was then disconnected and kept unchanged as the physical
+backup. The lab did not write the JetPack 6.2 image to the original drive.
 
 The original NVMe is a data backup, but it is not a complete one-step rollback.
 After PC2's module firmware is updated to JetPack 6.2, booting JetPack 5.1.1
 again also requires restoring the matching Unitree JetPack 5.1.1 module
 firmware.
 
-### 2. Identify the replacement NVMe
+### 2. Identify the Crucial P310 on the Ubuntu host
 
-Attach only the replacement NVMe to the Ubuntu host. Record its model, serial,
-capacity, device path, partitions, and the host's root device:
+The P310 was attached to the Ubuntu host through the NVMe-to-USB enclosure. It
+appeared as `/dev/sda` in the lab. Before writing anything, the model, capacity,
+USB transport, partitions, and host root device were checked:
 
 ```bash
 lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN
-lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,MOUNTPOINTS
+lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,LABEL,MOUNTPOINTS /dev/sda
 findmnt -no SOURCE /
 ```
 
-Set a task-specific variable to the **whole replacement disk**, not a partition.
-This example value is intentionally invalid; replace it with the path confirmed
-above:
-
-```bash
-G1_REPLACEMENT_DISK=/dev/replace-with-confirmed-disk
-lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN,FSTYPE,MOUNTPOINTS \
-  "$G1_REPLACEMENT_DISK"
-```
-
 <Callout type="warning">
-  Stop unless the model, serial, capacity, USB transport, and device path all
-  identify the replacement NVMe, and `findmnt` shows a different device for the
-  Ubuntu host's root filesystem. The next write cannot be undone.
+  `/dev/sda` was the P310 only on the lab Ubuntu host. Stop unless your own
+  output identifies the Crucial P310 replacement and shows a different device
+  for the host's root filesystem.
 </Callout>
 
-Unmount every mounted child partition shown by `lsblk`, one at a time:
+The P310's mounted partitions were unmounted before imaging:
 
 ```bash
-sudo umount <mounted-replacement-partition>
+sudo umount /dev/sda*
 ```
 
-### 3. Write the JetPack 6.2 system image
-
-First test that the downloaded bzip2 stream is complete:
+The Unitree system image was then written to the whole P310:
 
 ```bash
-bzip2 -tvv g1-nx-j6.2.img.bz2
-```
-
-Recheck `G1_REPLACEMENT_DISK`, then write the image to the whole replacement
-disk:
-
-```bash
-lsblk -d -o NAME,PATH,SIZE,MODEL,SERIAL,TRAN "$G1_REPLACEMENT_DISK"
-bzip2 -dc g1-nx-j6.2.img.bz2 | \
-  sudo dd of="$G1_REPLACEMENT_DISK" bs=4M status=progress conv=fsync
+bzip2 -dc g1-nx-j6.2.img.bz2 | sudo dd of=/dev/sda status=progress
 sudo sync
-sudo udisksctl power-off -b "$G1_REPLACEMENT_DISK"
 ```
 
-Wait for `dd`, `sync`, and the power-off command to finish before unplugging the
-enclosure. Keep the imaged replacement NVMe out of the robot until the module
-firmware step is complete.
+After `dd` and `sync` completed, the P310 was disconnected from the enclosure
+and installed in the G1 development computer.
 
-### 4. Put PC2 into Force Recovery Mode
+### 3. Put the G1 development computer into recovery mode
 
-Remove the G1's rear cover using Unitree's service instructions and locate the
-two white PC2 buttons and its dedicated USB-C flashing port. Use the labeled
-photographs in NVIDIA's G1 flashing guide; do not identify the controls by
-guessing.
+With the P310 installed, the lab used the two PC2 buttons inside the rear
+electronics compartment. PWR is the upper button; REC is the lower button above
+PC2's USB-C flashing port.
 
 1. Power on the G1 and wait for all three power indicators to remain steady.
-2. Connect PC2's flashing USB-C port to the Ubuntu host with a data cable.
-3. Hold both white buttons for two seconds.
-4. Release the upper button while continuing to hold the lower button for two
-   more seconds.
-5. Release the lower button when the indicators change from three green lights
-   to two.
+2. Hold PWR and REC together for about two seconds.
+3. Release PWR while continuing to hold REC for two more seconds.
+4. Release REC.
+5. Connect the Ubuntu host to PC2's dedicated USB-C flashing port with a data
+   cable.
 
 On the Ubuntu host, confirm that the Orin NX appears in APX recovery mode:
 
 ```bash
-lsusb | grep -i nvidia
+lsusb
 ```
 
-The output must identify an NVIDIA APX device. If it does not, stop and repeat
-the button sequence or replace a charge-only USB cable. Do not run the firmware
-script until APX is visible.
+The lab continued only after `lsusb` displayed `NVIDIA Corp. APX`.
 
-### 5. Flash the matching PC2 module firmware
+### 4. Flash the matching PC2 module firmware
 
-Keep the robot powered and the USB cable connected throughout this step:
+The firmware archive stayed on the Ubuntu host; it was not copied to the P310 or
+to PC2. From the directory containing the archive, the lab ran:
 
 ```bash
-bzip2 -tvv Jetpack_6.2_nx.tar.bz2
-tar -xjvf Jetpack_6.2_nx.tar.bz2
+sudo tar -xjvf Jetpack_6.2_nx.tar.bz2
 cd Jetpack_6.2_nx/Linux_for_Tegra
 lsusb | grep -i nvidia
 sudo ./flash_nx_module.sh
 ```
 
-Do not interrupt the script, close the terminal, unplug USB, or allow the host
-to sleep. NVIDIA's G1 guide says this takes about eight minutes. Continue only
-after the script explicitly reports a successful flash.
+The G1 remained powered and connected over USB until the script explicitly
+reported success. The process took approximately eight minutes.
 
-### 6. Reassemble, boot, and verify
+### 5. Boot and verify the updated PC2
 
-After a successful firmware flash, power the G1 off and disconnect the recovery
-USB cable. Install the imaged replacement NVMe in PC2, secure its retaining
-screw, and reinstall the rear cover and handle before powering the robot on.
+After the firmware script completed, the G1 was powered off and the recovery
+USB cable was disconnected. The P310 was checked for secure installation, the
+rear compartment was closed, and the G1 was powered on normally. The first boot
+was given several minutes before the lab attempted network access.
 
-Allow extra time for the first boot. Start with non-motion checks. Connect to
-PC2 and record the installed versions:
+The lab then checked PC2 without enabling motion:
 
 ```bash
-head -n 1 /etc/nv_tegra_release
-dpkg-query -W nvidia-l4t-core 2>/dev/null || true
-. /etc/os-release && echo "$PRETTY_NAME"
-uname -m
-nvcc --version 2>/dev/null || true
+ping 192.168.123.164
+ssh unitree@192.168.123.164
+
+cat /etc/nv_tegra_release
+cat /etc/os-release
+nvcc --version
+uname -a
 ```
 
-The Unitree JetPack 6.2 packages should report Jetson Linux/L4T 36.4.x, Ubuntu
-22.04, and `aarch64`. Before installing Wendy Agent or enabling any motion app,
-verify all of the following against Unitree's recovery checklist:
+The remaining lab checks were performed in this order:
 
-- Ethernet and Wi-Fi interfaces and the expected `192.168.123.0/24` robot link
-- USB devices, cameras, and GPU/CUDA access
-- Unitree systemd services and DDS state topics
+- Ethernet and Wi-Fi
+- USB devices and cameras
+- GPU and CUDA
+- Unitree services and DDS communication
 - G1 app video/image display
-- No unexpected failed services in `systemctl --failed`
+- Controlled motion only after all non-motion checks passed
 
-Keep motion disabled during these checks. Test controlled movement only after
-Unitree's non-motion validation passes, with the G1 supported on its gantry and
-the physical remote and E-stop held by the operator.
+Keep the G1 supported on its gantry and keep the physical remote and E-stop with
+the operator for the final controlled-motion check.
 
 ## Next steps
 

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -165,6 +165,24 @@ guide — `wendy` can introspect the live ROS 2 graph on the robot with no SSH.
 
 ## Next Steps
 
+### Drive the G1 from your browser
+
+The fastest way to see the robot do something: the `g1-rc` template deploys
+a ready-made remote control — live camera view, touch joystick, posture and
+arm-gesture buttons, and a latching E-STOP — as one app:
+
+```bash
+wendy init --app-id my-g1-rc --template g1-rc --language python
+cd my-g1-rc
+wendy run --device 192.168.123.164
+```
+
+Then open `http://192.168.123.164:3500`, press **stand** → **ready-to-walk**,
+and drive. The scaffolded project's README covers the UI, the safety model,
+and how to customize it. First sessions: keep the robot on its gantry.
+
+### Build your own apps
+
 - [Hello World in Python](/docs/guides/tutorials/python/hello-world)
 - [ROS 2 on Wendy devices](/docs/integrations/ros2)
 - [App entitlements](/docs/device/entitlements)

--- a/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
+++ b/go/internal/cli/assets/docs/installation/wendy-agent-unitree-g1.mdx
@@ -15,14 +15,20 @@ motion-control computer. It does make persistent changes to PC2: the installer
 adds Wendy's signed APT repository, installs packages and systemd services, and
 adds an Avahi service for mDNS discovery.
 
-<Callout type="warning">
-  This page is still under hardware validation. Before publication, Wendy will
-  repeat the entire procedure on a factory-fresh Ubuntu 20.04 G1 and verify the
-  physical Ethernet port, default credentials, container runtime packages,
-  Wi-Fi setup, macOS and Linux internet-sharing procedures, upgrade behavior,
-  advertised agent ports, and rollback steps. Do not use this draft for
-  unattended or production provisioning yet.
+<Callout type="info">
+  These instructions follow Unitree's documented G1 development environment
+  and Wendy's supported installation procedure. Wendy also completed an
+  end-to-end upgrade-path trial on a lab G1 running Ubuntu 20.04.6 on aarch64.
+  We will reconfirm the procedure on the lab G1 and update this guide if its
+  configuration differs.
 </Callout>
+
+The lab trial confirmed the PC2 address and SSH credentials, direct Wi-Fi
+internet access, macOS internet-sharing mechanics, a running `containerd`, the
+Wendy Agent installer and upgrade recovery, and successful discovery from the
+developer machine. The tested robot was not factory-fresh, so clean-image
+dependency resolution and the revised internet-sharing commands remain marked
+for testing where they appear below.
 
 ## Requirements
 
@@ -33,7 +39,7 @@ adds an Avahi service for mDNS discovery.
 - Administrator access on the developer machine and `sudo` access on PC2
 - Approximately 15–30 minutes
 
-The factory account documented for PC2 is:
+The factory account documented for PC2 and confirmed on the lab G1 is:
 
 ```text
 Address:  192.168.123.164
@@ -147,10 +153,11 @@ If this prints an HTTP success response, skip to Step 4.
 PC2 may already be connected to Wi-Fi. A persistent, organization-approved
 Wi-Fi connection is preferable to routing through the developer machine.
 
-<Callout type="warning">
-  The exact PC2 Wi-Fi procedure will be tested on the factory Ubuntu 20.04
-  image before publication. Use Unitree's networking instructions for the
-  current image, then repeat the internet check above.
+<Callout type="info">
+  The lab G1 already had a working `wlan0` connection and could reach Wendy's
+  installer directly. If PC2 is not already online, use Unitree's networking
+  instructions for its installed image, then repeat the internet check above.
+  Wendy will test configuring Wi-Fi from an unconfigured image separately.
 </Callout>
 
 ### Temporary macOS internet sharing fallback
@@ -184,10 +191,11 @@ curl -sSIf --max-time 10 https://install.wendy.dev/agent.sh | head -1
 ```
 
 <Callout type="warning">
-  The named-anchor procedure is safer than replacing the main PF ruleset, but
-  Wendy will perform another end-to-end G1 test before publication. A Linux
-  internet-sharing fallback will also be tested and documented. These settings
-  are temporary and are lost on reboot.
+  macOS-to-G1 internet sharing was confirmed during the lab trial. That trial
+  used the older main-ruleset command, so Wendy will retest the safer named
+  anchor and its teardown end-to-end. A Linux internet-sharing fallback will
+  also be tested and documented. These settings are temporary and are lost on
+  reboot.
 </Callout>
 
 After installation, remove the temporary route and DNS setting on PC2:
@@ -218,10 +226,15 @@ Do not unconditionally install or upgrade `containerd`. The Wendy Debian
 package declares it as a dependency, so APT installs it when absent. This
 avoids unexpectedly restarting an existing runtime merely to perform a check.
 
+On the lab G1, `containerd` 1.7.12 was already installed and active. An earlier
+unconditional installation command upgraded it to 1.7.24 and restarted the
+runtime, which is why this guide performs only the read-only checks above.
+
 <Callout type="warning">
-  Wendy will test a factory image with no runtime and an image using Docker's
-  `containerd.io` package before publication. This is required to confirm that
-  dependency resolution does not remove or replace an existing Docker runtime.
+  The lab result confirms the already-installed runtime path. Wendy will also
+  test an image with no runtime and an image using Docker's `containerd.io`
+  package to confirm that dependency resolution does not remove or replace an
+  existing Docker runtime.
 </Callout>
 
 Download the installer so it can be reviewed before execution:
@@ -291,10 +304,10 @@ sudo journalctl -u wendy-agent -n 100 --no-pager
 ```
 
 <Callout type="warning">
-  An upgrade test observed the package stopping an existing agent without
-  restarting it. Wendy will fix and retest the package lifecycle before this
-  guide is published. The manual start above is a temporary recovery step, not
-  the final expected upgrade behavior.
+  The lab G1 upgrade test observed the package stopping an existing agent
+  without restarting it. The manual start above recovered the agent and made
+  it discoverable. Wendy will fix and retest the package lifecycle; manual
+  recovery is not the final expected upgrade behavior.
 </Callout>
 
 Inspect the listening services before connecting PC2 to a shared network:
@@ -320,7 +333,9 @@ wendy discover
 
 The device may appear under a generic Ubuntu hostname rather than a name that
 contains “G1.” Match its address, architecture, operating system, and agent
-version to the PC2 values recorded earlier.
+version to the PC2 values recorded earlier. During the lab trial,
+`wendy discover` found the provisioned agent at `192.168.123.164` on its
+advertised mTLS port, `50052`.
 
 You are done when all of the following are true:
 

--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -3755,9 +3755,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
> [!IMPORTANT]
> **Keep this PR in draft. Do not merge.** The G1 is now validated over its live Wi-Fi/SSH path, but the direct-Ethernet/NAT maintenance path and the other explicitly listed variants still need controlled testing.

## Action plan

- [x] Integrate the review and lab feedback into the PR documentation.
- [x] Walk through the current guide on the humanoid from the perspective of a first-time operator with no robotics background.
  - Completed on the lab G1 without issuing motion commands.
  - Read-only checks, credential verification, installer retrieval/inspection, service checks, discovery, device inspection, and hardware enumeration were executed in guide order.
  - Reinstallation, service/runtime restarts, password rotation, and removal were intentionally not executed while shared demo and envelope-trigger applications were running.
  - The direct-Ethernet/NAT branch remains pending because the development Mac had no active wired adapter during this walkthrough.
- [x] Document the exact lab process used to update the G1 development computer from Unitree JetPack 5.1.1 to the G1-specific JetPack 6.2 recovery image, including the historical Google Drive source.

## Summary

Adds and substantially revises `installation/wendy-agent-unitree-g1.mdx`, a novice-oriented guide for installing `wendy-agent` on the Unitree G1 EDU development computer (PC2), and registers it in the Installation sidebar.

The latest on-robot walkthrough found several differences from the earlier Ubuntu 20.04 image and updates the guide accordingly: the current Unitree image is Ubuntu 22.04.5/arm64 with Jetson Linux R36.4.3, its interfaces are not named `eth0`/`wlan0`, it includes `wget` but not `curl`, and `containerd` was installed by Wendy's APT dependency rather than being preinstalled.

## Confirmed on the lab G1

- PC2 accepts the documented `unitree` / `123` credential and has `sudo` access.
- The SSH host-key change after the JetPack reflash was verified locally on PC2 before accepting the new key; the guide now documents the safe recovery procedure.
- PC2 reports Ubuntu 22.04.5 on arm64, kernel `5.15.148-tegra`, and Jetson Linux R36.4.3. NVIDIA identifies R36.4.3 as the JetPack 6.2 BSP.
- The installed Unitree image does not include the full `nvidia-jetpack` metapackage or `nvcc`; Wendy Agent does not require either.
- PC2 uses `enP8p1s0` at `192.168.123.164/24` for the robot network and `wlxfc23cd8f7621` at `192.168.0.108/24` for Wi-Fi. The guide no longer hard-codes `eth0` or `wlan0`.
- DNS and direct Wi-Fi internet access work. The stock image's `wget` reached `https://install.wendy.dev/agent.sh` with HTTP 200; `curl` was absent before the Wendy installer prerequisite step.
- The current installer downloaded successfully, passed `bash -n`, documents `-y`, and installs `ca-certificates`, `curl`, and `gnupg` before adding Wendy's APT repository.
- DPKG history shows `containerd` 2.2.1 and `wendy-agent` `2026.07.27-003050` installed in the same transaction. This confirms dependency resolution when the runtime is absent.
- `containerd` and `wendy-agent` are enabled and active after boot, with no failed systemd units.
- Wendy Agent listens on the provisioned mTLS port `50052`, mesh proxy `50058`, and development registry `5000`.
- `wendy discover` reports **Unitree G1 Nx** at `unitree-g1-nx.local:50052`; `wendy device info` connects and reports both robot interfaces, GPU, storage, and Agent version.
- The NVIDIA Orin GPU is detected with compute capability 8.7.
- The Intel RealSense D435i enumerates as six V4L2 nodes and appears through `wendy device camera list` and `wendy device hardware list`.
- The current demo, RealSense, person-tracker, Foxglove, and envelope-trigger containers remained running throughout the read-only audit.
- The original ZHITAI JetPack 5.1.1 NVMe was preserved, and the update used a replacement Crucial P310 1 TB plus Unitree's matching system-image and module-firmware packages.
- The guide links the exact Google Drive folder used for that lab flash and labels it as a historical source that must be reconfirmed with Unitree before reuse.

## Findings incorporated into the guide

- Uses `wget` for the pre-install internet check and installer download because it is available on the current Unitree image while `curl` is not.
- Detects the PC2 Ethernet interface from `192.168.123.164` instead of assuming `eth0`.
- Records both confirmed containerd paths: absent on the fresh image and installed by Wendy's dependency, and already active on the earlier Ubuntu 20.04 image.
- Records Ubuntu 22.04.5 and R36.4.3/JetPack 6.2 as the current lab configuration while retaining the earlier Ubuntu 20.04 upgrade-path result.
- Explains that Unitree's image provides the JetPack BSP without necessarily providing the full CUDA development toolkit.
- Documents the current Wendy Agent JetPack-detection mismatch: Agent `2026.07.27-003050` reports 6.1 for R36.4.3, while NVIDIA maps that BSP to 6.2.
- Adds safe SSH host-key handling after a PC2 reflash.
- Documents RealSense enumeration separately from video streaming. The generic Wendy camera viewer could not configure the device while the live G1 RealSense service was running, so the walkthrough did not interrupt that workload.
- Keeps developer-machine and PC2 command environments explicit and keeps every normal installation check non-motion.
- Preserves password rotation, DDS host-networking guidance, physical E-stop/gantry requirements, troubleshooting, uninstall guidance, and the exact replacement-NVMe/APX/firmware-flash sequence.

## Validation completed

- [x] Christos and Oliver's Slack acceptance criteria cross-referenced
- [x] Martien's PR/document feedback integrated
- [x] Earlier 2026-07-28 Ubuntu 20.04 upgrade-path trial cross-referenced
- [x] Earlier JetPack flashing chat and recorded lab commands cross-referenced
- [x] Live G1 identity, SSH credential, sudo, OS, architecture, BSP, network, DNS, internet, runtime, Agent, ports, discovery, device info, GPU, storage, system health, USB, and camera enumeration checked
- [x] Current installer retrieved with `wget`, syntax-checked, and inspected without restarting the live Agent
- [x] Fumadocs MDX generation passed
- [x] Next route type generation passed
- [x] TypeScript `--noEmit` passed
- [x] `git diff --check` passed

## Keep in draft until these are completed

- [ ] Connect the development Mac to the correct PC2 Ethernet port, repeat `192.168.123.99/24` link setup, and add a labeled port photograph.
- [ ] Test the revised named-anchor macOS NAT workflow and teardown end-to-end over that physical link.
- [ ] Add and test a Linux internet-sharing fallback and teardown.
- [ ] Exercise dependency handling when Docker's `containerd.io` package is already installed.
- [ ] Configure PC2 Wi-Fi from an unconfigured image.
- [ ] Fix and retest the Wendy Agent JetPack mapping for R36.4.3.
- [ ] Fix and retest the Debian upgrade lifecycle so an enabled Agent remains running after upgrade.
- [ ] Verify the uninstall/rollback sequence during a maintenance window.
- [ ] Retest `wendy device camera view` with the G1 demo's RealSense service stopped, or validate the intended G1 app feed separately.
- [ ] Publish and crane-commission `g1-rc` before restoring any motion quick-start.

Closes WDY-1999 only after the remaining checklist is complete and this PR is intentionally moved out of draft.
