### PR TITLE
agent: capture MJPEG from USB cameras instead of raw video

### DIFF
--- a/go/internal/agent/services/video_framesize_test.go
+++ b/go/internal/agent/services/video_framesize_test.go
@@ -1,8 +1,12 @@
 package services
 
 import (
+	"strings"
 	"testing"
 	"unsafe"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // The VIDIOC_ENUM_FRAMESIZES request code encodes the struct's size, so the
@@ -64,5 +68,71 @@ func TestDefaultFrameSizeCapIs720p(t *testing.T) {
 	if defaultMaxDefaultWidth != 1280 || defaultMaxDefaultHeight != 720 {
 		t.Fatalf("default cap is %dx%d, want 1280x720",
 			defaultMaxDefaultWidth, defaultMaxDefaultHeight)
+	}
+}
+
+// withMJPEGProbe overrides the MJPEG capability probe for the duration of a test.
+func withMJPEGProbe(t *testing.T, fn func(string, uint32, uint32) bool) {
+	t.Helper()
+	orig := deviceSupportsMJPEGSize
+	deviceSupportsMJPEGSize = fn
+	t.Cleanup(func() { deviceSupportsMJPEGSize = orig })
+}
+
+// A USB camera that advertises MJPEG at the negotiated size should be captured
+// compressed (image/jpeg + jpegdec) — raw capture is USB-bandwidth-capped to
+// single-digit frame rates at 720p+ on common webcams.
+func TestBuildGStreamerArgs_USB_PrefersMJPEG(t *testing.T) {
+	withMJPEGProbe(t, func(path string, w, h uint32) bool { return w == 1280 && h == 720 })
+	req := &agentpb.StreamVideoRequest{Width: 1280, Height: 720}
+	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
+		"x264enc", true, camera.TransportUSB, "", map[string]bool{"jpegdec": true})
+	if err != nil {
+		t.Fatalf("buildGStreamerArgs: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "image/jpeg,width=1280,height=720") {
+		t.Fatalf("expected MJPEG capture caps, got: %s", joined)
+	}
+	if !strings.Contains(joined, "jpegdec") {
+		t.Fatalf("expected jpegdec in pipeline, got: %s", joined)
+	}
+	// The leaky queue must sit on the compressed side, before the decode.
+	if strings.Index(joined, "jpegdec") < strings.Index(joined, "leaky=downstream") {
+		t.Fatalf("leaky queue must precede jpegdec, got: %s", joined)
+	}
+}
+
+// Without MJPEG support at the negotiated size, capture stays raw.
+func TestBuildGStreamerArgs_USB_RawWhenNoMJPEG(t *testing.T) {
+	withMJPEGProbe(t, func(string, uint32, uint32) bool { return false })
+	req := &agentpb.StreamVideoRequest{Width: 640, Height: 480}
+	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
+		"x264enc", true, camera.TransportUSB, "", map[string]bool{"jpegdec": true})
+	if err != nil {
+		t.Fatalf("buildGStreamerArgs: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "jpegdec") || strings.Contains(joined, "image/jpeg") {
+		t.Fatalf("expected raw capture, got: %s", joined)
+	}
+	if !strings.Contains(joined, "video/x-raw,width=640,height=480") {
+		t.Fatalf("expected raw caps, got: %s", joined)
+	}
+}
+
+// MJPEG capture also needs jpegdec present on the device; otherwise stay raw
+// even when the camera offers MJPEG.
+func TestBuildGStreamerArgs_USB_RawWhenNoJpegdec(t *testing.T) {
+	withMJPEGProbe(t, func(string, uint32, uint32) bool { return true })
+	req := &agentpb.StreamVideoRequest{Width: 1280, Height: 720}
+	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
+		"x264enc", true, camera.TransportUSB, "", map[string]bool{"x264enc": true})
+	if err != nil {
+		t.Fatalf("buildGStreamerArgs: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "jpegdec") || strings.Contains(joined, "image/jpeg") {
+		t.Fatalf("expected raw capture without jpegdec available, got: %s", joined)
 	}
 }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -167,6 +167,31 @@ func bestDefaultFrameSizeForDevice(path string) (uint32, uint32) {
 	return bestW, bestH
 }
 
+// deviceSupportsMJPEGSize reports whether the device advertises MJPEG output at
+// exactly width x height. Behind a var so pipeline-construction tests can fake
+// camera capabilities without a real V4L2 device (same spirit as gstFallbackDirs).
+var deviceSupportsMJPEGSize = func(path string, width, height uint32) bool {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return false
+	}
+	defer unix.Close(fd) //nolint:errcheck
+	for index := uint32(0); index < 64; index++ {
+		fse := v4l2FrmSizeEnum{Index: index, PixelFormat: v4l2PixFmtMJPEG}
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocEnumFramesizes,
+			uintptr(unsafe.Pointer(&fse))); errno != 0 {
+			return false
+		}
+		if fse.Type != v4l2FrmsizeTypeDiscrete {
+			return false
+		}
+		if fse.Width == width && fse.Height == height {
+			return true
+		}
+	}
+	return false
+}
+
 // v4l2ReqBuffers matches struct v4l2_requestbuffers (20 bytes).
 type v4l2ReqBuffers struct {
 	Count        uint32
@@ -1352,8 +1377,24 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 		capsParts = append(capsParts, fmt.Sprintf("framerate=%d/1", req.GetFramerate()))
 	}
 
+	// Prefer compressed (MJPEG) capture from USB cameras when the device offers
+	// it at the chosen size and jpegdec is available to unpack it. Raw capture
+	// is bottlenecked by USB bandwidth, and UVC descriptors cap raw modes at
+	// frame rates as low as 5 fps for 720p/1080p — the SAME camera delivers
+	// 30 fps over MJPEG (measured on a Brio 101: 5 fps raw at both 1080p and
+	// 720p). jpegdec is cheap relative to the H.264 encode that follows. The
+	// leaky queue sits on the compressed side so backlog is dropped before,
+	// not after, the decode work is spent.
+	useMJPEG := !strings.HasPrefix(src, "libcamerasrc") &&
+		capW > 0 && capH > 0 &&
+		available["jpegdec"] &&
+		deviceSupportsMJPEGSize(devicePath, capW, capH)
+
 	var pipeline string
-	if len(capsParts) > 0 {
+	if useMJPEG {
+		caps := "image/jpeg," + strings.Join(capsParts, ",")
+		pipeline = fmt.Sprintf("%s ! %s ! %s ! jpegdec ! %s ! fdsink fd=1", src, caps, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
+	} else if len(capsParts) > 0 {
 		caps := "video/x-raw," + strings.Join(capsParts, ",")
 		pipeline = fmt.Sprintf("%s ! %s ! %s ! %s ! fdsink fd=1", src, caps, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
 	} else {


### PR DESCRIPTION
## Problem
Every USB camera without onboard H.264 was frame-rate-capped by its **raw mode**, not by our pipeline. The capture caps pinned `video/x-raw`, and UVC descriptors limit raw (YUYV) modes to single-digit frame rates at 720p+ because of USB bandwidth — measured **5 fps on a Brio 101 at both 1080p and 720p** (the same rate at two sizes is what ruled out the encoder and implicated the transport). The same camera does ~30 fps over MJPEG.

## Change
When the device advertises MJPEG at the negotiated size (probed via `VIDIOC_ENUM_FRAMESIZES` with the MJPEG fourcc) and `jpegdec` is available, capture `image/jpeg` and decode before the encoder:

```
v4l2src ! image/jpeg,width=W,height=H ! queue(leaky) ! jpegdec ! videoconvert ! <encoder> …
```

The leaky queue stays on the **compressed** side so backlog is dropped before decode work is spent. Cameras without MJPEG at the chosen size, devices without `jpegdec`, and the CSI/libcamerasrc path keep the existing raw pipeline unchanged.

## Measured (wendy-arms, side-loaded, Brio 101 at the 720p default)
| | raw (before) | MJPEG (after) |
|---|---|---|
| App-side frame rate | 5.0 fps | **19.7 fps** |

The residual gap to 30 is consistent with the x264 software encode now being the bound — which the hardware-encoder plugin work can lift later. Cameras with onboard H.264 (e.g. Elgato) are unaffected (they never enter this path).

## Stacked on #1523
Based on `agent-camera-default-resolution` (uses its frame-size enumeration plumbing and its 720p default is what the measurements were taken at). Retarget to `main` after #1523 merges.

## Testing
- Unit tests for pipeline construction: MJPEG preferred when advertised, raw fallback when not / when `jpegdec` missing, leaky-queue-before-decode ordering.
- Full `internal/agent/services` package green.
- On-device verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)