### PR TITLE
Improve BLE scan view & performance

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -25,6 +25,13 @@ ifeq ($(UNAME_S),Darwin)
 # the duplicate even though it is harmless.
 CGO_LDFLAGS += -Wl,-no_warn_duplicate_libraries
 export CGO_LDFLAGS
+# If Swiftly is installed, its clang shim (~/.swiftly/bin/clang) is often
+# ahead of /usr/bin on PATH and refuses to run whenever the repo's
+# .swift-version doesn't match an installed Swift toolchain — which breaks
+# cgo builds with an opaque "exit status 2" and no output. Force the real
+# Apple clang so Go's cgo toolchain never goes through the shim.
+CC ?= /usr/bin/clang
+export CC
 endif
 
 # Build both CLI and agent (native)

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -21,6 +21,11 @@ const (
 	deviceIface  = "org.bluez.Device1"
 	// scanDuration is how long discovery runs before results are collected.
 	scanDuration = 8 * time.Second
+	// quickScanDuration is how long to wait before sending an early, partial
+	// batch of results, so a caller has something to show almost immediately
+	// while discovery keeps running for the full scanDuration to find more
+	// devices before the final, more thorough batch.
+	quickScanDuration = 1 * time.Second
 	// resolveDiscoveryTimeout bounds the on-demand discovery Connect runs when
 	// the target device is not in BlueZ's cache (BlueZ evicts unpaired devices
 	// ~30s after a scan stops, so this is the common case when connecting a
@@ -260,7 +265,10 @@ func (m *BlueZManager) connectFailureError(address string, pairErr, connectErr e
 // discovered devices on the channel. It powers on the adapter, runs discovery
 // for scanDuration, then enumerates known devices through the BlueZ
 // ObjectManager so typed properties (RSSI, paired/connected/trusted, icon) are
-// read directly rather than parsed from bluetoothctl text output.
+// read directly rather than parsed from bluetoothctl text output. An early,
+// partial batch is sent after quickScanDuration so callers get data fast,
+// followed by a second, more thorough batch once the full scanDuration
+// elapses.
 func (m *BlueZManager) Scan(ctx context.Context) (<-chan []*agentpb.DiscoveredBluetoothPeripheral, error) {
 	ch := make(chan []*agentpb.DiscoveredBluetoothPeripheral, 10)
 
@@ -301,11 +309,25 @@ func (m *BlueZManager) Scan(ctx context.Context) (<-chan []*agentpb.DiscoveredBl
 			return
 		}
 
-		// Let discovery run, then collect results while it is still active —
-		// some BlueZ versions clear volatile properties (RSSI) once discovery
-		// stops, which would defeat the includePeripheral presence filter.
+		// Send an early, partial batch after a short quick pass so a caller has
+		// something to show fast, while discovery keeps running underneath.
 		select {
-		case <-time.After(scanDuration):
+		case <-time.After(quickScanDuration):
+		case <-ctx.Done():
+		}
+		if quick := m.collectPeripherals(ctx, conn, adapterPath, preexisting); len(quick) > 0 {
+			select {
+			case ch <- quick:
+			case <-ctx.Done():
+			}
+		}
+
+		// Let discovery run the rest of the way, then collect results while it
+		// is still active — some BlueZ versions clear volatile properties
+		// (RSSI) once discovery stops, which would defeat the includePeripheral
+		// presence filter.
+		select {
+		case <-time.After(scanDuration - quickScanDuration):
 		case <-ctx.Done():
 		}
 		peripherals := m.collectPeripherals(ctx, conn, adapterPath, preexisting)
@@ -359,7 +381,10 @@ func deviceFromProps(props map[string]dbus.Variant) *agentpb.DiscoveredBluetooth
 		p.Address = s
 	}
 	// Alias is the user-facing name (falls back to Name when unset by BlueZ).
-	if s, ok := stringProp(props, "Alias"); ok && s != "" {
+	// BlueZ synthesizes a default Alias for devices advertising no real name —
+	// the address with ':' replaced by '-' — which must not count as a name,
+	// or every anonymous device would sort as if it were named.
+	if s, ok := stringProp(props, "Alias"); ok && s != "" && !isDefaultAlias(s, p.Address) {
 		p.Name = s
 	} else if s, ok := stringProp(props, "Name"); ok {
 		p.Name = s
@@ -378,6 +403,16 @@ func deviceFromProps(props map[string]dbus.Variant) *agentpb.DiscoveredBluetooth
 	p.Trusted = boolProp(props, "Trusted")
 
 	return p
+}
+
+// isDefaultAlias reports whether alias is BlueZ's synthesized default for a
+// device advertising no name: the address with ':' replaced by '-' (e.g.
+// "AA:BB:CC:DD:EE:FF" -> "AA-BB-CC-DD-EE-FF").
+func isDefaultAlias(alias, address string) bool {
+	if address == "" {
+		return false
+	}
+	return strings.EqualFold(alias, strings.ReplaceAll(address, ":", "-"))
 }
 
 func stringProp(props map[string]dbus.Variant, key string) (string, bool) {

--- a/go/internal/agent/bluetooth/manager_linux_test.go
+++ b/go/internal/agent/bluetooth/manager_linux_test.go
@@ -389,3 +389,54 @@ func TestWrapBluetoothError(t *testing.T) {
 		}
 	})
 }
+
+func TestDeviceFromPropsIgnoresBlueZDefaultAlias(t *testing.T) {
+	// BlueZ sets Alias to the address (':' -> '-') when a device has never
+	// advertised a real name. That must not surface as a Name, or every
+	// anonymous device sorts as if it were named.
+	props := deviceProps("03:F8:5C:73:77:6B", map[string]dbus.Variant{
+		"Alias": dbus.MakeVariant("03-F8-5C-73-77-6B"),
+	})
+	p := deviceFromProps(props)
+	if p.Name != "" {
+		t.Fatalf("Name = %q, want empty for BlueZ default alias", p.Name)
+	}
+}
+
+func TestDeviceFromPropsKeepsRealAlias(t *testing.T) {
+	props := deviceProps("40:C1:F6:E2:53:24", map[string]dbus.Variant{
+		"Alias": dbus.MakeVariant("JBL Flip 5"),
+	})
+	p := deviceFromProps(props)
+	if p.Name != "JBL Flip 5" {
+		t.Fatalf("Name = %q, want %q", p.Name, "JBL Flip 5")
+	}
+}
+
+func TestDeviceFromPropsFallsBackToNameWhenAliasIsDefault(t *testing.T) {
+	props := deviceProps("AA:BB:CC:DD:EE:FF", map[string]dbus.Variant{
+		"Alias": dbus.MakeVariant("AA-BB-CC-DD-EE-FF"),
+		"Name":  dbus.MakeVariant("Real Advertised Name"),
+	})
+	p := deviceFromProps(props)
+	if p.Name != "Real Advertised Name" {
+		t.Fatalf("Name = %q, want fallback to Name property", p.Name)
+	}
+}
+
+func TestIsDefaultAlias(t *testing.T) {
+	tests := []struct {
+		alias, address string
+		want           bool
+	}{
+		{"AA-BB-CC-DD-EE-FF", "AA:BB:CC:DD:EE:FF", true},
+		{"aa-bb-cc-dd-ee-ff", "AA:BB:CC:DD:EE:FF", true},
+		{"JBL Flip 5", "AA:BB:CC:DD:EE:FF", false},
+		{"AA-BB-CC-DD-EE-FF", "", false},
+	}
+	for _, tt := range tests {
+		if got := isDefaultAlias(tt.alias, tt.address); got != tt.want {
+			t.Errorf("isDefaultAlias(%q, %q) = %v, want %v", tt.alias, tt.address, got, tt.want)
+		}
+	}
+}

--- a/go/internal/cli/tui/bttable/peripherals.go
+++ b/go/internal/cli/tui/bttable/peripherals.go
@@ -47,9 +47,12 @@ func NormalizeAddress(addr string) string {
 	return strings.ToUpper(strings.TrimSpace(addr))
 }
 
-// Sort sorts peripherals in-place: connected first, then paired, then by
-// descending RSSI (stronger signal first), then by name and address ascending
-// so the ordering is stable and obvious at a glance.
+// Sort sorts peripherals in-place: connected first, then paired, then named
+// devices ahead of unnamed ones (a scan often turns up far more anonymous
+// UUIDs than named devices, and the named ones are what people are actually
+// looking for). Within the named group, sort alphabetically by name; within
+// the unnamed group, sort by descending RSSI (stronger signal first). Ties
+// fall back to address ascending so the ordering is stable.
 func Sort(ps []Peripheral) {
 	sort.SliceStable(ps, func(i, j int) bool {
 		a, b := ps[i], ps[j]
@@ -59,11 +62,18 @@ func Sort(ps []Peripheral) {
 		if a.Paired != b.Paired {
 			return a.Paired
 		}
+		aNamed, bNamed := a.Name != "", b.Name != ""
+		if aNamed != bNamed {
+			return aNamed
+		}
+		if aNamed {
+			if a.Name != b.Name {
+				return a.Name < b.Name
+			}
+			return a.Address < b.Address
+		}
 		if a.RSSI != b.RSSI {
 			return a.RSSI > b.RSSI
-		}
-		if a.Name != b.Name {
-			return a.Name < b.Name
 		}
 		return a.Address < b.Address
 	})

--- a/go/internal/cli/tui/bttable/peripherals_test.go
+++ b/go/internal/cli/tui/bttable/peripherals_test.go
@@ -32,7 +32,7 @@ func TestFromProtoPopulatesFields(t *testing.T) {
 	}
 }
 
-func TestSortConnectedThenPairedThenRSSIThenName(t *testing.T) {
+func TestSortConnectedThenPairedThenNamedAlphabetically(t *testing.T) {
 	ps := []Peripheral{
 		{Name: "Zeta", Address: "00:00:00:00:00:05", RSSI: -90},
 		{Name: "Paired Weak", Address: "00:00:00:00:00:02", Paired: true, RSSI: -80},
@@ -46,11 +46,35 @@ func TestSortConnectedThenPairedThenRSSIThenName(t *testing.T) {
 	for _, p := range ps {
 		got = append(got, p.Name)
 	}
-	// Connected first; then paired (strong RSSI before weak); then unpaired by
-	// RSSI tie (-90 == -90) broken by name ascending (Alpha before Zeta).
+	// Connected first; then paired (both named, so alphabetical: Strong before
+	// Weak); then unpaired (both named, alphabetical: Alpha before Zeta).
 	want := []string{"Connected", "Paired Strong", "Paired Weak", "Alpha", "Zeta"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Sort order = %v; want %v", got, want)
+	}
+}
+
+func TestSortNamedBeforeUnnamedRegardlessOfRSSI(t *testing.T) {
+	ps := []Peripheral{
+		{Name: "", Address: "00:00:00:00:00:01", RSSI: -20},
+		{Name: "Zeta", Address: "00:00:00:00:00:02", RSSI: -90},
+		{Name: "", Address: "00:00:00:00:00:03", RSSI: -10},
+		{Name: "Alpha", Address: "00:00:00:00:00:04", RSSI: -95},
+	}
+	Sort(ps)
+
+	var got []string
+	for _, p := range ps {
+		got = append(got, p.Name)
+	}
+	// Named devices come first (alphabetically) even though the unnamed ones
+	// have much stronger RSSI; unnamed devices follow, sorted by RSSI desc.
+	want := []string{"Alpha", "Zeta", "", ""}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Sort order = %v; want %v", got, want)
+	}
+	if ps[2].Address != "00:00:00:00:00:03" || ps[3].Address != "00:00:00:00:00:01" {
+		t.Fatalf("expected unnamed devices sorted by RSSI desc, got addresses %v, %v", ps[2].Address, ps[3].Address)
 	}
 }
 
@@ -58,6 +82,17 @@ func TestSortRSSITiebreakByAddress(t *testing.T) {
 	ps := []Peripheral{
 		{Name: "Dup", Address: "BB:BB:BB:BB:BB:BB", RSSI: -50},
 		{Name: "Dup", Address: "AA:AA:AA:AA:AA:AA", RSSI: -50},
+	}
+	Sort(ps)
+	if ps[0].Address != "AA:AA:AA:AA:AA:AA" {
+		t.Fatalf("expected lower address first on full tie, got %v", ps[0].Address)
+	}
+}
+
+func TestSortUnnamedRSSITiebreakByAddress(t *testing.T) {
+	ps := []Peripheral{
+		{Name: "", Address: "BB:BB:BB:BB:BB:BB", RSSI: -50},
+		{Name: "", Address: "AA:AA:AA:AA:AA:AA", RSSI: -50},
 	}
 	Sort(ps)
 	if ps[0].Address != "AA:AA:AA:AA:AA:AA" {


### PR DESCRIPTION
## Summary
- Send an early, partial batch of BLE scan results after 1s so callers see devices almost immediately, while discovery keeps running for the full scan duration to find more.
- Stop BlueZ's synthesized default alias (device address with `:` replaced by `-`) from surfacing as a device name.
- Sort named devices ahead of anonymous ones in the peripherals table, since a scan typically turns up far more unnamed UUIDs than named devices.
- Force `CC=/usr/bin/clang` on Darwin so cgo builds don't break when Swiftly's clang shim rejects a mismatched `.swift-version`.

## Test plan
- [x] `go test ./internal/cli/tui/bttable/... ./internal/agent/bluetooth/...` (darwin)
- [x] `GOOS=linux go vet ./internal/agent/bluetooth/...` (BlueZ code is Linux-only)
- [ ] Manual verification of scan UX on a real Linux device with BlueZ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXAiGuBTgWJQU1Sd6kaAka