### PR TITLE
cli: wendy auth use pins the org, not just the endpoint

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -755,7 +755,12 @@ func newAuthUseCmd() *cobra.Command {
 			if len(chosen.Certificates) == 0 {
 				return fmt.Errorf("auth session %s has no certificates; re-run 'wendy auth login'", chosen.CloudGRPC)
 			}
+			// Persist the org alongside the endpoint: several orgs can share
+			// one endpoint (multiple orgs on the production cloud), and the
+			// endpoint alone resolved to whichever of them was logged into
+			// first — silently overriding the org the user just selected.
 			cfg.DefaultCloudGRPC = chosen.CloudGRPC
+			cfg.DefaultOrgID = int32(chosen.Certificates[0].OrganizationID)
 			if err := config.Save(cfg); err != nil {
 				return fmt.Errorf("saving config: %w", err)
 			}
@@ -777,20 +782,42 @@ func newAuthDefaultCmd() *cobra.Command {
 			}
 			if clear {
 				cfg.DefaultCloudGRPC = ""
+				cfg.DefaultOrgID = 0
 				if err := config.Save(cfg); err != nil {
 					return fmt.Errorf("saving config: %w", err)
 				}
 				fmt.Println(tui.SuccessMessage("Default session cleared."))
 				return nil
 			}
-			if cfg.DefaultCloudGRPC == "" {
+			if cfg.DefaultCloudGRPC == "" && cfg.DefaultOrgID == 0 {
 				fmt.Println("No default session set.")
+				return nil
+			}
+			// The default org is what actually disambiguates sessions when
+			// several orgs share one endpoint, so show its session first.
+			if cfg.DefaultOrgID != 0 {
+				for i := range cfg.Auth {
+					a := &cfg.Auth[i]
+					if len(a.Certificates) > 0 && int32(a.Certificates[0].OrganizationID) == cfg.DefaultOrgID {
+						fmt.Printf("Default session: %s\n", authSessionLabel(a))
+						return nil
+					}
+				}
+			}
+			if cfg.DefaultCloudGRPC == "" {
+				// Only a stale org default remains (its session is gone).
+				fmt.Println(tui.WarningMessage(fmt.Sprintf("Default session for org %d no longer exists; clearing it.", cfg.DefaultOrgID)))
+				cfg.DefaultOrgID = 0
+				if err := config.Save(cfg); err != nil {
+					return fmt.Errorf("saving config: %w", err)
+				}
 				return nil
 			}
 			def, ok := cfg.DefaultAuth()
 			if !ok {
 				fmt.Println(tui.WarningMessage(fmt.Sprintf("Default session %s no longer exists; clearing it.", cfg.DefaultCloudGRPC)))
 				cfg.DefaultCloudGRPC = ""
+				cfg.DefaultOrgID = 0
 				if err := config.Save(cfg); err != nil {
 					return fmt.Errorf("saving config: %w", err)
 				}

--- a/go/internal/cli/commands/auth_default_test.go
+++ b/go/internal/cli/commands/auth_default_test.go
@@ -48,3 +48,99 @@ func TestMatchAuthSelectorAmbiguous(t *testing.T) {
 		t.Fatalf("ambiguous error should list candidates, got %v", err)
 	}
 }
+
+// seedConfig writes cfg as the CLI config in a temp HOME and returns a loader
+// for asserting what a command persisted.
+func seedConfig(t *testing.T, cfg *config.Config) func() *config.Config {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("seeding config: %v", err)
+	}
+	return func() *config.Config {
+		c, err := config.Load()
+		if err != nil {
+			t.Fatalf("reloading config: %v", err)
+		}
+		return c
+	}
+}
+
+// sharedEndpointConfig models several orgs on one cloud endpoint (login order:
+// org 9 first) — the shape where an endpoint-only default is ambiguous.
+func sharedEndpointConfig() *config.Config {
+	return &config.Config{Auth: []config.AuthConfig{
+		{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "prod:443", Certificates: []config.CertificateInfo{{OrganizationID: 9}}},
+		{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "prod:443", Certificates: []config.CertificateInfo{{OrganizationID: 75}}},
+	}}
+}
+
+// Regression: `wendy auth use 75` used to persist only the (shared) endpoint,
+// so resolution silently returned org 9 — the first login. It must persist the
+// org too, and resolution must then return the selected org's session.
+func TestAuthUsePersistsOrgDefault(t *testing.T) {
+	load := seedConfig(t, sharedEndpointConfig())
+
+	cmd := newAuthUseCmd()
+	cmd.SetArgs([]string{"75"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth use 75: %v", err)
+	}
+
+	cfg := load()
+	if cfg.DefaultCloudGRPC != "prod:443" {
+		t.Errorf("DefaultCloudGRPC = %q, want prod:443", cfg.DefaultCloudGRPC)
+	}
+	if cfg.DefaultOrgID != 75 {
+		t.Errorf("DefaultOrgID = %d, want 75", cfg.DefaultOrgID)
+	}
+	auth, err := config.ResolveAuth(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("ResolveAuth: %v", err)
+	}
+	if got := auth.Certificates[0].OrganizationID; got != 75 {
+		t.Fatalf("resolution after 'auth use 75' returned org %d, want 75", got)
+	}
+}
+
+func TestAuthDefaultClearClearsBothFields(t *testing.T) {
+	seeded := sharedEndpointConfig()
+	seeded.DefaultCloudGRPC = "prod:443"
+	seeded.DefaultOrgID = 75
+	load := seedConfig(t, seeded)
+
+	cmd := newAuthDefaultCmd()
+	cmd.SetArgs([]string{"--clear"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth default --clear: %v", err)
+	}
+
+	cfg := load()
+	if cfg.DefaultCloudGRPC != "" || cfg.DefaultOrgID != 0 {
+		t.Fatalf("clear must reset both fields, got grpc=%q org=%d", cfg.DefaultCloudGRPC, cfg.DefaultOrgID)
+	}
+}
+
+// The session picker's 'd' key goes through persistSessionDefault; it must
+// store the org half of the "endpoint::org" key, not just the endpoint.
+func TestPersistSessionDefaultStoresOrg(t *testing.T) {
+	load := seedConfig(t, sharedEndpointConfig())
+
+	if err := persistSessionDefault("prod:443::75"); err != nil {
+		t.Fatalf("persistSessionDefault: %v", err)
+	}
+	cfg := load()
+	if cfg.DefaultCloudGRPC != "prod:443" || cfg.DefaultOrgID != 75 {
+		t.Fatalf("want prod:443/org 75, got grpc=%q org=%d", cfg.DefaultCloudGRPC, cfg.DefaultOrgID)
+	}
+
+	// Cert-less sessions have an endpoint-only key; the org resets to 0 so a
+	// stale previous org can't shadow the new default.
+	if err := persistSessionDefault("dev:50051"); err != nil {
+		t.Fatalf("persistSessionDefault (no org): %v", err)
+	}
+	cfg = load()
+	if cfg.DefaultCloudGRPC != "dev:50051" || cfg.DefaultOrgID != 0 {
+		t.Fatalf("want dev:50051/org 0, got grpc=%q org=%d", cfg.DefaultCloudGRPC, cfg.DefaultOrgID)
+	}
+}

--- a/go/internal/cli/commands/auth_picker.go
+++ b/go/internal/cli/commands/auth_picker.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -118,6 +119,29 @@ func authPickerItems(cfg *config.Config, orgNames map[int32]string) []tui.Picker
 	return items
 }
 
+// persistSessionDefault stores the picker's highlighted session ("endpoint" or
+// "endpoint::orgID" key) as the default. Both halves are persisted: the org ID
+// is what actually disambiguates sessions when several orgs share one endpoint
+// — persisting only the endpoint made the default resolve to whichever of them
+// was logged into first, not the one the user picked.
+func persistSessionDefault(key string) error {
+	c, err := config.Load()
+	if err != nil {
+		return err
+	}
+	endpoint := key
+	orgID := 0
+	if idx := strings.Index(key, "::"); idx >= 0 {
+		endpoint = key[:idx]
+		if n, convErr := strconv.Atoi(key[idx+2:]); convErr == nil {
+			orgID = n
+		}
+	}
+	c.DefaultCloudGRPC = endpoint
+	c.DefaultOrgID = int32(orgID)
+	return config.Save(c)
+}
+
 // pickAuthSession shows the interactive session picker. 'd' marks the
 // highlighted session as the persisted default (written immediately, mirroring
 // the device picker), 'x' clears it, and Enter selects a session for this
@@ -150,22 +174,15 @@ func pickAuthSession(cfg *config.Config) (*config.AuthConfig, error) {
 		if key == "" {
 			return ""
 		}
-		c, err := config.Load()
-		if err != nil {
+		if err := persistSessionDefault(key); err != nil {
 			return fmt.Sprintf("Could not save default: %v", err)
 		}
-		// Persist as DefaultCloudGRPC (the endpoint portion before "::").
-		endpoint := key
-		if idx := strings.Index(key, "::"); idx >= 0 {
-			endpoint = key[:idx]
-		}
-		c.DefaultCloudGRPC = endpoint
-		_ = config.Save(c)
 		return fmt.Sprintf("Default set to %s.", item.Name)
 	}
 	picker.OnUnsetDefault = func() string {
 		if c, err := config.Load(); err == nil {
 			c.DefaultCloudGRPC = ""
+			c.DefaultOrgID = 0
 			_ = config.Save(c)
 		}
 		return "Default cleared."

--- a/go/internal/shared/config/auth_resolve.go
+++ b/go/internal/shared/config/auth_resolve.go
@@ -33,7 +33,8 @@ func (c *Config) DefaultAuth() (*AuthConfig, bool) {
 }
 
 // ResolveAuth chooses the auth session to use. Precedence:
-//  1. cloudGRPC flag set      -> exact endpoint match (error if none)
+//  1. cloudGRPC flag set      -> endpoint match; when several orgs share that
+//     endpoint, prefer the DefaultOrgID session, then the first (error if none)
 //  2. exactly one session     -> use it
 //  3. DefaultOrgID set        -> session whose cert org matches (if unique)
 //  4. valid persisted default -> use it (DefaultCloudGRPC)
@@ -46,12 +47,27 @@ func ResolveAuth(cfg *Config, cloudGRPC string, pick SessionPicker) (*AuthConfig
 		return nil, ErrNotLoggedIn
 	}
 	if cloudGRPC != "" {
+		// Several orgs can share one endpoint (multiple orgs on the production
+		// cloud). The flag alone cannot name an org, so among the endpoint's
+		// sessions honor the persisted default org before falling back to the
+		// first — otherwise the flag silently pins the oldest login's org.
+		var matches []*AuthConfig
 		for i := range cfg.Auth {
 			if cfg.Auth[i].CloudGRPC == cloudGRPC {
-				return authWithCerts(&cfg.Auth[i])
+				matches = append(matches, &cfg.Auth[i])
 			}
 		}
-		return nil, fmt.Errorf("no auth session for %s; run 'wendy auth login --cloud-grpc %s' first", cloudGRPC, cloudGRPC)
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no auth session for %s; run 'wendy auth login --cloud-grpc %s' first", cloudGRPC, cloudGRPC)
+		}
+		if cfg.DefaultOrgID != 0 {
+			for _, m := range matches {
+				if len(m.Certificates) > 0 && int32(m.Certificates[0].OrganizationID) == cfg.DefaultOrgID {
+					return authWithCerts(m)
+				}
+			}
+		}
+		return authWithCerts(matches[0])
 	}
 	if len(cfg.Auth) == 1 {
 		return authWithCerts(&cfg.Auth[0])

--- a/go/internal/shared/config/auth_resolve_test.go
+++ b/go/internal/shared/config/auth_resolve_test.go
@@ -99,6 +99,68 @@ func TestResolveAuthPickerResultCertValidated(t *testing.T) {
 	}
 }
 
+// sameEndpointOrgs models the common real-world shape: several orgs, all on
+// the production cloud endpoint, in login order (org 9 first).
+func sameEndpointOrgs() *Config {
+	return &Config{Auth: []AuthConfig{
+		{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "prod:443", Certificates: []CertificateInfo{{OrganizationID: 9}}},
+		{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "prod:443", Certificates: []CertificateInfo{{OrganizationID: 2}}},
+		{CloudDashboard: "https://cloud.wendy.dev", CloudGRPC: "prod:443", Certificates: []CertificateInfo{{OrganizationID: 75}}},
+	}}
+}
+
+func TestResolveAuthFlagPrefersDefaultOrgOnSharedEndpoint(t *testing.T) {
+	cfg := sameEndpointOrgs()
+	cfg.DefaultOrgID = 75
+	auth, err := ResolveAuth(cfg, "prod:443", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := auth.Certificates[0].OrganizationID; got != 75 {
+		t.Fatalf("flag + default org must pick org 75, got org %d", got)
+	}
+}
+
+func TestResolveAuthFlagFallsBackToFirstWithoutDefaultOrg(t *testing.T) {
+	auth, err := ResolveAuth(sameEndpointOrgs(), "prod:443", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := auth.Certificates[0].OrganizationID; got != 9 {
+		t.Fatalf("without a default org the first session wins, got org %d", got)
+	}
+}
+
+func TestResolveAuthFlagIgnoresDefaultOrgFromOtherEndpoint(t *testing.T) {
+	cfg := sameEndpointOrgs()
+	cfg.Auth = append(cfg.Auth, AuthConfig{CloudGRPC: "dev:50051", Certificates: []CertificateInfo{{OrganizationID: 4}}})
+	cfg.DefaultOrgID = 4 // default org lives on a different endpoint
+	auth, err := ResolveAuth(cfg, "prod:443", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := auth.Certificates[0].OrganizationID; got != 9 {
+		t.Fatalf("default org on another endpoint must not hijack the flag, got org %d", got)
+	}
+}
+
+// The bug this file exists to pin down: `wendy auth use <org>` on a shared
+// endpoint used to persist only DefaultCloudGRPC, which resolves to the FIRST
+// session on that endpoint — the org the user selected was silently ignored.
+// With DefaultOrgID persisted alongside, resolution honors the selection.
+func TestResolveAuthDefaultOrgDisambiguatesSharedEndpoint(t *testing.T) {
+	cfg := sameEndpointOrgs()
+	cfg.DefaultCloudGRPC = "prod:443"
+	cfg.DefaultOrgID = 75
+	auth, err := ResolveAuth(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := auth.Certificates[0].OrganizationID; got != 75 {
+		t.Fatalf("default org must disambiguate, got org %d", got)
+	}
+}
+
 func TestDefaultAuthLookup(t *testing.T) {
 	cfg := twoSessions()
 	if _, ok := cfg.DefaultAuth(); ok {


### PR DESCRIPTION
## Bug

Several orgs commonly share one cloud endpoint (multiple orgs on the production cloud). `wendy auth use <org>` persisted only `DefaultCloudGRPC` — the shared endpoint string — and `ResolveAuth` then returned the **first** session on that endpoint. So after `wendy auth use 75`, `wendy cloud discover` silently operated on whichever org you logged into *first*, while claiming `Default session set to org 75 ✓`.

**Reproduced on release `2026.07.27-003050`** with three orgs (9, 2, 75) on the production endpoint, logged in oldest-first as 9:

| Step | Result |
|---|---|
| `wendy auth use 75` → `wendy cloud discover --json` | **org 9's fleet** (org 75 has zero devices, so unambiguous) |
| `wendy auth use 2` → discover | **org 9's fleet again** (org 2 has devices; they never appeared) |
| config after each `auth use` | `defaultCloudGRPC` = shared endpoint, `defaultOrgId` absent |
| control: `defaultOrgId: 75` written directly → discover | org 75's (empty) fleet — the org-default path resolves correctly |

## Fix

- `wendy auth use` persists `DefaultOrgID` alongside `DefaultCloudGRPC`; `ResolveAuth`'s existing org-default step (which runs before the endpoint default) then resolves the selected org's session.
- The session picker's `d` key persists both halves of the `endpoint::org` key (logic extracted into `persistSessionDefault`); `x` and `wendy auth default --clear` clear both fields.
- `wendy auth default` shows the org-default's session first, and clears a stale org-only default with a proper warning.
- `--cloud-grpc` matching an endpoint shared by several orgs now prefers the `DefaultOrgID` session before falling back to the first — previously the flag also silently pinned the oldest login's org.

No config-shape changes: both fields already existed (`defaultCloudGRPC`, `defaultOrgId`); this aligns the writers with the resolver that already preferred the org.

## Tests

- Resolver: shared-endpoint fixtures — flag prefers the default org; falls back to first without one; a default org on a *different* endpoint can't hijack the flag; org default disambiguates the endpoint default (the exact reproduced bug).
- Commands: `auth use 75` persists both fields and resolution returns org 75; `auth default --clear` resets both; `persistSessionDefault` stores the org half and resets it for cert-less endpoint-only keys.

Note: local `go test` on my machine is blocked by an unrelated local cgo/toolchain issue (the pure-Go `internal/shared/config` suite passed before it appeared); relying on CI for the full run — will iterate if anything is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)