### PR TITLE
fix(cli): surface the implicit device, and make flags and arguments honest

### DIFF
--- a/go/internal/cli/commands/bluetooth.go
+++ b/go/internal/cli/commands/bluetooth.go
@@ -270,7 +270,7 @@ func newBluetoothConnectCmd() *cobra.Command {
 	var trust bool
 
 	cmd := &cobra.Command{
-		Use:   "connect [address]",
+		Use:   "connect <address>",
 		Short: "Connect to a Bluetooth peripheral",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -307,7 +307,7 @@ func newBluetoothConnectCmd() *cobra.Command {
 
 func newBluetoothDisconnectCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "disconnect [address]",
+		Use:   "disconnect <address>",
 		Short: "Disconnect a Bluetooth peripheral",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -333,7 +333,7 @@ func newBluetoothDisconnectCmd() *cobra.Command {
 
 func newBluetoothForgetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "forget [address]",
+		Use:   "forget <address>",
 		Short: "Forget a paired Bluetooth peripheral",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/go/internal/cli/commands/cloud.go
+++ b/go/internal/cli/commands/cloud.go
@@ -69,9 +69,9 @@ func newCloudDeviceCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint (optional when a default session is set via 'wendy auth use')")
 	cmd.PersistentFlags().StringVar(&brokerURL, "broker-url", os.Getenv("WENDY_BROKER_URL"), "Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)")
 
-	wrapCloudDeviceCommands(cmd, func() cloudDeviceConfig {
+	wrapCloudDeviceCommands(cmd, func(executing *cobra.Command) cloudDeviceConfig {
 		return cloudDeviceConfig{
-			CloudGRPC:  cloudGRPC,
+			CloudGRPC:  resolveCloudGRPCFlag(executing, cloudGRPC),
 			DeviceName: deviceFlag,
 			BrokerURL:  brokerURL,
 		}
@@ -79,18 +79,56 @@ func newCloudDeviceCmd() *cobra.Command {
 	return cmd
 }
 
-func wrapCloudDeviceCommands(cmd *cobra.Command, cfg func() cloudDeviceConfig) {
+// resolveCloudGRPCFlag reads --cloud-grpc from the command actually being run,
+// falling back to the value bound to this group's persistent flag.
+//
+// `enroll`, `unenroll`, and `rename` declare their own local --cloud-grpc for
+// the cloud-side cleanup they perform. A local flag shadows an inherited
+// persistent one of the same name, so under `wendy cloud device` those three
+// bound the user's value to their own variable and left this group's persistent
+// flag empty. The endpoint documented on the parent was therefore impossible to
+// set on exactly the three subcommands that talk to the cloud most.
+//
+// Looking the flag up on the executing command resolves whichever definition is
+// in effect, so one --cloud-grpc means one thing regardless of where it is
+// declared.
+func resolveCloudGRPCFlag(executing *cobra.Command, fallback string) string {
+	if executing == nil {
+		return fallback
+	}
+	if f := executing.Flags().Lookup("cloud-grpc"); f != nil && f.Value.String() != "" {
+		return f.Value.String()
+	}
+	return fallback
+}
+
+// effectiveDeviceName prefers a command's own --device value and falls back to the
+// root's persistent --device.
+//
+// `cloud run` and `cloud tunnel` each declare a local --device bound to their own
+// variable, which shadows the persistent one. Without this fallback the flag is
+// position-dependent: `wendy cloud tunnel --device thor` is honoured while
+// `wendy --device thor cloud tunnel` is silently ignored and falls through to the
+// interactive picker.
+func effectiveDeviceName(local string) string {
+	if local != "" {
+		return local
+	}
+	return deviceFlag
+}
+
+func wrapCloudDeviceCommands(cmd *cobra.Command, cfg func(*cobra.Command) cloudDeviceConfig) {
 	if cmd.RunE != nil {
 		runE := cmd.RunE
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			cmd.SetContext(context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cfg()))
+			cmd.SetContext(context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cfg(cmd)))
 			return runE(cmd, args)
 		}
 	}
 	if cmd.Run != nil {
 		run := cmd.Run
 		cmd.Run = func(cmd *cobra.Command, args []string) {
-			cmd.SetContext(context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cfg()))
+			cmd.SetContext(context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cfg(cmd)))
 			run(cmd, args)
 		}
 	}

--- a/go/internal/cli/commands/cloud_forward.go
+++ b/go/internal/cli/commands/cloud_forward.go
@@ -30,7 +30,7 @@ func newCloudTunnelCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return cloudTunnelCommand(cmd.Context(), cloudGRPC, deviceName, brokerURL, localPort, remotePort)
+			return cloudTunnelCommand(cmd.Context(), cloudGRPC, effectiveDeviceName(deviceName), brokerURL, localPort, remotePort)
 		},
 	}
 

--- a/go/internal/cli/commands/cloud_run.go
+++ b/go/internal/cli/commands/cloud_run.go
@@ -14,13 +14,17 @@ func newCloudRunCmd() *cobra.Command {
 	var brokerURL string
 
 	cmd := &cobra.Command{
-		Use:    "run",
-		Short:  "Deprecated: use 'wendy run' instead",
-		Hidden: true,
+		Use:   "run",
+		Short: "Deprecated: use 'wendy run' instead",
+		// Hidden keeps it off the help menu, which also means the Short above is
+		// never read. Deprecated makes cobra warn at the point of use, so a
+		// script still calling this finds out.
+		Deprecated: "use 'wendy run' instead",
+		Hidden:     true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.WithValue(cmd.Context(), cloudDeviceContextKey{}, cloudDeviceConfig{
 				CloudGRPC:  cloudGRPC,
-				DeviceName: deviceName,
+				DeviceName: effectiveDeviceName(deviceName),
 				BrokerURL:  brokerURL,
 			})
 			return runCommand(ctx, opts)

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -470,6 +470,13 @@ func pickCloudDeviceWithRelogin(ctx context.Context, auth *config.AuthConfig, de
 	} else {
 		asset, err := resolveCloudAsset(assets, deviceName)
 		if err != nil || asset != nil {
+			// With no --device, resolveCloudAsset picks the org's only enrolled
+			// device without asking. Say so, rather than leaving the target
+			// implicit. Note this is not the configured default device: the
+			// cloud path does not consult that setting.
+			if err == nil && deviceName == "" {
+				noteImplicitDevice(asset.GetName(), implicitSoleCloudDevice)
+			}
 			return asset, err
 		}
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -941,11 +941,23 @@ func connectResolvedAgent(ctx context.Context, hostname, addr string, isDefault 
 
 func connectResolvedAgentWithProvisionedHint(ctx context.Context, hostname, addr string, isDefault bool, provisionedMTLS func() bool) (*grpcclient.AgentConnection, error) {
 	if isDefault && !jsonOutput && isInteractiveTerminal() {
-		return runAgentConnectionSpinner(ctx, defaultDeviceSearchLabel(hostname), func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
+		conn, err := runAgentConnectionSpinner(ctx, defaultDeviceSearchLabel(hostname), func(spinCtx context.Context) (*grpcclient.AgentConnection, error) {
 			return connectAgentAtAddressWithProvisionedHint(spinCtx, addr, provisionedMTLS)
 		})
+		if err != nil {
+			// The unreachable-default paths report the hostname themselves.
+			return nil, err
+		}
+		// The spinner above clears once it succeeds, so without this the choice
+		// of device leaves no trace.
+		noteImplicitDevice(hostname, implicitDefaultDevice)
+		return conn, nil
 	}
-	return connectAgentAtAddressWithProvisionedHint(ctx, addr, provisionedMTLS)
+	conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, provisionedMTLS)
+	if err == nil && isDefault {
+		noteImplicitDevice(hostname, implicitDefaultDevice)
+	}
+	return conn, err
 }
 
 // connectToAgent establishes a gRPC connection to the target device.

--- a/go/internal/cli/commands/implicit_device_notice.go
+++ b/go/internal/cli/commands/implicit_device_notice.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// implicitDeviceReason describes how a device was chosen when the user did not
+// name one. The two cases need different wording: the direct path falls back to
+// the device recorded by `wendy device set-default`, while the cloud path never
+// consults that setting and instead auto-selects when the org has exactly one
+// enrolled device. Calling the latter a "default" would be untrue.
+type implicitDeviceReason int
+
+const (
+	// implicitDefaultDevice is the hostname from config, used because neither
+	// --device nor an interactive pick supplied one.
+	implicitDefaultDevice implicitDeviceReason = iota
+	// implicitSoleCloudDevice is the org's only enrolled cloud asset, selected
+	// without asking because there was nothing to choose between.
+	implicitSoleCloudDevice
+)
+
+// noticedImplicitDevice guards against repeating the notice inside one
+// invocation. connectResolvedAgent is called again on the retry paths in
+// connectToAgent, which would otherwise announce the same device up to four
+// times for a single command.
+var noticedImplicitDevice bool
+
+// noteImplicitDevice tells the user which device a command acted on when they
+// did not name one, so an implicit target is never invisible.
+//
+// The line naming the device prints every time, because that is the whole
+// point: knowing which machine was touched. The follow-up explaining how to
+// change it is throttled to once a day, since repeating it on every command
+// would be noise rather than help.
+func noteImplicitDevice(name string, reason implicitDeviceReason) {
+	if name == "" || noticedImplicitDevice {
+		return
+	}
+	// Machine-readable output must stay parseable, and the existing
+	// default-device spinner is gated the same way. Note the CLI turns this on by
+	// itself when stdout is not a terminal, so piped and CI runs stay quiet.
+	if jsonOutput {
+		return
+	}
+	noticedImplicitDevice = true
+
+	withHint := !implicitDeviceHintShownToday()
+	for _, line := range implicitDeviceLines(tui.Device(name), reason, withHint) {
+		cliNotice("%s", line)
+	}
+	if withHint {
+		recordImplicitDeviceHintShown()
+	}
+}
+
+// implicitDeviceLines builds the notice. Split out from the printing so the
+// wording and the hint-throttling decision can be asserted in tests.
+func implicitDeviceLines(name string, reason implicitDeviceReason, withHint bool) []string {
+	var lines []string
+	switch reason {
+	case implicitSoleCloudDevice:
+		lines = append(lines, "Using "+name+", the only device enrolled in this organisation.")
+	default:
+		lines = append(lines, "Using default device "+name+".")
+	}
+	if withHint {
+		lines = append(lines, "Target a different device for one command with --device, or change the default with 'wendy device set-default'.")
+	}
+	return lines
+}
+
+func implicitDeviceHintToday() string {
+	return time.Now().Format("2006-01-02")
+}
+
+func implicitDeviceHintShownToday() bool {
+	cfg, err := config.Load()
+	if err != nil {
+		// Without config state, prefer showing the hint over hiding it.
+		return false
+	}
+	return cfg.ImplicitDeviceHintShownAt == implicitDeviceHintToday()
+}
+
+func recordImplicitDeviceHintShown() {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	cfg.ImplicitDeviceHintShownAt = implicitDeviceHintToday()
+	_ = config.Save(cfg)
+}

--- a/go/internal/cli/commands/implicit_device_notice_test.go
+++ b/go/internal/cli/commands/implicit_device_notice_test.go
@@ -1,0 +1,123 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestImplicitDeviceLinesNamesTheDevice(t *testing.T) {
+	lines := implicitDeviceLines("thor.local", implicitDefaultDevice, false)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1 without the hint: %q", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "thor.local") {
+		t.Errorf("line = %q, want it to name the device", lines[0])
+	}
+	if !strings.Contains(lines[0], "default device") {
+		t.Errorf("line = %q, want it to say the default was used", lines[0])
+	}
+}
+
+// The cloud path never consults the configured default, so calling its choice a
+// "default device" would tell the user something untrue.
+func TestImplicitDeviceLinesDoesNotCallSoleCloudDeviceADefault(t *testing.T) {
+	lines := implicitDeviceLines("thor.local", implicitSoleCloudDevice, false)
+	if strings.Contains(lines[0], "default") {
+		t.Errorf("line = %q, must not describe a sole cloud device as a default", lines[0])
+	}
+	if !strings.Contains(lines[0], "only device enrolled") {
+		t.Errorf("line = %q, want it to explain why this device was chosen", lines[0])
+	}
+}
+
+func TestImplicitDeviceLinesHintIsSeparateAndOptional(t *testing.T) {
+	with := implicitDeviceLines("thor.local", implicitDefaultDevice, true)
+	if len(with) != 2 {
+		t.Fatalf("got %d lines, want 2 with the hint: %q", len(with), with)
+	}
+	if !strings.Contains(with[1], "--device") {
+		t.Errorf("hint = %q, want it to mention the override flag", with[1])
+	}
+	if !strings.Contains(with[1], "wendy device set-default") {
+		t.Errorf("hint = %q, want it to mention how to change the default", with[1])
+	}
+}
+
+// The identity line must never be throttled away: knowing which device was
+// touched is the entire point, so only the explanation is rate-limited.
+func TestImplicitDeviceLinesAlwaysIncludesIdentityLine(t *testing.T) {
+	for _, withHint := range []bool{true, false} {
+		lines := implicitDeviceLines("thor.local", implicitDefaultDevice, withHint)
+		if len(lines) == 0 || !strings.Contains(lines[0], "thor.local") {
+			t.Errorf("withHint=%v: identity line missing from %q", withHint, lines)
+		}
+	}
+}
+
+func TestNoteImplicitDeviceSuppressedInJSONMode(t *testing.T) {
+	origJSON, origNoticed := jsonOutput, noticedImplicitDevice
+	t.Cleanup(func() { jsonOutput, noticedImplicitDevice = origJSON, origNoticed })
+
+	jsonOutput = true
+	noticedImplicitDevice = false
+	noteImplicitDevice("thor.local", implicitDefaultDevice)
+	if noticedImplicitDevice {
+		t.Error("notice was emitted in JSON mode; machine-readable output must stay clean")
+	}
+}
+
+// connectResolvedAgent runs again on the retry paths in connectToAgent, so
+// without the guard one command could announce the same device several times.
+func TestNoteImplicitDeviceOnlyFiresOncePerInvocation(t *testing.T) {
+	origJSON, origNoticed := jsonOutput, noticedImplicitDevice
+	t.Cleanup(func() { jsonOutput, noticedImplicitDevice = origJSON, origNoticed })
+
+	jsonOutput = true // keep the test quiet; the guard is what is under test
+	noticedImplicitDevice = false
+	noteImplicitDevice("thor.local", implicitDefaultDevice)
+	noticedImplicitDevice = true
+	before := noticedImplicitDevice
+	noteImplicitDevice("other.local", implicitDefaultDevice)
+	if noticedImplicitDevice != before {
+		t.Error("guard did not hold across repeated calls")
+	}
+}
+
+func TestNoteImplicitDeviceIgnoresEmptyName(t *testing.T) {
+	origNoticed := noticedImplicitDevice
+	t.Cleanup(func() { noticedImplicitDevice = origNoticed })
+
+	noticedImplicitDevice = false
+	noteImplicitDevice("", implicitDefaultDevice)
+	if noticedImplicitDevice {
+		t.Error("announced a device with no name")
+	}
+}
+
+// resolveCloudGRPCFlag must prefer whichever --cloud-grpc definition is in
+// effect on the command being run, since enroll/unenroll/rename shadow the
+// group's persistent flag with their own.
+func TestResolveCloudGRPCFlagPrefersTheExecutingCommandsFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "unenroll"}
+	var local string
+	cmd.Flags().StringVar(&local, "cloud-grpc", "", "")
+	if err := cmd.Flags().Set("cloud-grpc", "local.example:443"); err != nil {
+		t.Fatalf("setting flag: %v", err)
+	}
+
+	if got := resolveCloudGRPCFlag(cmd, "persistent.example:443"); got != "local.example:443" {
+		t.Errorf("resolveCloudGRPCFlag = %q, want the shadowing local value", got)
+	}
+}
+
+func TestResolveCloudGRPCFlagFallsBackWhenUnset(t *testing.T) {
+	cmd := &cobra.Command{Use: "info"}
+	if got := resolveCloudGRPCFlag(cmd, "persistent.example:443"); got != "persistent.example:443" {
+		t.Errorf("resolveCloudGRPCFlag = %q, want the group's persistent value", got)
+	}
+	if got := resolveCloudGRPCFlag(nil, "persistent.example:443"); got != "persistent.example:443" {
+		t.Errorf("resolveCloudGRPCFlag(nil) = %q, want the fallback", got)
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -3,6 +3,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/analytics"
@@ -241,8 +242,40 @@ func NewRootCmd() *cobra.Command {
 	root.SetHelpCommandGroupID("settings")
 	root.SetCompletionCommandGroupID("settings")
 
+	rejectStrayArguments(root)
+
 	root.Version = version.Version
 	return root
+}
+
+// rejectStrayArguments gives every command that takes no positional arguments a
+// NoArgs validator, so a stray word is reported instead of silently dropped.
+//
+// Without a validator cobra defaults to accepting anything, which means
+// `wendy device wifi connect MyNetwork` discards "MyNetwork" and proceeds as if
+// no network had been named -- the SSID is supplied with --ssid. Around ninety
+// commands were in that state; none of them had opted into it deliberately.
+//
+// A command is only treated as argument-free when its Use string declares no
+// placeholder. Anything documenting a positional, such as "logs [app]" or
+// "record [topics...]", already states its own contract and is left alone, as is
+// any command that already sets Args.
+func rejectStrayArguments(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		rejectStrayArguments(child)
+	}
+	if !cmd.Runnable() || cmd.Args != nil {
+		return
+	}
+	for _, token := range strings.Fields(cmd.Use)[1:] {
+		if token == "[flags]" {
+			continue
+		}
+		if strings.HasPrefix(token, "<") || strings.HasPrefix(token, "[") {
+			return
+		}
+	}
+	cmd.Args = cobra.NoArgs
 }
 
 // nextStepHint returns a one-line suggestion for the next command to run after

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -1672,7 +1672,7 @@ func drainExecStream(ctx context.Context, stream execRecvStream, args []string, 
 func newROS2ExecCmd() *cobra.Command {
 	var domain int32
 	cmd := &cobra.Command{
-		Use:   "exec [args...]",
+		Use:   "exec <args>...",
 		Short: "Run a raw ros2 CLI command on the device",
 		Long: `Run a raw ros2 CLI command inside the device's ROS 2 sidecar.
 

--- a/go/internal/cli/commands/stray_arguments_test.go
+++ b/go/internal/cli/commands/stray_arguments_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Every runnable command that documents no positional argument must reject one,
+// rather than accepting and discarding it.
+func TestNoCommandSilentlyAcceptsStrayArguments(t *testing.T) {
+	var unguarded []string
+
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		for _, c := range cmd.Commands() {
+			if c.Runnable() && !declaresPositionals(c.Use) {
+				if c.Args == nil || c.Args(c, []string{"zzstray"}) == nil {
+					unguarded = append(unguarded, c.CommandPath())
+				}
+			}
+			walk(c)
+		}
+	}
+	walk(NewRootCmd())
+
+	if len(unguarded) > 0 {
+		t.Errorf("%d command(s) silently accept a stray positional argument:\n  %s",
+			len(unguarded), strings.Join(unguarded, "\n  "))
+	}
+}
+
+// Commands that do document a positional must keep accepting it: the sweep must
+// not have blanket-applied NoArgs over a real contract.
+func TestCommandsDocumentingPositionalsStillAcceptThem(t *testing.T) {
+	for _, path := range [][]string{
+		{"device", "logs"},
+		{"device", "ros2", "bag", "record"},
+		{"os", "update"},
+		{"auth", "use"},
+		{"json", "validate"},
+	} {
+		cmd, _, err := NewRootCmd().Find(path)
+		if err != nil {
+			t.Errorf("Find(%q): %v", path, err)
+			continue
+		}
+		if cmd.Args == nil {
+			continue // no validator at all, so nothing is being rejected
+		}
+		if err := cmd.Args(cmd, []string{"something"}); err != nil {
+			t.Errorf("%s rejects its documented positional: %v", cmd.CommandPath(), err)
+		}
+	}
+}
+
+func declaresPositionals(use string) bool {
+	fields := strings.Fields(use)
+	if len(fields) < 2 {
+		return false
+	}
+	for _, tok := range fields[1:] {
+		if tok == "[flags]" {
+			continue
+		}
+		if strings.HasPrefix(tok, "<") || strings.HasPrefix(tok, "[") {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -41,6 +41,11 @@ type Config struct {
 	// (YYYY-MM-DD) of the last time the tip (or a build-time optimize scan) was
 	// surfaced for that project.
 	OptimizeTipShownAt map[string]string `json:"optimizeTipShownAt,omitempty"`
+	// ImplicitDeviceHintShownAt throttles the follow-up hint that explains how to
+	// override an implicitly chosen device, to once per day. The line naming the
+	// device is always shown; only the explanation is rate-limited. Value is a
+	// date (YYYY-MM-DD).
+	ImplicitDeviceHintShownAt string `json:"implicitDeviceHintShownAt,omitempty"`
 	// DevicePins binds a device hostname to the organisation + cloud host its
 	// TLS identity must belong to (WDY-1149), so a different trust domain
 	// answering at that hostname is caught. Renewal/re-enrollment within the


### PR DESCRIPTION
## Summary

Five fixes from a structural audit of all 252 commands, each a case where the CLI did something without saying so, or documented something it did not do. Three commits, one per theme, reviewable independently.

## 1. Say which device was used when none was named

Running a command against the default device left no trace. The only signal was a spinner reading `Searching for default device "<name>"...` ([helpers.go:869](go/internal/cli/commands/helpers.go:869)), which clears the moment it succeeds. A command that reconfigured real hardware gave no lasting indication of which machine it touched.

The line naming the device now prints every time. The follow-up explaining how to change it is throttled to once a day, because repeating it on every command would be noise rather than help:

```
Using default device thor-gamma.local
Target a different device for one command with --device, or change the default with 'wendy device set-default'.
```

**Cloud devices are covered, with deliberately different wording.** The cloud path never consults the configured default. It auto-selects when the organisation has exactly one enrolled device ([cloud_tunnel.go:391](go/internal/cli/commands/cloud_tunnel.go:391)), so calling that a "default device" would state something untrue. It reads `Using thor-gamma.local, the only device enrolled in this organisation.` instead. A test asserts that wording never claims a default.

Suppressed under `--json`, which the CLI enables by itself when stdout is not a terminal, so piped and CI runs stay clean. Guarded against repeating inside one invocation, since `connectResolvedAgent` runs again on the retry paths in `connectToAgent`.

Worth flagging separately: that the configured default has no effect on `wendy cloud device ...` is arguably wrong in itself. This PR surfaces the behaviour rather than changing it, since changing which device gets targeted deserves its own discussion.

## 2. Reject stray positional arguments

Cobra accepts any positional when a command sets no `Args` validator, and about ninety commands were in that state. The argument was silently dropped.

The clearest case is `wendy device wifi connect MyNetwork` — the obvious thing to type, where the SSID is actually passed with `--ssid`. `MyNetwork` was discarded and the command proceeded as though no network had been named. `wendy cloud status banana` printed normal output and exited 0.

Applied centrally rather than across ninety call sites, and only to commands whose `Use` declares no placeholder. Anything documenting a positional (`logs [app]`, `record [topics...]`) states its own contract and is untouched, as is any command that already sets `Args`. Two tests lock both halves in: nothing argument-free may accept a stray token, and the commands that do take positionals must still accept them.

This is the sibling of #1550. That one catches an unknown *subcommand* on a group; this catches an unknown *argument* on a leaf. Unlike the group case, `NoArgs` works here, because these commands are runnable so `ValidateArgs` is actually reached.

## 3. `--cloud-grpc` was impossible to set on three subcommands

`wendy cloud device` declares `--cloud-grpc` persistently as "which cloud to connect through" ([cloud.go:69](go/internal/cli/commands/cloud.go:69)). `enroll`, `unenroll`, and `rename` each declare a local `--cloud-grpc` for their cloud-side cleanup. A local flag shadows an inherited persistent one of the same name, so the user's value bound to the subcommand's variable while the group's persistent flag stayed empty. The endpoint documented on the parent could not be set on exactly the three subcommands that talk to the cloud most, and it was not even listed under Global Flags, unlike on `wendy cloud device info`.

The value is now read from the command actually being run, so one flag name means one thing wherever it is declared.

## 4. `--device` was position-dependent on two commands

`cloud run` and `cloud tunnel` bind their own `--device`, so `wendy cloud tunnel --device thor` was honoured while `wendy --device thor cloud tunnel` was silently ignored and fell through to the interactive picker. Both spellings now agree. `mcp serve` also redeclares `--device` but binds it to the same variable, so it needed no change.

## 5. Brackets that meant mandatory, and a silent deprecation

`bluetooth connect`, `disconnect`, and `forget` all showed `[address]` while requiring it via `ExactArgs(1)`; `ros2 exec` showed `[args...]` while requiring at least one. Brackets conventionally mean optional. Now `<address>` and `<args>...`.

`wendy cloud run` announced its deprecation only in `Short`, which is never read because the command is hidden. Setting cobra's `Deprecated` field makes it warn at the point of use: `Command "run" is deprecated, use 'wendy run' instead`.

## Verification

macOS on arm64. `go build ./...`, `go vet`, and `gofmt` clean; `go test ./internal/cli/... ./internal/shared/config/ ./cmd/wendy/` passes. 11 new tests.

Checked against the built binary — now correctly exit 1: `cloud status banana`, `device wifi connect MyNetwork`, `device apps list banana`, `device info banana`. Still exit 0 and unchanged: `--help`, `device`, `device apps`, `cloud device --help`, `cloud device unenroll --help`, `device logs --help`, `device attach --help`, `device ros2 bag record --help`, `os update --help`, `auth use --help`, `cloud status`, `--version`, `completion zsh`.

**Not verified end to end:** the device notice itself. This environment has no TTY, and the CLI switches to JSON mode without one, which correctly suppresses the notice. The message content, the JSON suppression, the once-per-invocation guard, and the throttle split are covered by unit tests, but nobody has yet seen the line in a real terminal. Worth one manual `wendy device info` before merging.

## Behaviour changes to be aware of

Invocations that previously exited 0 while ignoring an argument now exit 1. That is the intent, but a script passing a stray argument will start failing.

The audit also came back clean on several fronts worth recording: no dead-end commands, no name or alias collisions, no empty help text, and no stale command references in help output.
