### PR TITLE
fix(discovery): browse mDNS through dns_sd.h instead of the dns-sd tool

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -31,7 +31,7 @@ wendy discover [flags]
 
 mDNS discovery works on all platforms. On Linux, the CLI performs an mDNS browse
 that requires UDP port 5353 open on the host firewall (e.g., `sudo ufw allow 5353/udp`).
-On macOS, the CLI shells out to `dns-sd` and requires Local Network TCC permission.
+On macOS, the CLI browses through mDNSResponder in-process and requires Local Network TCC permission.
 For USB-connected devices on Linux, run `wendy device usb-setup` first to bring up
 the interface.
 

--- a/go/internal/cli/assets/docs/wendyos/networking/mdns.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/mdns.md
@@ -112,7 +112,7 @@ dns-sd -L "wendyos-my-device" _wendyos._udp local.
 
 ### wendy-agent Discovery Code
 
-The wendy-agent Go code (`internal/shared/discovery/`) uses `_wendyos._udp` as the service type constant. On Linux it prefers `avahi-browse -rptl _wendyos._udp` when Avahi is installed; otherwise it falls back to the `hashicorp/mdns` library which queries each multicast-capable interface individually. On macOS it uses `dns-sd -B` to browse and `dns-sd -L` to resolve.
+The wendy-agent Go code (`internal/shared/discovery/`) uses `_wendyos._udp` as the service type constant. On Linux it prefers `avahi-browse -rptl _wendyos._udp` when Avahi is installed; otherwise it falls back to the `hashicorp/mdns` library which queries each multicast-capable interface individually. On macOS it browses and resolves in-process through `<dns_sd.h>`, the same mDNSResponder daemon that the `dns-sd` tool wraps, so no helper processes are spawned.
 
 **CLI-side note:** The shipped CLI binary is built with `CGO_ENABLED=0`, so it cannot use nss-mdns to resolve `.local` names. Instead, it performs its own mDNS browse for `.local` hostnames when connecting. Set `WENDY_MDNS_DEBUG=1` to log browse failures, or `WENDY_MDNS_TIMEOUT` (1s–30s) to adjust the timeout.
 

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -5,6 +5,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -123,10 +124,6 @@ func darwinCachedInterfaceLinkSpeed(ctx context.Context, interfaceName string, l
 	return linkSpeed
 }
 
-// deviceFromBrowse builds a LANDevice from browse results alone, without
-// resolving via dns-sd -L. Used as a fallback when resolve fails (e.g.
-// the service has no TXT records).
-
 var hostnameLabelRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
 // isValidHostnameLabel reports whether s is a valid RFC1123 hostname label.
@@ -137,6 +134,8 @@ func isValidHostnameLabel(s string) bool {
 	return hostnameLabelRegexp.MatchString(s)
 }
 
+// deviceFromBrowse builds a LANDevice from browse results alone. Used as a
+// fallback when resolve fails (e.g. the service has no TXT records).
 func deviceFromBrowse(inst browseResult, interfaceDisplayNames map[string]string) models.LANDevice {
 	// Instance names arrive decoded from mDNSResponder, matching the Linux and
 	// Windows backends — no display-format unescaping to undo.
@@ -184,7 +183,11 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	// Resolving inside the callback blocks the browse socket pump for up to the
 	// resolve timeout. That matches the previous sequential behaviour, and
 	// mDNSResponder queues further browse replies meanwhile.
-	_ = dnssdBrowseStream(ctx, wendyServiceType, func(inst browseResult) {
+	//
+	// An error here ends discovery for the rest of this call — mDNSResponder
+	// restarting, say. Callers get no further devices, so log rather than
+	// swallow it; the picker's list simply stops growing and gives no clue why.
+	if err := dnssdBrowseStream(ctx, wendyServiceType, func(inst browseResult) {
 		key := inst.instanceName + "%" + inst.interfaceName
 		if seen[key] {
 			return
@@ -202,5 +205,7 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 		case ch <- dev:
 		case <-ctx.Done():
 		}
-	})
+	}); err != nil {
+		log.Printf("discovery: continuous mDNS browse stopped: %v", err)
+	}
 }

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -3,11 +3,8 @@
 package discovery
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"net"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,7 +13,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
-// discoverLAN uses the macOS dns-sd command to browse for WendyOS devices.
+// discoverLAN browses for WendyOS devices through mDNSResponder.
 // This works across all network interfaces including USB host-mode connections,
 // unlike raw multicast libraries which miss interfaces the system resolver covers.
 func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
@@ -62,171 +59,16 @@ type browseResult struct {
 	interfaceName string
 }
 
-// dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
-// It uses a short settle timer: once the first result arrives, it waits up to
-// 500ms for more results before returning. This avoids waiting for the full timeout.
-func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
-	cmd := exec.CommandContext(ctx, "dns-sd", "-B", serviceType, "local")
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
+// dnssdBrowseSettle is how long a browse waits for further results after one
+// arrives. Browsing is open-ended, so this is what bounds a scan on a network
+// that has already answered.
+const dnssdBrowseSettle = 500 * time.Millisecond
 
-	// Parse lines on a channel so we can select with a timer.
-	type parsedLine struct {
-		result browseResult
-		ok     bool
-	}
-	lineCh := make(chan parsedLine, 16)
-
-	go func() {
-		defer close(lineCh)
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.Contains(line, "Add") {
-				continue
-			}
-			fields := strings.Fields(line)
-			if len(fields) < 7 {
-				continue
-			}
-			interfaceName := ""
-			if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
-				// Silently falls through with empty interfaceName when the
-				// interface disappears between browse and resolve; USB detection
-				// will be skipped for that device rather than returning an error.
-				if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
-					interfaceName = iface.Name
-				}
-			}
-			lineCh <- parsedLine{
-				result: browseResult{
-					instanceName:  strings.Join(fields[6:], " "),
-					domain:        fields[4],
-					interfaceName: interfaceName,
-				},
-				ok: true,
-			}
-		}
-	}()
-
-	var results []browseResult
-	seen := make(map[string]bool)
-
-	// Wait up to the context deadline for the first result.
-	// Once we get one, use a short settle timer for additional results.
-	var settle <-chan time.Time
-	for {
-		select {
-		case <-ctx.Done():
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-			return results, nil
-		case pl, open := <-lineCh:
-			if !open {
-				_ = cmd.Wait()
-				return results, nil
-			}
-			key := pl.result.instanceName + "%" + pl.result.interfaceName
-			if pl.ok && !seen[key] {
-				seen[key] = true
-				results = append(results, pl.result)
-				// Reset settle timer: wait 500ms for more results.
-				settle = time.After(500 * time.Millisecond)
-			}
-		case <-settle:
-			// No new results in 500ms, we're done.
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-			return results, nil
-		}
-	}
-}
-
-// dnssdResolve runs dns-sd -L to resolve an instance to hostname, port, and TXT records.
-// Returns as soon as the "can be reached at" line is parsed.
+// dnssdResolve resolves a browse result into a LANDevice.
 func dnssdResolve(ctx context.Context, inst browseResult, interfaceDisplayNames map[string]string, linkSpeeds map[string]string) (models.LANDevice, error) {
-	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, wendyServiceType, inst.domain)
-	stdout, err := cmd.StdoutPipe()
+	hostname, port, txtRecords, err := dnssdResolveInstance(ctx, inst, wendyServiceType)
 	if err != nil {
 		return models.LANDevice{}, err
-	}
-	if err := cmd.Start(); err != nil {
-		return models.LANDevice{}, err
-	}
-
-	var hostname string
-	var port int
-	txtRecords := make(map[string]string)
-
-	// parseTXT extracts key=value pairs from a dns-sd TXT record line.
-	// dns-sd escapes spaces inside values as "\ "; we split on unescaped
-	// whitespace so that values like "Dynamic\ Cosmos" round-trip correctly.
-	parseTXT := func(line string) {
-		var fields []string
-		var cur strings.Builder
-		for i := 0; i < len(line); i++ {
-			if line[i] == '\\' && i+1 < len(line) && (line[i+1] == ' ' || line[i+1] == '\t') {
-				cur.WriteByte(line[i+1])
-				i++
-			} else if line[i] == ' ' || line[i] == '\t' {
-				if cur.Len() > 0 {
-					fields = append(fields, cur.String())
-					cur.Reset()
-				}
-			} else {
-				cur.WriteByte(line[i])
-			}
-		}
-		if cur.Len() > 0 {
-			fields = append(fields, cur.String())
-		}
-		for _, field := range fields {
-			if k, v, ok := strings.Cut(field, "="); ok {
-				txtRecords[k] = v
-			}
-		}
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if strings.Contains(line, "can be reached at") {
-			parts := strings.Fields(line)
-			for i, p := range parts {
-				if p == "at" && i+1 < len(parts) {
-					hostPort := parts[i+1]
-					h, p, err := net.SplitHostPort(hostPort)
-					if err == nil {
-						hostname = strings.TrimSuffix(h, ".")
-						fmt.Sscanf(p, "%d", &port)
-					}
-					break
-				}
-			}
-
-			// TXT records on the same line (some versions).
-			parseTXT(line)
-
-			// TXT records are typically on the next line indented with a space.
-			if scanner.Scan() {
-				parseTXT(scanner.Text())
-			}
-
-			_ = cmd.Process.Kill()
-			break
-		}
-	}
-
-	_ = cmd.Wait()
-
-	if hostname == "" {
-		return models.LANDevice{}, fmt.Errorf("could not resolve instance %q", inst.instanceName)
 	}
 
 	displayName := strings.TrimSuffix(hostname, ".local")
@@ -295,14 +137,10 @@ func isValidHostnameLabel(s string) bool {
 	return hostnameLabelRegexp.MatchString(s)
 }
 
-// unescapeDNSSDName converts dns-sd's backslash-escaped spaces ("\ ") back to
-// regular spaces, matching the display form of an mDNS service instance name.
-func unescapeDNSSDName(s string) string {
-	return strings.ReplaceAll(s, `\ `, " ")
-}
-
 func deviceFromBrowse(inst browseResult, interfaceDisplayNames map[string]string) models.LANDevice {
-	displayName := unescapeDNSSDName(inst.instanceName)
+	// Instance names arrive decoded from mDNSResponder, matching the Linux and
+	// Windows backends — no display-format unescaping to undo.
+	displayName := inst.instanceName
 
 	var (
 		id       string
@@ -331,52 +169,25 @@ func deviceFromBrowse(inst browseResult, interfaceDisplayNames map[string]string
 	return dev
 }
 
-// discoverLANContinuous keeps dns-sd -B running and sends each newly
-// discovered device to ch as it's resolved. Runs until ctx is cancelled.
+// discoverLANContinuous keeps a browse open and sends each newly discovered
+// device to ch as it's resolved. Runs until ctx is cancelled.
 // linkSpeeds is intentionally not shared across goroutines — each call to
 // discoverLANContinuous owns its own map, and dnssdResolve is called
-// synchronously within the same goroutine, so no mutex is required.
+// synchronously from the browse callback, so no mutex is required.
 func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	defer close(ch)
 	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)
 	linkSpeeds := make(map[string]string)
 
-	cmd := exec.CommandContext(ctx, "dns-sd", "-B", wendyServiceType, "local")
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return
-	}
-	if err := cmd.Start(); err != nil {
-		return
-	}
-
 	seen := make(map[string]bool)
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.Contains(line, "Add") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 7 {
-			continue
-		}
 
-		interfaceName := ""
-		if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
-			if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
-				interfaceName = iface.Name
-			}
-		}
-		inst := browseResult{
-			instanceName:  strings.Join(fields[6:], " "),
-			domain:        fields[4],
-			interfaceName: interfaceName,
-		}
-
+	// Resolving inside the callback blocks the browse socket pump for up to the
+	// resolve timeout. That matches the previous sequential behaviour, and
+	// mDNSResponder queues further browse replies meanwhile.
+	_ = dnssdBrowseStream(ctx, wendyServiceType, func(inst browseResult) {
 		key := inst.instanceName + "%" + inst.interfaceName
 		if seen[key] {
-			continue
+			return
 		}
 		seen[key] = true
 
@@ -390,9 +201,6 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 		select {
 		case ch <- dev:
 		case <-ctx.Done():
-			return
 		}
-	}
-
-	_ = cmd.Wait()
+	})
 }

--- a/go/internal/shared/discovery/dnssd_darwin.c
+++ b/go/internal/shared/discovery/dnssd_darwin.c
@@ -1,0 +1,48 @@
+#include "dnssd_darwin.h"
+#include "_cgo_export.h"
+
+#include <arpa/inet.h>
+
+// mDNSResponder invokes these on the goroutine that called
+// DNSServiceProcessResult, so forwarding straight into Go is safe. Strings
+// borrowed from the callback are only valid for its duration; the Go side
+// copies them before returning.
+
+static void browse_reply(DNSServiceRef ref, DNSServiceFlags flags,
+                         uint32_t ifIndex, DNSServiceErrorType err,
+                         const char *name, const char *regtype,
+                         const char *domain, void *ctx) {
+  (void)ref;
+  (void)regtype;
+  wendyDNSSDBrowseReply((uintptr_t)ctx, (uint32_t)flags, ifIndex, (int32_t)err,
+                        (char *)name, (char *)domain);
+}
+
+DNSServiceErrorType wendy_dnssd_browse(DNSServiceRef *ref, const char *regtype,
+                                       uintptr_t handle) {
+  return DNSServiceBrowse(ref, 0, kDNSServiceInterfaceIndexAny, regtype, NULL,
+                          browse_reply, (void *)handle);
+}
+
+static void resolve_reply(DNSServiceRef ref, DNSServiceFlags flags,
+                          uint32_t ifIndex, DNSServiceErrorType err,
+                          const char *fullname, const char *hosttarget,
+                          uint16_t port, uint16_t txtLen,
+                          const unsigned char *txt, void *ctx) {
+  (void)ref;
+  (void)flags;
+  (void)ifIndex;
+  (void)fullname;
+  // port arrives in network byte order.
+  wendyDNSSDResolveReply((uintptr_t)ctx, (int32_t)err, (char *)hosttarget,
+                         ntohs(port), (void *)txt, txtLen);
+}
+
+DNSServiceErrorType wendy_dnssd_resolve(DNSServiceRef *ref, const char *name,
+                                        const char *regtype, const char *domain,
+                                        uintptr_t handle) {
+  // kDNSServiceInterfaceIndexAny matches the previous `dns-sd -L` behaviour,
+  // which did not pin the resolve to the interface the browse replied on.
+  return DNSServiceResolve(ref, 0, kDNSServiceInterfaceIndexAny, name, regtype,
+                           domain, resolve_reply, (void *)handle);
+}

--- a/go/internal/shared/discovery/dnssd_darwin.go
+++ b/go/internal/shared/discovery/dnssd_darwin.go
@@ -1,0 +1,321 @@
+//go:build darwin
+
+package discovery
+
+/*
+#include <dns_sd.h>
+#include <stdlib.h>
+#include "dnssd_darwin.h"
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// mDNS browse and resolve against mDNSResponder through <dns_sd.h>, which is
+// what the dns-sd command line tool itself wraps. Talking to the daemon
+// in-process keeps the interface coverage that motivated shelling out — the
+// system resolver sees interfaces raw multicast misses, notably USB host-mode —
+// while removing the helper processes. A spawned dns-sd outlives a parent that
+// dies without unwinding (macOS has no PR_SET_PDEATHSIG), and those orphans
+// accumulate under sustained polling until the per-user process limit is hit
+// (WDY-1831). A daemon connection cannot outlive the process holding it.
+//
+// The API also returns structured records, so instance names and TXT values no
+// longer have to be recovered by parsing dns-sd's human-readable output.
+
+// dnssdPollInterval bounds how long a session waits on its socket before
+// rechecking ctx. It caps cancellation latency; results themselves arrive as
+// soon as the socket is readable.
+const dnssdPollInterval = 100 * time.Millisecond
+
+// dnssdSession carries the callbacks for one DNSServiceRef. It is reached from
+// C by an integer handle: cgo forbids passing Go pointers into C and holding
+// them there.
+type dnssdSession struct {
+	onBrowse  func(flags uint32, ifIndex uint32, name, domain string)
+	onResolve func(host string, port int, txt []byte)
+
+	// err and stop are written by the reply callback and read by the poll loop
+	// that invoked DNSServiceProcessResult. Callbacks run synchronously on that
+	// same goroutine, so no lock is needed.
+	err  error
+	stop bool
+}
+
+var (
+	dnssdMu       sync.Mutex
+	dnssdSessions = make(map[uintptr]*dnssdSession)
+	dnssdNextID   uintptr
+)
+
+func registerSession(s *dnssdSession) uintptr {
+	dnssdMu.Lock()
+	defer dnssdMu.Unlock()
+	dnssdNextID++
+	id := dnssdNextID
+	dnssdSessions[id] = s
+	return id
+}
+
+func unregisterSession(id uintptr) {
+	dnssdMu.Lock()
+	defer dnssdMu.Unlock()
+	delete(dnssdSessions, id)
+}
+
+func lookupSession(id uintptr) *dnssdSession {
+	dnssdMu.Lock()
+	defer dnssdMu.Unlock()
+	return dnssdSessions[id]
+}
+
+// dnssdError converts a DNSServiceErrorType into an error, or nil on success.
+func dnssdError(code C.DNSServiceErrorType) error {
+	if code == C.kDNSServiceErr_NoError {
+		return nil
+	}
+	return fmt.Errorf("dns-sd error %d", int(code))
+}
+
+//export wendyDNSSDBrowseReply
+func wendyDNSSDBrowseReply(handle C.uintptr_t, flags C.uint32_t, ifIndex C.uint32_t, errCode C.int32_t, name *C.char, domain *C.char) {
+	s := lookupSession(uintptr(handle))
+	if s == nil {
+		return
+	}
+	if err := dnssdError(C.DNSServiceErrorType(errCode)); err != nil {
+		s.err = err
+		return
+	}
+	// Removals share this callback and are distinguished only by the Add flag.
+	if uint32(flags)&uint32(C.kDNSServiceFlagsAdd) == 0 {
+		return
+	}
+	s.onBrowse(uint32(flags), uint32(ifIndex), C.GoString(name), C.GoString(domain))
+}
+
+//export wendyDNSSDResolveReply
+func wendyDNSSDResolveReply(handle C.uintptr_t, errCode C.int32_t, host *C.char, port C.uint16_t, txt unsafe.Pointer, txtLen C.uint16_t) {
+	s := lookupSession(uintptr(handle))
+	if s == nil {
+		return
+	}
+	if err := dnssdError(C.DNSServiceErrorType(errCode)); err != nil {
+		s.err = err
+		s.stop = true
+		return
+	}
+	s.onResolve(C.GoString(host), int(port), C.GoBytes(txt, C.int(txtLen)))
+	// One reply is enough; the old code killed dns-sd at the first resolved line.
+	s.stop = true
+}
+
+// runDNSSDSession starts an operation and pumps its socket until ctx ends, the
+// callback sets stop, or an error occurs. Deallocating the ref closes the
+// daemon connection, so nothing survives this function.
+func runDNSSDSession(ctx context.Context, s *dnssdSession, start func(*C.DNSServiceRef, C.uintptr_t) C.DNSServiceErrorType) error {
+	handle := registerSession(s)
+	defer unregisterSession(handle)
+
+	var ref C.DNSServiceRef
+	if err := dnssdError(start(&ref, C.uintptr_t(handle))); err != nil {
+		return err
+	}
+	defer C.DNSServiceRefDeallocate(ref)
+
+	fd := C.DNSServiceRefSockFD(ref)
+	if fd < 0 {
+		return errors.New("dns-sd: no socket for service ref")
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		pollFds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+		n, err := unix.Poll(pollFds, int(dnssdPollInterval.Milliseconds()))
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return fmt.Errorf("polling dns-sd socket: %w", err)
+		}
+		if n == 0 {
+			continue
+		}
+
+		// Invokes the reply callback synchronously on this goroutine.
+		if err := dnssdError(C.DNSServiceProcessResult(ref)); err != nil {
+			return err
+		}
+		if s.err != nil {
+			return s.err
+		}
+		if s.stop {
+			return nil
+		}
+	}
+}
+
+// dnssdBrowseStream browses serviceType and calls onResult for each instance
+// added, until ctx ends. It does not decide when enough results have arrived —
+// that is the caller's policy.
+func dnssdBrowseStream(ctx context.Context, serviceType string, onResult func(browseResult)) error {
+	cServiceType := C.CString(serviceType)
+	defer C.free(unsafe.Pointer(cServiceType))
+
+	session := &dnssdSession{
+		onBrowse: func(_ uint32, ifIndex uint32, name, domain string) {
+			interfaceName := ""
+			// Silently leaves interfaceName empty when the interface disappears
+			// between browse and resolve; USB detection is skipped for that
+			// device rather than failing the browse.
+			if iface, err := net.InterfaceByIndex(int(ifIndex)); err == nil {
+				interfaceName = iface.Name
+			}
+			onResult(browseResult{
+				instanceName:  name,
+				domain:        domain,
+				interfaceName: interfaceName,
+			})
+		},
+	}
+
+	err := runDNSSDSession(ctx, session, func(ref *C.DNSServiceRef, handle C.uintptr_t) C.DNSServiceErrorType {
+		return C.wendy_dnssd_browse(ref, cServiceType, handle)
+	})
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	return err
+}
+
+// dnssdBrowse collects browse results, returning once results stop arriving.
+// Once the first result lands it waits dnssdBrowseSettle for more, so a
+// populated network does not pay the full timeout.
+func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
+	browseCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	resultCh := make(chan browseResult, 16)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- dnssdBrowseStream(browseCtx, serviceType, func(r browseResult) {
+			select {
+			case resultCh <- r:
+			case <-browseCtx.Done():
+			}
+		})
+	}()
+
+	var results []browseResult
+	seen := make(map[string]bool)
+	var settle <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return results, nil
+		case err := <-errCh:
+			if err != nil && len(results) == 0 {
+				return nil, err
+			}
+			return results, nil
+		case r := <-resultCh:
+			key := r.instanceName + "%" + r.interfaceName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			results = append(results, r)
+			settle = time.After(dnssdBrowseSettle)
+		case <-settle:
+			return results, nil
+		}
+	}
+}
+
+// dnssdRegister advertises a service until the returned stop func is called.
+// It exists for tests: it lets the browse and resolve paths run against a known
+// service without a device on the network. cgo cannot be used from _test.go
+// files, so the helper has to live here.
+func dnssdRegister(instance, serviceType string, port uint16, txt map[string]string) (func(), error) {
+	cInstance := C.CString(instance)
+	defer C.free(unsafe.Pointer(cInstance))
+	cServiceType := C.CString(serviceType)
+	defer C.free(unsafe.Pointer(cServiceType))
+
+	var txtWire []byte
+	for k, v := range txt {
+		entry := k + "=" + v
+		txtWire = append(txtWire, byte(len(entry)))
+		txtWire = append(txtWire, entry...)
+	}
+	var txtPtr unsafe.Pointer
+	if len(txtWire) > 0 {
+		txtPtr = C.CBytes(txtWire)
+		defer C.free(txtPtr)
+	}
+
+	var ref C.DNSServiceRef
+	// DNSServiceRegister takes the port in network byte order, and accepts a
+	// nil callback when the caller does not need the confirmation reply.
+	netPort := C.uint16_t(port<<8 | port>>8)
+	err := dnssdError(C.DNSServiceRegister(&ref, 0, C.kDNSServiceInterfaceIndexAny,
+		cInstance, cServiceType, nil, nil, netPort,
+		C.uint16_t(len(txtWire)), txtPtr, nil, nil))
+	if err != nil {
+		return nil, err
+	}
+	return func() { C.DNSServiceRefDeallocate(ref) }, nil
+}
+
+// dnssdResolveInstance resolves one browse result to its hostname, port and TXT
+// records.
+func dnssdResolveInstance(ctx context.Context, inst browseResult, serviceType string) (string, int, map[string]string, error) {
+	cName := C.CString(inst.instanceName)
+	defer C.free(unsafe.Pointer(cName))
+	cServiceType := C.CString(serviceType)
+	defer C.free(unsafe.Pointer(cServiceType))
+	cDomain := C.CString(inst.domain)
+	defer C.free(unsafe.Pointer(cDomain))
+
+	var (
+		hostname   string
+		port       int
+		txtRecords map[string]string
+	)
+	session := &dnssdSession{
+		onResolve: func(host string, p int, txt []byte) {
+			hostname = strings.TrimSuffix(host, ".")
+			port = p
+			txtRecords = parseTXTRecord(txt)
+		},
+	}
+
+	err := runDNSSDSession(ctx, session, func(ref *C.DNSServiceRef, handle C.uintptr_t) C.DNSServiceErrorType {
+		return C.wendy_dnssd_resolve(ref, cName, cServiceType, cDomain, handle)
+	})
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return "", 0, nil, err
+	}
+	if hostname == "" {
+		return "", 0, nil, fmt.Errorf("could not resolve instance %q", inst.instanceName)
+	}
+	if txtRecords == nil {
+		txtRecords = make(map[string]string)
+	}
+	return hostname, port, txtRecords, nil
+}

--- a/go/internal/shared/discovery/dnssd_darwin.h
+++ b/go/internal/shared/discovery/dnssd_darwin.h
@@ -1,0 +1,19 @@
+#ifndef WENDY_DNSSD_DARWIN_H
+#define WENDY_DNSSD_DARWIN_H
+
+#include <dns_sd.h>
+#include <stdint.h>
+
+// Browse and resolve wrappers around <dns_sd.h>. Each takes an opaque handle
+// that identifies the Go-side session; the C reply callbacks forward it back
+// to Go. Declarations only — cgo forbids C definitions in the preamble of a
+// file that also uses //export.
+
+DNSServiceErrorType wendy_dnssd_browse(DNSServiceRef *ref, const char *regtype,
+                                       uintptr_t handle);
+
+DNSServiceErrorType wendy_dnssd_resolve(DNSServiceRef *ref, const char *name,
+                                        const char *regtype, const char *domain,
+                                        uintptr_t handle);
+
+#endif

--- a/go/internal/shared/discovery/dnssd_darwin_test.go
+++ b/go/internal/shared/discovery/dnssd_darwin_test.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestDNSSDBrowseAndResolve exercises the cgo binding end to end against
+// mDNSResponder: the C trampolines, the session handle registry, and the socket
+// pump. It registers its own service, so it needs no device on the network.
+//
+// The assertions are the two things the binding can get wrong without failing
+// loudly: the port arrives in network byte order and must be swapped, and TXT
+// values are length-prefixed records that must survive spaces intact — the case
+// the previous implementation recovered by unescaping dns-sd's display output.
+func TestDNSSDBrowseAndResolve(t *testing.T) {
+	// A service type of its own, so a browse cannot pick up real devices, and a
+	// pid in the instance name so concurrent test binaries do not collide and
+	// trigger mDNSResponder's conflict renaming.
+	const serviceType = "_wendy-selftest._tcp"
+	instance := fmt.Sprintf("wendy-selftest-%d", os.Getpid())
+
+	want := map[string]string{
+		"displayname": "Tom Rpi4",
+		"assetid":     "338",
+		"tls":         "true",
+	}
+	stop, err := dnssdRegister(instance, serviceType, 51234, want)
+	if err != nil {
+		t.Skipf("cannot register an mDNS service (is mDNSResponder reachable?): %v", err)
+	}
+	t.Cleanup(stop)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	results, err := dnssdBrowse(ctx, serviceType)
+	if err != nil {
+		t.Fatalf("dnssdBrowse: %v", err)
+	}
+	var inst browseResult
+	for _, r := range results {
+		if r.instanceName == instance {
+			inst = r
+			break
+		}
+	}
+	if inst.instanceName == "" {
+		t.Fatalf("browse did not return %q; got %+v", instance, results)
+	}
+
+	hostname, port, txt, err := dnssdResolveInstance(ctx, inst, serviceType)
+	if err != nil {
+		t.Fatalf("dnssdResolveInstance: %v", err)
+	}
+	if hostname == "" {
+		t.Error("resolve returned an empty hostname")
+	}
+	if port != 51234 {
+		t.Errorf("port = %d, want 51234", port)
+	}
+	for k, v := range want {
+		if txt[k] != v {
+			t.Errorf("TXT[%q] = %q, want %q", k, txt[k], v)
+		}
+	}
+}

--- a/go/internal/shared/discovery/mdns.go
+++ b/go/internal/shared/discovery/mdns.go
@@ -1,6 +1,9 @@
 package discovery
 
-import "net"
+import (
+	"net"
+	"strings"
+)
 
 // MDNSService represents a generic mDNS service entry discovered on the network.
 type MDNSService struct {
@@ -9,6 +12,35 @@ type MDNSService struct {
 	IPAddress    string
 	Port         int
 	TXTRecords   map[string]string
+}
+
+// parseTXTRecord decodes a DNS-SD TXT record from its wire format: a sequence
+// of length-prefixed "key=value" strings (RFC 6763 §6.1). A entry with no "="
+// is a boolean attribute and maps to an empty value.
+//
+// Per RFC 6763 §6.4 the first occurrence of a repeated key wins. A length that
+// overruns the buffer ends parsing and keeps what was decoded so far, so a
+// truncated record still yields its leading entries.
+func parseTXTRecord(txt []byte) map[string]string {
+	records := make(map[string]string)
+	for i := 0; i < len(txt); {
+		n := int(txt[i])
+		i++
+		if n == 0 || i+n > len(txt) {
+			break
+		}
+		entry := string(txt[i : i+n])
+		i += n
+
+		key, value, _ := strings.Cut(entry, "=")
+		if key == "" {
+			continue
+		}
+		if _, exists := records[key]; !exists {
+			records[key] = value
+		}
+	}
+	return records
 }
 
 // preferIPv4Addr returns the first IPv4 address in addrs, or the first address

--- a/go/internal/shared/discovery/mdns.go
+++ b/go/internal/shared/discovery/mdns.go
@@ -15,18 +15,23 @@ type MDNSService struct {
 }
 
 // parseTXTRecord decodes a DNS-SD TXT record from its wire format: a sequence
-// of length-prefixed "key=value" strings (RFC 6763 §6.1). A entry with no "="
+// of length-prefixed "key=value" strings (RFC 6763 §6.1). An entry with no "="
 // is a boolean attribute and maps to an empty value.
 //
-// Per RFC 6763 §6.4 the first occurrence of a repeated key wins. A length that
-// overruns the buffer ends parsing and keeps what was decoded so far, so a
-// truncated record still yields its leading entries.
+// Per RFC 6763 §6.4 the first occurrence of a repeated key wins. A zero-length
+// string carries no attribute and is skipped rather than ending the record, so
+// one cannot mask the entries behind it. A length that overruns the buffer does
+// end parsing, keeping what was decoded so far, so a truncated record still
+// yields its leading entries.
 func parseTXTRecord(txt []byte) map[string]string {
 	records := make(map[string]string)
 	for i := 0; i < len(txt); {
 		n := int(txt[i])
 		i++
-		if n == 0 || i+n > len(txt) {
+		if n == 0 {
+			continue
+		}
+		if i+n > len(txt) {
 			break
 		}
 		entry := string(txt[i : i+n])

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -3,17 +3,14 @@
 package discovery
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net"
-	"os/exec"
-	"strings"
 	"time"
 )
 
 // BrowseMDNSServices discovers mDNS services of the given type on macOS
-// using dns-sd. Returns all services found within the timeout.
+// through mDNSResponder. Returns all services found within the timeout.
 func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Duration) ([]MDNSService, error) {
 	if timeout == 0 {
 		timeout = defaultTimeout
@@ -49,60 +46,11 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	return services, nil
 }
 
-// resolveMDNSService runs dns-sd -L to resolve a browse result into an MDNSService.
+// resolveMDNSService resolves a browse result into an MDNSService.
 func resolveMDNSService(ctx context.Context, inst browseResult, serviceType string) (MDNSService, error) {
-	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, serviceType, inst.domain)
-	stdout, err := cmd.StdoutPipe()
+	hostname, port, txtRecords, err := dnssdResolveInstance(ctx, inst, serviceType)
 	if err != nil {
 		return MDNSService{}, err
-	}
-	if err := cmd.Start(); err != nil {
-		return MDNSService{}, err
-	}
-
-	var hostname string
-	var port int
-	txtRecords := make(map[string]string)
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if strings.Contains(line, "can be reached at") {
-			parts := strings.Fields(line)
-			for i, p := range parts {
-				if p == "at" && i+1 < len(parts) {
-					hostPort := parts[i+1]
-					h, portStr, splitErr := net.SplitHostPort(hostPort)
-					if splitErr == nil {
-						hostname = strings.TrimSuffix(h, ".")
-						fmt.Sscanf(portStr, "%d", &port)
-					}
-					break
-				}
-			}
-
-			if scanner.Scan() {
-				txtLine := scanner.Text()
-				if strings.HasPrefix(txtLine, " ") {
-					txtParts := strings.Fields(txtLine)
-					for _, field := range txtParts {
-						if k, v, ok := strings.Cut(field, "="); ok {
-							txtRecords[k] = v
-						}
-					}
-				}
-			}
-
-			_ = cmd.Process.Kill()
-			break
-		}
-	}
-
-	_ = cmd.Wait()
-
-	if hostname == "" {
-		return MDNSService{}, fmt.Errorf("could not resolve instance %q", inst.instanceName)
 	}
 
 	ipAddr := ""

--- a/go/internal/shared/discovery/mdns_test.go
+++ b/go/internal/shared/discovery/mdns_test.go
@@ -1,6 +1,78 @@
 package discovery
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// txtWire encodes entries into DNS-SD TXT wire format.
+func txtWire(entries ...string) []byte {
+	var out []byte
+	for _, e := range entries {
+		out = append(out, byte(len(e)))
+		out = append(out, e...)
+	}
+	return out
+}
+
+func TestParseTXTRecord(t *testing.T) {
+	cases := []struct {
+		name string
+		txt  []byte
+		want map[string]string
+	}{
+		{name: "empty", txt: nil, want: map[string]string{}},
+		{
+			name: "key=value pairs",
+			txt:  txtWire("tls=true", "assetid=338"),
+			want: map[string]string{"tls": "true", "assetid": "338"},
+		},
+		{
+			// The reason this parser exists: dns-sd's display format escaped
+			// spaces as "\ " and the old code had to undo that by hand.
+			name: "value containing spaces is preserved verbatim",
+			txt:  txtWire("displayname=Tom Rpi4"),
+			want: map[string]string{"displayname": "Tom Rpi4"},
+		},
+		{
+			name: "value containing an equals sign keeps it",
+			txt:  txtWire("token=abc=def"),
+			want: map[string]string{"token": "abc=def"},
+		},
+		{
+			name: "attribute with no value maps to empty string",
+			txt:  txtWire("standalone"),
+			want: map[string]string{"standalone": ""},
+		},
+		{
+			name: "first occurrence of a repeated key wins (RFC 6763 6.4)",
+			txt:  txtWire("dup=first", "dup=second"),
+			want: map[string]string{"dup": "first"},
+		},
+		{
+			name: "entry with an empty key is skipped",
+			txt:  txtWire("=orphaned", "tls=true"),
+			want: map[string]string{"tls": "true"},
+		},
+		{
+			name: "zero length byte ends parsing",
+			txt:  append(txtWire("tls=true"), 0x00, 'x'),
+			want: map[string]string{"tls": "true"},
+		},
+		{
+			name: "length overrunning the buffer keeps what was decoded",
+			txt:  append(txtWire("tls=true"), 0x40, 'a', 'b'),
+			want: map[string]string{"tls": "true"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseTXTRecord(tc.txt); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseTXTRecord(%v) = %v, want %v", tc.txt, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestPreferIPv4Addr(t *testing.T) {
 	cases := []struct {

--- a/go/internal/shared/discovery/mdns_test.go
+++ b/go/internal/shared/discovery/mdns_test.go
@@ -55,9 +55,10 @@ func TestParseTXTRecord(t *testing.T) {
 			want: map[string]string{"tls": "true"},
 		},
 		{
-			name: "zero length byte ends parsing",
-			txt:  append(txtWire("tls=true"), 0x00, 'x'),
-			want: map[string]string{"tls": "true"},
+			// A zero-length string must not mask the entries after it.
+			name: "zero length string is skipped, later entries still decoded",
+			txt:  append(append(txtWire("displayname=Tom Rpi4"), 0x00), txtWire("tls=true")...),
+			want: map[string]string{"displayname": "Tom Rpi4", "tls": "true"},
 		},
 		{
 			name: "length overrunning the buffer keeps what was decoded",


### PR DESCRIPTION
Fixes WDY-1831.

## Problem

Sustained polling of the CLI on macOS leaves orphaned `dns-sd` helper processes behind. They accumulate until the per-user process limit is reached, at which point every process spawn on the machine fails and the user session freezes. Two incidents on one laptop, ~2,200 orphans each.

Any `dns-sd` still alive when the CLI process dies is reparented to launchd and never exits. macOS has no `PR_SET_PDEATHSIG`, so parent-side signal handling cannot close this: a harness confirmed that SIGKILLing a parent holding a live browse orphans the helper every time, on any service type, with or without a pipe. The issue's suggested direction (same process group, kill on signal/exit) does not work — the helper is already in the parent's process group.

The only fix that holds is to not spawn a process.

## Change

Browse and resolve in-process through `<dns_sd.h>`, which is what the `dns-sd` tool itself wraps. Same mDNSResponder daemon, so the interface coverage that motivated shelling out is unchanged, including USB host-mode. A daemon connection cannot outlive the process holding it.

Linux and Windows are untouched.

The API returns structured records, so the parsing of human-readable output goes: the `can be reached at` scrape, the hand-rolled unescaping of `\ ` in TXT values, and `unescapeDNSSDName`. Instance names now arrive decoded, matching what the Linux and Windows backends already produced.

TXT decoding moves to `parseTXTRecord`, reading the length-prefixed wire format. Two deliberate behaviour changes over the old line parser: an entry with no `=` is a boolean attribute rather than being dropped, and a repeated key takes its first value (RFC 6763 6.4) rather than its last.

## Why not a library

Every maintained Go mDNS library is a pure-Go reimplementation of multicast DNS, not a client of mDNSResponder — including `hashicorp/mdns`, which this repo already carries as the weaker fallback for Linux-without-avahi and for Windows. Adopting one on macOS would trade a process leak for missing devices. The one library that did bind `dns_sd.h`, `andrewtj/dnssd`, is gone from GitHub.

The added C is 48 lines, against 234 lines of Objective-C already in this package for CoreBluetooth. Unlike CoreBluetooth, `dns_sd.h` is a frozen system API in libSystem.

## Verification

Against a Raspberry Pi 4 and a Jetson AGX Thor:

- `discover --json` output byte-identical to the previous build across repeated runs, including `displayName` values containing spaces
- `device info` works over mTLS on both devices
- five concurrent pollers for 30s, sampled twice a second: peak of zero `dns-sd` processes, where the previous build leaked
- continuous discovery streams both devices and tears down on cancel
- race detector clean

## Tests

Two, covering what can break silently:

- `parseTXTRecord`: wire-format decoding, including malformed input. Runs on Linux CI.
- `TestDNSSDBrowseAndResolve`: the cgo binding end to end — browse and resolve against a service the test registers itself, so it needs no device. Checks the network-byte-order port and TXT values containing spaces.

Both were mutation-tested: dropping the buffer-overrun guard, inverting repeated-key precedence, dropping the zero-length-string skip, and dropping `ntohs` on the resolved port each fail a test.

`dnssdRegister` lives in non-test code because cgo cannot be used from `_test.go` files. It exists only for the test above.