### PR TITLE
fix(cli): fail loudly on an unknown subcommand instead of printing help

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -22,7 +22,14 @@ import (
 func main() {
 	start := time.Now()
 	cmd := commands.NewRootCmd()
-	executed, err := cmd.ExecuteC()
+
+	// Reject an unknown subcommand before cobra can quietly answer it with the
+	// parent group's help page and a zero exit code. See UnknownSubcommandError.
+	var executed *cobra.Command
+	err := commands.UnknownSubcommandError(os.Args[1:])
+	if err == nil {
+		executed, err = cmd.ExecuteC()
+	}
 	trackCommand(executed, err, time.Since(start))
 	analytics.Close()
 

--- a/go/internal/cli/commands/unknown_command.go
+++ b/go/internal/cli/commands/unknown_command.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+)
+
+// UnknownSubcommandError returns a non-nil error when args name a subcommand
+// that does not exist under a group command, and nil in every other case.
+//
+// Cobra does not do this for us. Its legacyArgs check rejects an unknown
+// subcommand only for the root command, because it tests !cmd.HasParent()
+// before erroring. Any nested group accepts the stray token as a positional
+// argument instead. The group has no action of its own, so Command.execute
+// takes its !c.Runnable() branch and returns flag.ErrHelp, which ExecuteC
+// renders as that group's help page and a zero exit code. The result is that
+// `wendy banana` fails loudly while `wendy device banana` prints the ordinary
+// `wendy device` help and reports success, which is indistinguishable from
+// having run `wendy device` on purpose.
+//
+// This runs ahead of cobra rather than through Command.Args because execute
+// honours the help flag before it validates arguments: `wendy device banana
+// --help` never reaches a validator, and that is the spelling people actually
+// type when they are exploring an unfamiliar command.
+func UnknownSubcommandError(args []string) error {
+	// Resolution and flag parsing both mutate command state, so probe a
+	// throwaway tree and leave the caller's root untouched.
+	target, remaining, err := NewRootCmd().Find(args)
+	if err != nil || target == nil {
+		// Cobra found its own problem here; let it report that itself.
+		return nil
+	}
+	// Only groups are affected. A command with an action of its own is entitled
+	// to positional arguments, and validates them itself.
+	if !target.HasSubCommands() || target.Runnable() {
+		return nil
+	}
+
+	// Let pflag split flags from positionals so that a flag value is never
+	// mistaken for a subcommand, as in `wendy device --device foo bar`.
+	target.InitDefaultHelpFlag()
+	if err := target.Flags().Parse(remaining); err != nil {
+		// A malformed flag is cobra's error to report, not ours.
+		return nil
+	}
+	positional := target.Flags().Args()
+	if len(positional) == 0 {
+		return nil
+	}
+
+	msg := fmt.Sprintf("unknown command %q for %q", positional[0], target.CommandPath())
+	if suggestions := target.SuggestionsFor(positional[0]); len(suggestions) > 0 {
+		msg += "\n\nDid you mean this?\n"
+		for _, s := range suggestions {
+			msg += fmt.Sprintf("\t%s\n", s)
+		}
+	}
+	msg += fmt.Sprintf("\nRun '%s --help' to see the available commands.", target.CommandPath())
+	return errors.New(msg)
+}

--- a/go/internal/cli/commands/unknown_command_test.go
+++ b/go/internal/cli/commands/unknown_command_test.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnknownSubcommandErrorRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string // substring the error must contain
+	}{
+		{
+			name: "unknown group under device",
+			args: []string{"device", "cloud"},
+			want: `unknown command "cloud" for "wendy device"`,
+		},
+		{
+			// The spelling that reads as a valid command: cobra honours the help
+			// flag before it validates arguments, so this must be caught ahead of
+			// cobra or it prints the `wendy device` help and exits 0.
+			name: "unknown group with the help flag",
+			args: []string{"device", "cloud", "--help"},
+			want: `unknown command "cloud" for "wendy device"`,
+		},
+		{
+			name: "unknown subcommand two levels down",
+			args: []string{"device", "apps", "banana"},
+			want: `unknown command "banana" for "wendy device apps"`,
+		},
+		{
+			// A flag value must never be mistaken for the mistyped subcommand.
+			name: "flag value before the unknown subcommand",
+			args: []string{"device", "--device", "somehost", "banana"},
+			want: `unknown command "banana" for "wendy device"`,
+		},
+		{
+			name: "unknown subcommand under a cloud-scoped group",
+			args: []string{"cloud", "device", "banana"},
+			want: `unknown command "banana" for "wendy cloud device"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := UnknownSubcommandError(tt.args)
+			if err == nil {
+				t.Fatalf("UnknownSubcommandError(%q) = nil, want an error", tt.args)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("UnknownSubcommandError(%q) = %q, want it to contain %q", tt.args, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommandErrorAllows(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no arguments", []string{}},
+		{"group on its own", []string{"device"}},
+		{"group with the help flag", []string{"device", "--help"}},
+		{"group with a persistent flag", []string{"device", "--device", "somehost"}},
+		{"nested group on its own", []string{"device", "apps"}},
+		{"leaf command", []string{"device", "info"}},
+		{"leaf command with the help flag", []string{"device", "apps", "start", "--help"}},
+		{"leaf command with a positional", []string{"device", "apps", "start", "myapp"}},
+		{"real cloud-scoped leaf", []string{"cloud", "device", "unenroll"}},
+		// Root-level resolution stays cobra's job: its legacyArgs check already
+		// reports these, and bailing out here is what keeps the hidden
+		// __complete and help commands working, since cobra registers those
+		// during Execute rather than at construction.
+		{"unknown command at the root", []string{"banana"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := UnknownSubcommandError(tt.args); err != nil {
+				t.Errorf("UnknownSubcommandError(%q) = %q, want nil", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommandErrorSuggests(t *testing.T) {
+	err := UnknownSubcommandError([]string{"device", "unenrol"})
+	if err == nil {
+		t.Fatal("UnknownSubcommandError = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "unenroll") {
+		t.Errorf("UnknownSubcommandError = %q, want it to suggest %q", err, "unenroll")
+	}
+}


### PR DESCRIPTION
## The problem

`wendy device cloud --help` printed the ordinary `wendy device` help page and exited 0. A command that does not exist was indistinguishable from one that does, and the output gave every impression of success.

That is not a hypothetical. Two of us, including the person who built most of Wendy, read that screen as proof that a `wendy device cloud` command tree existed. It does not, and never has. The only clues that anything was wrong are subtle enough to miss entirely:

```
$ wendy device cloud --help
Manage WendyOS devices

Usage:
  wendy device [command]      <- says "device", not "device cloud"
...
  -h, --help   help for device  <- "for device", not "for cloud"
```

The failure was also inconsistent by depth, which made it harder to reason about:

| Command | Before |
| --- | --- |
| `wendy banana` | `unknown command "banana" for "wendy"`, exit 1 |
| `wendy device banana` | `wendy device` help page, **exit 0** |
| `wendy device apps banana` | `wendy device apps` help page, **exit 0** |

## The cause

This is cobra's own behaviour, not something in our command definitions. Three steps, in cobra v1.10.2:

1. `legacyArgs` in `args.go` is the unknown-command check, and it is gated on `!cmd.HasParent() && len(args) > 0`. It therefore fires **only for the root command**. Any nested group returns nil and accepts the stray token as a positional argument.
2. Group commands such as `device` have no `Run` of their own, so `Command.execute` reaches `if !c.Runnable() { return flag.ErrHelp }`.
3. `ExecuteC` sees `flag.ErrHelp`, calls the help function, and returns a **nil** error, which is a zero exit code.

The function is named "legacy" because this is retained for backwards compatibility. Our code contributes only by leaving `Args` unset on group commands, which is the ordinary thing to do.

## Why the obvious fix does not work

Setting `Args: cobra.NoArgs` on the group commands has no effect. In `command.go`, the `!c.Runnable()` bail is at line 955 and `ValidateArgs` is not called until line 968, so for a group command cobra returns help before it ever validates arguments. The help flag is honoured earlier still, around line 935, which means nothing routed through argument validation can catch `wendy device cloud --help` at all. That spelling matters, because it is what people type when exploring an unfamiliar command.

## The solution

`UnknownSubcommandError` in `go/internal/cli/commands/unknown_command.go` runs ahead of cobra, from `main`. It resolves the arguments with `Command.Find`, and if that lands on a group command (has subcommands, has no action of its own) with a leftover positional argument, it returns an error naming the offending token.

Splitting flags from positionals is delegated to pflag, so a flag value is never blamed as the mistyped subcommand: `wendy device --device somehost banana` correctly reports `banana`, not `somehost`.

Root-level resolution is deliberately left to cobra, which already reports it correctly. That is also what keeps the hidden `__complete` and `help` commands working, since cobra registers those during `Execute` rather than at construction time, so they are absent from the probe tree.

After:

```
$ wendy device cloud --help
✗ unknown command "cloud" for "wendy device"

Run 'wendy device --help' to see the available commands.
$ echo $?
1
```

Near misses get a suggestion, via cobra's own `SuggestionsFor`:

```
$ wendy device unenrol
✗ unknown command "unenrol" for "wendy device"

Did you mean this?
	unenroll

Run 'wendy device --help' to see the available commands.
```

## A note on the design

The error replaces the help page rather than printing above it. Burying a one-line error under thirty lines of help is close to how the original confusion happened, so the pointer to `--help` is offered instead of the help text itself. Happy to change this if reviewers would rather see both.

## Verification

Run on macOS on arm64. `go build ./...`, `go vet`, and `gofmt` are all clean, and `go test ./internal/cli/commands/ ./cmd/wendy/` passes.

`unknown_command_test.go` covers 16 cases: the rejections above including the `--help` spelling and the flag-value case, and the invocations that must keep working. Behaviour was also checked end to end against the built binary:

Now correctly exit 1: `wendy banana`, `wendy device cloud`, `wendy device cloud --help`, `wendy device cloud unenroll`, `wendy device banana`, `wendy device apps banana`, `wendy device --device foo banana`.

Still exit 0 and unchanged: `wendy --help`, `wendy device`, `wendy device --help`, `wendy device apps`, `wendy device info --help`, `wendy device apps start --help`, `wendy cloud device --help`, `wendy cloud device unenroll --help`, `wendy device --device foo`, `wendy --version`, `wendy help device`, `wendy completion zsh`, and `wendy __complete device ""` still enumerates subcommands for shell completion.

One behaviour change worth calling out for anyone with scripts: invocations that previously exited 0 while printing a help page now exit 1. That is the point of the change, but a script relying on the old silence will start failing, which is the correct outcome.
