### PR TITLE
fix(agent): resolve stop/delete targets by container ID, then app-id label

### DIFF
--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -256,8 +256,7 @@ func (m *statefulContainerdClient) ContainerIDsForApp(_ context.Context, appID s
 }
 
 // ResolveAppContainerIDs mirrors the real resolver: an exact container name
-// first, then the app-id, then NotFound. This fake keys containers by name, so
-// a bare appID matches the container itself or its "{appID}_{service}" members.
+// first, then the app-id, then NotFound.
 func (m *statefulContainerdClient) ResolveAppContainerIDs(_ context.Context, name string) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/go/integration_test.go
+++ b/go/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -250,6 +251,28 @@ func (m *statefulContainerdClient) ContainerIDsForApp(_ context.Context, appID s
 		if name == appID || strings.HasPrefix(name, prefix) {
 			ids = append(ids, name)
 		}
+	}
+	return ids, nil
+}
+
+// ResolveAppContainerIDs mirrors the real resolver: an exact container name
+// first, then the app-id, then NotFound. This fake keys containers by name, so
+// a bare appID matches the container itself or its "{appID}_{service}" members.
+func (m *statefulContainerdClient) ResolveAppContainerIDs(_ context.Context, name string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.containers[name]; ok {
+		return []string{name}, nil
+	}
+	var ids []string
+	prefix := name + "_"
+	for ctr := range m.containers {
+		if strings.HasPrefix(ctr, prefix) {
+			ids = append(ids, ctr)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("%w: no app or service named %q", errdefs.ErrNotFound, name)
 	}
 	return ids, nil
 }

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -119,12 +119,19 @@ func (m *ContainerMonitor) Unregister(appName string) {
 }
 
 // MarkExplicitStop marks a container as explicitly stopped, preventing restart.
+// An unknown key is logged rather than ignored: a mark that silently evaporates
+// leaves the restart policy live on a container the user believes is stopped,
+// and that silence is what hid WDY-1847.
 func (m *ContainerMonitor) MarkExplicitStop(appName string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if state, ok := m.states[appName]; ok {
-		state.ExplicitStop = true
+	state, ok := m.states[appName]
+	if !ok {
+		m.logger.Warn("MarkExplicitStop: container not registered for monitoring; restart policy unchanged",
+			zap.String("app_name", appName))
+		return
 	}
+	state.ExplicitStop = true
 }
 
 // ClearExplicitStop reverts a prior MarkExplicitStop, re-enabling automatic

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -119,9 +119,8 @@ func (m *ContainerMonitor) Unregister(appName string) {
 }
 
 // MarkExplicitStop marks a container as explicitly stopped, preventing restart.
-// An unknown key is logged rather than ignored: a mark that silently evaporates
-// leaves the restart policy live on a container the user believes is stopped,
-// and that silence is what hid WDY-1847.
+// An unknown key leaves the restart policy live on a container the user
+// believes is stopped, so it is logged rather than ignored.
 func (m *ContainerMonitor) MarkExplicitStop(appName string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -111,6 +111,9 @@ func (f *fakeContainerd) DeleteContainer(ctx context.Context, appName string, de
 func (f *fakeContainerd) ContainerIDsForApp(ctx context.Context, appID string) ([]string, error) {
 	return nil, nil
 }
+func (f *fakeContainerd) ResolveAppContainerIDs(ctx context.Context, name string) ([]string, error) {
+	return nil, nil
+}
 func (f *fakeContainerd) GetContainerStats(ctx context.Context) ([]*agentpb.ContainerStats, error) {
 	return nil, nil
 }

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1478,10 +1478,8 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	}()
 	ctx = c.withNamespace(ctx)
 
-	// Shared with StopContainer: the container ID first, then the app-id label,
-	// so a bare appID and "{appID}_{serviceName}" both work. Start needs exactly
-	// one container because it streams that container's output, so a bare appID
-	// naming a multi-service group is an error here rather than a fan-out.
+	// Start streams one container's output, so a bare appID naming a group is
+	// an error here rather than a fan-out.
 	ctrs, _, _, err := c.resolveTargets(ctx, appName)
 	if err != nil {
 		return nil, fmt.Errorf("loading container %q: %w", appName, err)
@@ -1608,7 +1606,10 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// getIsolation requires c.mu (held here via muHeld).
 	isolation := c.getIsolation(appID)
 	if appconfig.IsSharedNamespaceIsolation(isolation) {
-		if _, alreadyHasPrimary := c.getPrimaryPID(appID); !alreadyHasPrimary {
+		// Presence alone is not enough: a per-service stop leaves the group
+		// entry behind, so a dead PID must be replaced rather than kept.
+		primaryPID, hasPrimary := c.getPrimaryPID(appID)
+		if !hasPrimary || !c.primaryTaskAlive(ctx, appID, primaryPID) {
 			c.setPrimaryPID(appID, task.Pid())
 		}
 	}
@@ -2783,46 +2784,43 @@ func (c *Client) streamOutput(
 	outputCh <- services.ContainerOutput{Done: true}
 }
 
-// resolveTargets resolves a caller-supplied name to the containers it
-// addresses. Resolution order is the same one StartContainer uses:
+// resolveTargets resolves name to the containers it addresses:
 //
 //  1. a container whose ID equals name — a single-container app, or one service
-//     of a multi-service app addressed as "{appID}_{serviceName}"
-//  2. containers whose labelKeyAppID equals name — a bare appID addressing every
-//     service in the group
+//     addressed as "{appID}_{serviceName}"
+//  2. containers whose labelKeyAppID equals name — every service in the group
 //  3. neither — errdefs.ErrNotFound
 //
-// Rule 1 is deterministic rather than a guess: container IDs are unique within
-// the containerd namespace, and both readings of "myapp_alpha" (a single-container
-// app of that name, and service "alpha" of app "myapp") want the same container
-// ID, so at most one can exist.
-//
-// A name that resolves to nothing must be an error, never a silent success: the
-// label-only lookup that predated this returned no containers for any
-// service-qualified name and reported the stop as done (WDY-1847).
-//
-// appID is the label-derived group identity, used for per-app bookkeeping.
-// wholeApp reports whether the name addressed every container in the group,
-// which is true for a bare appID and for any single-container app.
+// Container IDs are unique within the namespace, so rule 1 has at most one hit.
+// appID is the label-derived group identity; wholeApp reports whether name
+// addressed every container in the group.
 //
 // Caller must hold c.mu. ctx must already have the containerd namespace set.
 func (c *Client) resolveTargets(ctx context.Context, name string) (ctrs []containerd.Container, appID string, wholeApp bool, err error) {
-	// Re-validate at the injection site: name reaches the containerd filter
-	// expression via containersForApp below (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+	// name reaches the containerd filter expression via containersForApp
+	// (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
 	if verr := appconfig.ValidateAppID(name); verr != nil {
 		return nil, "", false, fmt.Errorf("invalid app name: %w", verr)
 	}
 
-	if ctr, loadErr := c.client.LoadContainer(ctx, name); loadErr == nil {
-		appID = c.appIDForContainer(ctx, ctr, name)
-		group, groupErr := c.containersForApp(ctx, appID)
-		if groupErr != nil {
-			return nil, "", false, groupErr
+	ctr, loadErr := c.client.LoadContainer(ctx, name)
+	switch {
+	case loadErr == nil:
+		// The "default" namespace is shared with anything else that speaks to
+		// containerd, so an ID match alone is not proof this is ours: require
+		// the app-id label (SOC2-CC6, NIST-AC-3, ISO27001-A.8).
+		if id, ok := c.wendyAppIDOf(ctx, ctr); ok {
+			group, groupErr := c.containersForApp(ctx, id)
+			if groupErr != nil {
+				return nil, "", false, groupErr
+			}
+			return []containerd.Container{ctr}, id, len(group) <= 1, nil
 		}
-		// A group of one means this container is the whole app, however it was
-		// addressed. Containers predating the app-id label report no group at
-		// all; treat that as whole-app too so their metadata is still released.
-		return []containerd.Container{ctr}, appID, len(group) <= 1, nil
+		// Unlabelled or foreign: fall through, which reports NotFound.
+	case !errdefs.IsNotFound(loadErr):
+		// A real lookup failure must not be laundered into NotFound.
+		return nil, "", false, fmt.Errorf("loading container %q: %w",
+			sanitizeForLog(name, 253), loadErr)
 	}
 
 	group, err := c.containersForApp(ctx, name)
@@ -2836,22 +2834,20 @@ func (c *Client) resolveTargets(ctx context.Context, name string) (ctrs []contai
 	return group, name, true, nil
 }
 
-// appIDForContainer returns the group identity for ctr, preferring the label
-// written at create time over the container ID. The ID is ambiguous for
-// multi-service containers because '_' is legal inside an appID, so
-// "myapp_alpha" would otherwise key group bookkeeping under the wrong identity.
-// Labels are external state, so the value is re-validated before use
-// (SOC2-CC6, NIST-SI-10). Falls back to fallbackID when the label is missing or
-// malformed.
-func (c *Client) appIDForContainer(ctx context.Context, ctr containerd.Container, fallbackID string) string {
+// wendyAppIDOf returns ctr's group identity from its app-id label, and whether
+// ctr is Wendy-managed at all. The container ID cannot stand in for a missing
+// label: '_' is legal inside an appID, so "myapp_alpha" is ambiguous. Labels are
+// external state, so the value is re-validated (SOC2-CC6, NIST-SI-10).
+func (c *Client) wendyAppIDOf(ctx context.Context, ctr containerd.Container) (string, bool) {
 	labels, err := ctr.Labels(ctx)
 	if err != nil {
-		return fallbackID
+		return "", false
 	}
-	if id := labels[labelKeyAppID]; id != "" && appconfig.ValidateAppID(id) == nil {
-		return id
+	id := labels[labelKeyAppID]
+	if id == "" || appconfig.ValidateAppID(id) != nil {
+		return "", false
 	}
-	return fallbackID
+	return id, true
 }
 
 // containersForApp returns all Wendy-managed containers whose labelKeyAppID
@@ -2904,15 +2900,8 @@ func (c *Client) ContainerIDsForApp(ctx context.Context, appID string) ([]string
 	return ids, nil
 }
 
-// ResolveAppContainerIDs returns the container IDs addressed by name, using the
-// same resolution as StopContainer: a bare appID yields every service in the
-// app, "{appID}_{serviceName}" yields that one service, and a name matching
-// neither returns errdefs.ErrNotFound.
-//
-// The service layer uses this to mark containers in the monitor and persist the
-// stopped-by-user label. It must never invent an ID for an unresolvable name:
-// doing so wrote both marks against a container the stop had not touched
-// (WDY-1847).
+// ResolveAppContainerIDs returns the container IDs addressed by name. See
+// resolveTargets.
 func (c *Client) ResolveAppContainerIDs(ctx context.Context, name string) ([]string, error) {
 	ctx = c.withNamespace(ctx)
 	c.mu.Lock()
@@ -3025,9 +3014,8 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 	return nil
 }
 
-// StopContainer stops the containers addressed by name. A bare appID stops
-// every service in the app; "{appID}_{serviceName}" stops that one service.
-// A name matching neither is an error — stopping nothing is never a success.
+// StopContainer stops the containers addressed by name: a bare appID stops
+// every service, "{appID}_{serviceName}" stops one. See resolveTargets.
 // c.mu is held for the full duration to prevent a concurrent
 // CreateContainerWithProgress from inserting a new service container between
 // the list query and the stop loop (TOCTOU, SOC2-CC6, NIST-AC-4).
@@ -3063,10 +3051,8 @@ func (c *Client) StopContainer(ctx context.Context, name string) error {
 		}
 	}
 
-	// Per-app state belongs to the whole group, so it is only released when the
-	// whole group was stopped. Stopping one service of a multi-service app must
-	// leave its siblings' isolation mode, service IPs and namespace-owner PID
-	// intact — they are still running.
+	// Per-app state is only released once the whole group is stopped; siblings
+	// still need it.
 	if wholeApp {
 		// Re-acquire mutex for map cleanup. Both reads and writes of these maps
 		// are protected by c.mu to prevent data races with concurrent callers
@@ -3082,8 +3068,6 @@ func (c *Client) StopContainer(ctx context.Context, name string) error {
 		// resolveStopOrder snapshotted the list (e.g. a concurrent StartContainer
 		// mid-CNI-ADD). stopOne is idempotent for already-stopped containers.
 		// appStopping is still set during this sweep to block new concurrent creates.
-		// Scoped to the whole-app case: sweeping the group after a single-service
-		// stop would take that service's siblings down with it.
 		if lateCtrs, lateErr := c.containersForApp(ctx, appID); lateErr == nil && len(lateCtrs) > 0 {
 			for _, ctr := range lateCtrs {
 				if stopErr := c.stopOne(ctx, ctr.ID()); stopErr != nil {
@@ -3300,20 +3284,15 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 // DeleteContainer deletes all containers belonging to appID. For multi-service
 // apps all service containers are removed. When deleteImage is true, each
 // distinct image is deleted once (services sharing an image are handled safely).
-func (c *Client) DeleteContainer(ctx context.Context, appID string, deleteImage bool) error {
+func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	ctx = c.withNamespace(ctx)
-	ctrs, err := c.containersForApp(ctx, appID)
+	// A bare appID deletes every service; "{appID}_{serviceName}" deletes one.
+	ctrs, appID, wholeApp, err := c.resolveTargets(ctx, name)
 	if err != nil {
 		return err
-	}
-	if len(ctrs) == 0 {
-		if c.systemAPISocketProvider != nil {
-			c.systemAPISocketProvider.ReleaseApp(appID)
-		}
-		return nil // Already gone.
 	}
 
 	seen := make(map[string]bool)
@@ -3337,7 +3316,8 @@ func (c *Client) DeleteContainer(ctx context.Context, appID string, deleteImage 
 			}
 		}
 	}
-	if len(errs) == 0 && c.systemAPISocketProvider != nil {
+	// The system-API socket is per app: only release it once the app is gone.
+	if len(errs) == 0 && wholeApp && c.systemAPISocketProvider != nil {
 		c.systemAPISocketProvider.ReleaseApp(appID)
 	}
 	return errors.Join(errs...)

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1478,22 +1478,18 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	}()
 	ctx = c.withNamespace(ctx)
 
-	container, err := c.client.LoadContainer(ctx, appName)
+	// Shared with StopContainer: the container ID first, then the app-id label,
+	// so a bare appID and "{appID}_{serviceName}" both work. Start needs exactly
+	// one container because it streams that container's output, so a bare appID
+	// naming a multi-service group is an error here rather than a fan-out.
+	ctrs, _, _, err := c.resolveTargets(ctx, appName)
 	if err != nil {
-		// Fall back to a label-based lookup so that callers can pass the bare
-		// appID (e.g. "myapp") even when the container was created under a
-		// multi-service name (e.g. "myapp/api" for serviceName="api").
-		// If the label query returns exactly one container we use it; if it
-		// returns multiple the caller must be more specific.
-		ctrs, labelErr := c.containersForApp(ctx, appName)
-		if labelErr != nil || len(ctrs) == 0 {
-			return nil, fmt.Errorf("loading container %q: %w", appName, err)
-		}
-		if len(ctrs) > 1 {
-			return nil, fmt.Errorf("app %q has multiple service containers; use the full container name (appID_serviceName) to start a specific service", appName)
-		}
-		container = ctrs[0]
+		return nil, fmt.Errorf("loading container %q: %w", appName, err)
 	}
+	if len(ctrs) > 1 {
+		return nil, fmt.Errorf("app %q has multiple service containers; use the full container name (appID_serviceName) to start a specific service", appName)
+	}
+	container := ctrs[0]
 
 	// Name parsing is ambiguous for multi-service containers because '_' is
 	// also legal inside appIDs: "app_talker" parses as a bare appID, which
@@ -2787,6 +2783,77 @@ func (c *Client) streamOutput(
 	outputCh <- services.ContainerOutput{Done: true}
 }
 
+// resolveTargets resolves a caller-supplied name to the containers it
+// addresses. Resolution order is the same one StartContainer uses:
+//
+//  1. a container whose ID equals name — a single-container app, or one service
+//     of a multi-service app addressed as "{appID}_{serviceName}"
+//  2. containers whose labelKeyAppID equals name — a bare appID addressing every
+//     service in the group
+//  3. neither — errdefs.ErrNotFound
+//
+// Rule 1 is deterministic rather than a guess: container IDs are unique within
+// the containerd namespace, and both readings of "myapp_alpha" (a single-container
+// app of that name, and service "alpha" of app "myapp") want the same container
+// ID, so at most one can exist.
+//
+// A name that resolves to nothing must be an error, never a silent success: the
+// label-only lookup that predated this returned no containers for any
+// service-qualified name and reported the stop as done (WDY-1847).
+//
+// appID is the label-derived group identity, used for per-app bookkeeping.
+// wholeApp reports whether the name addressed every container in the group,
+// which is true for a bare appID and for any single-container app.
+//
+// Caller must hold c.mu. ctx must already have the containerd namespace set.
+func (c *Client) resolveTargets(ctx context.Context, name string) (ctrs []containerd.Container, appID string, wholeApp bool, err error) {
+	// Re-validate at the injection site: name reaches the containerd filter
+	// expression via containersForApp below (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+	if verr := appconfig.ValidateAppID(name); verr != nil {
+		return nil, "", false, fmt.Errorf("invalid app name: %w", verr)
+	}
+
+	if ctr, loadErr := c.client.LoadContainer(ctx, name); loadErr == nil {
+		appID = c.appIDForContainer(ctx, ctr, name)
+		group, groupErr := c.containersForApp(ctx, appID)
+		if groupErr != nil {
+			return nil, "", false, groupErr
+		}
+		// A group of one means this container is the whole app, however it was
+		// addressed. Containers predating the app-id label report no group at
+		// all; treat that as whole-app too so their metadata is still released.
+		return []containerd.Container{ctr}, appID, len(group) <= 1, nil
+	}
+
+	group, err := c.containersForApp(ctx, name)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if len(group) == 0 {
+		return nil, "", false, fmt.Errorf("%w: no app or service named %q",
+			errdefs.ErrNotFound, sanitizeForLog(name, 253))
+	}
+	return group, name, true, nil
+}
+
+// appIDForContainer returns the group identity for ctr, preferring the label
+// written at create time over the container ID. The ID is ambiguous for
+// multi-service containers because '_' is legal inside an appID, so
+// "myapp_alpha" would otherwise key group bookkeeping under the wrong identity.
+// Labels are external state, so the value is re-validated before use
+// (SOC2-CC6, NIST-SI-10). Falls back to fallbackID when the label is missing or
+// malformed.
+func (c *Client) appIDForContainer(ctx context.Context, ctr containerd.Container, fallbackID string) string {
+	labels, err := ctr.Labels(ctx)
+	if err != nil {
+		return fallbackID
+	}
+	if id := labels[labelKeyAppID]; id != "" && appconfig.ValidateAppID(id) == nil {
+		return id
+	}
+	return fallbackID
+}
+
 // containersForApp returns all Wendy-managed containers whose labelKeyAppID
 // label equals appID. Both single-container apps (one container) and
 // multi-service apps (one container per service) are found this way, with no
@@ -2827,6 +2894,30 @@ func (c *Client) containersForApp(ctx context.Context, appID string) ([]containe
 func (c *Client) ContainerIDsForApp(ctx context.Context, appID string) ([]string, error) {
 	ctx = c.withNamespace(ctx)
 	ctrs, err := c.containersForApp(ctx, appID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(ctrs))
+	for i, ctr := range ctrs {
+		ids[i] = ctr.ID()
+	}
+	return ids, nil
+}
+
+// ResolveAppContainerIDs returns the container IDs addressed by name, using the
+// same resolution as StopContainer: a bare appID yields every service in the
+// app, "{appID}_{serviceName}" yields that one service, and a name matching
+// neither returns errdefs.ErrNotFound.
+//
+// The service layer uses this to mark containers in the monitor and persist the
+// stopped-by-user label. It must never invent an ID for an unresolvable name:
+// doing so wrote both marks against a container the stop had not touched
+// (WDY-1847).
+func (c *Client) ResolveAppContainerIDs(ctx context.Context, name string) ([]string, error) {
+	ctx = c.withNamespace(ctx)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ctrs, _, _, err := c.resolveTargets(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -2934,12 +3025,13 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 	return nil
 }
 
-// StopContainer stops all containers belonging to appID. For single-container
-// apps this is one container; for multi-service apps it stops every service.
+// StopContainer stops the containers addressed by name. A bare appID stops
+// every service in the app; "{appID}_{serviceName}" stops that one service.
+// A name matching neither is an error — stopping nothing is never a success.
 // c.mu is held for the full duration to prevent a concurrent
 // CreateContainerWithProgress from inserting a new service container between
 // the list query and the stop loop (TOCTOU, SOC2-CC6, NIST-AC-4).
-func (c *Client) StopContainer(ctx context.Context, appID string) error {
+func (c *Client) StopContainer(ctx context.Context, name string) error {
 	ctx = c.withNamespace(ctx)
 
 	// Hold mutex only long enough to enumerate containers and resolve stop order.
@@ -2947,17 +3039,10 @@ func (c *Client) StopContainer(ctx context.Context, appID string) error {
 	// blocking I/O (SIGTERM wait, 10 s timeout), which would starve concurrent
 	// StartContainer / CreateContainerWithProgress calls (SOC2-CC6, NIST-AC-3).
 	c.mu.Lock()
-	ctrs, err := c.containersForApp(ctx, appID)
+	ctrs, appID, wholeApp, err := c.resolveTargets(ctx, name)
 	if err != nil {
 		c.mu.Unlock()
 		return err
-	}
-	if len(ctrs) == 0 {
-		// Idempotent: already stopped / never created.
-		c.logger.Info("StopContainer: no containers found, already stopped",
-			zap.String(logfields.AppID, sanitizeForLog(appID, 253)))
-		c.mu.Unlock()
-		return nil
 	}
 	stopOrder := c.resolveStopOrder(ctx, appID, ctrs)
 	// Mark app as stopping before releasing the mutex so any concurrent
@@ -2978,26 +3063,34 @@ func (c *Client) StopContainer(ctx context.Context, appID string) error {
 		}
 	}
 
-	// Re-acquire mutex for map cleanup. Both reads and writes of these maps
-	// are protected by c.mu to prevent data races with concurrent callers
-	// (SOC2-CC6, NIST-AC-3, ISO27001-A.8).
-	// clearPrimaryPID under the lock; other per-app metadata is kept alive until
-	// after the late sweep so that appIsolation is still readable by any
-	// concurrent code that observes appStopping (SOC2-CC6, NIST-AC-3).
-	c.mu.Lock()
-	c.clearPrimaryPID(appID)
-	c.mu.Unlock()
+	// Per-app state belongs to the whole group, so it is only released when the
+	// whole group was stopped. Stopping one service of a multi-service app must
+	// leave its siblings' isolation mode, service IPs and namespace-owner PID
+	// intact — they are still running.
+	if wholeApp {
+		// Re-acquire mutex for map cleanup. Both reads and writes of these maps
+		// are protected by c.mu to prevent data races with concurrent callers
+		// (SOC2-CC6, NIST-AC-3, ISO27001-A.8).
+		// clearPrimaryPID under the lock; other per-app metadata is kept alive until
+		// after the late sweep so that appIsolation is still readable by any
+		// concurrent code that observes appStopping (SOC2-CC6, NIST-AC-3).
+		c.mu.Lock()
+		c.clearPrimaryPID(appID)
+		c.mu.Unlock()
 
-	// Re-enumerate unconditionally to catch any containers that appeared after
-	// resolveStopOrder snapshotted the list (e.g. a concurrent StartContainer
-	// mid-CNI-ADD). stopOne is idempotent for already-stopped containers.
-	// appStopping is still set during this sweep to block new concurrent creates.
-	if lateCtrs, lateErr := c.containersForApp(ctx, appID); lateErr == nil && len(lateCtrs) > 0 {
-		for _, ctr := range lateCtrs {
-			if stopErr := c.stopOne(ctx, ctr.ID()); stopErr != nil {
-				c.logger.Error("StopContainer: failed to stop late-appearing container",
-					zap.String("container_id", ctr.ID()), zap.Error(stopErr))
-				errs = append(errs, stopErr)
+		// Re-enumerate to catch any containers that appeared after
+		// resolveStopOrder snapshotted the list (e.g. a concurrent StartContainer
+		// mid-CNI-ADD). stopOne is idempotent for already-stopped containers.
+		// appStopping is still set during this sweep to block new concurrent creates.
+		// Scoped to the whole-app case: sweeping the group after a single-service
+		// stop would take that service's siblings down with it.
+		if lateCtrs, lateErr := c.containersForApp(ctx, appID); lateErr == nil && len(lateCtrs) > 0 {
+			for _, ctr := range lateCtrs {
+				if stopErr := c.stopOne(ctx, ctr.ID()); stopErr != nil {
+					c.logger.Error("StopContainer: failed to stop late-appearing container",
+						zap.String("container_id", ctr.ID()), zap.Error(stopErr))
+					errs = append(errs, stopErr)
+				}
 			}
 		}
 	}
@@ -3008,9 +3101,11 @@ func (c *Client) StopContainer(ctx context.Context, appID string) error {
 	// appStopping) until this section completes (SOC2-CC6, NIST-AC-3, NIST-SI-16,
 	// ISO27001-A.8, SOC2-CC8/ISO27001-A.12 unbounded-growth prevention).
 	c.mu.Lock()
-	delete(c.appServices, appID)
-	delete(c.appIsolation, appID)
-	delete(c.serviceIPs, appID)
+	if wholeApp {
+		delete(c.appServices, appID)
+		delete(c.appIsolation, appID)
+		delete(c.serviceIPs, appID)
+	}
 	delete(c.appStopping, appID)
 	c.mu.Unlock()
 

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -907,16 +908,20 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 	unlock := s.appMu.lockApp(appName)
 	defer unlock()
 
-	// Resolve every container ID that belongs to this app (one for
-	// single-container apps, one per service for multi-service apps) so the
-	// monitor can mark each before any stop is issued. Marking only the bare
-	// appName would miss {appID}_{serviceName} entries registered by the monitor.
-	ids, err := s.containerd.ContainerIDsForApp(ctx, appName)
+	// Resolve the containers this name addresses: every service for a bare
+	// appID, one service for "{appID}_{serviceName}". Resolution is shared with
+	// the stop below so the monitor marks and the stopped-by-user labels can only
+	// ever be written against containers that were actually stopped.
+	//
+	// A name matching neither is NotFound. It used to fall back to
+	// ids = []string{appName}, which manufactured a plausible ID out of an
+	// unresolvable name and reported success without stopping anything (WDY-1847).
+	ids, err := s.containerd.ResolveAppContainerIDs(ctx, appName)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "no app or service named %q", appName)
+		}
 		return nil, status.Errorf(codes.Internal, "resolving containers for app %q: %v", appName, err)
-	}
-	if len(ids) == 0 {
-		ids = []string{appName}
 	}
 
 	// Mark BEFORE stop so the monitor cannot observe the exit and restart in
@@ -964,12 +969,14 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 	// each one. Unregistering only the bare appName would leave
 	// {appID}_{serviceName} monitor entries alive and potentially trigger
 	// spurious restart attempts while the container is being removed.
-	ids, err := s.containerd.ContainerIDsForApp(ctx, appName)
+	// Same resolution as stop, and the same reason not to invent an ID for an
+	// unresolvable name (WDY-1847).
+	ids, err := s.containerd.ResolveAppContainerIDs(ctx, appName)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "no app or service named %q", appName)
+		}
 		return nil, status.Errorf(codes.Internal, "resolving containers for app %q: %v", appName, err)
-	}
-	if len(ids) == 0 {
-		ids = []string{appName}
 	}
 
 	// Unregister from the monitor BEFORE deletion to close the window where the

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -908,14 +908,8 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 	unlock := s.appMu.lockApp(appName)
 	defer unlock()
 
-	// Resolve the containers this name addresses: every service for a bare
-	// appID, one service for "{appID}_{serviceName}". Resolution is shared with
-	// the stop below so the monitor marks and the stopped-by-user labels can only
-	// ever be written against containers that were actually stopped.
-	//
-	// A name matching neither is NotFound. It used to fall back to
-	// ids = []string{appName}, which manufactured a plausible ID out of an
-	// unresolvable name and reported success without stopping anything (WDY-1847).
+	// Shared with the stop below, so monitor marks and stopped-by-user labels
+	// are only ever written against containers that were actually stopped.
 	ids, err := s.containerd.ResolveAppContainerIDs(ctx, appName)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -969,8 +963,6 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 	// each one. Unregistering only the bare appName would leave
 	// {appID}_{serviceName} monitor entries alive and potentially trigger
 	// spurious restart attempts while the container is being removed.
-	// Same resolution as stop, and the same reason not to invent an ID for an
-	// unresolvable name (WDY-1847).
 	ids, err := s.containerd.ResolveAppContainerIDs(ctx, appName)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -983,7 +975,8 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 	// monitor could attempt a restart while containers are being removed.
 	if s.monitor != nil {
 		for _, id := range ids {
-			s.monitor.MarkExplicitStop(id)
+			// Unregister alone closes the restart window: the monitor only
+			// restarts containers it still has state for.
 			s.monitor.Unregister(id)
 		}
 	}

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -158,9 +158,7 @@ func (m *mockContainerdClient) ContainerIDsForApp(_ context.Context, appID strin
 	return []string{appID}, nil
 }
 
-// mockContainerIDs returns the container IDs a deployed app would have.
-// Mirrors appconfig.AppConfig.ContainerName: a single-container app is named
-// for its appID, a multi-service app names each service "{appID}_{service}".
+// mockContainerIDs mirrors appconfig.AppConfig.ContainerName.
 func mockContainerIDs(c *agentpb.AppContainer) []string {
 	svcs := c.GetServices()
 	if len(svcs) <= 1 {
@@ -174,18 +172,14 @@ func mockContainerIDs(c *agentpb.AppContainer) []string {
 }
 
 // ResolveAppContainerIDs mirrors the real resolver: an exact container ID
-// first, then the app-id, then NotFound.
-//
-// Deliberately faithful. The permissive stub this replaces returned
-// []string{name} for every input, so no service-layer test could observe a name
-// that resolves to nothing — which is exactly how WDY-1847 stayed green.
+// first, then the app-id, then NotFound. Faithful on purpose — a mock that
+// accepts any name cannot observe a name that resolves to nothing.
 func (m *mockContainerdClient) ResolveAppContainerIDs(_ context.Context, name string) ([]string, error) {
 	m.resolveCalls = append(m.resolveCalls, name)
 	if m.resolveErr != nil {
 		return nil, m.resolveErr
 	}
-	// Rule 1 wins over rule 2 globally, so scan every app for an exact
-	// container-ID match before considering app-id matches.
+	// Rule 1 wins globally, so scan all apps for an ID match first.
 	for _, c := range m.containers {
 		for _, id := range mockContainerIDs(c) {
 			if id == name {
@@ -657,6 +651,7 @@ type mockMonitorRegistrar struct {
 	registerCalls     []registerCall
 	explicitStopCalls []string
 	clearStopCalls    []string
+	unregisterCalls   []string
 }
 
 type registerCall struct {
@@ -669,7 +664,9 @@ func (m *mockMonitorRegistrar) Register(appName string, policy int, maxRetries i
 	m.registerCalls = append(m.registerCalls, registerCall{appName, policy, maxRetries})
 }
 
-func (m *mockMonitorRegistrar) Unregister(_ string) {}
+func (m *mockMonitorRegistrar) Unregister(appName string) {
+	m.unregisterCalls = append(m.unregisterCalls, appName)
+}
 
 func (m *mockMonitorRegistrar) MarkExplicitStop(appName string) {
 	m.explicitStopCalls = append(m.explicitStopCalls, appName)
@@ -780,8 +777,7 @@ func TestStopContainer_CallsMarkExplicitStop(t *testing.T) {
 	}
 }
 
-// multiServiceMock returns a mock with one two-service app deployed:
-// containers "myapp_alpha" and "myapp_beta", both labelled app-id "myapp".
+// multiServiceMock deploys one app with containers "myapp_alpha"/"myapp_beta".
 func multiServiceMock() *mockContainerdClient {
 	return &mockContainerdClient{
 		containers: []*agentpb.AppContainer{{
@@ -794,11 +790,8 @@ func multiServiceMock() *mockContainerdClient {
 	}
 }
 
-// TestStopContainer_ServiceQualifiedName_StopsOnlyThatService is the WDY-1847
-// regression. "{appID}_{serviceName}" matches no app-id label, so the old
-// label-only resolution found nothing, invented the ID back, reported success,
-// and never issued a stop — while still marking the monitor and writing the
-// stopped-by-user label against a container that kept running.
+// A service-qualified name matches no app-id label, so label-only resolution
+// found nothing, invented the ID back, and reported a stop it never issued.
 func TestStopContainer_ServiceQualifiedName_StopsOnlyThatService(t *testing.T) {
 	mc := multiServiceMock()
 	mon := &mockMonitorRegistrar{}
@@ -811,20 +804,14 @@ func TestStopContainer_ServiceQualifiedName_StopsOnlyThatService(t *testing.T) {
 		t.Fatalf("StopContainer: %v", err)
 	}
 
-	// Resolution must go through the shared resolver. This is the assertion the
-	// old code fails: it called ContainerIDsForApp (an app-id-label lookup that
-	// returns nothing for a service-qualified name) and fell back to the name
-	// itself. Everything downstream then looked correct while the containerd
-	// layer stopped nothing — which is why the rest of this test alone cannot
-	// distinguish fixed from broken.
+	// The assertion the old code fails: it resolved via ContainerIDsForApp and
+	// fell back to the name itself, leaving everything below looking correct.
 	if len(mc.resolveCalls) != 1 || mc.resolveCalls[0] != "myapp_alpha" {
 		t.Errorf("ResolveAppContainerIDs calls = %v; want [myapp_alpha]", mc.resolveCalls)
 	}
-	// The stop must actually be issued, and for the service that was named.
 	if len(mc.stopCalls) != 1 || mc.stopCalls[0] != "myapp_alpha" {
 		t.Errorf("stopCalls = %v; want [myapp_alpha]", mc.stopCalls)
 	}
-	// Bookkeeping must cover that service and no other.
 	if len(mon.explicitStopCalls) != 1 || mon.explicitStopCalls[0] != "myapp_alpha" {
 		t.Errorf("MarkExplicitStop = %v; want [myapp_alpha]", mon.explicitStopCalls)
 	}
@@ -836,8 +823,7 @@ func TestStopContainer_ServiceQualifiedName_StopsOnlyThatService(t *testing.T) {
 	}
 }
 
-// TestStopContainer_BareAppID_StopsEveryService verifies the group form still
-// fans out to every service after the resolution change.
+// The group form must still fan out to every service.
 func TestStopContainer_BareAppID_StopsEveryService(t *testing.T) {
 	mc := multiServiceMock()
 	mon := &mockMonitorRegistrar{}
@@ -862,9 +848,7 @@ func TestStopContainer_BareAppID_StopsEveryService(t *testing.T) {
 	}
 }
 
-// TestStopContainer_UnknownName_NotFound: a name that resolves to nothing must
-// be an error and must leave no trace. Reporting success for an app that does
-// not exist is what made the service-qualified no-op invisible.
+// A name that resolves to nothing must error and leave no trace.
 func TestStopContainer_UnknownName_NotFound(t *testing.T) {
 	mc := multiServiceMock()
 	mon := &mockMonitorRegistrar{}
@@ -888,8 +872,32 @@ func TestStopContainer_UnknownName_NotFound(t *testing.T) {
 	}
 }
 
-// TestDeleteContainer_UnknownName_NotFound: delete carried the same
-// invented-ID fallback as stop.
+// Delete must resolve through the shared resolver and unregister only the
+// named service.
+func TestDeleteContainer_ServiceQualifiedName_ResolvesOneService(t *testing.T) {
+	mc := multiServiceMock()
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	if _, err := client.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+		AppName: "myapp_alpha",
+	}); err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+
+	if len(mc.resolveCalls) != 1 || mc.resolveCalls[0] != "myapp_alpha" {
+		t.Errorf("ResolveAppContainerIDs calls = %v; want [myapp_alpha]", mc.resolveCalls)
+	}
+	if len(mon.unregisterCalls) != 1 || mon.unregisterCalls[0] != "myapp_alpha" {
+		t.Errorf("Unregister = %v; want [myapp_alpha]", mon.unregisterCalls)
+	}
+	if len(mon.explicitStopCalls) != 0 {
+		t.Errorf("MarkExplicitStop = %v; want none on the delete path", mon.explicitStopCalls)
+	}
+}
+
+// Delete carried the same invented-ID fallback as stop.
 func TestDeleteContainer_UnknownName_NotFound(t *testing.T) {
 	mc := multiServiceMock()
 	client, cleanup := startContainerServer(t, mc)
@@ -1170,9 +1178,8 @@ func TestListVolumes_UsedByFromDeclaredVolumes(t *testing.T) {
 
 // deleteVolumesTestSetup creates volume dirs and starts a server whose mock
 // reports the given declared-volumes map.
-// deployedApps names the apps that exist on the fake device. DeleteContainer
-// resolves its target before touching volumes, so an app under test has to be
-// deployed for the delete to reach the volume logic at all.
+// deployedApps names the apps that exist on the fake device; a delete must
+// resolve before it reaches the volume logic.
 func deleteVolumesTestSetup(t *testing.T, dirs []string, declared map[string][]string, declaredErr error, deployedApps ...string) (agentpb.WendyContainerServiceClient, string) {
 	t.Helper()
 	tmp := t.TempDir()

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -49,6 +50,9 @@ type mockContainerdClient struct {
 	listeningPorts        []*agentpb.PortEntry
 	listeningPortsErr     error
 	stoppedByUserCalls    []stoppedByUserCall
+	stopCalls             []string
+	resolveCalls          []string
+	resolveErr            error
 	declaredVolumes       map[string][]string
 	declaredVolumesErr    error
 	assembleImageCalls    int
@@ -79,7 +83,8 @@ func (m *mockContainerdClient) ListContainers(_ context.Context) ([]*agentpb.App
 func (m *mockContainerdClient) AppDeclaredVolumes(_ context.Context) (map[string][]string, error) {
 	return m.declaredVolumes, m.declaredVolumesErr
 }
-func (m *mockContainerdClient) StopContainer(_ context.Context, _ string) error {
+func (m *mockContainerdClient) StopContainer(_ context.Context, name string) error {
+	m.stopCalls = append(m.stopCalls, name)
 	return m.stopErr
 }
 func (m *mockContainerdClient) DeleteContainer(_ context.Context, _ string, _ bool) error {
@@ -151,6 +156,49 @@ func (m *mockContainerdClient) GetContainerRestartPolicyLabel(_ context.Context,
 
 func (m *mockContainerdClient) ContainerIDsForApp(_ context.Context, appID string) ([]string, error) {
 	return []string{appID}, nil
+}
+
+// mockContainerIDs returns the container IDs a deployed app would have.
+// Mirrors appconfig.AppConfig.ContainerName: a single-container app is named
+// for its appID, a multi-service app names each service "{appID}_{service}".
+func mockContainerIDs(c *agentpb.AppContainer) []string {
+	svcs := c.GetServices()
+	if len(svcs) <= 1 {
+		return []string{c.GetAppName()}
+	}
+	ids := make([]string, 0, len(svcs))
+	for _, s := range svcs {
+		ids = append(ids, c.GetAppName()+"_"+s.GetName())
+	}
+	return ids
+}
+
+// ResolveAppContainerIDs mirrors the real resolver: an exact container ID
+// first, then the app-id, then NotFound.
+//
+// Deliberately faithful. The permissive stub this replaces returned
+// []string{name} for every input, so no service-layer test could observe a name
+// that resolves to nothing — which is exactly how WDY-1847 stayed green.
+func (m *mockContainerdClient) ResolveAppContainerIDs(_ context.Context, name string) ([]string, error) {
+	m.resolveCalls = append(m.resolveCalls, name)
+	if m.resolveErr != nil {
+		return nil, m.resolveErr
+	}
+	// Rule 1 wins over rule 2 globally, so scan every app for an exact
+	// container-ID match before considering app-id matches.
+	for _, c := range m.containers {
+		for _, id := range mockContainerIDs(c) {
+			if id == name {
+				return []string{id}, nil
+			}
+		}
+	}
+	for _, c := range m.containers {
+		if c.GetAppName() == name {
+			return mockContainerIDs(c), nil
+		}
+	}
+	return nil, fmt.Errorf("%w: no app or service named %q", errdefs.ErrNotFound, name)
 }
 
 func (m *mockContainerdClient) MissingChunks(_ context.Context, hashes [][32]byte) ([][32]byte, error) {
@@ -270,7 +318,9 @@ func TestListContainers(t *testing.T) {
 }
 
 func TestStopContainer(t *testing.T) {
-	client, cleanup := startContainerServer(t, &mockContainerdClient{})
+	client, cleanup := startContainerServer(t, &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "test-app"}},
+	})
 	defer cleanup()
 
 	_, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{
@@ -284,7 +334,9 @@ func TestStopContainer(t *testing.T) {
 // TestStopContainer_PersistsStoppedByUser verifies a deliberate stop is
 // recorded as a container label so the boot reconcile won't undo it on reboot.
 func TestStopContainer_PersistsStoppedByUser(t *testing.T) {
-	mock := &mockContainerdClient{}
+	mock := &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "test-app"}},
+	}
 	client, cleanup := startContainerServer(t, mock)
 	defer cleanup()
 
@@ -304,7 +356,9 @@ func TestStopContainer_PersistsStoppedByUser(t *testing.T) {
 }
 
 func TestDeleteContainer(t *testing.T) {
-	client, cleanup := startContainerServer(t, &mockContainerdClient{})
+	client, cleanup := startContainerServer(t, &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "test-app"}},
+	})
 	defer cleanup()
 
 	_, err := client.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
@@ -317,7 +371,9 @@ func TestDeleteContainer(t *testing.T) {
 }
 
 func TestDeleteContainer_WithImage(t *testing.T) {
-	client, cleanup := startContainerServer(t, &mockContainerdClient{})
+	client, cleanup := startContainerServer(t, &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "test-app"}},
+	})
 	defer cleanup()
 
 	_, err := client.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
@@ -702,7 +758,9 @@ func TestStartContainer_RegistersMonitor_UnlessStopped(t *testing.T) {
 // TestStopContainer_CallsMarkExplicitStop verifies that StopContainer calls
 // MarkExplicitStop on the monitor before stopping the container.
 func TestStopContainer_CallsMarkExplicitStop(t *testing.T) {
-	mc := &mockContainerdClient{}
+	mc := &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "my-app"}},
+	}
 	mon := &mockMonitorRegistrar{}
 	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
 	defer cleanup()
@@ -719,6 +777,129 @@ func TestStopContainer_CallsMarkExplicitStop(t *testing.T) {
 	}
 	if mon.explicitStopCalls[0] != "my-app" {
 		t.Errorf("MarkExplicitStop appName = %q; want my-app", mon.explicitStopCalls[0])
+	}
+}
+
+// multiServiceMock returns a mock with one two-service app deployed:
+// containers "myapp_alpha" and "myapp_beta", both labelled app-id "myapp".
+func multiServiceMock() *mockContainerdClient {
+	return &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{
+			AppName: "myapp",
+			Services: []*agentpb.ServiceEntry{
+				{Name: "alpha"},
+				{Name: "beta"},
+			},
+		}},
+	}
+}
+
+// TestStopContainer_ServiceQualifiedName_StopsOnlyThatService is the WDY-1847
+// regression. "{appID}_{serviceName}" matches no app-id label, so the old
+// label-only resolution found nothing, invented the ID back, reported success,
+// and never issued a stop — while still marking the monitor and writing the
+// stopped-by-user label against a container that kept running.
+func TestStopContainer_ServiceQualifiedName_StopsOnlyThatService(t *testing.T) {
+	mc := multiServiceMock()
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	if _, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+		AppName: "myapp_alpha",
+	}); err != nil {
+		t.Fatalf("StopContainer: %v", err)
+	}
+
+	// Resolution must go through the shared resolver. This is the assertion the
+	// old code fails: it called ContainerIDsForApp (an app-id-label lookup that
+	// returns nothing for a service-qualified name) and fell back to the name
+	// itself. Everything downstream then looked correct while the containerd
+	// layer stopped nothing — which is why the rest of this test alone cannot
+	// distinguish fixed from broken.
+	if len(mc.resolveCalls) != 1 || mc.resolveCalls[0] != "myapp_alpha" {
+		t.Errorf("ResolveAppContainerIDs calls = %v; want [myapp_alpha]", mc.resolveCalls)
+	}
+	// The stop must actually be issued, and for the service that was named.
+	if len(mc.stopCalls) != 1 || mc.stopCalls[0] != "myapp_alpha" {
+		t.Errorf("stopCalls = %v; want [myapp_alpha]", mc.stopCalls)
+	}
+	// Bookkeeping must cover that service and no other.
+	if len(mon.explicitStopCalls) != 1 || mon.explicitStopCalls[0] != "myapp_alpha" {
+		t.Errorf("MarkExplicitStop = %v; want [myapp_alpha]", mon.explicitStopCalls)
+	}
+	if len(mc.stoppedByUserCalls) != 1 {
+		t.Fatalf("stoppedByUserCalls = %v; want exactly one", mc.stoppedByUserCalls)
+	}
+	if got := mc.stoppedByUserCalls[0]; got.containerID != "myapp_alpha" || !got.stopped {
+		t.Errorf("stoppedByUser = %+v; want {myapp_alpha true}", got)
+	}
+}
+
+// TestStopContainer_BareAppID_StopsEveryService verifies the group form still
+// fans out to every service after the resolution change.
+func TestStopContainer_BareAppID_StopsEveryService(t *testing.T) {
+	mc := multiServiceMock()
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	if _, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+		AppName: "myapp",
+	}); err != nil {
+		t.Fatalf("StopContainer: %v", err)
+	}
+
+	if len(mon.explicitStopCalls) != 2 {
+		t.Errorf("MarkExplicitStop = %v; want both services", mon.explicitStopCalls)
+	}
+	marked := map[string]bool{}
+	for _, c := range mc.stoppedByUserCalls {
+		marked[c.containerID] = c.stopped
+	}
+	if !marked["myapp_alpha"] || !marked["myapp_beta"] {
+		t.Errorf("stoppedByUser = %+v; want both services marked", mc.stoppedByUserCalls)
+	}
+}
+
+// TestStopContainer_UnknownName_NotFound: a name that resolves to nothing must
+// be an error and must leave no trace. Reporting success for an app that does
+// not exist is what made the service-qualified no-op invisible.
+func TestStopContainer_UnknownName_NotFound(t *testing.T) {
+	mc := multiServiceMock()
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, mc, mon)
+	defer cleanup()
+
+	_, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{
+		AppName: "no-such-app",
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("StopContainer error = %v; want NotFound", err)
+	}
+	if len(mc.stopCalls) != 0 {
+		t.Errorf("stopCalls = %v; want none", mc.stopCalls)
+	}
+	if len(mon.explicitStopCalls) != 0 {
+		t.Errorf("MarkExplicitStop = %v; want none", mon.explicitStopCalls)
+	}
+	if len(mc.stoppedByUserCalls) != 0 {
+		t.Errorf("stoppedByUserCalls = %v; want none", mc.stoppedByUserCalls)
+	}
+}
+
+// TestDeleteContainer_UnknownName_NotFound: delete carried the same
+// invented-ID fallback as stop.
+func TestDeleteContainer_UnknownName_NotFound(t *testing.T) {
+	mc := multiServiceMock()
+	client, cleanup := startContainerServer(t, mc)
+	defer cleanup()
+
+	_, err := client.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
+		AppName: "no-such-app",
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("DeleteContainer error = %v; want NotFound", err)
 	}
 }
 
@@ -989,7 +1170,10 @@ func TestListVolumes_UsedByFromDeclaredVolumes(t *testing.T) {
 
 // deleteVolumesTestSetup creates volume dirs and starts a server whose mock
 // reports the given declared-volumes map.
-func deleteVolumesTestSetup(t *testing.T, dirs []string, declared map[string][]string, declaredErr error) (agentpb.WendyContainerServiceClient, string) {
+// deployedApps names the apps that exist on the fake device. DeleteContainer
+// resolves its target before touching volumes, so an app under test has to be
+// deployed for the delete to reach the volume logic at all.
+func deleteVolumesTestSetup(t *testing.T, dirs []string, declared map[string][]string, declaredErr error, deployedApps ...string) (agentpb.WendyContainerServiceClient, string) {
 	t.Helper()
 	tmp := t.TempDir()
 	old := volumesDir
@@ -1002,7 +1186,11 @@ func deleteVolumesTestSetup(t *testing.T, dirs []string, declared map[string][]s
 		}
 	}
 
-	mock := &mockContainerdClient{declaredVolumes: declared, declaredVolumesErr: declaredErr}
+	ctrs := make([]*agentpb.AppContainer, 0, len(deployedApps))
+	for _, app := range deployedApps {
+		ctrs = append(ctrs, &agentpb.AppContainer{AppName: app})
+	}
+	mock := &mockContainerdClient{containers: ctrs, declaredVolumes: declared, declaredVolumesErr: declaredErr}
 	cl, cleanup := startContainerServer(t, mock)
 	t.Cleanup(cleanup)
 	return cl, tmp
@@ -1035,7 +1223,7 @@ func TestDeleteContainer_DeleteVolumes_DeclaredNotPrefixed(t *testing.T) {
 		map[string][]string{
 			"autotest-churn":             {"autotest-churn-data", "autotest-orphanvol"},
 			"sh.wendy.examples.hellovlm": {"hellovlm-models"},
-		}, nil)
+		}, nil, "autotest-churn")
 
 	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
 		AppName:       "autotest-churn",
@@ -1059,7 +1247,7 @@ func TestDeleteContainer_DeleteVolumes_PrefixCollision(t *testing.T) {
 		map[string][]string{
 			"hellovlm":                   {"hellovlm-data"},
 			"sh.wendy.examples.hellovlm": {"hellovlm-models"},
-		}, nil)
+		}, nil, "hellovlm")
 
 	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
 		AppName:       "hellovlm",
@@ -1081,7 +1269,7 @@ func TestDeleteContainer_DeleteVolumes_SharedVolumeKept(t *testing.T) {
 		map[string][]string{
 			"app-a": {"app-a-data", "shared-cache"},
 			"app-b": {"shared-cache"},
-		}, nil)
+		}, nil, "app-a")
 
 	_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
 		AppName:       "app-a",
@@ -1102,7 +1290,7 @@ func TestDeleteContainer_DeleteVolumes_OwnershipUnknown(t *testing.T) {
 	t.Run("lookup error", func(t *testing.T) {
 		cl, tmp := deleteVolumesTestSetup(t,
 			[]string{"legacy-app-data"},
-			nil, fmt.Errorf("containerd unavailable"))
+			nil, fmt.Errorf("containerd unavailable"), "legacy-app")
 
 		_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
 			AppName:       "legacy-app",
@@ -1117,7 +1305,7 @@ func TestDeleteContainer_DeleteVolumes_OwnershipUnknown(t *testing.T) {
 	t.Run("no persist labels", func(t *testing.T) {
 		cl, tmp := deleteVolumesTestSetup(t,
 			[]string{"legacy-app-data"},
-			map[string][]string{}, nil)
+			map[string][]string{}, nil, "legacy-app")
 
 		_, err := cl.DeleteContainer(context.Background(), &agentpb.DeleteContainerRequest{
 			AppName:       "legacy-app",

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -63,6 +63,12 @@ type ContainerdClient interface {
 	// multi-service apps). Used by the service layer to mark every container in
 	// the monitor before issuing a stop or delete.
 	ContainerIDsForApp(ctx context.Context, appID string) ([]string, error)
+	// ResolveAppContainerIDs returns the container IDs addressed by name: a bare
+	// appID yields every service in the app, "{appID}_{serviceName}" yields that
+	// one service, and a name matching neither returns errdefs.ErrNotFound.
+	// Stop and delete resolve through this so they can never act on — or mark —
+	// an ID they invented for an unresolvable name (WDY-1847).
+	ResolveAppContainerIDs(ctx context.Context, name string) ([]string, error)
 	ListContainers(ctx context.Context) ([]*agentpb.AppContainer, error)
 	// AppDeclaredVolumes maps every deployed app (bare appID) to the persistent
 	// volume names its containers declare via persist entitlement labels. This

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -66,8 +66,6 @@ type ContainerdClient interface {
 	// ResolveAppContainerIDs returns the container IDs addressed by name: a bare
 	// appID yields every service in the app, "{appID}_{serviceName}" yields that
 	// one service, and a name matching neither returns errdefs.ErrNotFound.
-	// Stop and delete resolve through this so they can never act on — or mark —
-	// an ID they invented for an unresolvable name (WDY-1847).
 	ResolveAppContainerIDs(ctx context.Context, name string) ([]string, error)
 	ListContainers(ctx context.Context) ([]*agentpb.AppContainer, error)
 	// AppDeclaredVolumes maps every deployed app (bare appID) to the persistent


### PR DESCRIPTION
Closes WDY-1847

`apps stop myapp_alpha` reported success and stopped nothing.

Stop resolved only by app-id label. A service-qualified name is a valid container ID but never an app-id, so the lookup found nothing, the containerd call no-op'd, and the service layer fell back to `ids = []string{appName}` — marking the monitor and writing the stopped-by-user label against a container that kept running, with its restart policy now disabled. Delete had the same defect on both layers.

Start already resolved correctly. Now shared:

```
resolve(name):
  1. container whose ID == name            → [that container]   # single-service app, or appID_service
  2. containers whose app.id label == name → [all of them]      # group
  3. otherwise                             → NotFound
```

Also:
- unresolvable name → `codes.NotFound` instead of silent success
- late sweep and per-app state release scoped to whole-app stops, so stopping one service can't take its siblings down
- rule 1 requires the app-id label — the containerd namespace is shared, so an ID match alone is not proof the container is ours
- `StartContainer` replaces a stale primary PID rather than only setting when absent

## Verification

Two-service app on a Pi 4, dev agent: stopping or removing one service affects only that service, it stays stopped, start round-trips, a bare appID still fans out to both, and unknown names exit non-zero.

The service-layer mock returned `[]string{name}` for any input, so no test could observe a name that resolved to nothing; it now mirrors the real resolver.

## Known gap

`appMu` keys on the raw request name and `appStopping` is group-keyed, so concurrent per-service operations on one app no longer serialise. Fix is to thread the resolved set from the service layer into the containerd call; separate change, nothing triggers it today.