### PR TITLE
fix(agent): Jetson video encoder selection and NVMM caps

### DIFF
--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -1074,6 +1074,26 @@ func findGStreamerEncoder(inspectPath string) (gstEncoderResult, error) {
 	return findGStreamerEncoderFromSet(available)
 }
 
+// Encoders whose element registers even when the hardware is absent: Thor has no NVENC and
+// ships /dev/v4l2-nvenc as a /dev/null stub, so it loads and then fails to open.
+var encoderDeviceNodes = map[string]string{
+	"nvv4l2h264enc": "/dev/v4l2-nvenc",
+}
+
+// A stub such as /dev/null opens fine but rejects VIDIOC_QUERYCAP with ENOTTY. O_RDWR matches
+// how the encoder element opens it; no O_NOFOLLOW, since a platform may symlink the node and
+// the paths above are hardcoded. Indirected for tests.
+var v4l2NodeUsable = func(path string) bool {
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return false
+	}
+	defer unix.Close(fd) //nolint:errcheck
+	var caps v4l2Capability
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQueryCap, uintptr(unsafe.Pointer(&caps)))
+	return errno == 0
+}
+
 // findGStreamerEncoderFromSet performs encoder selection against a precomputed
 // element availability map. When available is nil (e.g. gst-inspect listing
 // failed), it falls back to attempting x264enc.
@@ -1082,7 +1102,25 @@ func findGStreamerEncoderFromSet(available map[string]bool) (gstEncoderResult, e
 		return gstEncoderResult{element: "x264enc", codec: agentpb.VideoCodec_VIDEO_CODEC_H264}, nil
 	}
 
-	hasElem := func(name string) bool { return available[name] }
+	// An element needing a V4L2 node counts as available only if that node really works.
+	// Probed at most once per element: hasElem is consulted from several fallback paths, and
+	// reopening a real encoder node each time is wasteful.
+	probed := make(map[string]bool)
+	hasElem := func(name string) bool {
+		if !available[name] {
+			return false
+		}
+		node, gated := encoderDeviceNodes[name]
+		if !gated {
+			return true
+		}
+		if usable, seen := probed[name]; seen {
+			return usable
+		}
+		usable := v4l2NodeUsable(node)
+		probed[name] = usable
+		return usable
+	}
 	h264Parse := hasElem("h264parse")
 
 	h264Encoders := []string{
@@ -1108,7 +1146,7 @@ func findGStreamerEncoderFromSet(available map[string]bool) (gstEncoderResult, e
 		}
 		for name := range available {
 			lower := strings.ToLower(name)
-			if strings.Contains(lower, "h264") && strings.Contains(lower, "enc") {
+			if strings.Contains(lower, "h264") && strings.Contains(lower, "enc") && hasElem(name) {
 				return gstEncoderResult{element: name, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, hasH264Parse: true}, nil
 			}
 		}
@@ -1131,7 +1169,7 @@ func findGStreamerEncoderFromSet(available map[string]bool) (gstEncoderResult, e
 	}
 	for name := range available {
 		lower := strings.ToLower(name)
-		if strings.Contains(lower, "h264") && strings.Contains(lower, "enc") {
+		if strings.Contains(lower, "h264") && strings.Contains(lower, "enc") && hasElem(name) {
 			return gstEncoderResult{element: name, codec: agentpb.VideoCodec_VIDEO_CODEC_H264}, nil
 		}
 	}
@@ -1454,9 +1492,8 @@ func encoderSegment(encoder string, hasH264Parse bool, gop int) string {
 	var enc string
 	switch encoder {
 	case "nvv4l2h264enc":
-		// Jetson L4T hardware encoder: NV12 only in NVMM memory, which is why the CSI path
-		// feeds it NVMM caps. videoconvert emits system memory, so nvvidconv has to move the
-		// frames across or the pipeline never links.
+		// Jetson L4T hardware encoder: NV12 only in NVMM memory. videoconvert emits system
+		// memory, so nvvidconv must move the frames across or the pipeline never links.
 		enc = "videoconvert ! video/x-raw,format=NV12 ! nvvidconv ! " +
 			"video/x-raw(memory:NVMM),format=NV12 ! nvv4l2h264enc" + kf
 	case "v4l2h264enc":

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -1454,8 +1454,11 @@ func encoderSegment(encoder string, hasH264Parse bool, gop int) string {
 	var enc string
 	switch encoder {
 	case "nvv4l2h264enc":
-		// Jetson L4T hardware encoder; NV12 is its preferred input format.
-		enc = "videoconvert ! video/x-raw,format=NV12 ! nvv4l2h264enc" + kf
+		// Jetson L4T hardware encoder: NV12 only in NVMM memory, which is why the CSI path
+		// feeds it NVMM caps. videoconvert emits system memory, so nvvidconv has to move the
+		// frames across or the pipeline never links.
+		enc = "videoconvert ! video/x-raw,format=NV12 ! nvvidconv ! " +
+			"video/x-raw(memory:NVMM),format=NV12 ! nvv4l2h264enc" + kf
 	case "v4l2h264enc":
 		// The Raspberry Pi bcm2835-codec rejects frames ("Failed to process
 		// frame") unless the output H.264 level is pinned — a bare or

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -447,6 +447,70 @@ bad:  h264parse: H.264 parser
 	}
 }
 
+// /dev/null is exactly what Thor ships as /dev/v4l2-nvenc: it opens, then rejects QUERYCAP.
+func TestV4L2NodeUsable(t *testing.T) {
+	if v4l2NodeUsable("/dev/null") {
+		t.Error("/dev/null must not pass as a V4L2 device")
+	}
+	if v4l2NodeUsable(t.TempDir() + "/absent") {
+		t.Error("a missing node must not pass")
+	}
+}
+
+// stubV4L2NodeUsable forces the hardware-encoder device probe for the test's duration.
+func stubV4L2NodeUsable(t *testing.T, usable bool) {
+	t.Helper()
+	prev := v4l2NodeUsable
+	v4l2NodeUsable = func(string) bool { return usable }
+	t.Cleanup(func() { v4l2NodeUsable = prev })
+}
+
+// Thor's exact element set: it registers nvv4l2h264enc but /dev/v4l2-nvenc is a /dev/null
+// stub, so the pipeline cannot preroll. Selection has to fall through to the software encoder.
+func TestFindGStreamerEncoder_SkipsNVENCWithUnusableNode(t *testing.T) {
+	stubV4L2NodeUsable(t, false)
+	available := map[string]bool{
+		"nvv4l2h264enc": true, "x264enc": true, "h264parse": true,
+		"vp8enc": true, "webmmux": true,
+	}
+
+	result, err := findGStreamerEncoderFromSet(available)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.element != "x264enc" {
+		t.Errorf("expected fallback to x264enc, got %q", result.element)
+	}
+}
+
+func TestFindGStreamerEncoder_UsesNVENCWithUsableNode(t *testing.T) {
+	stubV4L2NodeUsable(t, true)
+	available := map[string]bool{"nvv4l2h264enc": true, "x264enc": true, "h264parse": true}
+
+	result, err := findGStreamerEncoderFromSet(available)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.element != "nvv4l2h264enc" {
+		t.Errorf("expected nvv4l2h264enc, got %q", result.element)
+	}
+}
+
+// With only a stubbed encoder there is nothing to fall back to. Reporting that names the
+// remedy, where selecting it anyway produced an opaque preroll failure.
+func TestFindGStreamerEncoder_GatedEncoderIsNeverAFallback(t *testing.T) {
+	stubV4L2NodeUsable(t, false)
+	available := map[string]bool{"nvv4l2h264enc": true, "h264parse": true}
+
+	_, err := findGStreamerEncoderFromSet(available)
+	if err == nil {
+		t.Fatal("expected an error rather than selecting the gated encoder")
+	}
+	if !strings.Contains(err.Error(), "no supported GStreamer encoder found") {
+		t.Errorf("error should name the remedy, got: %v", err)
+	}
+}
+
 func TestFindGStreamerEncoder_PrefersX264(t *testing.T) {
 	tmpDir := t.TempDir()
 	script := tmpDir + "/gst-inspect-1.0"
@@ -496,6 +560,7 @@ func TestFindGStreamerEncoder_H264ParseDetection(t *testing.T) {
 }
 
 func TestFindGStreamerEncoder_PrefersNVV4L2OverOtherH264Encoders(t *testing.T) {
+	stubV4L2NodeUsable(t, true) // no NVENC node on the build host
 	tmpDir := t.TempDir()
 	script := tmpDir + "/gst-inspect-1.0"
 	listing := "x264:  x264enc: H264 video encoder\nvideo4linux2:  v4l2h264enc: V4L2 H264 encoder\nnvvideo4linux2:  nvv4l2h264enc: NVIDIA V4L2 H264 encoder\n"

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -368,6 +368,11 @@ func TestBuildGStreamerArgs_NVV4L2HardwareEncoder(t *testing.T) {
 	if !strings.Contains(joined, "video/x-raw,format=NV12") {
 		t.Errorf("expected NV12 capsfilter for nvv4l2h264enc: %v", args)
 	}
+	// Without nvvidconv the encoder rejects system-memory NV12 and a USB camera on a
+	// Jetson never streams.
+	if !strings.Contains(joined, "nvvidconv ! video/x-raw(memory:NVMM),format=NV12 ! nvv4l2h264enc") {
+		t.Errorf("nvv4l2h264enc must be fed NVMM NV12 via nvvidconv: %v", args)
+	}
 }
 
 func TestBuildGStreamerArgs_VP8Encoder(t *testing.T) {


### PR DESCRIPTION
Two independent defects that made camera streaming impossible on Jetson. Found while testing WDY-1994 on an AGX Thor; neither belongs to that ticket.

**1. `nvv4l2h264enc` was fed system-memory NV12.** The encoder accepts NV12 only in NVMM memory, so the pipeline could never link (`nvv4l2h264enc0 can't handle caps video/x-raw, format=(string)NV12`). The CSI path already passed NVMM caps; the generic path did not. Fixed by inserting `nvvidconv`. This affected any USB camera on any Jetson, via the dashboard and the CLI alike.

**2. Encoder selection trusted element registration.** AGX Thor has no NVENC engine, but ships `/dev/v4l2-nvenc` as a `/dev/null` stub (same device numbers, `1, 3`) so the plugin still loads. `VIDIOC_QUERYCAP` on it returns ENOTTY, which is the "It isn't a v4l2 driver" error. Selection now gates elements that need a V4L2 node on that node answering `QUERYCAP`, probed at most once per element. Reproducible with no camera involved:

```
gst-launch-1.0 videotestsrc ! nvvidconv ! 'video/x-raw(memory:NVMM),format=NV12' ! nvv4l2h264enc ! fakesink
-> Failed to open encoder
```

Consequence worth knowing: on Thor, selection now falls through to `x264enc`, so H.264 is encoded in **software**. Where no usable encoder exists at all, selection returns `no supported GStreamer encoder found (... install gst-plugins-ugly (x264enc))` rather than building a pipeline that cannot preroll.

Verified on an AGX Thor with a USB camera: 6.7 MB streamed in 25s, agent log confirming `encoder=x264enc`, capture validating as real H.264. `TestV4L2NodeUsable` exercises the probe against `/dev/null`, reproducing Thor's stub on any host.
