### PR TITLE
refactor(cli): remove the top-level `wendy app` command group

### DIFF
--- a/go/internal/cli/commands/apps_install.go
+++ b/go/internal/cli/commands/apps_install.go
@@ -81,20 +81,6 @@ func resolveAppImage(ctx context.Context, base, appID string) (appImageResolutio
 	return out, nil
 }
 
-// newAppCmd is the top-level "app" command group, the AppStore-facing entry
-// point. Device-scoped management (list/start/stop/remove) lives under
-// "wendy device apps"; this group surfaces "wendy app install <app-id>" to match
-// the install command shown on https://appstore.wendy.dev.
-func newAppCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "app",
-		Short: "Install apps from the Wendy AppStore",
-		Long:  "Browse https://appstore.wendy.dev, then install an app onto a device with 'wendy app install <app-id>'.",
-	}
-	cmd.AddCommand(newAppsInstallCmd())
-	return cmd
-}
-
 func newAppsInstallCmd() *cobra.Command {
 	var apiBase string
 	var noStart bool

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -122,8 +122,6 @@ func NewRootCmd() *cobra.Command {
 	initCmd.GroupID = "develop"
 	runCmd := newRunCmd()
 	runCmd.GroupID = "develop"
-	appCmd := newAppCmd()
-	appCmd.GroupID = "develop"
 	// `wendy install` is the surfaced alias for `wendy os install` (the `os`
 	// group is hidden). A fresh command instance is used because a cobra
 	// command can only be attached to one parent.
@@ -212,7 +210,6 @@ func NewRootCmd() *cobra.Command {
 		// Develop & Deploy
 		initCmd,
 		runCmd,
-		appCmd,
 		installCmd,
 		// Manage
 		projectCmd,


### PR DESCRIPTION
## What

Removes the top-level `wendy app` command group. `wendy device apps install` is unchanged and remains the canonical way to install an app from the Wendy AppStore.

## Why

`wendy app` was a thin alias group with exactly one subcommand, `install`. It was added in #1229 so the install line shown on appstore.wendy.dev would work verbatim. The same `install` subcommand was wired under `wendy device apps` in that same change, so the functionality has always been reachable by two paths. This removes the duplicate top-level surface and keeps app management under the device-scoped group where list, start, stop, and remove already live.

## Changes

- `go/internal/cli/commands/apps_install.go`: delete `newAppCmd`.
- `go/internal/cli/commands/root.go`: drop the `appCmd` construction and its entry in the "develop" help group.

The AppStore resolution helpers `resolveAppStoreAPIBase` and `resolveAppImage` are deliberately untouched, because `wendy device apps install` still uses them. Net change is 17 deletions, no additions.

## Scope note for the reviewer

This removes the `wendy app` command tree only. It does not remove the AppStore install feature. If the intent is to retire AppStore install altogether, that is a larger change than this pull request and should also delete `apps_install.go`, its tests, and the `install` wiring under `wendy device apps`.

## Compatibility

`wendy app install <app-id>` becomes an unknown command after this change. The install instructions published on appstore.wendy.dev use that exact form, so the website copy needs updating to `wendy device apps install <app-id>` in step with this merging, or users following the site will hit an error. Flagging this because it is user-visible and lives outside this repository.

## Verification

Run on macOS on arm64:

- `go build ./...` passes.
- `go test ./internal/cli/commands/` passes.
- `gofmt` reports no changes for both edited files.
- `wendy --help` no longer lists `app` under "Develop & Deploy".
- `wendy device apps install --help` still resolves and shows its flags.

Note for anyone reproducing locally: `main` pins Swift 6.3.2 in `.swift-version`, and because `clang` resolves to the swiftly shim, any cgo build fails with a bare `cgo: exit status 2` unless that toolchain is installed. Installing it with `swiftly install 6.3.2`, or setting `CC=/usr/bin/clang`, works around it. This is unrelated to the change in this pull request.
