### PR TITLE
ClaudeOnDevice: refresh the README — stale branch gate, on-device build path, gotchas

### DIFF
--- a/Examples/ClaudeOnDevice/README.md
+++ b/Examples/ClaudeOnDevice/README.md
@@ -88,11 +88,12 @@ hundreds of MB, so it is slow on a poor link.
 ## Log in & use
 
 Attach an interactive terminal and run Claude. The app id is the full
-`sh.wendy.examples.claude-on-device`, and a device reached through the cloud
-needs `wendy cloud device attach`:
+`sh.wendy.examples.claude-on-device`. Use `wendy device attach` for a device
+on your LAN, or `wendy cloud device attach` when reaching it through the
+cloud instead:
 
 ```
-wendy cloud device attach sh.wendy.examples.claude-on-device --device <host>
+wendy device attach sh.wendy.examples.claude-on-device --device <host>
 ```
 
 On first run, `claude` prints an OAuth URL + code — approve it in your laptop
@@ -142,7 +143,7 @@ and remove it when decommissioning).
 
 ```sh
 B64=$(base64 -i ~/.wendy/config.json | tr -d '\n')
-wendy cloud device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
+wendy device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
   "mkdir -p /root/.wendy && echo $B64 | base64 -d > /root/.wendy/config.json && chmod 600 /root/.wendy/config.json"
 ```
 
@@ -151,7 +152,7 @@ heredoc — see the gotchas below):
 
 ```sh
 TOKEN=$(gh auth token)
-wendy cloud device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
+wendy device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
   "printf 'https://x-access-token:%s@github.com\n' '$TOKEN' > /root/.git-credentials && chmod 600 /root/.git-credentials && git config --global credential.helper store"
 ```
 

--- a/Examples/ClaudeOnDevice/README.md
+++ b/Examples/ClaudeOnDevice/README.md
@@ -25,45 +25,74 @@ device** so a stale credential isn't left behind on disk. The token also
 outlives the container: `wendy device apps remove` deletes the container but not
 the persist volume.
 
-## Build & deploy (from an amd64 dev host)
+## Build & deploy
 
-> **Both the agent and the staged CLI below must be built from this branch
-> (`jo/claude-on-device-sp2`).** The on-device builder is split across both: the
-> agent applies the `build` entitlement (relaxing the sandbox for BuildKit) and
-> the CLI carries the BuildKit build backend it auto-selects on the device.
-> Mixing an old binary with this app silently loses on-device building — and does
-> so quietly, because neither side hard-fails:
->
-> - An **older agent** applies entitlements best-effort (it just skips any type it
->   doesn't recognize), so it starts the container but never relaxes
->   caps/seccomp/cgroups for `build`. BuildKit then fails at runtime.
-> - An **older CLI** validates `wendy.json` strictly and rejects `{"type":"build"}`
->   as an unknown entitlement type before it ever deploys.
+Both the agent and the staged CLI must be new enough to know the `build`
+entitlement and `WENDY_AGENT_SOCKET`. Both landed in `main` long ago, so a stock
+release works — the `2026.07.27-003050` CLI is verified. If you are on a much
+older agent, note that a mismatch fails *quietly* rather than loudly: an older
+agent applies entitlements best-effort and simply skips `build` (the container
+starts, BuildKit fails later at runtime), while an older CLI rejects
+`{"type":"build"}` as an unknown type before deploying at all.
 
-1. **Deploy a new-enough agent first.** The `ExecContainer` PTY RPC, the `admin`
-   socket, and the `build` entitlement (on-device BuildKit) only exist in an agent
-   built from this branch. Update the device's agent before deploying this app:
-   ```
-   wendy device update --binary <path-to-arm64-wendy-agent> --device <host>
-   ```
-2. **Stage the arm64 `wendy` CLI** into this directory as `wendy-linux-arm64`,
-   built from this branch so it understands `WENDY_AGENT_SOCKET` **and** ships the
-   BuildKit build backend (auto-selected on the device):
+There are two ways to deploy. **Prefer building on the device** unless you have a
+fast link to it.
+
+### On the device (recommended)
+
+Everything — repo clone, base image pull, `apt`, `npm`, and the deploy itself —
+happens on the device's own connection. Nothing crosses your laptop link, so a
+slow or flaky connection is irrelevant. Requires only `git` + `curl` on the host
+and shell access.
+
+```sh
+wendy cloud device shell --device <host>
+
+# on the device
+mkdir -p /data/devbootstrap && cd /data/devbootstrap
+git clone --depth 1 https://github.com/wendylabsinc/WendyOS.git
+
+# the CLI: staged into the build context AND used to drive the deploy
+curl -fsSL -o cli.tgz https://github.com/wendylabsinc/WendyOS/releases/download/2026.07.27-003050/wendy-cli-linux-arm64-2026.07.27-003050.tar.gz
+tar -xzf cli.tgz
+cp wendy-cli-linux-arm64/wendy ./wendy
+cp ./wendy WendyOS/Examples/ClaudeOnDevice/wendy-linux-arm64
+
+cd WendyOS/Examples/ClaudeOnDevice
+WENDY_AGENT_SOCKET=/var/lib/wendy/agent-control/agent.sock HOME=/root \
+  /data/devbootstrap/wendy run --yes --detach --build-type docker --builder docker
+```
+
+Use `--builder buildkit` instead if the host has no Docker; stand up a temporary
+host `buildkitd` first and kill it afterwards (the container supervises its own).
+
+Detach long work with `setsid nohup … > log 2>&1 &` and poll the log — a remote
+command dies with the shell stream.
+
+### From a laptop
+
+Cross-builds and pushes the image over your connection. Simple, but it moves
+hundreds of MB, so it is slow on a poor link.
+
+1. **Stage the arm64 `wendy` CLI** into this directory as `wendy-linux-arm64` —
+   either from the release tarball above, or from source:
    ```
    GOOS=linux GOARCH=arm64 go build -o Examples/ClaudeOnDevice/wendy-linux-arm64 ./go/cmd/wendy
    ```
-3. **Build + deploy** the app to the device (Dockerfile-driven, cross-built for arm64):
+2. **Build + deploy:**
    ```
    cd Examples/ClaudeOnDevice
-   wendy run --yes --build-type docker --device <jetson-hostname>
+   wendy run --yes --build-type docker --device <hostname>
    ```
 
 ## Log in & use
 
-Attach an interactive terminal and run Claude:
+Attach an interactive terminal and run Claude. The app id is the full
+`sh.wendy.examples.claude-on-device`, and a device reached through the cloud
+needs `wendy cloud device attach`:
 
 ```
-wendy device attach claude-on-device
+wendy cloud device attach sh.wendy.examples.claude-on-device --device <host>
 ```
 
 On first run, `claude` prints an OAuth URL + code — approve it in your laptop
@@ -101,6 +130,54 @@ persists across restarts in the `/var/lib/buildkit` volume.
 If builds fail with an overlayfs error on your device kernel, set
 `BUILDKIT_SNAPSHOTTER=native` in the container environment (slower, but avoids
 overlayfs-on-overlayfs).
+
+### Cloud auth and git credentials
+
+`wendy auth login` **cannot work headless** — it needs a localhost browser
+callback in the CLI's own process, and there is no device-code flow. Copy an
+existing session from an authenticated laptop into the persisted `/root`
+instead. Have the human run this: it ships their private-key credential, which
+then lives unencrypted in the persist volume (trusted first-party devices only,
+and remove it when decommissioning).
+
+```sh
+B64=$(base64 -i ~/.wendy/config.json | tr -d '\n')
+wendy cloud device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
+  "mkdir -p /root/.wendy && echo $B64 | base64 -d > /root/.wendy/config.json && chmod 600 /root/.wendy/config.json"
+```
+
+For private repos, store a git credential the same way (`printf`, **not** a
+heredoc — see the gotchas below):
+
+```sh
+TOKEN=$(gh auth token)
+wendy cloud device attach sh.wendy.examples.claude-on-device --device <host> -- sh -c \
+  "printf 'https://x-access-token:%s@github.com\n' '$TOKEN' > /root/.git-credentials && chmod 600 /root/.git-credentials && git config --global credential.helper store"
+```
+
+### Gotchas
+
+- **Blank `WENDY_AGENT_SOCKET` to target another device.** The injected variable
+  makes `connectWithAutoTLS` route every command through the *local* agent,
+  silently ignoring `--device` — wrong-machine results look like success. Use
+  `WENDY_AGENT_SOCKET= wendy run --yes --builder buildkit --device <robot>`, and
+  keep `--builder buildkit` explicit, because builder auto-selection is keyed off
+  that same variable. Plain `wendy run --yes` deploys to the host device, which
+  is what you want when that is the intent.
+- **The agent's local socket is `/var/lib/wendy/agent-control/agent.sock`.** Older
+  docs and comments say `/run/wendy/agent.sock`; that path does not exist.
+- **`/workspace` and `/root` are mounted `noexec`.** Source clones are fine, but a
+  downloaded tool binary will not run from there (`Permission denied` even after
+  `chmod +x`).
+- **Heredocs do not survive `attach … -- sh -c '…'`** (`Syntax error: newline
+  unexpected`), and piping binary data through `attach` corrupts it and never
+  delivers EOF — it is a PTY. Use `printf` for file contents.
+- **If the container exits 0 within milliseconds on a restart loop**, check
+  `ctr -n default containers info <app> | grep -A3 '"args"'`. If it shows
+  `["/bin/sh"]` instead of the image's `CMD`, the container spec lost it
+  (WDY-2184). A plain redeploy reports `No changes detected` and reuses the
+  broken spec — you must delete the container first:
+  `ctr -n default containers delete <app>`, then redeploy.
 
 ### ⚠️ The `build` entitlement is privileged-equivalent
 


### PR DESCRIPTION
Docs only, no behaviour change. Split from #1535 (the `init.sh` stale-lock fix) so a doc review doesn't block a bug fix.

The setup instructions no longer matched reality and would send a new user down a path that does not exist.

### Removed the branch gate

The README opened with a prominent block requiring both agent and CLI to be built from **`jo/claude-on-device-sp2`**. That branch is **gone from origin**, and `EntitlementBuild` is in `main`. Verified empirically: the stock **`2026.07.27-003050` release tarball** drove an on-device BuildKit deploy fine on `spark-3011`.

The quiet-failure warning for genuinely old binaries is kept (condensed) — that failure mode is still real and still silent in both directions.

### Documented the on-device build path

This was missing entirely, and it is the one that actually works on a slow link:

| | |
|---|---|
| built **on the device** | **33.7s** |
| cross-built from a laptop | stalled 31 min on a network fetch, abandoned |

WendyOS is a public repo, so the recipe needs **no credentials**: clone on the box, `curl` the CLI release, deploy through the local agent socket. The laptop path is kept as the second option, with the tradeoff stated.

Also dropped *"from an amd64 dev host"* — the build works from arm64 hosts, and the recommended path builds on an aarch64 device.

### Fixed the attach command

Was `wendy device attach claude-on-device`. The app id is `sh.wendy.examples.claude-on-device`, and a cloud-reached device needs `wendy cloud device attach`.

### Added the traps that cost real time

None of these were documented anywhere:

- **Copying cloud auth into `/root`** — `wendy auth login` cannot work headless (localhost browser callback, no device-code flow), so this is the only route. Flagged as a step the human runs, since it ships their private-key credential.
- **Storing a git credential** for private repos.
- **Blanking `WENDY_AGENT_SOCKET`** to target another device — otherwise `--device` is silently ignored and wrong-machine results look like success.
- **The real agent socket path** `/var/lib/wendy/agent-control/agent.sock` (older docs say `/run/wendy/agent.sock`, which does not exist).
- **`/workspace` and `/root` are `noexec`** — source clones fine, downloaded binaries will not run.
- **Heredocs do not survive `attach … -- sh -c '…'`**, and piping binary through `attach` corrupts it (PTY, no EOF). Use `printf`.
- **The exit-0-in-milliseconds container-spec bug** (WDY-2184): how to recognise it via `ctr … containers info`, and that it needs the container **deleted** — a plain redeploy reports `No changes detected` and reuses the broken spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
