### PR TITLE
fix(agent): retry transient BlueZ connect failures

### DIFF
--- a/go/internal/agent/bluetooth/errors.go
+++ b/go/internal/agent/bluetooth/errors.go
@@ -52,6 +52,30 @@ func friendlyBluetoothError(name, message string) (text string, notFound, ok boo
 	return "", false, false
 }
 
+// isTransientBluetoothError reports whether a D-Bus/BlueZ failure, identified
+// by its error name and message body, is worth retrying rather than
+// surfacing immediately. BlueZ's "unknown" bearer reason
+// (br-connection-unknown / le-connection-unknown) is its catch-all for an
+// HCI-level disconnect status it could not classify, and in practice this
+// often fires as a momentary race — e.g. a speaker still tearing down its
+// previous connection — rather than a permanent rejection, so a short retry
+// frequently succeeds. org.bluez.Error.InProgress and a bus-level NoReply are
+// likewise transient by definition. Every other classified reason (refused,
+// timeout, adapter-not-powered, authentication rejected, device not found,
+// ...) reflects a real condition that a bare retry will not fix.
+func isTransientBluetoothError(name, message string) bool {
+	switch name {
+	case "org.bluez.Error.InProgress", "org.freedesktop.DBus.Error.NoReply":
+		return true
+	case "org.bluez.Error.Failed":
+		return strings.Contains(message, "br-connection-unknown") ||
+			strings.Contains(message, "le-connection-unknown") ||
+			strings.Contains(message, "br-connection-busy") ||
+			strings.Contains(message, "le-connection-busy")
+	}
+	return false
+}
+
 // friendlyBearerFailure maps the reason strings BlueZ places in
 // org.bluez.Error.Failed messages (src/error.c, e.g. "br-connection-refused")
 // to actionable text. Unrecognized bearer reasons get a generic hint that

--- a/go/internal/agent/bluetooth/errors_test.go
+++ b/go/internal/agent/bluetooth/errors_test.go
@@ -93,3 +93,38 @@ func TestFriendlyBluetoothError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTransientBluetoothError(t *testing.T) {
+	tests := []struct {
+		name       string
+		errName    string
+		errMessage string
+		want       bool
+	}{
+		// BlueZ's catch-all "unknown" bearer failure is frequently a transient
+		// HCI-level race (observed on real hardware: a JBL Flip 5 that is
+		// already bonded/trusted but momentarily busy tearing down its
+		// previous connection) rather than a permanent rejection.
+		{"br unknown is transient", "org.bluez.Error.Failed", "br-connection-unknown", true},
+		{"le unknown is transient", "org.bluez.Error.Failed", "le-connection-unknown", true},
+		{"br busy is transient", "org.bluez.Error.Failed", "br-connection-busy", true},
+		{"le busy is transient", "org.bluez.Error.Failed", "le-connection-busy", true},
+		{"adapter InProgress is transient", "org.bluez.Error.InProgress", "", true},
+		{"bus NoReply is transient", "org.freedesktop.DBus.Error.NoReply", "", true},
+
+		// Reasons that indicate a real, non-transient condition must not retry.
+		{"br refused is not transient", "org.bluez.Error.Failed", "br-connection-refused", false},
+		{"adapter not powered is not transient", "org.bluez.Error.Failed", "br-connection-adapter-not-powered", false},
+		{"auth rejected is not transient", "org.bluez.Error.AuthenticationRejected", "", false},
+		{"device not found is not transient", "org.freedesktop.DBus.Error.UnknownObject", "", false},
+		{"unclassified name is not transient", "org.bluez.Error.NotSupported", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientBluetoothError(tt.errName, tt.errMessage); got != tt.want {
+				t.Errorf("isTransientBluetoothError(%q, %q) = %v, want %v", tt.errName, tt.errMessage, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -530,7 +530,7 @@ func (m *BlueZManager) resolveDevice(ctx context.Context, conn *dbus.Conn, addre
 // waits delay between attempts, returning early if ctx is done first.
 func (m *BlueZManager) retryConnect(ctx context.Context, delay time.Duration, attempt func() error) error {
 	var err error
-	for i := range maxConnectAttempts {
+	for i := 0; i < maxConnectAttempts; i++ {
 		err = attempt()
 		if err == nil {
 			return nil

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -544,10 +544,14 @@ func (m *BlueZManager) retryConnect(ctx context.Context, delay time.Duration, at
 		}
 		m.logger.Info("Retrying transient Bluetooth connect failure",
 			zap.String("dbus_error", name), zap.Int("attempt", i+1))
+		timer := time.NewTimer(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 		case <-ctx.Done():
-			return err
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
 		}
 	}
 	return err

--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -38,6 +38,16 @@ const (
 	// typically appear a few hundred ms into discovery, so a sub-second poll
 	// keeps the added connect latency small.
 	resolvePollInterval = 500 * time.Millisecond
+	// maxConnectAttempts bounds how many times Connect retries the final
+	// device.Connect() call when BlueZ reports a transient failure (see
+	// isTransientBluetoothError). Real hardware (e.g. a JBL Flip 5 that is
+	// already bonded/trusted) has been observed rejecting a connect with
+	// BlueZ's generic "unknown" bearer failure while momentarily busy tearing
+	// down a previous session; a couple of retries clears this without
+	// requiring the caller to re-run the whole command.
+	maxConnectAttempts = 3
+	// connectRetryDelay is the wait between retry attempts.
+	connectRetryDelay = 750 * time.Millisecond
 )
 
 // managedObjects is the result shape of org.freedesktop.DBus.ObjectManager's
@@ -513,6 +523,36 @@ func (m *BlueZManager) resolveDevice(ctx context.Context, conn *dbus.Conn, addre
 	}
 }
 
+// retryConnect calls attempt up to maxConnectAttempts times, retrying only
+// when the failure is classified as transient by isTransientBluetoothError
+// (BlueZ's generic "unknown" bearer failure, InProgress, or a bus-level
+// NoReply). Any other failure, or a non-D-Bus error, returns immediately. It
+// waits delay between attempts, returning early if ctx is done first.
+func (m *BlueZManager) retryConnect(ctx context.Context, delay time.Duration, attempt func() error) error {
+	var err error
+	for i := range maxConnectAttempts {
+		err = attempt()
+		if err == nil {
+			return nil
+		}
+		name, message, ok := dbusErrorInfo(err)
+		if !ok || !isTransientBluetoothError(name, message) {
+			return err
+		}
+		if i == maxConnectAttempts-1 {
+			break
+		}
+		m.logger.Info("Retrying transient Bluetooth connect failure",
+			zap.String("dbus_error", name), zap.Int("attempt", i+1))
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return err
+		}
+	}
+	return err
+}
+
 // Connect connects to a Bluetooth peripheral by address via BlueZ over D-Bus,
 // discovering the device first if BlueZ no longer has it cached. When pair is
 // set it registers a headless pairing agent and pairs first (skipped if the
@@ -562,8 +602,11 @@ func (m *BlueZManager) Connect(ctx context.Context, address string, pair, trust 
 		}
 	}
 
-	if call := device.CallWithContext(ctx, deviceIface+".Connect", 0); call.Err != nil {
-		return false, m.connectFailureError(address, pairErr, call.Err)
+	connectErr := m.retryConnect(ctx, connectRetryDelay, func() error {
+		return device.CallWithContext(ctx, deviceIface+".Connect", 0).Err
+	})
+	if connectErr != nil {
+		return false, m.connectFailureError(address, pairErr, connectErr)
 	}
 
 	// The device's live Paired property is the source of truth: pairing may

--- a/go/internal/agent/bluetooth/manager_linux_test.go
+++ b/go/internal/agent/bluetooth/manager_linux_test.go
@@ -3,10 +3,12 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"go.uber.org/zap"
@@ -205,6 +207,87 @@ func TestConnectFailureErrorPrefersNotFound(t *testing.T) {
 		err := m.connectFailureError("AA:BB:CC:DD:EE:FF", nil, connErr)
 		if !strings.Contains(err.Error(), "refused") {
 			t.Errorf("err = %q, want the connect failure text", err.Error())
+		}
+	})
+}
+
+func TestRetryConnect(t *testing.T) {
+	m := &BlueZManager{logger: zap.NewNop()}
+	const testDelay = time.Millisecond
+
+	t.Run("succeeds on first attempt without retrying", func(t *testing.T) {
+		calls := 0
+		err := m.retryConnect(context.Background(), testDelay, func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("retries a transient failure and succeeds", func(t *testing.T) {
+		calls := 0
+		err := m.retryConnect(context.Background(), testDelay, func() error {
+			calls++
+			if calls < 3 {
+				return dbus.Error{Name: "org.bluez.Error.Failed", Body: []any{"br-connection-unknown"}}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v, want nil after retries", err)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("does not retry a non-transient failure", func(t *testing.T) {
+		calls := 0
+		wantErr := dbus.Error{Name: "org.bluez.Error.AuthenticationRejected"}
+		err := m.retryConnect(context.Background(), testDelay, func() error {
+			calls++
+			return wantErr
+		})
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (no retry for a non-transient error)", calls)
+		}
+		if err == nil {
+			t.Fatal("want the non-transient error returned")
+		}
+	})
+
+	t.Run("gives up after the max attempts", func(t *testing.T) {
+		calls := 0
+		err := m.retryConnect(context.Background(), testDelay, func() error {
+			calls++
+			return dbus.Error{Name: "org.bluez.Error.InProgress"}
+		})
+		if calls != maxConnectAttempts {
+			t.Errorf("calls = %d, want %d", calls, maxConnectAttempts)
+		}
+		if err == nil {
+			t.Fatal("want an error after exhausting retries")
+		}
+	})
+
+	t.Run("stops early when the context is done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		err := m.retryConnect(ctx, time.Hour, func() error {
+			calls++
+			cancel()
+			return dbus.Error{Name: "org.bluez.Error.InProgress"}
+		})
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (context canceled before the retry delay elapses)", calls)
+		}
+		if err == nil {
+			t.Fatal("want an error")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- BlueZ's generic `br-connection-unknown`/`le-connection-unknown` bearer failure (an `org.bluez.Error.Failed` catch-all for an HCI status it can't classify) was surfacing on the first attempt, even though it's often a transient race — observed on real hardware where a JBL Flip 5 already `Paired`/`Bonded`/`Trusted` rejected a connect momentarily before succeeding on a bare retry.
- `retryConnect` now retries the final `device.Connect()` call up to 3 times (750ms apart) when the failure is classified as transient (`isTransientBluetoothError`: the "unknown"/"busy" bearer reasons, `org.bluez.Error.InProgress`, or a bus-level `NoReply`). Every other failure (refused, adapter-off, auth-rejected, device-not-found) returns immediately, since a retry won't fix those.

## Test plan
- [x] TDD: wrote failing tests first for both `isTransientBluetoothError` (errors_test.go) and `retryConnect` (manager_linux_test.go), watched them fail, implemented, watched them pass.
- [x] Full `go/internal/agent/bluetooth` package test suite passes in a `golang:1.26` Linux container (this code is Linux-only via build tags, so tests can't run natively on macOS).
- [x] Verified against real hardware: a Raspberry Pi 5 + JBL Flip 5 speaker exhibiting exactly this failure mode.
- [x] Clean `go build ./...` on both darwin and linux/arm64.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CtcSqFXhd4ETmswG2J67BD