### PR TITLE
ClaudeOnDevice: clear a stale buildkitd.lock so on-device builds survive a crash

### DIFF
--- a/Examples/ClaudeOnDevice/init.sh
+++ b/Examples/ClaudeOnDevice/init.sh
@@ -32,7 +32,32 @@ BUILDKITD_PID=""
 # container log stream, rather than an unbounded /var/log file: the container
 # runtime's log driver bounds and rotates it, so a chatty or misbehaving daemon
 # can't fill the writable layer / persist volume and wedge the container.
+# buildkitd's lock lives in /var/lib/buildkit, which is a PERSIST volume, so it
+# outlives the container. Any unclean stop — SIGKILL, a crash-loop, a host reboot
+# — leaves it behind, and buildkitd then refuses to start forever:
+#
+#   buildkitd: could not lock /var/lib/buildkit/buildkitd.lock, another instance running?
+#
+# The supervisor below would retry that failure indefinitely, so on-device
+# building stays permanently dead while the container itself looks healthy. It
+# surfaces much later as a confusing builder error from `wendy run`, not as
+# anything pointing at a lock. Observed on spark-3011 after the container
+# crash-looped.
+#
+# Only this container uses the volume (a per-app persist mount), so if our own
+# daemon is not running, any lock present is by definition stale.
+clear_stale_lock() {
+  if [ -n "$BUILDKITD_PID" ] && kill -0 "$BUILDKITD_PID" 2>/dev/null; then
+    return
+  fi
+  if [ -e /var/lib/buildkit/buildkitd.lock ]; then
+    echo "note: clearing stale buildkitd.lock (no buildkitd running)" >&2
+    rm -f /var/lib/buildkit/buildkitd.lock
+  fi
+}
+
 start_buildkitd() {
+  clear_stale_lock
   buildkitd \
     ${BUILDKIT_SNAPSHOTTER:+--oci-worker-snapshotter="$BUILDKIT_SNAPSHOTTER"} \
     >&2 2>&1 &


### PR DESCRIPTION
One-line behaviour change in `init.sh`, plus the comment explaining why.

### The bug

buildkitd's lock lives in `/var/lib/buildkit`, which is a **persist volume**, so it outlives the container. Any unclean stop — SIGKILL, a crash-loop, a host reboot — leaves it behind, and buildkitd then refuses to start **forever**:

```
buildkitd: could not lock /var/lib/buildkit/buildkitd.lock, another instance running?
```

`init.sh`'s supervisor retries that failure indefinitely, so **on-device building is permanently dead while the container looks perfectly healthy**. Nothing points at a lock — it surfaces much later as a confusing builder error from `wendy run` / `wendy build`, on a device where `buildctl` appears installed and `attach` works fine.

### Why it matters more than it looks

Hit on `spark-3011` immediately after the container crash-looped on an unrelated platform bug (container created with `args: ["/bin/sh"]`, exits 0 in ~3ms — WDY-2184 item 1). The two compound: a **transient** platform failure permanently disables the build capability this example exists to provide, and survives redeploys because the volume persists.

### The fix

`start_buildkitd` clears the lock first, guarded on our own daemon not being alive. Only this container uses the volume (per-app persist mount), so if `BUILDKITD_PID` is unset or dead, any lock present is by definition stale. Logged when it fires, silent otherwise.

### Verification

`sh -n` clean, and the decision logic exercised on all four paths:

| case | expected | result |
|---|---|---|
| first start, stale lock | clear | ✅ removed |
| **live daemon** | **keep** | ✅ kept (does not remove a lock in use) |
| restart after daemon died | clear | ✅ removed |
| no lock present | no-op | ✅ silent |

The live-daemon case is the one that matters for safety, and it is covered.

Not verified end-to-end on hardware: I cleared the lock manually on spark-3011 and confirmed BuildKit came back (`buildctl debug info` → v0.16.0), which is the same effect this change automates — but I have not yet re-run a container start with this code on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
