### PR TITLE
cli: show OS/arch type for cloud-discovered non-board devices

### DIFF
--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -341,6 +341,9 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 	rows := make([]bubbleTable.Row, 0, len(assets))
 	for _, a := range assets {
 		devType := humanReadableDeviceType(a.GetDeviceType())
+		if devType == "" {
+			devType = humanReadableOSType(a.GetOsType(), a.GetArchitecture())
+		}
 		ver := "—"
 		if v := versions[a.GetId()]; v != nil {
 			ver = v.GetVersion()
@@ -349,6 +352,9 @@ func cloudDiscoverTableRows(assets []*cloudpb.Asset, versions map[int32]*agentpb
 			}
 			if devType == "" {
 				devType = humanReadableDeviceType(v.GetDeviceType())
+			}
+			if devType == "" {
+				devType = humanReadableOSType(v.GetOs(), v.GetCpuArchitecture())
 			}
 		}
 		rows = append(rows, bubbleTable.Row{"", a.GetName(), devType, ver})
@@ -379,9 +385,15 @@ func cloudDeviceInfoFromAsset(a *cloudpb.Asset, ver *agentpb.GetAgentVersionResp
 		Type:    humanReadableDeviceType(a.GetDeviceType()),
 		Address: a.GetIpAddress(),
 	}
+	if info.Type == "" {
+		info.Type = humanReadableOSType(a.GetOsType(), a.GetArchitecture())
+	}
 	if ver != nil {
 		if info.Type == "" {
 			info.Type = humanReadableDeviceType(ver.GetDeviceType())
+		}
+		if info.Type == "" {
+			info.Type = humanReadableOSType(ver.GetOs(), ver.GetCpuArchitecture())
 		}
 		info.Version = ver.GetVersion()
 	}

--- a/go/internal/cli/commands/cloud_discover_test.go
+++ b/go/internal/cli/commands/cloud_discover_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
@@ -11,5 +12,49 @@ func TestCloudDeviceInfoIncludesID(t *testing.T) {
 	info := cloudDeviceInfoFromAsset(a, nil)
 	if info.ID != 77 {
 		t.Fatalf("expected ID 77, got %d", info.ID)
+	}
+}
+
+func TestCloudDeviceInfoFallsBackToOSTypeFromAsset(t *testing.T) {
+	osType, arch := "darwin", "arm64"
+	a := &cloudpb.Asset{Id: 1, OsType: &osType, Architecture: &arch}
+	info := cloudDeviceInfoFromAsset(a, nil)
+	if info.Type != "macOS (arm64)" {
+		t.Fatalf("expected %q, got %q", "macOS (arm64)", info.Type)
+	}
+}
+
+func TestCloudDeviceInfoFallsBackToOSTypeFromAgentVersion(t *testing.T) {
+	a := &cloudpb.Asset{Id: 1}
+	ver := &agentpb.GetAgentVersionResponse{Os: "ubuntu", CpuArchitecture: "amd64"}
+	info := cloudDeviceInfoFromAsset(a, ver)
+	if info.Type != "Linux (x86_64)" {
+		t.Fatalf("expected %q, got %q", "Linux (x86_64)", info.Type)
+	}
+}
+
+func TestCloudDeviceInfoPrefersDeviceTypeOverOSType(t *testing.T) {
+	deviceType, osType := "raspberry-pi-5", "wendyos"
+	a := &cloudpb.Asset{Id: 1, DeviceType: &deviceType, OsType: &osType}
+	info := cloudDeviceInfoFromAsset(a, nil)
+	if info.Type != "Raspberry Pi 5" {
+		t.Fatalf("expected %q, got %q", "Raspberry Pi 5", info.Type)
+	}
+}
+
+func TestHumanReadableOSType(t *testing.T) {
+	cases := []struct {
+		os, arch, want string
+	}{
+		{"darwin", "arm64", "macOS (arm64)"},
+		{"darwin", "", "macOS"},
+		{"ubuntu", "amd64", "Linux (x86_64)"},
+		{"linux", "aarch64", "Linux (arm64)"},
+		{"", "arm64", ""},
+	}
+	for _, c := range cases {
+		if got := humanReadableOSType(c.os, c.arch); got != c.want {
+			t.Errorf("humanReadableOSType(%q, %q) = %q, want %q", c.os, c.arch, got, c.want)
+		}
 	}
 }

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -885,6 +885,39 @@ func humanReadableDeviceType(dt string) string {
 	return dt
 }
 
+// humanReadableOSType builds a Type label from an os/architecture pair for
+// machines with no board-specific device type (e.g. Mac agents, generic
+// Linux hosts), falling back to whatever information is present.
+func humanReadableOSType(os, arch string) string {
+	os = strings.ToLower(strings.TrimSpace(os))
+	arch = humanReadableArch(arch)
+
+	var label string
+	switch os {
+	case "":
+		return ""
+	case "darwin", "macos":
+		label = "macOS"
+	default:
+		label = "Linux"
+	}
+	if arch != "" {
+		return fmt.Sprintf("%s (%s)", label, arch)
+	}
+	return label
+}
+
+func humanReadableArch(arch string) string {
+	switch strings.ToLower(strings.TrimSpace(arch)) {
+	case "amd64", "x86_64":
+		return "x86_64"
+	case "arm64", "aarch64":
+		return "arm64"
+	default:
+		return ""
+	}
+}
+
 // discoverNoAccessHint explains a blank version column on a provisioned
 // device: the metadata probe failed because this CLI has no certificate the
 // device accepts (unprovisioned CLI, or logged into a different account).

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -889,17 +889,24 @@ func humanReadableDeviceType(dt string) string {
 // machines with no board-specific device type (e.g. Mac agents, generic
 // Linux hosts), falling back to whatever information is present.
 func humanReadableOSType(os, arch string) string {
-	os = strings.ToLower(strings.TrimSpace(os))
+	osRaw := strings.TrimSpace(os)
+	osNorm := strings.ToLower(osRaw)
 	arch = humanReadableArch(arch)
 
 	var label string
-	switch os {
+	switch osNorm {
 	case "":
 		return ""
 	case "darwin", "macos":
 		label = "macOS"
-	default:
+	case "windows":
+		label = "Windows"
+	case "wendyos", "edgeos":
+		label = "WendyOS"
+	case "linux", "ubuntu", "debian", "alpine", "raspbian":
 		label = "Linux"
+	default:
+		label = osRaw
 	}
 	if arch != "" {
 		return fmt.Sprintf("%s (%s)", label, arch)
@@ -908,13 +915,14 @@ func humanReadableOSType(os, arch string) string {
 }
 
 func humanReadableArch(arch string) string {
-	switch strings.ToLower(strings.TrimSpace(arch)) {
+	arch = strings.ToLower(strings.TrimSpace(arch))
+	switch arch {
 	case "amd64", "x86_64":
 		return "x86_64"
 	case "arm64", "aarch64":
 		return "arm64"
 	default:
-		return ""
+		return arch
 	}
 }
 


### PR DESCRIPTION
## Summary
- `wendy cloud discover` left the **Type** column blank for Mac and generic Linux (Ubuntu) agents, since it only reads the board-id `device_type` field, which is only populated on WendyOS board images via `/etc/wendyos/device-type`.
- Adds a fallback: when `device_type` is empty, derive a label from the asset's `os_type`/`architecture` (cloud roster fields), or the agent-reported `os`/`cpu_architecture` once fetched — rendering e.g. `macOS (arm64)` or `Linux (x86_64)`.
- Applies to both the live TUI table (`cloudDiscoverTableRows`) and the copy-to-clipboard JSON path (`cloudDeviceInfoFromAsset`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cli/commands/...` (full package, including new `TestHumanReadableOSType` / `TestCloudDeviceInfoFallsBackToOSType*` / `TestCloudDeviceInfoPrefersDeviceTypeOverOSType`)
- [ ] Manual verification against a real Mac/Ubuntu-enrolled cloud asset (couldn't verify whether `Asset.os_type`/`Asset.architecture` are actually populated server-side for these platforms today — the agent-reported fallback path is exercised by hardware/agent connection regardless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pNR2NGdkHHcspEkUA9iyZ