### PR TITLE
Fix JetPack 6.2 version detection

### DIFF
--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -220,6 +220,7 @@ func jetPackVersionFromTegraRelease(data []byte) string {
 	jetpackExact := map[string]string{
 		"36.4.4": "6.2.1",
 		"36.4.3": "6.2",
+		"36.4.0": "6.1",
 	}
 	if jp, ok := jetpackExact[l4tVersion]; ok {
 		return jp
@@ -233,7 +234,6 @@ func jetPackVersionFromTegraRelease(data []byte) string {
 	// https://developer.nvidia.com/embedded/jetpack-archive
 	jetpack := map[string]string{
 		"39.2": "7.2",
-		"36.4": "6.1",
 		"36.3": "6.0",
 		"36.2": "6.0",
 		"35.5": "5.1.3",

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -197,12 +197,16 @@ func detectGPUInfo() gpuInfo {
 
 var tegraReleaseRe = regexp.MustCompile(`R(\d+)\s+\([^)]+\),\s+REVISION:\s+([\d.]+)`)
 
-// Falls back to "L4T {version}" when no mapping is found.
+// Falls back to "L4T-{version}" when no mapping is found.
 func detectJetPackVersion() string {
 	data, err := os.ReadFile("/etc/nv_tegra_release")
 	if err != nil {
 		return ""
 	}
+	return jetPackVersionFromTegraRelease(data)
+}
+
+func jetPackVersionFromTegraRelease(data []byte) string {
 	m := tegraReleaseRe.FindSubmatch(data)
 	if len(m) < 3 {
 		return ""
@@ -210,7 +214,18 @@ func detectJetPackVersion() string {
 	major := string(m[1])
 	revision := string(m[2]) // e.g. "4.4"
 
-	// Use major.minor for the table key (e.g. "36.4").
+	// Some JetPack releases share an L4T major.minor family, so prefer the
+	// complete L4T version before falling back to the family mapping.
+	l4tVersion := major + "." + revision
+	jetpackExact := map[string]string{
+		"36.4.4": "6.2.1",
+		"36.4.3": "6.2",
+	}
+	if jp, ok := jetpackExact[l4tVersion]; ok {
+		return jp
+	}
+
+	// Use major.minor for releases where the patch version is not significant.
 	minor := strings.SplitN(revision, ".", 2)[0]
 	key := major + "." + minor
 
@@ -238,7 +253,7 @@ func detectJetPackVersion() string {
 	if jp, ok := jetpack[key]; ok {
 		return jp
 	}
-	return "L4T-" + major + "." + revision
+	return "L4T-" + l4tVersion
 }
 
 var cudaVersionFileRe = regexp.MustCompile(`(?i)CUDA[^0-9]*([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)

--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -899,9 +899,14 @@ func TestJetPackVersionFromTegraRelease(t *testing.T) {
 			want:    "6.2",
 		},
 		{
-			name:    "JetPack 6.1 family fallback",
+			name:    "JetPack 6.1",
 			release: "# R36 (release), REVISION: 4.0, GCID: 37537400, BOARD: generic, EABI: aarch64",
 			want:    "6.1",
+		},
+		{
+			name:    "unknown patch in version-sensitive family",
+			release: "# R36 (release), REVISION: 4.5, GCID: 50000000, BOARD: generic, EABI: aarch64",
+			want:    "L4T-36.4.5",
 		},
 		{
 			name:    "JetPack 7.2 family fallback",

--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -880,6 +880,55 @@ func TestFinishCommittedUpdateRestartsEvenWhenAckFails(t *testing.T) {
 	})
 }
 
+// ---------- jetPackVersionFromTegraRelease ----------
+
+func TestJetPackVersionFromTegraRelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		release string
+		want    string
+	}{
+		{
+			name:    "JetPack 6.2.1",
+			release: "# R36 (release), REVISION: 4.4, GCID: 41834240, BOARD: generic, EABI: aarch64",
+			want:    "6.2.1",
+		},
+		{
+			name:    "JetPack 6.2",
+			release: "# R36 (release), REVISION: 4.3, GCID: 38968081, BOARD: generic, EABI: aarch64",
+			want:    "6.2",
+		},
+		{
+			name:    "JetPack 6.1 family fallback",
+			release: "# R36 (release), REVISION: 4.0, GCID: 37537400, BOARD: generic, EABI: aarch64",
+			want:    "6.1",
+		},
+		{
+			name:    "JetPack 7.2 family fallback",
+			release: "# R39 (release), REVISION: 2.0, GCID: 50000000, BOARD: generic, EABI: aarch64",
+			want:    "7.2",
+		},
+		{
+			name:    "unknown L4T version",
+			release: "# R37 (release), REVISION: 1.2, GCID: 40000000, BOARD: generic, EABI: aarch64",
+			want:    "L4T-37.1.2",
+		},
+		{
+			name:    "malformed release",
+			release: "not an L4T release",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jetPackVersionFromTegraRelease([]byte(tt.release)); got != tt.want {
+				t.Errorf("jetPackVersionFromTegraRelease() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // ---------- detectCUDAVersionIn ----------
 
 const nvccVersionOutput = `nvcc: NVIDIA (R) Cuda compiler driver


### PR DESCRIPTION
## Summary

- preserve the complete L4T version while parsing `/etc/nv_tegra_release`
- map L4T 36.4.0 to JetPack 6.1, 36.4.3 to JetPack 6.2, and 36.4.4 to JetPack 6.2.1
- keep existing family mappings for releases where the patch component is not version-significant
- report unknown 36.4 patch releases as their raw L4T version instead of guessing an incorrect JetPack release
- add regression coverage for known JetPack releases, unknown patches, unknown L4T families, and malformed input

## Root cause

`detectJetPackVersion` discarded the L4T patch component before lookup. That reduced 36.4.0, 36.4.3, and 36.4.4 to the same 36.4 key, whose existing mapping returned JetPack 6.1 for all three.

## Impact

Wendy now reports the correct JetPack version for known L4T 36.4.x releases. Future or otherwise unknown 36.4 patch releases remain accurately identified by L4T version rather than being mislabeled as JetPack 6.1. Existing mappings outside the version-sensitive 36.4 family remain unchanged.

## Validation

- `go test ./go/internal/agent/services -run '^TestJetPackVersionFromTegraRelease$' -count=1`
- `go test ./go/internal/agent/... -count=1`