### PR TITLE
fix(cli): decide agent updates against the release channel (WDY-2039)

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -220,7 +220,7 @@ func (m cloudDiscoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			asset := m.assets[cursor]
 			m.updatingName = asset.GetName()
-			m.flashMessage = "Updating " + asset.GetName() + "..."
+			m.flashMessage = "Checking " + asset.GetName() + "..."
 			m.flashIsError = false
 			return m, m.startCloudUpdateCmd(asset)
 		}
@@ -230,12 +230,18 @@ func (m cloudDiscoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case discoverUpdateDoneMsg:
 		m.updatingName = ""
-		if msg.err != nil {
-			m.flashMessage = fmt.Sprintf("Update failed for %s: %v", msg.deviceName, msg.err)
-			m.flashIsError = true
-		} else {
-			m.flashMessage = fmt.Sprintf("Updated %s successfully.", msg.deviceName)
-			m.flashIsError = false
+		m.flashMessage, m.flashIsError = discoverUpdateFlash(msg)
+		switch {
+		case msg.err != nil:
+			// Nothing learned about the device; leave the cached row alone.
+		case msg.note != "":
+			// No update happened, but the probe behind the note is fresher than
+			// the cached row.
+			if msg.version != nil {
+				m.versions[msg.assetID] = msg.version
+				m.versionPending[msg.assetID] = false
+			}
+		default:
 			// Invalidate cached version so the table shows fresh data after update.
 			delete(m.versions, msg.assetID)
 			delete(m.versionPending, msg.assetID)
@@ -266,7 +272,7 @@ func (m cloudDiscoverModel) View() string {
 	} else {
 		sb.WriteString(m.viewLine(scanStyle.Render("⟳ Scanning for cloud devices...")) + "\n")
 		if m.updatingName != "" {
-			sb.WriteString(m.viewLine(dimStyle.Render("  updating "+m.updatingName+"... (q quit)")) + "\n")
+			sb.WriteString(m.viewLine(dimStyle.Render("  working on "+m.updatingName+"... (q quit)")) + "\n")
 		} else {
 			hint := "  ↑/↓ navigate, enter copy, a copy all, u update, q quit"
 			if m.table.CanScroll() {
@@ -283,6 +289,11 @@ func (m cloudDiscoverModel) View() string {
 	}
 	if len(m.assets) > 0 {
 		sb.WriteString(m.table.View() + "\n")
+		// Cloud rows carry no provisioned/default markers, so the legend exists
+		// only to explain a warning glyph that is actually present.
+		if legend := tui.DeviceWarningLegend(cloudLegendItems(m.assets, m.versions)); legend != "" {
+			sb.WriteString(m.viewLine(dimStyle.Render("  "+legend)) + "\n")
+		}
 	} else if m.err == nil {
 		if m.hasResults {
 			if m.all {
@@ -332,7 +343,10 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 		devType := humanReadableDeviceType(a.GetDeviceType())
 		ver := "—"
 		if v := versions[a.GetId()]; v != nil {
-			ver = markOutdated(v.GetVersion())
+			ver = v.GetVersion()
+			if agentBehindCLI(version.Version, ver) {
+				ver += " " + tui.GlyphOutdated
+			}
 			if devType == "" {
 				devType = humanReadableDeviceType(v.GetDeviceType())
 			}
@@ -340,6 +354,22 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 		rows = append(rows, bubbleTable.Row{"", a.GetName(), devType, ver})
 	}
 	return rows
+}
+
+// cloudLegendItems reduces cloud rows to the fields the shared legend reads.
+func cloudLegendItems(assets []*cloudpb.Asset, versions map[int32]*agentpb.GetAgentVersionResponse) []tui.PickerItem {
+	items := make([]tui.PickerItem, 0, len(assets))
+	for _, a := range assets {
+		v := versions[a.GetId()]
+		if v == nil {
+			continue
+		}
+		items = append(items, tui.PickerItem{
+			AgentVersion:  v.GetVersion(),
+			AgentOutdated: agentBehindCLI(version.Version, v.GetVersion()),
+		})
+	}
+	return items
 }
 
 func cloudDeviceInfoFromAsset(a *cloudpb.Asset, ver *agentpb.GetAgentVersionResponse) discoverDeviceInfo {
@@ -417,10 +447,9 @@ func (m cloudDiscoverModel) startCloudUpdateCmd(asset *cloudpb.Asset) tea.Cmd {
 		if cpuArch := resp.GetCpuArchitecture(); cpuArch != "" {
 			arch = cpuArch
 		}
-		agentVer := resp.GetVersion()
-		if agentVer != "" && version.CompareVersions(latestVer, agentVer) <= 0 {
+		if note := agentAlreadyAtReleaseNote(name, resp.GetVersion(), latestVer); note != "" {
 			conn.Close()
-			return discoverUpdateDoneMsg{assetID: id, deviceName: name, err: fmt.Errorf("device is already up to date (%s)", agentVer)}
+			return discoverUpdateDoneMsg{assetID: id, deviceName: name, note: note, version: resp}
 		}
 
 		if arch == "" {

--- a/go/internal/cli/commands/cloud_discover_legend_test.go
+++ b/go/internal/cli/commands/cloud_discover_legend_test.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/version"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// The cloud table marks staleness with the same glyph as the LAN table, and
+// documents it only when a row carries it. It has no provisioned/default
+// markers, so the base legend must not appear.
+func TestCloudDiscoverLegendMatchesRows(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	assets := []*cloudpb.Asset{{Id: 1, Name: "Tom Thor Mac"}}
+	versions := map[int32]*agentpb.GetAgentVersionResponse{
+		1: {Version: "2026.07.27-003050"},
+	}
+
+	for _, tt := range []struct {
+		cliVer      string
+		wantMarked  bool
+		description string
+	}{
+		{"2026.07.29-120000", true, "CLI ahead of the agent"},
+		{"2026.07.27-003050", false, "matched pair"},
+		{"dev", false, "dev CLI has no comparable version"},
+	} {
+		version.Version = tt.cliVer
+
+		rows := cloudDiscoverTableRows(assets, versions)
+		marked := strings.Contains(strings.Join(rows[0], " "), tui.GlyphOutdated)
+		legend := tui.DeviceWarningLegend(cloudLegendItems(assets, versions))
+
+		if marked != tt.wantMarked {
+			t.Errorf("%s: row marked=%v, want %v (%q)", tt.description, marked, tt.wantMarked, rows[0])
+		}
+		if documented := strings.Contains(legend, tui.LegendOutdated); documented != marked {
+			t.Errorf("%s: row marked=%v but legend documents=%v (%q)", tt.description, marked, documented, legend)
+		}
+		if strings.Contains(legend, "provisioned") || strings.Contains(legend, "default") {
+			t.Errorf("%s: legend %q documents markers the cloud table cannot render", tt.description, legend)
+		}
+	}
+}
+
+// An unreachable device has no version to compare, so nothing is marked and no
+// legend line is printed.
+func TestCloudDiscoverLegendEmptyWithoutVersions(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = "2026.07.29-120000"
+
+	assets := []*cloudpb.Asset{{Id: 1, Name: "offline"}}
+	rows := cloudDiscoverTableRows(assets, nil)
+	if got := strings.Join(rows[0], " "); strings.Contains(got, tui.GlyphOutdated) {
+		t.Errorf("marked a row with no probe: %q", got)
+	}
+	if legend := tui.DeviceWarningLegend(cloudLegendItems(assets, nil)); legend != "" {
+		t.Errorf("legend = %q, want none", legend)
+	}
+}

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -268,6 +268,12 @@ type discoverUpdateDoneMsg struct {
 	deviceName string
 	assetID    int32
 	err        error
+	// note carries a non-error outcome that is not a successful update, e.g.
+	// the device already running the release we would install.
+	note string
+	// version is the probe taken while deciding, set only alongside note so a
+	// caller can refresh a cached row it would otherwise leave stale.
+	version *agentpb.GetAgentVersionResponse
 }
 
 // bleRetentionPeriod is how long a BLE device stays visible after it was last
@@ -452,13 +458,10 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.flashIsError = true
 				return m, clearFlashAfter(3 * time.Second)
 			}
-			if !agentBehindCLI(version.Version, item.info.Version) {
-				m.flashMessage = "Device is already up to date."
-				m.flashIsError = false
-				return m, clearFlashAfter(3 * time.Second)
-			}
+			// Whether an update is needed is decided against the release
+			// channel in startDeviceUpdateCmd, not against this CLI's version.
 			m.updatingDeviceName = item.info.Name
-			m.flashMessage = "Updating " + item.info.Name + "..."
+			m.flashMessage = "Checking " + item.info.Name + "..."
 			m.flashIsError = false
 			return m, m.startDeviceUpdateCmd(addr, item.info.Name)
 		case "d":
@@ -626,13 +629,7 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flashIsError = false
 	case discoverUpdateDoneMsg:
 		m.updatingDeviceName = ""
-		if msg.err != nil {
-			m.flashMessage = fmt.Sprintf("Update failed for %s: %v", msg.deviceName, msg.err)
-			m.flashIsError = true
-		} else {
-			m.flashMessage = fmt.Sprintf("Updated %s successfully.", msg.deviceName)
-			m.flashIsError = false
-		}
+		m.flashMessage, m.flashIsError = discoverUpdateFlash(msg)
 		return m, clearFlashAfter(10 * time.Second)
 	}
 
@@ -663,7 +660,9 @@ func (m discoverModel) View() string {
 
 	sb.WriteString(m.viewLine(scanStyle.Render("⟳ Scanning for WendyOS devices...")) + "\n")
 	if m.updatingDeviceName != "" {
-		sb.WriteString(m.viewLine(dimStyle.Render("  updating "+m.updatingDeviceName+"... (q quit)")) + "\n")
+		// One keypress covers the channel check and the upload it may not reach,
+		// so the wording has to fit both.
+		sb.WriteString(m.viewLine(dimStyle.Render("  working on "+m.updatingDeviceName+"... (q quit)")) + "\n")
 	} else {
 		scrollHint := ""
 		if m.canScrollTable() {
@@ -684,7 +683,7 @@ func (m discoverModel) View() string {
 
 	if !m.collection.IsEmpty() {
 		sb.WriteString(tui.ColorizeProbeGlyphs(m.tableView()) + "\n")
-		sb.WriteString(m.viewLine(dimStyle.Render("  "+tui.DeviceTableLegend)) + "\n")
+		sb.WriteString(m.viewLine(dimStyle.Render("  "+tui.DeviceTableLegend(discoverPickerItems(m.tableItems)))) + "\n")
 		if hint := m.selectedHint(); hint != "" {
 			sb.WriteString(m.viewLine(hintWarnStyle.Render("  ⚠  "+hint)) + "\n")
 		}
@@ -789,6 +788,10 @@ func lanDeviceAddr(collection *models.DevicesCollection, displayName string) str
 func (m discoverModel) startDeviceUpdateCmd(addr, name string) tea.Cmd {
 	ctx := m.ctx
 	return func() tea.Msg {
+		latestVer, _, err := resolveAgentVersion(false)
+		if err != nil {
+			return discoverUpdateDoneMsg{deviceName: name, err: fmt.Errorf("resolving agent version: %w", err)}
+		}
 		conn, err := connectWithAutoTLS(ctx, addr)
 		if err != nil {
 			return discoverUpdateDoneMsg{deviceName: name, err: fmt.Errorf("connecting to device: %w", err)}
@@ -797,6 +800,10 @@ func (m discoverModel) startDeviceUpdateCmd(addr, name string) tea.Cmd {
 		if err != nil {
 			conn.Close()
 			return discoverUpdateDoneMsg{deviceName: name, err: fmt.Errorf("querying device: %w", err)}
+		}
+		if note := agentAlreadyAtReleaseNote(name, versionResp.GetVersion(), latestVer); note != "" {
+			conn.Close()
+			return discoverUpdateDoneMsg{deviceName: name, note: note}
 		}
 		arch := versionResp.GetCpuArchitecture()
 		if arch == "" {
@@ -844,7 +851,7 @@ func renderDeviceTable(collection *models.DevicesCollection) string {
 	t.SetWidth(tui.PickerTableWidth(t.Columns()))
 	t.SetHeight(max(len(rows)+1, 1))
 
-	return t.View() + "\n" + dimStyle.Render("  "+tui.DeviceTableLegend) + "\n"
+	return t.View() + "\n" + dimStyle.Render("  "+tui.DeviceTableLegend(pickerItems)) + "\n"
 }
 
 func newDiscoverTable(interactive bool) tui.BubbleTable {
@@ -927,13 +934,29 @@ func cliBehindAgent(cliVer, agentVer string) bool {
 	return version.CompareVersions(cliVer, agentVer) < 0
 }
 
-// markOutdated prefixes the version string with "* " when the agent is behind
-// the CLI, serving as a visible indicator in discover-style tables.
-func markOutdated(agentVer string) string {
-	if agentBehindCLI(version.Version, agentVer) {
-		return "* " + agentVer
+// agentAlreadyAtReleaseNote returns a flash note when an explicit update would
+// be a no-op: the agent already reports releaseVer or newer. Whether an update
+// is needed is a question about the release channel, so it is never answered by
+// comparing against this CLI's own version. A dev agent is never current here —
+// an explicit update overwrites it with the release, as `wendy device update`
+// does. An unknown version on either side means "attempt the update".
+func agentAlreadyAtReleaseNote(deviceName, agentVer, releaseVer string) string {
+	if releaseVer == "" || version.IsDev(agentVer) || !agentUpdateVerified(agentVer, releaseVer) {
+		return ""
 	}
-	return agentVer
+	return fmt.Sprintf("%s is already at the latest release (%s).", deviceName, agentVer)
+}
+
+// discoverUpdateFlash renders the flash line for a finished update attempt.
+func discoverUpdateFlash(msg discoverUpdateDoneMsg) (message string, isError bool) {
+	switch {
+	case msg.err != nil:
+		return fmt.Sprintf("Update failed for %s: %v", msg.deviceName, msg.err), true
+	case msg.note != "":
+		return msg.note, false
+	default:
+		return fmt.Sprintf("Updated %s successfully.", msg.deviceName), false
+	}
 }
 
 func discoverTableColumns(rows []bubbleTable.Row) []bubbleTable.Column {
@@ -1057,13 +1080,14 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		}
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:         discovery.SanitiseDisplayName(d.DisplayName),
-				Type:         deviceType,
-				USB:          d.USBVersion,
-				Address:      d.Hostname,
-				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
-				DedupKey:     d.DisplayName,
-				SortKey:      deviceSortKey(d.DisplayName, d.USBVersion),
+				Name:          discovery.SanitiseDisplayName(d.DisplayName),
+				Type:          deviceType,
+				USB:           d.USBVersion,
+				Address:       d.Hostname,
+				AgentVersion:  discovery.SanitiseDisplayName(d.AgentVersion),
+				AgentOutdated: agentBehindCLI(version.Version, d.AgentVersion),
+				DedupKey:      d.DisplayName,
+				SortKey:       deviceSortKey(d.DisplayName, d.USBVersion),
 			},
 			info: discoverDeviceInfo{
 				Name:    d.DisplayName,
@@ -1092,17 +1116,18 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		provisioned := lanProvisionedDisplay(d.LAN)
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:         discovery.SanitiseDisplayName(d.DisplayName),
-				Type:         deviceType,
-				USB:          usb,
-				Address:      address,
-				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
-				OS:           d.OS,
-				OSVersion:    d.OSVersion,
-				Provisioned:  provisioned,
-				Hint:         lanNoAccessHint(d.LAN, d.AgentVersion),
-				DedupKey:     d.DisplayName,
-				SortKey:      deviceSortKey(d.DisplayName, usb),
+				Name:          discovery.SanitiseDisplayName(d.DisplayName),
+				Type:          deviceType,
+				USB:           usb,
+				Address:       address,
+				AgentVersion:  discovery.SanitiseDisplayName(d.AgentVersion),
+				AgentOutdated: agentBehindCLI(version.Version, d.AgentVersion),
+				OS:            d.OS,
+				OSVersion:     d.OSVersion,
+				Provisioned:   provisioned,
+				Hint:          lanNoAccessHint(d.LAN, d.AgentVersion),
+				DedupKey:      d.DisplayName,
+				SortKey:       deviceSortKey(d.DisplayName, usb),
 			},
 			info: discoverDeviceInfo{
 				Name:        d.DisplayName,
@@ -1125,10 +1150,12 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 		deviceType := externalProviderDisplayName(d.ProviderKey)
 		items = append(items, discoverTableItem{
 			picker: tui.PickerItem{
-				Name:         discovery.SanitiseDisplayName(d.DisplayName),
-				Type:         deviceType,
-				Address:      addr,
-				AgentVersion: discoverAgentVersionDisplay(d.AgentVersion),
+				Name:    discovery.SanitiseDisplayName(d.DisplayName),
+				Type:    deviceType,
+				Address: addr,
+				// Not AgentOutdated: a provider reports its own runtime version
+				// (e.g. Docker's), which is not comparable to the CLI's.
+				AgentVersion: discovery.SanitiseDisplayName(d.AgentVersion),
 				OS:           d.OS,
 				OSVersion:    d.OSVersion,
 				DedupKey:     d.DisplayName,
@@ -1161,17 +1188,6 @@ func discoverPickerItems(items []discoverTableItem) []tui.PickerItem {
 		pickerItems = append(pickerItems, pickerItem)
 	}
 	return pickerItems
-}
-
-func discoverAgentVersionDisplay(agentVer string) string {
-	displayVersion := discovery.SanitiseDisplayName(agentVer)
-	if displayVersion == "" {
-		return ""
-	}
-	if agentBehindCLI(version.Version, agentVer) {
-		displayVersion += " ⚠"
-	}
-	return displayVersion
 }
 
 func discoverSortKey(item tui.PickerItem) string {

--- a/go/internal/cli/commands/discover_test.go
+++ b/go/internal/cli/commands/discover_test.go
@@ -305,7 +305,7 @@ func TestDiscoverTableItemsHidesAddressForDockerAndLocal(t *testing.T) {
 func TestDiscoverModel_ViewShowsLegendWithDevices(t *testing.T) {
 	m := newDiscoverModel(context.Background(), defaultOpts(), true)
 
-	if strings.Contains(m.View(), tui.DeviceTableLegend) {
+	if strings.Contains(m.View(), tui.DeviceTableLegendBase) {
 		t.Fatalf("expected no legend before any device is found, got %q", m.View())
 	}
 
@@ -316,7 +316,7 @@ func TestDiscoverModel_ViewShowsLegendWithDevices(t *testing.T) {
 	}}})
 	m = updated.(discoverModel)
 
-	if !strings.Contains(m.View(), tui.DeviceTableLegend) {
+	if !strings.Contains(m.View(), tui.DeviceTableLegendBase) {
 		t.Fatalf("expected legend under device table, got %q", m.View())
 	}
 }
@@ -333,7 +333,7 @@ func TestRenderDeviceTable(t *testing.T) {
 	}
 
 	output := renderDeviceTable(collection)
-	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10", tui.DeviceTableLegend} {
+	for _, want := range []string{"Name", "Type", "Address", "Agent", "OS", "wendy-alpha", "1.2.3", "WendyOS-0.10.4", "LAN", "192.168.1.10", tui.DeviceTableLegendBase} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, output)
 		}

--- a/go/internal/cli/commands/discover_update_test.go
+++ b/go/internal/cli/commands/discover_update_test.go
@@ -1,0 +1,143 @@
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/internal/shared/version"
+)
+
+func outdatedLANModel(t *testing.T) discoverModel {
+	t.Helper()
+	m := newDiscoverModel(context.Background(), defaultOpts(), false)
+	m.collection.LANDevices = []models.LANDevice{{
+		DisplayName:  "Tom Thor Mac",
+		Hostname:     "wendyos-tom-thor-mac.local",
+		IPAddress:    "10.1.1.99",
+		Port:         defaultAgentPort,
+		AgentVersion: "2026.07.27-003050",
+	}}
+	m.refreshTable()
+	m.table.SetCursor(0)
+	return m
+}
+
+// Pressing "u" must not decide the outcome from the CLI's own version: whether
+// an update is needed is a question about the release channel, answered in the
+// worker. WDY-2039(c) — a dev CLI always claimed the device was up to date.
+func TestDiscoverModel_UpdateKeyDefersToTheReleaseChannel(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	for _, cliVer := range []string{"dev", "2026.07.28-225011-dev", "2026.07.27-003050", "2026.07.29-120000"} {
+		version.Version = cliVer
+		m := outdatedLANModel(t)
+
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+		dm := updated.(discoverModel)
+
+		if cmd == nil {
+			t.Errorf("cli %s: no update command started", cliVer)
+		}
+		if dm.updatingDeviceName != "Tom Thor Mac" {
+			t.Errorf("cli %s: updatingDeviceName = %q, want the device", cliVer, dm.updatingDeviceName)
+		}
+		if strings.Contains(dm.flashMessage, "up to date") {
+			t.Errorf("cli %s: refused before checking the channel: %q", cliVer, dm.flashMessage)
+		}
+		if want := "Checking Tom Thor Mac..."; dm.flashMessage != want {
+			t.Errorf("cli %s: flash = %q, want %q", cliVer, dm.flashMessage, want)
+		}
+	}
+}
+
+func TestAgentAlreadyAtReleaseNote(t *testing.T) {
+	tests := []struct {
+		name             string
+		agent, release   string
+		wantNote         bool
+		wantVersionInMsg string
+	}{
+		{"agent behind the release", "2026.07.27-003050", "2026.07.28-225023", false, ""},
+		{"agent at the release", "2026.07.27-003050", "2026.07.27-003050", true, "2026.07.27-003050"},
+		{"agent ahead of the release", "2026.07.28-225023", "2026.07.27-003050", true, "2026.07.28-225023"},
+		// An explicit update replaces a dev agent with the release, matching
+		// `wendy device update`.
+		{"dev agent", "dev", "2026.07.27-003050", false, ""},
+		{"branch-build agent", "2026.07.28-225011-dev", "2026.07.27-003050", false, ""},
+		{"unknown agent version", "", "2026.07.27-003050", false, ""},
+		{"unresolved release", "2026.07.27-003050", "", false, ""},
+	}
+
+	for _, tt := range tests {
+		note := agentAlreadyAtReleaseNote("Tom Thor Mac", tt.agent, tt.release)
+		if got := note != ""; got != tt.wantNote {
+			t.Errorf("%s: note=%q, wantNote=%v", tt.name, note, tt.wantNote)
+		}
+		if tt.wantNote {
+			if !strings.Contains(note, tt.wantVersionInMsg) {
+				t.Errorf("%s: note %q does not name version %q", tt.name, note, tt.wantVersionInMsg)
+			}
+			// "latest release" is the honest claim: the TUI resolves the stable
+			// channel, so a newer nightly may still exist.
+			if !strings.Contains(note, "latest release") {
+				t.Errorf("%s: note %q should say which channel it checked", tt.name, note)
+			}
+		}
+	}
+}
+
+// The already-current outcome is good news, not a failure.
+func TestDiscoverUpdateFlash(t *testing.T) {
+	msg := discoverUpdateDoneMsg{deviceName: "Tom Thor Mac", note: "Tom Thor Mac is already at the latest release (2026.07.27-003050)."}
+	got, isErr := discoverUpdateFlash(msg)
+	if isErr {
+		t.Errorf("already-current outcome rendered as an error: %q", got)
+	}
+	if got != msg.note {
+		t.Errorf("flash = %q, want the note verbatim", got)
+	}
+
+	if got, isErr := discoverUpdateFlash(discoverUpdateDoneMsg{deviceName: "alpha"}); isErr || !strings.Contains(got, "successfully") {
+		t.Errorf("success flash = %q (isError=%v)", got, isErr)
+	}
+	if got, isErr := discoverUpdateFlash(discoverUpdateDoneMsg{deviceName: "alpha", err: context.Canceled}); !isErr || !strings.Contains(got, "failed") {
+		t.Errorf("error flash = %q (isError=%v)", got, isErr)
+	}
+}
+
+// The discover table marks a stale agent whenever the comparison is meaningful,
+// and the legend follows the rows.
+func TestDiscoverTableItems_MarksOutdatedAgent(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = "2026.07.29-120000"
+
+	collection := &models.DevicesCollection{LANDevices: []models.LANDevice{{
+		DisplayName:  "Tom Thor Mac",
+		IPAddress:    "10.1.1.99",
+		Port:         defaultAgentPort,
+		AgentVersion: "2026.07.27-003050",
+	}}}
+
+	items := discoverTableItems(collection)
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if !items[0].picker.AgentOutdated {
+		t.Fatal("expected the agent to be marked outdated")
+	}
+	// Version text stays clean; the glyph is the table's business.
+	if got := items[0].picker.AgentVersion; got != "2026.07.27-003050" {
+		t.Errorf("AgentVersion = %q, want the bare version", got)
+	}
+
+	output := renderDeviceTable(collection)
+	if !strings.Contains(output, tui.GlyphOutdated) || !strings.Contains(output, tui.LegendOutdated) {
+		t.Errorf("expected a marked row and a matching legend, got %q", output)
+	}
+}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2245,19 +2245,20 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 			hint = lanNoAccessHint(&devCopy, dev.AgentVersion)
 		}
 		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
-			Name:         dev.DisplayName,
-			Type:         "LAN",
-			USB:          dev.USB,
-			Address:      preferredLANAddress(dev),
-			AgentVersion: dev.AgentVersion,
-			OS:           dev.OS,
-			OSVersion:    dev.OSVersion,
-			Provisioned:  lanProvisionedDisplay(&devCopy),
-			Hint:         hint,
-			Probe:        probe,
-			DedupKey:     deviceDedupKey(dev.HostKey(), dev.DisplayName),
-			SortKey:      deviceSortKey(dev.DisplayName, dev.USB),
-			Insecure:     insecure,
+			Name:          dev.DisplayName,
+			Type:          "LAN",
+			USB:           dev.USB,
+			Address:       preferredLANAddress(dev),
+			AgentVersion:  dev.AgentVersion,
+			AgentOutdated: agentBehindCLI(version.Version, dev.AgentVersion),
+			OS:            dev.OS,
+			OSVersion:     dev.OSVersion,
+			Provisioned:   lanProvisionedDisplay(&devCopy),
+			Hint:          hint,
+			Probe:         probe,
+			DedupKey:      deviceDedupKey(dev.HostKey(), dev.DisplayName),
+			SortKey:       deviceSortKey(dev.DisplayName, dev.USB),
+			Insecure:      insecure,
 			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 				DisplayName:     dev.DisplayName,
 				AgentVersion:    dev.AgentVersion,
@@ -2369,14 +2370,16 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 							connType = "BLE (Lite)"
 						}
 						items = append(items, tui.PickerItem{
-							Name:         bleDevices[i].DisplayName,
-							DedupKey:     deviceDedupKey(bleDevices[i].HostKey(), bleDevices[i].DisplayName),
-							SortKey:      deviceSortKey(bleDevices[i].DisplayName, ""),
-							Type:         connType,
-							Address:      bleDevices[i].Address,
-							AgentVersion: bleDevices[i].AgentVersion,
-							OS:           bleDevices[i].OS,
-							OSVersion:    bleDevices[i].OSVersion,
+							Name:     bleDevices[i].DisplayName,
+							DedupKey: deviceDedupKey(bleDevices[i].HostKey(), bleDevices[i].DisplayName),
+							SortKey:  deviceSortKey(bleDevices[i].DisplayName, ""),
+							Type:     connType,
+							Address:  bleDevices[i].Address,
+							// A Lite device reports firmware here, not an agent version.
+							AgentVersion:  bleDevices[i].AgentVersion,
+							AgentOutdated: bleDevices[i].IsWendyAgent() && agentBehindCLI(version.Version, bleDevices[i].AgentVersion),
+							OS:            bleDevices[i].OS,
+							OSVersion:     bleDevices[i].OSVersion,
 							Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
 								DisplayName:     bleDevices[i].DisplayName,
 								AgentVersion:    bleDevices[i].AgentVersion,

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -152,6 +152,10 @@ type PickerItem struct {
 	// secured with mTLS. A warning is shown in the picker when this item is highlighted.
 	Insecure bool
 
+	// AgentOutdated marks the agent as older than the CLI, rendered as a glyph
+	// on the Agent column. Callers own the comparison; the picker only displays it.
+	AgentOutdated bool
+
 	// Value is the opaque payload returned when this item is selected.
 	Value interface{}
 }
@@ -238,7 +242,7 @@ type PickerModel struct {
 	spinner      spinner.Model // animates Agent/OS cells while probes are pending
 	columns      []pickerColumnDef
 	fixedColumns bool
-	legend       string // optional glyph legend rendered under the table
+	deviceLegend bool // render the device glyph legend under the table
 	selected     *PickerItem
 	scanning     bool
 	quitting     bool
@@ -262,7 +266,7 @@ func NewPicker() PickerModel {
 		spinner:      newProbeSpinner(),
 		columns:      pickerDeviceColumnDefs,
 		fixedColumns: true,
-		legend:       DeviceTableLegend,
+		deviceLegend: true,
 		scanning:     true,
 	}
 	m.refreshTable()
@@ -583,12 +587,12 @@ func (m PickerModel) View() string {
 		sb.WriteString(m.viewLine(style.Render("  "+m.flashMessage)) + "\n")
 	}
 
-	if m.legend != "" {
-		sb.WriteString(m.viewLine(pickerHint.Render("  "+m.legend)) + "\n")
+	if m.deviceLegend {
+		sb.WriteString(m.viewLine(pickerHint.Render("  "+DeviceTableLegend(visible))) + "\n")
 	}
 
 	if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) && visible[idx].Insecure {
-		sb.WriteString(m.viewLine(pickerInsecure.Render("  ⚠  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
+		sb.WriteString(m.viewLine(pickerInsecure.Render("  "+GlyphInsecure+"  Connection is not secured with mTLS. PKI support is coming soon.")) + "\n")
 	}
 
 	if m.scanning {
@@ -654,8 +658,62 @@ func (m PickerModel) Selected() *PickerItem {
 	return m.selected
 }
 
-// DeviceTableLegend explains the glyphs used in the compact device table.
-const DeviceTableLegend = "● provisioned  ○ unprovisioned  ✦ default  ⚠ agent older than CLI"
+// Glyphs marking a warning state on a device row, and the legend entries that
+// explain them. Each glyph has exactly one meaning across every device table.
+const (
+	GlyphOutdated = "⚠"
+	GlyphInsecure = "!"
+
+	LegendOutdated = GlyphOutdated + " agent older than CLI"
+	LegendInsecure = GlyphInsecure + " not using mTLS"
+)
+
+// DeviceTableLegendBase documents the glyphs the device table always explains.
+// These are common enough that their absence from a row is itself informative,
+// so they stay listed whether or not any row carries them.
+const DeviceTableLegendBase = "● provisioned  ○ unprovisioned  ✦ default"
+
+// DeviceTableLegend documents the base glyphs plus each warning glyph that
+// items actually render, so a warning is never advertised when none is shown.
+func DeviceTableLegend(items []PickerItem) string {
+	legend := DeviceTableLegendBase
+	for _, entry := range deviceLegendWarnings(items) {
+		legend += "  " + entry
+	}
+	return legend
+}
+
+// deviceLegendWarnings returns the legend entries for the warning glyphs items
+// render, in glyph order. Empty when no row carries one.
+func deviceLegendWarnings(items []PickerItem) []string {
+	var outdated, insecure bool
+	for _, item := range items {
+		outdated = outdated || itemShowsOutdated(item)
+		insecure = insecure || item.Insecure
+	}
+	var entries []string
+	if outdated {
+		entries = append(entries, LegendOutdated)
+	}
+	if insecure {
+		entries = append(entries, LegendInsecure)
+	}
+	return entries
+}
+
+// DeviceWarningLegend documents only the warning glyphs items render, for
+// tables that have no provisioned/default markers to explain. Empty when
+// nothing is marked, so the caller can omit the line entirely.
+func DeviceWarningLegend(items []PickerItem) string {
+	return strings.Join(deviceLegendWarnings(items), "  ")
+}
+
+// itemShowsOutdated reports whether the Agent cell renders the outdated glyph.
+// A pending probe shows a spinner and a failed one may show no version at all,
+// and neither can carry a marker.
+func itemShowsOutdated(item PickerItem) bool {
+	return item.AgentOutdated && item.AgentVersion != "" && item.Probe != ProbePending
+}
 
 type pickerColumnDef struct {
 	title    string
@@ -740,7 +798,11 @@ var pickerDeviceColumnDefs = []pickerColumnDef{
 		title:    "Agent",
 		minWidth: 7,
 		value: func(item PickerItem) string {
-			return probeColumnValue(item.Probe, item.AgentVersion, item.ProbeFrame)
+			val := probeColumnValue(item.Probe, item.AgentVersion, item.ProbeFrame)
+			if itemShowsOutdated(item) {
+				val += " " + GlyphOutdated
+			}
+			return val
 		},
 	},
 	{
@@ -1098,7 +1160,7 @@ func pickerRows(items []PickerItem, cols []pickerColumnDef, defaultKey string, h
 		for _, col := range cols {
 			val := col.value(item)
 			if col.required && item.Insecure {
-				val += " ⚠"
+				val += " " + GlyphInsecure
 			}
 			row = append(row, val)
 		}

--- a/go/internal/cli/tui/picker_legend_test.go
+++ b/go/internal/cli/tui/picker_legend_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The legend and the rows must agree: a warning glyph is documented exactly
+// when some row renders it. WDY-2039(a) shipped a legend describing ⚠ as
+// staleness while the only ⚠ rendered meant "no mTLS".
+func TestDeviceTableLegend_DocumentsExactlyTheGlyphsRendered(t *testing.T) {
+	stale := PickerItem{Name: "stale", AgentVersion: "2026.07.27-003050", AgentOutdated: true}
+	insecure := PickerItem{Name: "insecure", AgentVersion: "2026.07.28-225023", Insecure: true}
+	plain := PickerItem{Name: "plain", AgentVersion: "2026.07.28-225023"}
+
+	tests := []struct {
+		name  string
+		items []PickerItem
+	}{
+		{"none", []PickerItem{plain}},
+		{"outdated only", []PickerItem{plain, stale}},
+		{"insecure only", []PickerItem{plain, insecure}},
+		{"both", []PickerItem{stale, insecure}},
+		{"empty", nil},
+	}
+
+	for _, tt := range tests {
+		legend := DeviceTableLegend(tt.items)
+		if !strings.Contains(legend, DeviceTableLegendBase) {
+			t.Errorf("%s: legend %q is missing the always-documented glyphs", tt.name, legend)
+		}
+		_, rows := PickerDeviceTableData(tt.items, "", true)
+		var rendered string
+		for _, row := range rows {
+			rendered += strings.Join(row, " ")
+		}
+		for glyph, entry := range map[string]string{GlyphOutdated: LegendOutdated, GlyphInsecure: LegendInsecure} {
+			inRows := strings.Contains(rendered, glyph)
+			inLegend := strings.Contains(legend, entry)
+			if inRows != inLegend {
+				t.Errorf("%s: glyph %q rendered=%v documented=%v (legend %q, rows %q)",
+					tt.name, glyph, inRows, inLegend, legend, rendered)
+			}
+		}
+	}
+}
+
+// A pending probe renders a spinner frame in the Agent cell, so there is
+// nothing to mark and nothing to document.
+func TestDeviceTableLegend_SkipsOutdatedWhileProbePending(t *testing.T) {
+	items := []PickerItem{{
+		Name:          "alpha",
+		AgentVersion:  "2026.07.27-003050",
+		AgentOutdated: true,
+		Probe:         ProbePending,
+		ProbeFrame:    "⣟",
+	}}
+
+	if legend := DeviceTableLegend(items); strings.Contains(legend, LegendOutdated) {
+		t.Fatalf("legend documents staleness for a pending probe: %q", legend)
+	}
+	_, rows := PickerDeviceTableData(items, "", true)
+	if got := strings.Join(rows[0], " "); strings.Contains(got, GlyphOutdated) {
+		t.Fatalf("row marks staleness for a pending probe: %q", got)
+	}
+}
+
+// The two warning states are distinct glyphs on distinct columns: staleness
+// annotates the agent version, no-mTLS annotates the name.
+func TestPickerDeviceTableData_MarksStalenessAndInsecureSeparately(t *testing.T) {
+	cols, rows := PickerDeviceTableData([]PickerItem{{
+		Name:          "Tom Thor Mac",
+		Type:          "LAN",
+		Address:       "wendyos-tom-thor-mac.local",
+		AgentVersion:  "2026.07.27-003050",
+		OSVersion:     "WendyOS-0.17.0",
+		Provisioned:   "Unprovisioned",
+		AgentOutdated: true,
+		Insecure:      true,
+	}}, "", true)
+
+	cell := func(title string) string {
+		for i, col := range cols {
+			if col.Title == title {
+				return rows[0][i]
+			}
+		}
+		t.Fatalf("no %q column in %v", title, cols)
+		return ""
+	}
+
+	if got, want := cell("Agent"), "2026.07.27-003050 "+GlyphOutdated; got != want {
+		t.Errorf("Agent cell = %q, want %q", got, want)
+	}
+	if got, want := cell("Name"), "Tom Thor Mac "+GlyphInsecure; got != want {
+		t.Errorf("Name cell = %q, want %q", got, want)
+	}
+}
+
+// Tables without provisioned/default markers document only what they render,
+// and omit the line entirely when nothing is marked.
+func TestDeviceWarningLegend(t *testing.T) {
+	if got := DeviceWarningLegend([]PickerItem{{AgentVersion: "2026.07.28-225023"}}); got != "" {
+		t.Errorf("unmarked rows produced legend %q, want empty", got)
+	}
+	got := DeviceWarningLegend([]PickerItem{{AgentVersion: "2026.07.27-003050", AgentOutdated: true}})
+	if got != LegendOutdated {
+		t.Errorf("legend = %q, want %q", got, LegendOutdated)
+	}
+	if strings.Contains(got, "provisioned") {
+		t.Errorf("legend %q documents markers this table cannot render", got)
+	}
+}

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -305,8 +305,8 @@ func TestNewPicker_ShowsDeviceTableLegend(t *testing.T) {
 	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha", Value: "alpha"}}})
 	pm := updated.(PickerModel)
 
-	if !strings.Contains(pm.View(), DeviceTableLegend) {
-		t.Fatalf("expected device picker view to contain legend %q, got %q", DeviceTableLegend, pm.View())
+	if !strings.Contains(pm.View(), DeviceTableLegendBase) {
+		t.Fatalf("expected device picker view to contain legend %q, got %q", DeviceTableLegendBase, pm.View())
 	}
 }
 


### PR DESCRIPTION
Fixes [WDY-2039](https://linear.app/wendylabsinc/issue/WDY-2039).

## The update key asked the wrong question

Pressing `u` in `wendy device list` gated on `agentBehindCLI` — a *skew* check (is this agent older than my CLI?) — to decide whether to run a *channel* install (fetch the latest release and upload it). Three consequences:

1. A `dev` or `-dev` CLI always answered `Device is already up to date.`, however old the agent actually was. `IsDev` short-circuits the predicate, so this silenced every source-built CLI and every CI branch build.
2. An older *release* CLI said the same for an equal-version agent, even when a newer agent release existed.
3. Once past the gate, the worker uploaded unconditionally — so a newer CLI downloaded the latest release and restarted an agent that was already running it.

`wendy cloud discover` already resolved the channel in its worker, so the LAN path now matches it: resolve the release version, short-circuit with the version it found, and report that as a note rather than an error so good news stops rendering red. Wording now covers a check that may not reach an upload (`Checking X...` / `working on X...`).

## The legend documented the wrong glyph

`DeviceTableLegend` promised `⚠ agent older than CLI`. The discover table did mark staleness that way — but the **device picker** (what `wendy run` opens without `--device`) rendered `⚠` on the *name* column meaning "connection isn't mTLS", had no staleness marker at all, and documented neither. `wendy cloud discover` used a third spelling, `* `, with no legend.

- one meaning per glyph: `⚠` agent older than CLI, `!` not using mTLS
- `● ○ ✦` stay listed always, since their absence from a row is informative; a warning entry appears only when a row renders it
- the picker gains the staleness marker; the cloud table gains the same glyph and a warning-only legend (it has no provisioned/default markers to explain)
- external provider rows are no longer marked: a provider reports its own runtime version (Docker's, say), which isn't comparable to the CLI's

## Deliberately not fixed

A dev CLI still computes no staleness — it has no comparable version, per WDY-1770. Release and nightly CLIs are unaffected and already correct. Deriving a comparable timestamp from build info was considered and dropped; a note is on the issue.

## Testing

Verified on hardware against a Jetson AGX Thor on agent `2026.07.27-003050`, with latest stable confirmed identical beforehand so a no-op was the expected outcome:

| | result |
|---|---|
| dev CLI, table | unmarked row, legend shows only `● ○ ✦` |
| release-versioned CLI, table | `2026.07.27-003050 ⚠`, legend gains `⚠ agent older than CLI` |
| dev CLI, press `u` | `Checking...` → `Tom Thor Mac is already at the latest release (2026.07.27-003050).` (previously the false `Device is already up to date.`) |
| release-versioned CLI, press `u` | same no-op; previously this downloaded stable and restarted the agent |
| device afterwards | still `2026.07.27-003050`, no reflash |

The picker's new marker is unit-tested only — one device on the LAN, so the picker doesn't open.