### PR TITLE
Fix startMTLSRegistryProxy skipping server certificate verification

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2303,7 +2303,7 @@ func startMTLSRegistryProxy(ctx context.Context, target string) (*registryProxy,
 		return nil, fmt.Errorf("no valid CA certificates found in certInfo.PemCertificateChain")
 	}
 	tlsCfg := &tls.Config{
-		// Hostname check only; full chain validation happens in VerifyConnection.
+		// Skip hostname verification; full chain validation happens in VerifyConnection.
 		InsecureSkipVerify: true, //nolint:gosec
 		MinVersion:         tls.VersionTLS12,
 		Certificates:       []tls.Certificate{tlsCert},

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2298,10 +2298,16 @@ func startMTLSRegistryProxy(ctx context.Context, target string) (*registryProxy,
 	if err != nil {
 		return nil, fmt.Errorf("loading client certificate: %w", err)
 	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM([]byte(certInfo.PemCertificateChain)) {
+		return nil, fmt.Errorf("no valid CA certificates found in certInfo.PemCertificateChain")
+	}
 	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // device registries use self-signed certs; pinning is tracked separately
+		// Hostname check only; full chain validation happens in VerifyConnection.
+		InsecureSkipVerify: true, //nolint:gosec
 		MinVersion:         tls.VersionTLS12,
 		Certificates:       []tls.Certificate{tlsCert},
+		VerifyConnection:   wendyRegistryServerVerifier(caPool),
 	}
 	dialer := &tls.Dialer{Config: tlsCfg}
 	return startRegistryProxyWithDialer(ctx, "127.0.0.1:0", func(ctx context.Context) (net.Conn, error) {


### PR DESCRIPTION
## Summary
- `startMTLSRegistryProxy` (go/internal/cli/commands/docker.go) set `InsecureSkipVerify: true` with **no verification callback at all**, unlike its two sibling functions in the same file (`tlsClientDialer`, `startMTLSRegistryHTTPProxy`), which both build a CA pool from `certInfo.PemCertificateChain` and validate the presented chain via `wendyRegistryServerVerifier`.
- This function would accept **any** certificate presented by the dialed target — no chain validation whatsoever.
- Fix mirrors the existing, already-verified pattern from the two siblings exactly: build `caPool` from `certInfo.PemCertificateChain`, wire in `VerifyConnection: wendyRegistryServerVerifier(caPool)`.

## How this was found
Found via static analysis — I was dogfooding a static-analysis tool ([`aint`](https://github.com/wendylabsinc — n/a, local project)) against this repo and its `go-tls-insecure-skip-verify` check flagged all `InsecureSkipVerify: true` sites for manual review. 9 of 12 flagged sites turned out to be correctly implemented (paired with a real verification callback the regex-based check can't see); this one was a genuine gap.

## Risk / urgency
I confirmed by inspection that `startMTLSRegistryProxy` currently has **no callers anywhere in the repo** — this is unreferenced today, so there's no live exploit path. Fixing it now closes the gap before it's ever wired up (it's clearly meant to be used, per its doc comment: "lets tools that cannot perform mTLS ... push to provisioned devices").

## Test plan
- [x] `gofmt -l` on the touched file — clean
- [ ] CI: `go vet`, `go test`, race tests
- Could **not** run `go build`/`go vet`/`go test` locally for this package — `internal/cli/ble` and `internal/shared/discovery` fail to compile via cgo on this machine (missing libusb toolchain component), reproduced identically on `main` before this change by stashing and retesting. Pre-existing, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1KELttWXmKwubYyHYRx5Z