### PR TITLE
cli: let device top stop apps and clarify lifecycle state

### DIFF
--- a/.github/ci-tests/python-device-top/main.py
+++ b/.github/ci-tests/python-device-top/main.py
@@ -5,8 +5,8 @@
 and is observable. This app binds a TCP and a UDP port (so it also shows up in
 top's per-app ports panel) and then idles, doing only trivial periodic work so
 its CPU usage stays low. The test harness deploys it detached, runs
-`wendy device top --json`, asserts the host and container fields are present,
-then removes it.
+`wendy device top --json`, asserts the host and running container state fields
+are present, then removes it.
 """
 
 import socket

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
@@ -12,7 +12,9 @@ wendy device top [flags]
 
 `wendy device top` opens a full-screen, auto-refreshing dashboard showing whole-machine CPU and memory utilization, per-GPU utilization/memory (and temperature/power where reported), and a per-app/per-container table of CPU% and memory. CPU percentages are computed from deltas between refreshes, so the first frame may read low until a second sample is taken.
 
-Apps are grouped the same way as [`wendy device dashboard`](dashboard.md): multi-service apps show a group header with one subrow per service. A side panel shows the listening ports of the currently selected app.
+Apps are grouped the same way as [`wendy device dashboard`](dashboard.md): multi-service apps show a group header with one subrow per service. Running apps (`●`), stopped apps (`○`), and crash-looping apps (`↻`) have distinct row styling and are counted separately. Resource columns show unavailable values for stopped and crash-looping rows instead of presenting them as active zero-usage workloads. A side panel shows the listening ports of the currently selected running app.
+
+Press `x` to stop the selected app. For a multi-service app, this stops the whole app even when the cursor is on one of its service rows. Stop uses Wendy's normal graceful shutdown behavior and may escalate to a force kill when the app does not exit within its grace period.
 
 > **Note:** This command requires a recent device agent. Against an agent that's too old to report resource stats, the command reports that the agent doesn't support resource stats and suggests updating it with [`wendy device update`](update.md).
 
@@ -23,6 +25,7 @@ Apps are grouped the same way as [`wendy device dashboard`](dashboard.md): multi
 | `↑` / `k`, `↓` / `j` | Move the selection up / down |
 | `c` | Sort apps by CPU usage (descending) |
 | `m` | Sort apps by memory usage (descending) |
+| `x` | Stop the selected app and all of its services |
 | `q` / `Ctrl+C` | Quit |
 
 ## Flags
@@ -41,7 +44,7 @@ The [global `--json` flag](../../global-flags.md) is also honored — see below.
 wendy device top --json
 ```
 
-The snapshot has this shape:
+Plain snapshots include a `STATE` column. JSON snapshots have this shape:
 
 ```json
 {
@@ -70,6 +73,7 @@ The snapshot has this shape:
 
 - `host.gpus` is omitted on devices that report no GPU.
 - Each GPU's `tempC` and `powerW` are omitted when the agent doesn't report them.
+- `containers[].state` is `running`, `stopped`, or `crash-loop`.
 - `containers[].cpuPercent` is each container's share of the whole machine (0–100 across all cores).
 
 ## Related

--- a/go/internal/cli/commands/device_top.go
+++ b/go/internal/cli/commands/device_top.go
@@ -91,7 +91,7 @@ type topRow struct {
 	displayName   string
 	cpuPercent    float64
 	memBytes      int64
-	state         string // "running", "stopped", …
+	state         agentpb.AppRunningState
 	hasCPU        bool
 	isGroupHeader bool
 	isSubrow      bool
@@ -104,9 +104,26 @@ func topStateLabel(s agentpb.AppRunningState) string {
 		return "running"
 	case agentpb.AppRunningState_STOPPED:
 		return "stopped"
+	case agentpb.AppRunningState_CRASH_LOOPING:
+		return "crash-loop"
 	default:
 		return strings.ToLower(strings.TrimPrefix(s.String(), "APP_RUNNING_STATE_"))
 	}
+}
+
+func topStateIcon(s agentpb.AppRunningState) string {
+	switch s {
+	case agentpb.AppRunningState_RUNNING:
+		return "●"
+	case agentpb.AppRunningState_CRASH_LOOPING:
+		return "↻"
+	default:
+		return "○"
+	}
+}
+
+func topDisplayName(r topRow) string {
+	return topStateIcon(r.state) + " " + r.displayName
 }
 
 // buildTopRows groups containers by app (mirroring buildDashboardRows) with CPU%
@@ -147,24 +164,26 @@ func buildTopRows(containers []*agentpb.AppContainer, cpuByID map[string]float64
 	for _, a := range aggs {
 		c := a.container
 		appName := c.GetAppName()
+		appState := c.GetRunningState()
 		if len(c.GetServices()) > 1 {
 			rows = append(rows, topRow{
 				name:          appName,
 				displayName:   appName + " [group]",
 				cpuPercent:    a.cpu,
 				memBytes:      a.mem,
-				state:         topStateLabel(c.GetRunningState()),
-				hasCPU:        true,
+				state:         appState,
+				hasCPU:        appState == agentpb.AppRunningState_RUNNING,
 				isGroupHeader: true,
 			})
 			for _, svc := range c.GetServices() {
 				key := appName + "_" + svc.GetName()
+				svcState := svc.GetRunningState()
 				rows = append(rows, topRow{
 					displayName: "  ↳ " + svc.GetName(),
 					cpuPercent:  cpuByID[key],
 					memBytes:    memByID[key],
-					state:       topStateLabel(svc.GetRunningState()),
-					hasCPU:      true,
+					state:       svcState,
+					hasCPU:      svcState == agentpb.AppRunningState_RUNNING,
 					isSubrow:    true,
 				})
 			}
@@ -174,8 +193,8 @@ func buildTopRows(containers []*agentpb.AppContainer, cpuByID map[string]float64
 				displayName: appName,
 				cpuPercent:  a.cpu,
 				memBytes:    a.mem,
-				state:       topStateLabel(c.GetRunningState()),
-				hasCPU:      true,
+				state:       appState,
+				hasCPU:      appState == agentpb.AppRunningState_RUNNING,
 			})
 		}
 	}
@@ -296,6 +315,7 @@ func buildTopJSON(prev, cur topSample, containers []*agentpb.AppContainer) topJS
 		}
 		out.Containers = append(out.Containers, topJSONContainer{
 			Name:       r.displayName,
+			State:      topStateLabel(r.state),
 			CPUPercent: r.cpuPercent,
 			MemBytes:   r.memBytes,
 		})
@@ -338,33 +358,40 @@ func runTopSnapshot(ctx context.Context, conn *grpcclient.AgentConnection, asJSO
 		fmt.Println(string(data))
 		return nil
 	}
+	return writeTopPlainSnapshot(os.Stdout, prev, cur, containers)
+}
 
-	// Plain table.
+func writeTopPlainSnapshot(w io.Writer, prev, cur topSample, containers []*agentpb.AppContainer) error {
 	cpuCount := uint32(1)
 	if cur.host != nil && cur.host.GetCpuCount() > 0 {
 		cpuCount = cur.host.GetCpuCount()
 	}
 	if cur.host != nil {
-		fmt.Printf("CPU: %.1f%%  MEM: %s / %s\n",
+		fmt.Fprintf(w, "CPU: %.1f%%  MEM: %s / %s\n",
 			hostCPUPercent(prev, cur),
 			formatBytes(cur.host.GetMemTotalBytes()-cur.host.GetMemAvailableBytes()),
 			formatBytes(cur.host.GetMemTotalBytes()))
 		for _, g := range cur.host.GetGpus() {
-			fmt.Printf("GPU%d %s: %.0f%%  %s\n", g.GetIndex(), g.GetName(),
+			fmt.Fprintf(w, "GPU%d %s: %.0f%%  %s\n", g.GetIndex(), g.GetName(),
 				g.GetUtilPercent(), formatGPUMem(g))
 		}
 		if zones := cur.host.GetThermalZones(); len(zones) > 0 {
-			fmt.Printf("TEMP: %s\n", formatThermalZones(zones))
+			fmt.Fprintf(w, "TEMP: %s\n", formatThermalZones(zones))
 		}
 	}
 	cpuByID := map[string]float64{}
 	for id := range cur.containers {
 		cpuByID[id] = containerCPUPercent(prev, cur, id, cpuCount)
 	}
-	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "APP\tCPU%\tMEM")
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "APP\tSTATE\tCPU%\tMEM")
 	for _, r := range buildTopRows(containers, cpuByID, cur.mem, false) {
-		fmt.Fprintf(tw, "%s\t%.1f\t%s\n", r.displayName, r.cpuPercent, formatBytes(r.memBytes))
+		cpu, mem := "—", "—"
+		if r.state == agentpb.AppRunningState_RUNNING {
+			cpu = fmt.Sprintf("%.1f", r.cpuPercent)
+			mem = formatBytes(r.memBytes)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.displayName, topStateLabel(r.state), cpu, mem)
 	}
 	return tw.Flush()
 }
@@ -421,6 +448,12 @@ type topModel struct {
 	height    int
 	flash     string
 
+	// Lifecycle action state is separate from poll errors so a successful poll
+	// cannot erase stop progress or its result.
+	actionSeq    uint64
+	stoppingApp  string
+	actionStatus string
+
 	// Ports for the currently selected app (always-on side panel).
 	portsApp string
 	ports    []*agentpb.PortEntry
@@ -432,6 +465,14 @@ type topPortsMsg struct {
 	ports []*agentpb.PortEntry
 	err   error
 }
+
+type topStopResultMsg struct {
+	seq uint64
+	app string
+	err error
+}
+
+type topClearActionMsg struct{ seq uint64 }
 
 func newTopModel(ctx context.Context, conn *grpcclient.AgentConnection, interval time.Duration) topModel {
 	return topModel{
@@ -477,6 +518,33 @@ func (m topModel) selectedAppName() string {
 		}
 	}
 	return ""
+}
+
+func (m topModel) selectedAppState() (agentpb.AppRunningState, bool) {
+	for i := m.cursor; i >= 0 && i < len(m.rows); i-- {
+		if m.rows[i].name != "" {
+			return m.rows[i].state, true
+		}
+	}
+	return agentpb.AppRunningState_STOPPED, false
+}
+
+func (m topModel) stopAppCmd(app string, seq uint64) tea.Cmd {
+	conn, ctx := m.conn, m.ctx
+	return func() tea.Msg {
+		if conn == nil || conn.ContainerService == nil {
+			return topStopResultMsg{seq: seq, app: app, err: fmt.Errorf("container service unavailable")}
+		}
+		_, err := conn.ContainerService.StopContainer(ctx, &agentpb.StopContainerRequest{AppName: app})
+		return topStopResultMsg{seq: seq, app: app, err: err}
+	}
+}
+
+func clearTopActionStatus(seq uint64) tea.Cmd {
+	return func() tea.Msg {
+		time.Sleep(3 * time.Second)
+		return topClearActionMsg{seq: seq}
+	}
 }
 
 // fetchPortsCmd fetches the listening ports for app. The result carries the app
@@ -564,6 +632,7 @@ func (m topModel) runContainersPoll() {
 // rebuildRows recomputes the displayed rows from the cached samples, keeping
 // the cursor within bounds.
 func (m *topModel) rebuildRows() {
+	selectedApp := m.selectedAppName()
 	cpuCount := uint32(1)
 	if m.cur.host != nil && m.cur.host.GetCpuCount() > 0 {
 		cpuCount = m.cur.host.GetCpuCount()
@@ -575,6 +644,14 @@ func (m *topModel) rebuildRows() {
 		}
 	}
 	m.rows = buildTopRows(m.cachedContainers, cpuByID, m.cur.mem, m.sortByCPU)
+	if selectedApp != "" {
+		for i, r := range m.rows {
+			if r.name == selectedApp {
+				m.cursor = i
+				break
+			}
+		}
+	}
 	if m.cursor >= len(m.rows) {
 		m.cursor = len(m.rows) - 1
 	}
@@ -625,6 +702,24 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case topStopResultMsg:
+		if msg.seq != m.actionSeq {
+			return m, nil
+		}
+		m.stoppingApp = ""
+		if msg.err != nil {
+			m.actionStatus = fmt.Sprintf("Error stopping %s: %s", msg.app, userFacingGRPCError(msg.err))
+		} else {
+			m.actionStatus = fmt.Sprintf("Stopped %s", msg.app)
+		}
+		return m, clearTopActionStatus(msg.seq)
+
+	case topClearActionMsg:
+		if msg.seq == m.actionSeq && m.stoppingApp == "" {
+			m.actionStatus = ""
+		}
+		return m, nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -647,6 +742,20 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sortByCPU = false
 			m.rebuildRows()
 			return m, m.maybeFetchPorts()
+		case "x":
+			app := m.selectedAppName()
+			state, ok := m.selectedAppState()
+			if app == "" || !ok || m.stoppingApp != "" {
+				return m, nil
+			}
+			m.actionSeq++
+			if state == agentpb.AppRunningState_STOPPED {
+				m.actionStatus = fmt.Sprintf("%s is already stopped", app)
+				return m, clearTopActionStatus(m.actionSeq)
+			}
+			m.stoppingApp = app
+			m.actionStatus = fmt.Sprintf("Stopping %s…", app)
+			return m, m.stopAppCmd(app, m.actionSeq)
 		}
 		return m, nil
 	}
@@ -661,9 +770,11 @@ var (
 	topValDim     = lipgloss.NewStyle().Foreground(tui.ColorDim)
 	topHeaderBar  = lipgloss.NewStyle().Bold(true).Background(tui.Emerald500).Foreground(lipgloss.Color("#02160f"))
 	// Bright mint selection bar for strong contrast with the black row text.
-	topSelRow   = lipgloss.NewStyle().Background(lipgloss.Color("#9FE2BF")).Foreground(lipgloss.Color("#000000"))
-	topKeyCap   = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(lipgloss.Color("#d0d0d0"))
-	topKeyLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(tui.Emerald500)
+	topSelRow     = lipgloss.NewStyle().Background(lipgloss.Color("#9FE2BF")).Foreground(lipgloss.Color("#000000"))
+	topRunningRow = lipgloss.NewStyle().Foreground(tui.Emerald400)
+	topCrashRow   = lipgloss.NewStyle().Foreground(tui.Red500)
+	topKeyCap     = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(lipgloss.Color("#d0d0d0"))
+	topKeyLabel   = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(tui.Emerald500)
 )
 
 // topMeter renders an htop-style bracketed meter: LABEL[|||||      value].
@@ -703,11 +814,12 @@ func topMeter(label string, ratio float64, value string, width int) string {
 	return topMeterLabel.Render(label) + topBracket.Render("[") + bars + gap + topValDim.Render(value) + topBracket.Render("]")
 }
 
-// topColWidths returns the fixed column widths and the flexible name width for
-// a given total terminal width. Layout: " name  CPU%  MEM%  MEM  STATE".
+// topNameWidth returns the flexible name width after reserving the resource and
+// state columns. The state column is deliberately wide enough for "crash-loop".
 func topNameWidth(width int) int {
-	// 1 (lead) + name + 1 + 6 (cpu) + 1 + 6 (memp) + 1 + 10 (mem) + 1 + 8 (state)
-	nameW := width - 36
+	// 1 (lead) + name + 1 + 6 (cpu) + 1 + 6 (memp) + 1 + 10 (mem) +
+	// 1 + 10 (state) = name + 37. Keep one spare cell for terminal quirks.
+	nameW := width - 38
 	if nameW < 10 {
 		nameW = 10
 	}
@@ -719,7 +831,7 @@ func topFormatRow(name, cpu, memp, mem, state string, nameW int) string {
 	if len(r) > nameW {
 		name = string(r[:nameW])
 	}
-	return fmt.Sprintf(" %-*s %6s %6s %10s %-8s", nameW, name, cpu, memp, mem, state)
+	return fmt.Sprintf(" %-*s %6s %6s %10s %-10s", nameW, name, cpu, memp, mem, state)
 }
 
 func (m topModel) View() string {
@@ -734,7 +846,10 @@ func (m topModel) View() string {
 
 	// Reserve a right-hand ports panel when the terminal is wide enough.
 	panelW := 0
-	if width >= 70 {
+	// The app table needs 47 cells to retain its state column. Only split off
+	// the ports panel when both columns fit instead of cropping state at common
+	// terminal widths.
+	if width >= 84 {
 		panelW = 34
 	}
 	listW := width
@@ -788,13 +903,29 @@ func (m topModel) View() string {
 		top = append(top, topValDim.Render(" Connecting…"))
 	}
 
-	running := 0
+	running, stopped, crashLooping := 0, 0, 0
 	for _, c := range m.cachedContainers {
-		if c.GetRunningState() == agentpb.AppRunningState_RUNNING {
+		switch c.GetRunningState() {
+		case agentpb.AppRunningState_RUNNING:
 			running++
+		case agentpb.AppRunningState_CRASH_LOOPING:
+			crashLooping++
+		default:
+			stopped++
 		}
 	}
-	top = append(top, topValDim.Render(fmt.Sprintf(" Apps: %d, %d running", len(m.cachedContainers), running)))
+	summary := fmt.Sprintf(" Apps: %d  ● %d running  ○ %d stopped", len(m.cachedContainers), running, stopped)
+	if crashLooping > 0 {
+		summary += fmt.Sprintf("  ↻ %d crash-looping", crashLooping)
+	}
+	top = append(top, topValDim.Render(summary))
+	statusLine := m.actionStatus
+	if statusLine == "" {
+		statusLine = m.flash
+	}
+	if statusLine != "" {
+		top = append(top, topValDim.Render(" "+statusLine))
+	}
 	top = append(top, "")
 
 	// Build the left (container list) and right (ports) columns of the body.
@@ -858,17 +989,21 @@ func (m topModel) listLines(width int) []string {
 			cpu = fmt.Sprintf("%.1f", r.cpuPercent)
 		}
 		memp := "-"
-		if memTotal > 0 {
+		mem := "—"
+		if r.state == agentpb.AppRunningState_RUNNING && memTotal > 0 {
 			memp = fmt.Sprintf("%.1f", float64(r.memBytes)/float64(memTotal)*100)
+			mem = formatBytes(r.memBytes)
 		}
-		row := padOrCrop(topFormatRow(r.displayName, cpu, memp, formatBytes(r.memBytes), r.state, nameW), width)
+		row := padOrCrop(topFormatRow(topDisplayName(r), cpu, memp, mem, topStateLabel(r.state), nameW), width)
 		switch {
 		case i == m.cursor:
 			lines = append(lines, topSelRow.Render(row))
-		case r.isSubrow:
+		case r.state == agentpb.AppRunningState_CRASH_LOOPING:
+			lines = append(lines, topCrashRow.Render(row))
+		case r.state == agentpb.AppRunningState_STOPPED:
 			lines = append(lines, topValDim.Render(row))
 		default:
-			lines = append(lines, row)
+			lines = append(lines, topRunningRow.Render(row))
 		}
 	}
 	return lines
@@ -877,6 +1012,7 @@ func (m topModel) listLines(width int) []string {
 // portsPanelLines renders the open-ports panel for the selected app.
 func (m topModel) portsPanelLines(width int) []string {
 	app := m.selectedAppName()
+	appState, hasState := m.selectedAppState()
 	title := "OPEN PORTS"
 	if app != "" {
 		title = "OPEN PORTS — " + app
@@ -886,6 +1022,10 @@ func (m topModel) portsPanelLines(width int) []string {
 	switch {
 	case app == "":
 		lines = append(lines, topValDim.Render(" (no app selected)"))
+	case hasState && appState == agentpb.AppRunningState_STOPPED:
+		lines = append(lines, topValDim.Render(" (app is stopped)"))
+	case hasState && appState == agentpb.AppRunningState_CRASH_LOOPING:
+		lines = append(lines, topValDim.Render(" (app is crash-looping)"))
 	case m.portsErr != nil:
 		if errors.Is(m.portsErr, errResourceStatsUnimplemented) || status.Code(m.portsErr) == codes.Unimplemented {
 			lines = append(lines, topValDim.Render(" (agent too old)"))
@@ -921,11 +1061,11 @@ func padOrCrop(s string, width int) string {
 }
 
 func (m topModel) topKeyBar(width int) string {
-	flash := m.flash
 	segs := []struct{ key, label string }{
 		{"↑↓", "Nav"},
 		{"m", "Mem"},
 		{"c", "CPU"},
+		{"x", "Stop"},
 		{"q", "Quit"},
 	}
 	var b strings.Builder
@@ -934,11 +1074,6 @@ func (m topModel) topKeyBar(width int) string {
 		b.WriteString(topKeyCap.Render(s.key))
 		b.WriteString(topKeyLabel.Render(s.label + " "))
 		plainLen += lipgloss.Width(s.key) + lipgloss.Width(s.label) + 1
-	}
-	if flash != "" && plainLen+2+len(flash) < width {
-		msg := "  " + flash
-		b.WriteString(topKeyLabel.Render(msg))
-		plainLen += lipgloss.Width(msg)
 	}
 	if plainLen < width {
 		b.WriteString(topKeyLabel.Render(strings.Repeat(" ", width-plainLen)))

--- a/go/internal/cli/commands/device_top_test.go
+++ b/go/internal/cli/commands/device_top_test.go
@@ -1,13 +1,33 @@
 package commands
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"math"
 	"strings"
 	"testing"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
 )
+
+type topFakeContainerClient struct {
+	agentpb.WendyContainerServiceClient
+	stopCalls []string
+	stopErr   error
+}
+
+func (f *topFakeContainerClient) StopContainer(_ context.Context, req *agentpb.StopContainerRequest, _ ...grpc.CallOption) (*agentpb.StopContainerResponse, error) {
+	f.stopCalls = append(f.stopCalls, req.GetAppName())
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
+	return &agentpb.StopContainerResponse{}, nil
+}
 
 func approx(a, b float64) bool { return math.Abs(a-b) < 0.01 }
 
@@ -96,6 +116,15 @@ func TestBuildTopRowsMultiServiceGrouping(t *testing.T) {
 	if !rows[1].isSubrow || !rows[2].isSubrow {
 		t.Errorf("rows 1,2 should be subrows")
 	}
+	if rows[0].state != agentpb.AppRunningState_RUNNING || rows[1].state != agentpb.AppRunningState_RUNNING {
+		t.Errorf("running states not preserved in rows: %+v", rows)
+	}
+}
+
+func TestTopStateLabelCrashLoopingIsCompact(t *testing.T) {
+	if got := topStateLabel(agentpb.AppRunningState_CRASH_LOOPING); got != "crash-loop" {
+		t.Fatalf("topStateLabel(CRASH_LOOPING) = %q, want crash-loop", got)
+	}
 }
 
 func TestBuildTopJSON(t *testing.T) {
@@ -126,6 +155,151 @@ func TestBuildTopJSON(t *testing.T) {
 	}
 	if out.Containers[0].CPUPercent <= 0 {
 		t.Errorf("container cpu%% = %v, want > 0", out.Containers[0].CPUPercent)
+	}
+	if out.Containers[0].State != "running" {
+		t.Errorf("container state = %q, want running", out.Containers[0].State)
+	}
+}
+
+func TestWriteTopPlainSnapshotIncludesStateAndInactiveMetrics(t *testing.T) {
+	containers := []*agentpb.AppContainer{
+		{AppName: "active", RunningState: agentpb.AppRunningState_RUNNING},
+		{AppName: "idle", RunningState: agentpb.AppRunningState_STOPPED},
+	}
+	prev := topSample{
+		host:         &agentpb.HostStats{CpuCount: 2},
+		containers:   map[string]uint64{"active": 0},
+		mem:          map[string]int64{"active": 25},
+		takenAtNanos: 0,
+	}
+	cur := topSample{
+		host:         &agentpb.HostStats{CpuCount: 2},
+		containers:   map[string]uint64{"active": 500_000_000},
+		mem:          map[string]int64{"active": 25},
+		takenAtNanos: 1_000_000_000,
+	}
+
+	var out bytes.Buffer
+	if err := writeTopPlainSnapshot(&out, prev, cur, containers); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	if !strings.Contains(text, "STATE") || !strings.Contains(text, "active") || !strings.Contains(text, "running") {
+		t.Fatalf("plain snapshot does not show running state:\n%s", text)
+	}
+	if !strings.Contains(text, "idle") || !strings.Contains(text, "stopped") {
+		t.Fatalf("plain snapshot does not show stopped state:\n%s", text)
+	}
+	idleLine := ""
+	for _, line := range strings.Split(text, "\n") {
+		if strings.Contains(line, "idle") {
+			idleLine = line
+			break
+		}
+	}
+	if strings.Contains(idleLine, "0.0") || strings.Contains(idleLine, "0 B") {
+		t.Fatalf("stopped app should show unavailable resource values, got %q", idleLine)
+	}
+}
+
+func TestTopViewMakesAllAppStatesExplicit(t *testing.T) {
+	m := topModel{
+		width:  100,
+		height: 24,
+		cur: topSample{host: &agentpb.HostStats{MemTotalBytes: 100}, mem: map[string]int64{
+			"active": 25,
+		}},
+		havePrev: true,
+		cachedContainers: []*agentpb.AppContainer{
+			{AppName: "active", RunningState: agentpb.AppRunningState_RUNNING},
+			{AppName: "idle", RunningState: agentpb.AppRunningState_STOPPED},
+			{AppName: "broken", RunningState: agentpb.AppRunningState_CRASH_LOOPING},
+		},
+	}
+	m.rebuildRows()
+	view := m.View()
+	for _, want := range []string{"● active", "running", "○ idle", "stopped", "↻ broken", "crash-loop"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("top view missing %q:\n%s", want, view)
+		}
+	}
+	for _, want := range []string{"1 running", "1 stopped", "1 crash-looping"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("top summary missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTopViewKeepsStateVisibleAtSeventyColumns(t *testing.T) {
+	m := topModel{
+		width:            70,
+		height:           18,
+		havePrev:         true,
+		cur:              topSample{host: &agentpb.HostStats{MemTotalBytes: 100}},
+		cachedContainers: []*agentpb.AppContainer{{AppName: "idle", RunningState: agentpb.AppRunningState_STOPPED}},
+	}
+	m.rebuildRows()
+	view := m.View()
+	if !strings.Contains(view, "○ idle") || !strings.Contains(view, "stopped") {
+		t.Fatalf("state was cropped at 70 columns:\n%s", view)
+	}
+	if strings.Contains(view, "OPEN PORTS") {
+		t.Fatalf("ports panel should yield to the state table at 70 columns:\n%s", view)
+	}
+}
+
+func TestTopStopKeyStopsParentAppFromServiceRow(t *testing.T) {
+	fake := &topFakeContainerClient{}
+	conn := &grpcclient.AgentConnection{ContainerService: fake}
+	m := newTopModel(context.Background(), conn, 2*time.Second)
+	m.rows = []topRow{
+		{name: "group-app", displayName: "group-app [group]", state: agentpb.AppRunningState_RUNNING},
+		{displayName: "  ↳ worker", state: agentpb.AppRunningState_RUNNING, isSubrow: true},
+	}
+	m.cursor = 1
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(topModel)
+	if cmd == nil || m.stoppingApp != "group-app" || !strings.Contains(m.actionStatus, "Stopping group-app") {
+		t.Fatalf("stop did not enter pending state: stopping=%q status=%q cmd=%v", m.stoppingApp, m.actionStatus, cmd != nil)
+	}
+
+	msg := cmd()
+	updated, _ = m.Update(msg)
+	m = updated.(topModel)
+	if len(fake.stopCalls) != 1 || fake.stopCalls[0] != "group-app" {
+		t.Fatalf("StopContainer calls = %v, want [group-app]", fake.stopCalls)
+	}
+	if m.stoppingApp != "" || m.actionStatus != "Stopped group-app" {
+		t.Fatalf("stop result state: stopping=%q status=%q", m.stoppingApp, m.actionStatus)
+	}
+}
+
+func TestTopStopKeyDoesNotCallAlreadyStoppedApp(t *testing.T) {
+	fake := &topFakeContainerClient{}
+	m := newTopModel(context.Background(), &grpcclient.AgentConnection{ContainerService: fake}, 2*time.Second)
+	m.rows = []topRow{{name: "idle", displayName: "idle", state: agentpb.AppRunningState_STOPPED}}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(topModel)
+	if cmd == nil {
+		t.Fatal("already-stopped notice should schedule its own cleanup")
+	}
+	if len(fake.stopCalls) != 0 || m.actionStatus != "idle is already stopped" {
+		t.Fatalf("unexpected stopped-app action: calls=%v status=%q", fake.stopCalls, m.actionStatus)
+	}
+}
+
+func TestTopSuccessfulPollDoesNotClearStopStatus(t *testing.T) {
+	m := topModel{
+		actionStatus: "Stopping app…",
+		cur:          topSample{host: &agentpb.HostStats{}},
+		statsCh:      make(chan topStatsMsg),
+	}
+	updated, _ := m.Update(topStatsMsg{resp: &agentpb.GetResourceStatsResponse{}})
+	m = updated.(topModel)
+	if m.actionStatus != "Stopping app…" {
+		t.Fatalf("successful poll cleared lifecycle status: %q", m.actionStatus)
 	}
 }
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -485,8 +485,8 @@ for test_name in "${TESTS[@]}"; do
                 return 1
             fi
             if ! echo "$out" | jq -e --arg a "$app_id" \
-                '(.containers // []) | map(.name) | index($a) != null' >/dev/null 2>&1; then
-                echo "deployed app '$app_id' not found in containers[]: $out"
+				'(.containers // []) | any(.name == $a and .state == "running")' >/dev/null 2>&1; then
+				echo "running app '$app_id' with populated state not found in containers[]: $out"
                 return 1
             fi
             return 0


### PR DESCRIPTION
## Summary

- add an `x` action to stop the selected app from the live `wendy device top` TUI
- map service-row selection to the parent app so multi-service apps stop as one unit
- show asynchronous stop progress, success, and errors without polling clearing the action status
- distinguish running, stopped, and crash-looping rows with icons, styling, explicit counts, and unavailable resource values for inactive apps
- keep lifecycle state visible at narrower terminal widths
- populate the existing JSON `state` field and add `STATE` to plain snapshots
- update the command documentation and device-top CI assertion

## Why

`wendy device top` was read-only even though operators commonly need to stop the workload they identify as problematic. Stopped apps also looked like active zero-usage workloads, the summary only counted running apps, and responsive cropping could hide the state column. In snapshot mode, plain output omitted state and JSON declared `containers[].state` without assigning it, producing an empty string.

This uses Wendy's existing app-wide `StopContainer` behavior: graceful shutdown with the existing force-kill fallback. Pressing `x` requires no confirmation, matching the established apps dashboard interaction.

## User impact

Operators can stop an app without leaving `device top` and can immediately tell running, stopped, and crash-looping workloads apart across live, plain, and JSON output. Already-stopped apps produce a clear no-op notice.

## Validation

- `go test ./internal/cli/commands`
- `gofmt -d go/internal/cli/commands/device_top.go go/internal/cli/commands/device_top_test.go`
- `git diff --check`
- `bash -n go/scripts/test-ci.sh`