### PR TITLE
Wendy Lite improvements in WendyCom protocol

### DIFF
--- a/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
+++ b/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
@@ -44,7 +44,7 @@ WendyCom runs over the ESP32 USB Serial JTAG peripheral. This link supports seve
 
 ### Escape sequences
 
-`DLE` (0x1B) characters in the data stream are interpreted as commands. Each `DLE` is followed by a command byte:
+`DLE` (0x10) characters in the data stream are interpreted as commands. Each `DLE` is followed by a command byte:
 
 ```text
 DLE c  →  switch to console mode

--- a/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
+++ b/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
@@ -30,7 +30,7 @@ The device listens on TCP port 5054 and advertises itself via mDNS as `_wendy-li
 
 ## WendyCom over USB Serial JTAG
 
-WendyCom runs over the ESP32 USB Serial JTAG peripheral. This link supports several modes, WendyCom being one of them; the host switches between them by sending ESC sequences.
+WendyCom runs over the ESP32 USB Serial JTAG peripheral. This link supports several modes, WendyCom being one of them; the host switches between them by sending escape sequences.
 
 ### Modes
 
@@ -44,24 +44,24 @@ WendyCom runs over the ESP32 USB Serial JTAG peripheral. This link supports seve
 
 ### Escape sequences
 
-`ESC` (0x1B) characters in the data stream are interpreted as commands. Each `ESC` is followed by a command byte:
+`DLE` (0x1B) characters in the data stream are interpreted as commands. Each `DLE` is followed by a command byte:
 
 ```text
-ESC c  →  switch to console mode
-ESC e  →  switch to echo mode
-ESC m  →  switch to com mode
-ESC o  →  switch to off mode
+DLE c  →  switch to console mode
+DLE e  →  switch to echo mode
+DLE m  →  switch to com mode
+DLE o  →  switch to off mode
 ```
 
-In `USJ_MODE_COM`, the `wendy_com_uart` layer intercepts escapes before data reaches the `wendy_com` stack:
+In `USJ_MODE_COM`, the `wendy_com_uart` layer intercepts escape sequences before data reaches the `wendy_com` stack:
 
 ```text
-ESC _    →  pass a literal ESC byte through to the `wendy_com` stack
-ESC k    →  keep-alive (reserved, not yet implemented)
-ESC <x>  →  disconnect the `wendy_com` link, then switch to mode <x>
+DLE _    →  pass a literal DLE byte through to the `wendy_com` stack
+DLE k    →  keep-alive (reserved, not yet implemented)
+DLE <x>  →  disconnect the `wendy_com` link, then switch to mode <x>
 ```
 
-Two consecutive `ESC` characters are considered like one. Therefore, you can put as many `ESC` as you want in front of a command byte.
+Two consecutive `DLE` characters are considered like one. Therefore, you can put as many `DLE` as you want in front of a command byte.
 
 ### Establishing a WendyCom connection
 
@@ -69,12 +69,12 @@ Before entering `USJ_MODE_COM`, the host must flush any stale data buffered in t
 USB layer on both sides.  The handshake uses echo mode for this:
 
 1. Open the USB channel.
-2. Send `ESC e` to switch to echo mode.
+2. Send `DLE e` to switch to echo mode.
 3. Verify the link: send a few bytes and confirm that data flows back.
 4. Drain the channel: read until no data arrives within a timeout.
 5. Send a unique sentinel byte sequence and wait until it is echoed back —
    this confirms the channel is fully flushed and both sides are in sync.
-6. Send `ESC m` to switch to `USJ_MODE_COM`.
+6. Send `DLE m` to switch to `USJ_MODE_COM`.
 
 The channel is now in `USJ_MODE_COM` with no stale data in either buffer.
 

--- a/go/internal/cli/liteclient/client.go
+++ b/go/internal/cli/liteclient/client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +12,6 @@ import (
 	"math"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,7 +29,6 @@ const (
 	chunkSizeForSerial = 768
 	versionMajor       = 2
 	versionMinor       = 0
-	esc                = 0x1B
 )
 
 type protocolVersion struct {
@@ -190,11 +187,6 @@ func (c *WendyLiteClient) ConnectToSerial(device string) error {
 		lock.release()
 		return fmt.Errorf("open serial: %w", err)
 	}
-	if err := serialHandshake(port); err != nil {
-		port.Close()
-		lock.release()
-		return err
-	}
 	c.link = &directLink{conn: port, isSerial: true}
 	c.serialLock = lock
 	if err := c.handshake(); err != nil {
@@ -229,64 +221,6 @@ func (c *WendyLiteClient) ConnectViaCloudInsecure(serverAddr string, assetID uin
 	return nil
 }
 
-func serialHandshake(port serial.Port) error {
-	if _, err := port.Write([]byte{esc, esc, esc, esc, 'e'}); err != nil {
-		return fmt.Errorf("serial handshake: send escape: %w", err)
-	}
-
-	var sentinel string
-
-	if err := port.SetReadTimeout(100 * time.Millisecond); err != nil {
-		return fmt.Errorf("serial handshake: set timeout: %w", err)
-	}
-
-	window := make([]byte, 0, 32)
-	oneByte := make([]byte, 1)
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		n, err := port.Read(oneByte)
-		if err != nil {
-			return fmt.Errorf("serial handshake: read: %w", err)
-		}
-		if n == 0 {
-			// rx timeout, so rx buffer empty, so send sentinel
-			var randBytes [16]byte
-			if _, err := rand.Read(randBytes[:]); err != nil {
-				return fmt.Errorf("serial handshake: generate sentinel: %w", err)
-			}
-			sentinel = hex.EncodeToString(randBytes[:])
-			window = window[:0]
-			if _, err := port.Write([]byte(strings.Repeat(" ", 16) + sentinel)); err != nil {
-				return fmt.Errorf("serial handshake: send sentinel: %w", err)
-			}
-			continue
-		}
-		if n == 1 {
-			if len(window) < 32 {
-				window = append(window, oneByte[0])
-			} else {
-				copy(window, window[1:])
-				window[31] = oneByte[0]
-			}
-			if sentinel != "" && len(window) == 32 && string(window) == sentinel {
-				if err := port.SetReadTimeout(0); err != nil {
-					return fmt.Errorf("serial handshake: clear timeout: %w", err)
-				}
-				if _, err := port.Write([]byte{esc, 'm'}); err != nil {
-					return fmt.Errorf("serial handshake: send mode switch: %w", err)
-				}
-				return nil
-			}
-		}
-	}
-	return fmt.Errorf("serial handshake: sentinel not received within 3 seconds")
-}
-
-// Close tears the connection down. Closing the link unblocks the read loop's
-// pending recv; waiting for the loop to exit guarantees nothing is reading
-// from the port anymore before the serial lock is released. Safe to call more
-// than once and concurrently with in-flight commands: c.link stays in place,
-// so a late send fails on the closed link instead of dereferencing nil.
 func (c *WendyLiteClient) Close() error {
 	if c.link == nil {
 		return nil
@@ -860,6 +794,9 @@ func (c *WendyLiteClient) sendCommand(cmd *wendypb.WendyComCommand, timeout time
 }
 
 func (c *WendyLiteClient) handshake() error {
+	if err := c.link.linkHandshake(); err != nil {
+		return err
+	}
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		return fmt.Errorf("handshake id: %w", err)

--- a/go/internal/cli/liteclient/link.go
+++ b/go/internal/cli/liteclient/link.go
@@ -11,6 +11,9 @@ import (
 // exchanges bare message bodies through a cloud gRPC tunnel, where the
 // broker owns framing and channels.
 type wcomLink interface {
+	// linkHandshake performs any transport-level handshake needed before
+	// WendyCom messages can flow. Called once, before the protocol handshake.
+	linkHandshake() error
 	// send marshals and transmits one message; safe for concurrent use.
 	send(*wendypb.WendyComMessage) error
 	// recv blocks for the next message; timeout <= 0 means no deadline.

--- a/go/internal/cli/liteclient/link_direct.go
+++ b/go/internal/cli/liteclient/link_direct.go
@@ -2,10 +2,13 @@ package liteclient
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +17,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const escapeChar = 0x10 // CTRL-P, aka DLE (Data Link Escape)
+
 // directLink frames WendyComMessages with the 8-byte link header over a
 // direct connection (TCP-TLS or serial). The header channel byte stays 0:
 // direct links always use the default channel.
@@ -21,6 +26,68 @@ type directLink struct {
 	conn     io.ReadWriteCloser
 	isSerial bool
 	writeMu  sync.Mutex // serializes frames across command goroutines
+}
+
+// linkHandshake switches a serial device into WendyCom mode; on TCP-TLS there
+// is nothing to set up.
+func (l *directLink) linkHandshake() error {
+	if !l.isSerial {
+		return nil
+	}
+	return serialHandshake(l.conn.(serial.Port))
+}
+
+func serialHandshake(port serial.Port) error {
+	if _, err := port.Write([]byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}); err != nil {
+		return fmt.Errorf("serial handshake: send escape: %w", err)
+	}
+
+	var sentinel string
+
+	if err := port.SetReadTimeout(100 * time.Millisecond); err != nil {
+		return fmt.Errorf("serial handshake: set timeout: %w", err)
+	}
+
+	window := make([]byte, 0, 32)
+	oneByte := make([]byte, 1)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		n, err := port.Read(oneByte)
+		if err != nil {
+			return fmt.Errorf("serial handshake: read: %w", err)
+		}
+		if n == 0 {
+			// rx timeout, so rx buffer empty, so send sentinel
+			var randBytes [16]byte
+			if _, err := rand.Read(randBytes[:]); err != nil {
+				return fmt.Errorf("serial handshake: generate sentinel: %w", err)
+			}
+			sentinel = hex.EncodeToString(randBytes[:])
+			window = window[:0]
+			if _, err := port.Write([]byte(strings.Repeat(" ", 16) + sentinel)); err != nil {
+				return fmt.Errorf("serial handshake: send sentinel: %w", err)
+			}
+			continue
+		}
+		if n == 1 {
+			if len(window) < 32 {
+				window = append(window, oneByte[0])
+			} else {
+				copy(window, window[1:])
+				window[31] = oneByte[0]
+			}
+			if sentinel != "" && len(window) == 32 && string(window) == sentinel {
+				if err := port.SetReadTimeout(0); err != nil {
+					return fmt.Errorf("serial handshake: clear timeout: %w", err)
+				}
+				if _, err := port.Write([]byte{escapeChar, 'm'}); err != nil {
+					return fmt.Errorf("serial handshake: send mode switch: %w", err)
+				}
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("serial handshake: sentinel not received within 3 seconds")
 }
 
 func (l *directLink) send(req *wendypb.WendyComMessage) error {
@@ -37,7 +104,7 @@ func (l *directLink) send(req *wendypb.WendyComMessage) error {
 	binary.BigEndian.PutUint16(msg[6:8], uint16(len(body)))
 	copy(msg[headerSize:], body)
 	if l.isSerial {
-		msg = bytes.ReplaceAll(msg, []byte{esc}, []byte{esc, '_'})
+		msg = bytes.ReplaceAll(msg, []byte{escapeChar}, []byte{escapeChar, '_'})
 	}
 	l.writeMu.Lock()
 	defer l.writeMu.Unlock()
@@ -73,7 +140,7 @@ func (l *directLink) maxChunk() int {
 func (l *directLink) close() error {
 	if l.isSerial {
 		if port, ok := l.conn.(serial.Port); ok {
-			_, _ = port.Write([]byte{esc, 'o'})
+			_, _ = port.Write([]byte{escapeChar, 'o'})
 			_ = port.Drain()
 		}
 	}

--- a/go/internal/cli/liteclient/link_direct.go
+++ b/go/internal/cli/liteclient/link_direct.go
@@ -77,7 +77,7 @@ func serialHandshake(port serial.Port) error {
 				window[31] = oneByte[0]
 			}
 			if sentinel != "" && len(window) == 32 && string(window) == sentinel {
-				if err := port.SetReadTimeout(0); err != nil {
+				if err := port.SetReadTimeout(serial.NoTimeout); err != nil {
 					return fmt.Errorf("serial handshake: clear timeout: %w", err)
 				}
 				if _, err := port.Write([]byte{escapeChar, 'm'}); err != nil {

--- a/go/internal/cli/liteclient/link_tunnel.go
+++ b/go/internal/cli/liteclient/link_tunnel.go
@@ -94,6 +94,11 @@ func (l *tunnelLink) recvLoop() {
 	}
 }
 
+// linkHandshake is a no-op: the broker owns the transport, nothing to set up.
+func (l *tunnelLink) linkHandshake() error {
+	return nil
+}
+
 func (l *tunnelLink) send(req *wendypb.WendyComMessage) error {
 	body, err := proto.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Move serial-specific handshake logic out of the client and into the direct link via a new `linkHandshake()` method on the `wcomLink` interface (no-op for TCP-TLS and cloud tunnel links)
- Adopt the new escape character (`0x10`, DLE) for WendyCom serial links, replacing the previous escape byte in framing, mode-switch, and close sequences
- Serial handshake now drains the rx buffer, exchanges a random 16-byte hex sentinel to synchronize, then switches the device into WendyCom message mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)