### PR TITLE
Small fixes on Wendy Lite commands

### DIFF
--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -54,6 +54,11 @@ func runWifiInteractive(cmd *cobra.Command) error {
 
 	client, err := newWifiClient(target)
 	if err != nil {
+		if target.Provider != nil && target.External != nil {
+			if _, ok := target.Provider.(providers.WifiManager); ok {
+				return fmt.Errorf("The selected device does not support full Wi-Fi management. Use commands 'wendy device wifi connect' and 'wendy device wifi disconnect' instead.")
+			}
+		}
 		return err
 	}
 	defer client.Close()

--- a/go/internal/cli/commands/wifi.go
+++ b/go/internal/cli/commands/wifi.go
@@ -56,7 +56,7 @@ func runWifiInteractive(cmd *cobra.Command) error {
 	if err != nil {
 		if target.Provider != nil && target.External != nil {
 			if _, ok := target.Provider.(providers.WifiManager); ok {
-				return fmt.Errorf("The selected device does not support full Wi-Fi management. Use commands 'wendy device wifi connect' and 'wendy device wifi disconnect' instead.")
+				return errors.New("selected device does not support full Wi-Fi management; use 'wendy device wifi connect' and 'wendy device wifi disconnect' instead")
 			}
 		}
 		return err

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -475,9 +475,7 @@ func (p *MicroWendyProvider) pushWifiConf(device models.ExternalDevice, wifi *li
 	}
 	defer client.Close()
 
-	if err := client.StopApp(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: app stop: %v\n", err)
-	}
+	client.StopApp() // silently ignore errors, the app may not be running
 
 	fmt.Println("Configuring the device...")
 	conf := &litepb.WendyConf{Wifi: wifi}


### PR DESCRIPTION
## Summary
- `wendy device wifi` (interactive) now gives a clear message on Wendy Lite devices that don't support full Wi-Fi management, pointing to `wendy device wifi connect` / `wendy device wifi disconnect` instead of a raw connection error
- Wi-Fi configuration push no longer warns when stopping the app fails — the app may simply not be running, which previously blocked conf changes with native apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)