### PR TITLE
Clearer errors for macOS Xcode-selection and Mac-agent container-runtime failures

### DIFF
--- a/Examples/HelloMac/wendy.json
+++ b/Examples/HelloMac/wendy.json
@@ -2,5 +2,5 @@
   "appId": "sh.wendy.examples.HelloMac",
   "version": "1.0.0",
   "language": "swift",
-  "platform": "linux"
+  "platform": "darwin"
 }

--- a/Examples/HelloXcode/wendy.json
+++ b/Examples/HelloXcode/wendy.json
@@ -1,6 +1,6 @@
 {
   "appId": "helloxcode",
-  "platform": "linux",
+  "platform": "darwin",
   "version": "0.1.0",
   "language": "swift"
 }

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -6,8 +6,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"net/http"
@@ -2042,7 +2044,7 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 // can resolve mDNS hostnames directly, we pass the original hostname through
 // rather than resolving it to an IP. Only link-local addresses (USB) still
 // need the TCP proxy.
-func resolveRegistryForSwift(ctx context.Context, host string, port int) (registryAddr string, cleanup func(), err error) {
+func resolveRegistryForSwift(ctx context.Context, host string, port int) (registryAddr string, cleanup func(), dialErr func() error, err error) {
 	resolved := resolveRegistryIP(host)
 	if !isLinkLocalIP(resolved) {
 		// Use the original hostname (or bare IP) directly — mDNS-resolvable on the host.
@@ -2050,19 +2052,26 @@ func resolveRegistryForSwift(ctx context.Context, host string, port int) (regist
 		if strings.Contains(addr, ":") && !strings.HasPrefix(addr, "[") {
 			addr = "[" + addr + "]"
 		}
-		return fmt.Sprintf("%s:%d", addr, port), func() {}, nil
+		return fmt.Sprintf("%s:%d", addr, port), func() {}, func() error { return nil }, nil
 	}
 
 	// Link-local: proxy via 127.0.0.1 — Swift runs on the host, not in a VM.
 	target := net.JoinHostPort(host, strconv.Itoa(port))
 	proxy, err := startRegistryProxy(ctx, "127.0.0.1:0", target)
 	if err != nil {
-		return "", nil, fmt.Errorf("starting registry proxy for link-local device: %w", err)
+		return "", nil, nil, fmt.Errorf("starting registry proxy for link-local device: %w", err)
 	}
-	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, nil
+	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, proxy.LastDialError, nil
 }
 
-func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, swiftUseMTLS bool, cleanup func(), err error) {
+// resolveRegistryForSwiftAgent resolves a registry address for the Swift
+// container plugin to push to, alongside a dialErr accessor: after a push
+// fails, callers can call dialErr() to check whether the underlying proxy
+// (if any) ever failed to reach its target — e.g. connection refused because
+// a Mac agent has no container runtime listening — and surface that instead
+// of a generic build failure. dialErr is always safely callable (never nil)
+// on a nil-error return.
+func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, swiftUseMTLS bool, cleanup func(), dialErr func() error, err error) {
 	if conn.RegistryDialer == nil {
 		if conn.IsMTLS {
 			// Provisioned LAN device: the registry speaks HTTPS with a cert signed
@@ -2071,17 +2080,17 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 			// the Swift container plugin can push via plain HTTP on 127.0.0.1.
 			certInfo := loadCLICert()
 			if certInfo == nil {
-				return "", false, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
+				return "", false, nil, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
 			}
 			target := net.JoinHostPort(conn.Host, strconv.Itoa(port))
 			proxy, proxyErr := startMTLSRegistryHTTPProxy(target, certInfo.PemCertificate, certInfo.PemPrivateKey, certInfo.PemCertificateChain)
 			if proxyErr != nil {
-				return "", false, nil, fmt.Errorf("starting mTLS registry proxy for Swift: %w", proxyErr)
+				return "", false, nil, nil, fmt.Errorf("starting mTLS registry proxy for Swift: %w", proxyErr)
 			}
-			return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, nil
+			return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, proxy.LastDialError, nil
 		}
-		addr, addrCleanup, addrErr := resolveRegistryForSwift(ctx, conn.Host, port)
-		return addr, false, addrCleanup, addrErr
+		addr, addrCleanup, addrDialErr, addrErr := resolveRegistryForSwift(ctx, conn.Host, port)
+		return addr, false, addrCleanup, addrDialErr, addrErr
 	}
 
 	// Cloud tunnel. On a provisioned device the registry itself speaks TLS,
@@ -2100,20 +2109,20 @@ func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentCon
 	if conn.IsMTLS {
 		certInfo := loadCLICert()
 		if certInfo == nil {
-			return "", false, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
+			return "", false, nil, nil, fmt.Errorf("mTLS connection but no CLI certificates available")
 		}
 		tlsDial, tlsErr := tlsClientDialer(certInfo.PemCertificate, certInfo.PemPrivateKey, certInfo.PemCertificateChain, dial)
 		if tlsErr != nil {
-			return "", false, nil, fmt.Errorf("preparing TLS dialer for tunneled registry: %w", tlsErr)
+			return "", false, nil, nil, fmt.Errorf("preparing TLS dialer for tunneled registry: %w", tlsErr)
 		}
 		dial = tlsDial
 	}
 
 	proxy, proxyErr := startRegistryProxyWithDialer(ctx, "127.0.0.1:0", dial)
 	if proxyErr != nil {
-		return "", false, nil, fmt.Errorf("starting cloud registry proxy for Swift: %w", proxyErr)
+		return "", false, nil, nil, fmt.Errorf("starting cloud registry proxy for Swift: %w", proxyErr)
 	}
-	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, nil
+	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), false, proxy.Close, proxy.LastDialError, nil
 }
 
 // wendyRegistryServerVerifier returns a VerifyConnection callback that
@@ -2194,7 +2203,7 @@ func tlsClientDialer(certPEM, keyPEM, caPEM string, dial func(context.Context) (
 
 func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, err error) {
 	if conn.RegistryDialer != nil || conn.IsMTLS {
-		registryAddr, appleUseMTLS, cleanup, err := resolveRegistryForSwiftAgent(ctx, conn, port)
+		registryAddr, appleUseMTLS, cleanup, _, err := resolveRegistryForSwiftAgent(ctx, conn, port)
 		if err != nil {
 			return "", nil, false, err
 		}
@@ -2221,6 +2230,21 @@ func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.Agen
 	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, false, nil
 }
 
+// isDialRefused reports whether err looks like a TCP dial that was actively
+// refused — i.e. nothing was listening on the target port at all — as opposed
+// to a timeout, reset, or other network failure. Used to recognize "no
+// container runtime running on the Mac agent" specifically, so the CLI can
+// explain that instead of surfacing a raw dial/registry error.
+func isDialRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	return strings.Contains(err.Error(), "connection refused")
+}
+
 // mtlsRegistryHTTPProxy is a plain-HTTP reverse proxy that forwards requests
 // to a provisioned device's HTTPS registry using mTLS. The Swift container
 // plugin connects to 127.0.0.1:PORT via plain HTTP (with --allow-insecure-http)
@@ -2228,6 +2252,9 @@ func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.Agen
 type mtlsRegistryHTTPProxy struct {
 	listener net.Listener
 	server   *http.Server
+
+	mu      sync.Mutex
+	dialErr error
 }
 
 func (p *mtlsRegistryHTTPProxy) Port() int {
@@ -2236,6 +2263,21 @@ func (p *mtlsRegistryHTTPProxy) Port() int {
 
 func (p *mtlsRegistryHTTPProxy) Close() {
 	_ = p.server.Close()
+}
+
+func (p *mtlsRegistryHTTPProxy) recordDialErr(err error) {
+	p.mu.Lock()
+	p.dialErr = err
+	p.mu.Unlock()
+}
+
+// LastDialError returns the most recent error encountered while reaching the
+// proxy's target (e.g. connection refused because the Mac agent has no
+// container runtime listening), or nil if every request so far has reached it.
+func (p *mtlsRegistryHTTPProxy) LastDialError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.dialErr
 }
 
 func startMTLSRegistryHTTPProxy(target, certPEM, keyPEM, caPEM string) (*mtlsRegistryHTTPProxy, error) {
@@ -2251,6 +2293,8 @@ func startMTLSRegistryHTTPProxy(target, certPEM, keyPEM, caPEM string) (*mtlsReg
 	if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
 		return nil, fmt.Errorf("no valid CA certificates found in caPEM")
 	}
+
+	p := &mtlsRegistryHTTPProxy{}
 
 	rp := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
@@ -2270,15 +2314,29 @@ func startMTLSRegistryHTTPProxy(target, certPEM, keyPEM, caPEM string) (*mtlsReg
 				VerifyConnection:   wendyRegistryServerVerifier(caPool),
 			},
 		},
+		// The default ErrorHandler logs "http: proxy error: dial tcp ...: connect:
+		// connection refused" straight to stderr for every failed request, which
+		// reads like a CLI crash rather than "the agent has no container runtime
+		// running". Record the error instead so the caller can surface one clear,
+		// actionable message once the build actually fails, and silence the noisy
+		// default log line (still returns 502 to the pushing client, same as
+		// before — the caller establishes trust and gets attribution independent
+		// of the request that failed).
+		ErrorLog: log.New(io.Discard, "", 0),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, handlerErr error) {
+			p.recordDialErr(handlerErr)
+			w.WriteHeader(http.StatusBadGateway)
+		},
 	}
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
-	srv := &http.Server{Handler: rp}
-	go func() { _ = srv.Serve(ln) }()
-	return &mtlsRegistryHTTPProxy{listener: ln, server: srv}, nil
+	p.listener = ln
+	p.server = &http.Server{Handler: rp}
+	go func() { _ = p.server.Serve(ln) }()
+	return p, nil
 }
 
 // startMTLSRegistryProxy starts a local plain-TCP listener that tunnels each
@@ -2346,6 +2404,9 @@ type registryProxy struct {
 	dial     func(context.Context) (net.Conn, error)
 	cancel   context.CancelFunc
 	done     chan struct{}
+
+	mu      sync.Mutex
+	dialErr error
 }
 
 func startRegistryProxy(ctx context.Context, listenAddr string, target string) (*registryProxy, error) {
@@ -2386,6 +2447,20 @@ func (p *registryProxy) Close() {
 	<-p.done
 }
 
+func (p *registryProxy) recordDialErr(err error) {
+	p.mu.Lock()
+	p.dialErr = err
+	p.mu.Unlock()
+}
+
+// LastDialError returns the most recent error encountered while reaching the
+// proxy's target, or nil if every connection so far has reached it.
+func (p *registryProxy) LastDialError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.dialErr
+}
+
 func (p *registryProxy) serve(ctx context.Context) {
 	defer close(p.done)
 	for {
@@ -2410,6 +2485,7 @@ func (p *registryProxy) forward(ctx context.Context, client net.Conn) {
 
 	remote, err := p.dial(ctx)
 	if err != nil {
+		p.recordDialErr(err)
 		return
 	}
 	defer remote.Close()

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -20,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1640,6 +1642,119 @@ func TestRegistryProxyBindsLoopback(t *testing.T) {
 	ip := proxy.listener.Addr().(*net.TCPAddr).IP
 	if !ip.IsLoopback() {
 		t.Fatalf("registry proxy bound to %s, want a loopback address", ip)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isDialRefused / registry proxy dial-error recording
+//
+// These guard the "Mac agent has no container runtime" error path: a Mac
+// agent only opens its embedded registry when it found Docker/OrbStack/Apple
+// container at startup, so a push to a Mac with none installed dies with a
+// bare connection-refused. isDialRefused must recognize that specifically,
+// and both proxy types must record it so callers can explain what happened.
+// ---------------------------------------------------------------------------
+
+func TestIsDialRefused(t *testing.T) {
+	if isDialRefused(nil) {
+		t.Error("isDialRefused(nil) = true; want false")
+	}
+	if isDialRefused(errors.New("some other failure")) {
+		t.Error("isDialRefused(unrelated error) = true; want false")
+	}
+	refused := fmt.Errorf("dial tcp 192.168.0.200:5555: connect: %w", syscall.ECONNREFUSED)
+	if !isDialRefused(refused) {
+		t.Errorf("isDialRefused(%v) = false; want true", refused)
+	}
+	if !isDialRefused(errors.New("dial tcp 127.0.0.1:5555: connect: connection refused")) {
+		t.Error("isDialRefused should match on the 'connection refused' message even without a wrapped errno")
+	}
+}
+
+func TestRegistryProxy_RecordsDialError(t *testing.T) {
+	// Reserve a port, then close it immediately so nothing is listening —
+	// dialing it is refused, mirroring a Mac agent with no container runtime.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxy, err := startRegistryProxy(ctx, "127.0.0.1:0", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	if err := proxy.LastDialError(); err != nil {
+		t.Fatalf("LastDialError before any connection = %v; want nil", err)
+	}
+
+	conn, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(proxy.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	// The proxy closes the client connection once the dial to target fails.
+	buf := make([]byte, 1)
+	_, _ = conn.Read(buf)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if dialErr := proxy.LastDialError(); dialErr != nil {
+			if !isDialRefused(dialErr) {
+				t.Errorf("LastDialError = %v; want a connection-refused error", dialErr)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("LastDialError was never recorded")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestMTLSRegistryHTTPProxy_RecordsDialError(t *testing.T) {
+	ca := generateTestCA(t)
+	clientLeaf := generateTestLeaf(t, ca, x509.ExtKeyUsageClientAuth)
+
+	// Reserve then release a port so dialing it is refused.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := ln.Addr().String()
+	ln.Close()
+
+	proxy, err := startMTLSRegistryHTTPProxy(target, clientLeaf.pemStr, marshalKeyPEM(t, clientLeaf.key), ca.pemStr)
+	if err != nil {
+		t.Fatalf("startMTLSRegistryHTTPProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	if err := proxy.LastDialError(); err != nil {
+		t.Fatalf("LastDialError before any request = %v; want nil", err)
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/v2/", proxy.Port()))
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d; want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+
+	dialErr := proxy.LastDialError()
+	if dialErr == nil {
+		t.Fatal("LastDialError = nil after a refused request; want a recorded error")
+	}
+	if !isDialRefused(dialErr) {
+		t.Errorf("LastDialError = %v; want a connection-refused error", dialErr)
 	}
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -988,7 +988,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		return err
 	}
 
-	registryAddr, swiftUseMTLS, proxyCleanup, err := resolveRegistryForSwiftAgent(ctx, conn, regPort)
+	registryAddr, swiftUseMTLS, proxyCleanup, proxyDialErr, err := resolveRegistryForSwiftAgent(ctx, conn, regPort)
 	if err != nil {
 		return err
 	}
@@ -996,6 +996,24 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 
 	cliLogln("Building Swift container image for %s (%s)...", tui.App(product), tui.Value(architecture))
 	if err := buildSwiftContainerImage(ctx, cwd, product, registryAddr, architecture, swiftUseMTLS, opts.debug, &dimWriter{}, os.Stderr); err != nil {
+		// A Mac agent only runs a container registry when it found a Linux
+		// container backend (Docker, OrbStack, or Apple `container`) at startup;
+		// otherwise the registry proxy above never reaches anything and the push
+		// dies with a bare "connection refused" that reads like a CLI bug. A real
+		// WendyOS/Linux device always ships its container runtime as part of the
+		// OS, so a refused connection there is an actual fault, not a missing
+		// optional dependency — only reinterpret the error for darwin agents.
+		if strings.EqualFold(agentOS, appconfig.PlatformDarwin) {
+			if dialErr := proxyDialErr(); isDialRefused(dialErr) {
+				return fmt.Errorf(
+					"the Mac agent at %s isn't running a container registry (%v); "+
+						"install Docker, OrbStack, or Apple's `container` CLI on the agent to run "+
+						"Linux/WendyOS apps there, or set \"platform\": \"darwin\" in wendy.json to run "+
+						"this app natively on the Mac instead",
+					conn.Host, dialErr,
+				)
+			}
+		}
 		return fmt.Errorf("building Swift container image: %w", err)
 	}
 	cliLogln("Build and push completed.")

--- a/go/internal/cli/commands/xcode.go
+++ b/go/internal/cli/commands/xcode.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -27,6 +30,14 @@ import (
 // colour state that corrupts subsequent output in long-running commands like
 // wendy run; the tail hint already gives the user visibility into progress.
 func runXcodebuild(ctx context.Context, dir string, args ...string) error {
+	return runXcodebuildAttempt(ctx, dir, true, args...)
+}
+
+// runXcodebuildAttempt is runXcodebuild's implementation. allowRecovery gates a
+// single retry after resolving a Command Line Tools-only xcode-select state
+// (see xcodeSelectGuidance); it is false on the retry itself so a persistently
+// broken selection cannot loop.
+func runXcodebuildAttempt(ctx context.Context, dir string, allowRecovery bool, args ...string) error {
 	logDir := filepath.Join(dir, ".xcode")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return fmt.Errorf("creating .xcode directory: %w", err)
@@ -46,14 +57,21 @@ func runXcodebuild(ctx context.Context, dir string, args ...string) error {
 	fmt.Println(hintStyle.Render("  tail -f .xcode/xcodebuild.log"))
 	fmt.Println()
 
+	var stderrBuf strings.Builder
 	cmd := execCommandContext(ctx, "xcodebuild", args...)
 	cmd.Dir = dir
 	cmd.Stdout = logFile
-	cmd.Stderr = logFile
+	cmd.Stderr = io.MultiWriter(logFile, &stderrBuf)
 
 	if err := cmd.Run(); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("xcodebuild is required but not found in PATH; install Xcode from the App Store")
+		}
+		if allowRecovery && looksLikeCLTOnlySelected(stderrBuf.String()) {
+			if selErr := xcodeSelectGuidanceFn(ctx); selErr != nil {
+				return selErr
+			}
+			return runXcodebuildAttempt(ctx, dir, false, args...)
 		}
 		return err
 	}
@@ -112,6 +130,14 @@ func parseXcodeSchemes(data []byte) ([]string, error) {
 // available schemes in dir, then returns the single scheme found or an error.
 // Multiple schemes produce an error with a hint to set "xcode.scheme" in wendy.json.
 func findXcodeScheme(ctx context.Context, dir string) (string, error) {
+	return findXcodeSchemeAttempt(ctx, dir, true)
+}
+
+// findXcodeSchemeAttempt is findXcodeScheme's implementation. allowRecovery
+// gates a single retry after resolving a Command Line Tools-only xcode-select
+// state (see xcodeSelectGuidance); it is false on the retry itself so a
+// persistently broken selection cannot loop.
+func findXcodeSchemeAttempt(ctx context.Context, dir string, allowRecovery bool) (string, error) {
 	cmd := execCommandContext(ctx, "xcodebuild", "-list", "-json")
 	cmd.Dir = dir
 
@@ -126,6 +152,12 @@ func findXcodeScheme(ctx context.Context, dir string) (string, error) {
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = strings.TrimSpace(stdout.String())
+		}
+		if allowRecovery && looksLikeCLTOnlySelected(msg) {
+			if selErr := xcodeSelectGuidanceFn(ctx); selErr != nil {
+				return "", selErr
+			}
+			return findXcodeSchemeAttempt(ctx, dir, false)
 		}
 		return "", fmt.Errorf("xcodebuild -list -json failed: %s: %w", msg, err)
 	}
@@ -143,6 +175,157 @@ func findXcodeScheme(ctx context.Context, dir string) (string, error) {
 		"multiple schemes found (%s); set \"xcode.scheme\" in wendy.json to specify which one to build",
 		strings.Join(schemes, ", "),
 	)
+}
+
+// xcodeSelectCLTMarker is the substring xcodebuild prints (via xcode-select)
+// when the active developer directory is a Command Line Tools install rather
+// than a full Xcode.app. CLT ships none of the project/scheme tooling the
+// Xcode build path needs, so every xcodebuild invocation fails the same way
+// until a full Xcode is selected.
+const xcodeSelectCLTMarker = "requires Xcode, but active developer directory"
+
+// looksLikeCLTOnlySelected reports whether xcodebuild's output indicates
+// Command Line Tools (not a full Xcode.app) is the active developer directory.
+func looksLikeCLTOnlySelected(output string) bool {
+	return strings.Contains(output, xcodeSelectCLTMarker)
+}
+
+// applicationsDir is where installedXcodeApps looks for Xcode.app bundles.
+// Overridable in tests.
+var applicationsDir = "/Applications"
+
+// installedXcodeApps returns the full Xcode.app bundles found under
+// applicationsDir, sorted by name. A bundle only qualifies if it actually
+// ships xcodebuild (Command Line Tools and stray folders merely named
+// "*.app" are excluded), so a picker built from this list never offers a
+// dead end.
+func installedXcodeApps() []string {
+	matches, err := filepath.Glob(filepath.Join(applicationsDir, "*.app"))
+	if err != nil {
+		return nil
+	}
+	var apps []string
+	for _, m := range matches {
+		if _, statErr := os.Stat(filepath.Join(m, "Contents", "Developer", "usr", "bin", "xcodebuild")); statErr == nil {
+			apps = append(apps, m)
+		}
+	}
+	sort.Strings(apps)
+	return apps
+}
+
+// xcodeSelectGuidanceFn is called once xcodebuild's output has matched
+// looksLikeCLTOnlySelected. Declared as a var so tests can stub it without
+// driving the real interactive picker/confirm/sudo flow.
+var xcodeSelectGuidanceFn = xcodeSelectGuidance
+
+// xcodeSelectGuidance is called once xcodebuild's output has matched
+// looksLikeCLTOnlySelected. It explains the situation and, where possible,
+// resolves it outright:
+//
+//   - No Xcode installed: explains that Command Line Tools alone cannot build
+//     this project and points to the App Store / developer.apple.com for a
+//     full install (including betas).
+//   - Exactly one Xcode installed: offers to run `sudo xcode-select -s` for it.
+//   - Multiple Xcodes installed (e.g. a release plus a beta): shows a picker so
+//     the user can choose which one to select, then offers to run the command.
+//
+// A nil return means the active developer directory was fixed and the caller
+// should retry its xcodebuild invocation.
+func xcodeSelectGuidance(ctx context.Context) error {
+	apps := installedXcodeApps()
+
+	if len(apps) == 0 {
+		return fmt.Errorf(
+			"xcodebuild requires the full Xcode app, but only Command Line Tools is installed.\n" +
+				"Install Xcode from the App Store (search \"Xcode\"), or download a specific version " +
+				"(including betas) from https://developer.apple.com/download/all/ (requires a free Apple " +
+				"Developer account), then run:\n\n" +
+				"    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\n",
+		)
+	}
+
+	if jsonOutput || !isInteractiveTerminal() {
+		return xcodeSelectNonInteractiveErr(apps)
+	}
+
+	chosen := apps[0]
+	if len(apps) > 1 {
+		var err error
+		chosen, err = pickXcodeAppInteractive(apps)
+		if err != nil {
+			return err
+		}
+	}
+
+	developerDir := filepath.Join(chosen, "Contents", "Developer")
+	run, err := tui.ConfirmDefaultYes(fmt.Sprintf("Select %s as the active Xcode (runs: sudo xcode-select -s)?", chosen))
+	if err != nil {
+		return err
+	}
+	if !run {
+		return fmt.Errorf("run the following to continue, then re-run this command:\n\n    sudo xcode-select -s %s\n", developerDir)
+	}
+
+	selectCmd := execCommandContext(ctx, "sudo", "xcode-select", "-s", developerDir)
+	selectCmd.Stdin = os.Stdin
+	selectCmd.Stdout = os.Stdout
+	selectCmd.Stderr = os.Stderr
+	if err := selectCmd.Run(); err != nil {
+		return fmt.Errorf("sudo xcode-select -s %s failed: %w", developerDir, err)
+	}
+	return nil
+}
+
+// xcodeSelectNonInteractiveErr builds the guidance error for scripts/--json
+// callers, which cannot be shown a picker or a confirm prompt.
+func xcodeSelectNonInteractiveErr(apps []string) error {
+	return fmt.Errorf(
+		"xcodebuild requires the full Xcode app, but the active developer directory is Command Line "+
+			"Tools; found %s — select one with:\n\n    sudo xcode-select -s <path>/Contents/Developer\n",
+		strings.Join(apps, ", "),
+	)
+}
+
+// pickXcodeAppInteractive shows a picker over the given Xcode.app bundles
+// (used when more than one is installed, e.g. a stable release plus a beta)
+// and returns the one the user chose.
+func pickXcodeAppInteractive(apps []string) (string, error) {
+	items := make([]tui.PickerItem, 0, len(apps))
+	for _, a := range apps {
+		items = append(items, tui.PickerItem{Name: filepath.Base(a), Value: a})
+	}
+	picker := tui.NewPickerWithTitleAndColumns("Select an Xcode installation", []tui.PickerColumn{
+		{
+			Title:    "App",
+			MinWidth: 24,
+			Required: true,
+			Value:    func(item tui.PickerItem) string { return item.Name },
+		},
+	})
+
+	p := tea.NewProgram(picker)
+	go func() {
+		p.Send(tui.PickerAddMsg{Items: items})
+		p.Send(tui.PickerDoneMsg{})
+	}()
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("picker: %w", err)
+	}
+	pm, ok := finalModel.(tui.PickerModel)
+	if !ok {
+		return "", fmt.Errorf("picker: unexpected model type %T", finalModel)
+	}
+	if pm.Cancelled() || pm.Selected() == nil {
+		return "", ErrUserCancelled
+	}
+	appPath, ok := pm.Selected().Value.(string)
+	if !ok {
+		return "", fmt.Errorf("picker: unexpected selection value %T", pm.Selected().Value)
+	}
+	return appPath, nil
 }
 
 // findXcodeBuildProduct inspects the build products directory produced by

--- a/go/internal/cli/commands/xcode.go
+++ b/go/internal/cli/commands/xcode.go
@@ -280,8 +280,15 @@ func xcodeSelectGuidance(ctx context.Context) error {
 // xcodeSelectNonInteractiveErr builds the guidance error for scripts/--json
 // callers, which cannot be shown a picker or a confirm prompt.
 func xcodeSelectNonInteractiveErr(apps []string) error {
+	if len(apps) == 1 {
+		developerDir := filepath.Join(apps[0], "Contents", "Developer")
+		return fmt.Errorf(
+			"xcodebuild requires the full Xcode app, but the active developer directory is Command Line Tools; select it with:\n\n    sudo xcode-select -s %s\n",
+			developerDir,
+		)
+	}
 	return fmt.Errorf(
-		"xcodebuild requires the full Xcode app, but the active developer directory is Command Line "+
+		"xcodebuild requires the full Xcode app, but the active developer directory is Command Line " +
 			"Tools; found %s — select one with:\n\n    sudo xcode-select -s <path>/Contents/Developer\n",
 		strings.Join(apps, ", "),
 	)

--- a/go/internal/cli/commands/xcode_test.go
+++ b/go/internal/cli/commands/xcode_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -103,6 +104,187 @@ func TestRunXcodebuild_ReturnsErrorOnFailure(t *testing.T) {
 
 	if err := runXcodebuild(context.Background(), dir); err == nil {
 		t.Fatal("expected error on xcodebuild failure, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// looksLikeCLTOnlySelected / installedXcodeApps
+// ---------------------------------------------------------------------------
+
+func TestLooksLikeCLTOnlySelected(t *testing.T) {
+	cltOutput := `xcodebuild: error: unable to find utility "xcodebuild", not a developer tool or in PATH
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`
+	if !looksLikeCLTOnlySelected(cltOutput) {
+		t.Error("expected CLT-only output to be detected")
+	}
+	if looksLikeCLTOnlySelected("xcodebuild: error: Scheme MyScheme is not currently configured") {
+		t.Error("did not expect an unrelated xcodebuild error to be detected as CLT-only")
+	}
+	if looksLikeCLTOnlySelected("") {
+		t.Error("did not expect empty output to be detected as CLT-only")
+	}
+}
+
+func TestInstalledXcodeApps_FiltersToRealXcodeBundles(t *testing.T) {
+	dir := t.TempDir()
+	origAppsDir := applicationsDir
+	applicationsDir = dir
+	t.Cleanup(func() { applicationsDir = origAppsDir })
+
+	// A real Xcode install: has Contents/Developer/usr/bin/xcodebuild.
+	makeXcodeBundle(t, dir, "Xcode.app")
+	makeXcodeBundle(t, dir, "Xcode-beta.app")
+	// A stray folder that merely looks like an Xcode install (no xcodebuild inside).
+	if err := os.MkdirAll(filepath.Join(dir, "NotXcode.app", "Contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Command Line Tools is not an .app bundle, so it never matches the glob;
+	// nothing to special-case here.
+
+	apps := installedXcodeApps()
+	if len(apps) != 2 {
+		t.Fatalf("installedXcodeApps = %v; want 2 entries", apps)
+	}
+	if filepath.Base(apps[0]) != "Xcode-beta.app" || filepath.Base(apps[1]) != "Xcode.app" {
+		t.Errorf("installedXcodeApps = %v; want sorted [Xcode-beta.app Xcode.app]", apps)
+	}
+}
+
+func TestInstalledXcodeApps_NoneInstalled(t *testing.T) {
+	dir := t.TempDir()
+	origAppsDir := applicationsDir
+	applicationsDir = dir
+	t.Cleanup(func() { applicationsDir = origAppsDir })
+
+	if apps := installedXcodeApps(); len(apps) != 0 {
+		t.Errorf("installedXcodeApps = %v; want empty", apps)
+	}
+}
+
+// makeXcodeBundle creates a fake Xcode.app bundle under dir with just enough
+// structure (Contents/Developer/usr/bin/xcodebuild) to satisfy installedXcodeApps.
+func makeXcodeBundle(t *testing.T, dir, name string) string {
+	t.Helper()
+	binDir := filepath.Join(dir, name, "Contents", "Developer", "usr", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
+	if err := os.WriteFile(xcodebuildPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, name)
+}
+
+// ---------------------------------------------------------------------------
+// xcodeSelectGuidance
+// ---------------------------------------------------------------------------
+
+func TestXcodeSelectGuidance_NoXcodeInstalled(t *testing.T) {
+	dir := t.TempDir()
+	origAppsDir := applicationsDir
+	applicationsDir = dir
+	t.Cleanup(func() { applicationsDir = origAppsDir })
+
+	err := xcodeSelectGuidance(context.Background())
+	if err == nil {
+		t.Fatal("expected guidance error when no Xcode is installed")
+	}
+	if !strings.Contains(err.Error(), "App Store") || !strings.Contains(err.Error(), "developer.apple.com") {
+		t.Errorf("expected install guidance mentioning the App Store and developer.apple.com, got: %v", err)
+	}
+}
+
+func TestXcodeSelectGuidance_NonInteractive_ListsCandidates(t *testing.T) {
+	dir := t.TempDir()
+	origAppsDir := applicationsDir
+	applicationsDir = dir
+	t.Cleanup(func() { applicationsDir = origAppsDir })
+	makeXcodeBundle(t, dir, "Xcode.app")
+	makeXcodeBundle(t, dir, "Xcode-beta.app")
+
+	origInteractive := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = origInteractive })
+
+	err := xcodeSelectGuidance(context.Background())
+	if err == nil {
+		t.Fatal("expected guidance error in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "Xcode.app") || !strings.Contains(err.Error(), "Xcode-beta.app") {
+		t.Errorf("expected both candidates named in the error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "xcode-select -s") {
+		t.Errorf("expected the xcode-select -s command in the error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findXcodeScheme CLT recovery
+// ---------------------------------------------------------------------------
+
+func TestFindXcodeScheme_RecoversFromCLTOnlySelected(t *testing.T) {
+	origExec := execCommandContext
+	t.Cleanup(func() { execCommandContext = origExec })
+	origGuidance := xcodeSelectGuidanceFn
+	t.Cleanup(func() { xcodeSelectGuidanceFn = origGuidance })
+
+	calls := 0
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls++
+		if calls == 1 {
+			script := `echo "xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance" >&2; exit 1`
+			return exec.CommandContext(ctx, "sh", "-c", script)
+		}
+		script := `echo '{"project":{"schemes":["HelloXcode"]}}'`
+		return exec.CommandContext(ctx, "sh", "-c", script)
+	}
+	guidanceCalls := 0
+	xcodeSelectGuidanceFn = func(ctx context.Context) error {
+		guidanceCalls++
+		return nil // simulate a successful xcode-select fix
+	}
+
+	scheme, err := findXcodeScheme(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("findXcodeScheme error: %v", err)
+	}
+	if scheme != "HelloXcode" {
+		t.Errorf("findXcodeScheme = %q; want %q", scheme, "HelloXcode")
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 xcodebuild calls (fail + retry), got %d", calls)
+	}
+	if guidanceCalls != 1 {
+		t.Errorf("expected xcodeSelectGuidanceFn to be called once, got %d", guidanceCalls)
+	}
+}
+
+func TestFindXcodeScheme_CLTGuidanceErrorPropagates(t *testing.T) {
+	origExec := execCommandContext
+	t.Cleanup(func() { execCommandContext = origExec })
+	origGuidance := xcodeSelectGuidanceFn
+	t.Cleanup(func() { xcodeSelectGuidanceFn = origGuidance })
+
+	calls := 0
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls++
+		script := `echo "xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance" >&2; exit 1`
+		return exec.CommandContext(ctx, "sh", "-c", script)
+	}
+	xcodeSelectGuidanceFn = func(ctx context.Context) error {
+		return fmt.Errorf("install Xcode from the App Store")
+	}
+
+	_, err := findXcodeScheme(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error to propagate from xcodeSelectGuidanceFn")
+	}
+	if !strings.Contains(err.Error(), "App Store") {
+		t.Errorf("expected guidance error to propagate, got: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected only 1 xcodebuild call when guidance fails (no retry), got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `wendy run` for an Xcode project failed with a raw `xcodebuild -list -json failed: xcode-select: error: ... requires Xcode, but active developer directory ... is a command line tools instance` when only Command Line Tools (not a full Xcode.app) was selected. The CLI now detects this and either explains how to install Xcode / select a beta (showing a picker when more than one Xcode is installed) or offers to run `sudo xcode-select -s` itself.
- `wendy run` for a Swift project targeting `platform: linux` on a headless Mac agent with no container runtime (Docker, OrbStack, Apple `container`) failed with a bare `dial tcp ...: connection refused` / `502` from the registry proxy — the agent never opens its embedded registry without a backend. The registry proxy now records the dial failure instead of just logging it, and a refused connection to a darwin agent is turned into a clear explanation ("install Docker/OrbStack/`container`, or set `platform: darwin` to run natively") instead of a generic build failure.
- Fixes `Examples/HelloMac/wendy.json` and `Examples/HelloXcode/wendy.json`, which declared `"platform": "linux"` even though both are native-macOS-agent demos — that mismatch is what triggered the Linux cross-compile path in the first place.

## Test plan

- [x] `go build ./...` (whole module)
- [x] `go vet ./internal/cli/commands/...`
- [x] `gofmt -l` on all touched Go files (clean)
- [x] `go test ./internal/cli/commands/...` (full package, including new tests: `TestLooksLikeCLTOnlySelected`, `TestInstalledXcodeApps_*`, `TestXcodeSelectGuidance_*`, `TestFindXcodeScheme_RecoversFromCLTOnlySelected`, `TestFindXcodeScheme_CLTGuidanceErrorPropagates`, `TestIsDialRefused`, `TestRegistryProxy_RecordsDialError`, `TestMTLSRegistryHTTPProxy_RecordsDialError`)
- [ ] Manual verification on real hardware: Xcode-selection picker/recovery flow, and the Mac-agent-without-runtime error message end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaaDzAVdjKXro79AsEvYz6