### PR TITLE
Rank running apps first in device app lists

### DIFF
--- a/go/internal/cli/commands/apps.go
+++ b/go/internal/cli/commands/apps.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -134,6 +135,9 @@ func appsListAgent(ctx context.Context, conn *grpcclient.AgentConnection) error 
 			containers = append(containers, c)
 		}
 	}
+	sortRunningFirst(containers, func(c *agentpb.AppContainer) string {
+		return c.GetRunningState().String()
+	})
 
 	if jsonOutput {
 		type jsonService struct {
@@ -312,6 +316,9 @@ func appsListProvider(ctx context.Context, cm providers.ContainerManager) error 
 	if err != nil {
 		return err
 	}
+	sortRunningFirst(containers, func(c providers.ContainerInfo) string {
+		return c.State
+	})
 
 	if jsonOutput {
 		data, err := json.MarshalIndent(containers, "", "  ")
@@ -751,6 +758,16 @@ type appInfo struct {
 	IsGroup bool // true when this app has multiple service containers
 }
 
+// sortRunningFirst performs a stable partition so running apps appear before
+// every other state while preserving the device's order within each group.
+func sortRunningFirst[T any](items []T, state func(T) string) {
+	sort.SliceStable(items, func(i, j int) bool {
+		iRunning := strings.EqualFold(state(items[i]), "running")
+		jRunning := strings.EqualFold(state(items[j]), "running")
+		return iRunning && !jRunning
+	})
+}
+
 func listApps(ctx context.Context, target *SelectedDevice) ([]appInfo, error) {
 	if target.Bluetooth != nil && target.Bluetooth.IsWendyAgent() {
 		bleClient, err := connectBLEAgent(target.Bluetooth)
@@ -770,6 +787,7 @@ func listApps(ctx context.Context, target *SelectedDevice) ([]appInfo, error) {
 				State:   a.GetState(),
 			}
 		}
+		sortRunningFirst(apps, func(a appInfo) string { return a.State })
 		return apps, nil
 	}
 
@@ -796,6 +814,7 @@ func listApps(ctx context.Context, target *SelectedDevice) ([]appInfo, error) {
 				})
 			}
 		}
+		sortRunningFirst(apps, func(a appInfo) string { return a.State })
 		return apps, nil
 	}
 
@@ -812,6 +831,7 @@ func listApps(ctx context.Context, target *SelectedDevice) ([]appInfo, error) {
 		for i, c := range containers {
 			apps[i] = appInfo{Name: c.Name, State: c.State}
 		}
+		sortRunningFirst(apps, func(a appInfo) string { return a.State })
 		return apps, nil
 	}
 

--- a/go/internal/cli/commands/apps_dashboard.go
+++ b/go/internal/cli/commands/apps_dashboard.go
@@ -35,13 +35,19 @@ type dashboardRow struct {
 }
 
 // buildDashboardRows merges containers, stats, and volume data into display rows.
-// Order follows the containers slice. Multi-service apps produce a group-header
-// row followed by one sub-row per service; sub-rows are display-only (no actions).
+// Running apps appear first, preserving the device's order within each state
+// group. Multi-service apps produce a group-header row followed by one sub-row
+// per service; sub-rows are display-only (no actions).
 func buildDashboardRows(
 	containers []*agentpb.AppContainer,
 	stats []*agentpb.ContainerStats,
 	volumes []*agentpb.VolumeInfo,
 ) []dashboardRow {
+	orderedContainers := append([]*agentpb.AppContainer(nil), containers...)
+	sortRunningFirst(orderedContainers, func(c *agentpb.AppContainer) string {
+		return c.GetRunningState().String()
+	})
+
 	// Index stats by container ID (set to ctr.ID() by GetContainerStats).
 	statsMap := make(map[string]*agentpb.ContainerStats, len(stats))
 	for _, s := range stats {
@@ -59,7 +65,7 @@ func buildDashboardRows(
 	}
 
 	var rows []dashboardRow
-	for _, c := range containers {
+	for _, c := range orderedContainers {
 		appName := c.GetAppName()
 		services := c.GetServices()
 

--- a/go/internal/cli/commands/apps_dashboard_test.go
+++ b/go/internal/cli/commands/apps_dashboard_test.go
@@ -16,8 +16,8 @@ func TestBuildDashboardRows(t *testing.T) {
 	stopped := agentpb.AppRunningState_STOPPED
 
 	containers := []*agentpb.AppContainer{
-		{AppName: "my-app", AppVersion: "1.0", RunningState: running, FailureCount: 0},
 		{AppName: "idle-app", AppVersion: "2.0", RunningState: stopped, FailureCount: 3},
+		{AppName: "my-app", AppVersion: "1.0", RunningState: running, FailureCount: 0},
 	}
 
 	stats := []*agentpb.ContainerStats{

--- a/go/internal/cli/commands/apps_test.go
+++ b/go/internal/cli/commands/apps_test.go
@@ -28,6 +28,27 @@ func TestDeviceAppsListCommand_HelpDescribesDeployedApps(t *testing.T) {
 	}
 }
 
+func TestSortRunningFirstStable(t *testing.T) {
+	apps := []appInfo{
+		{Name: "stopped-1", State: "STOPPED"},
+		{Name: "running-1", State: "RUNNING"},
+		{Name: "crash-looping", State: "CRASH_LOOPING"},
+		{Name: "running-2", State: "running"},
+		{Name: "stopped-2", State: "STOPPED"},
+	}
+
+	sortRunningFirst(apps, func(a appInfo) string { return a.State })
+
+	got := make([]string, len(apps))
+	for i, app := range apps {
+		got[i] = app.Name
+	}
+	want := []string{"running-1", "running-2", "stopped-1", "crash-looping", "stopped-2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("app order = %v, want %v", got, want)
+	}
+}
+
 func TestAppsList_GroupDisplayShowsServiceSubRows(t *testing.T) {
 	containers := []*agentpb.AppContainer{
 		{


### PR DESCRIPTION
## What changed

- Rank apps in the `RUNNING` state before all other app states.
- Preserve the device-provided order within the running and non-running groups.
- Apply the ordering consistently to static table output, JSON output, the interactive dashboard, Bluetooth and provider-backed devices, and app pickers.
- Keep multi-service app rows grouped with their service subrows.

## Why

`wendy device apps list` previously displayed apps in the order returned by the backend, so stopped or crash-looping apps could appear above active workloads. This made the apps users are most likely to inspect harder to find.

## Impact

Running apps now appear at the top of app lists without changing the order of apps that share the same running/non-running classification.

## Validation

- `go test ./go/internal/cli/commands`
- `go test ./go/internal/cli/...`
- `git diff --check`