### PR TITLE
fix(agent): fan out ROS 2 topic count lookups instead of running them serially

### DIFF
--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -242,9 +242,14 @@ const ros2TopicInfoConcurrency = 8
 func (s *ROS2Service) fillROS2TopicCounts(ctx context.Context, sc ros2SC, topics []*agentpbv2.ROS2Topic) {
 	sem := make(chan struct{}, ros2TopicInfoConcurrency)
 	var wg sync.WaitGroup
+LOOP:
 	for _, t := range topics {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break LOOP
+		}
 		wg.Add(1)
-		sem <- struct{}{}
 		go func(t *agentpbv2.ROS2Topic) {
 			defer wg.Done()
 			defer func() { <-sem }()

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -211,22 +212,52 @@ func (s *ROS2Service) ListTopics(ctx context.Context, req *agentpbv2.ListROS2Top
 			continue
 		}
 		any = true
-		for _, t := range parseROS2TopicList(out) {
+		topics := parseROS2TopicList(out)
+		for _, t := range topics {
 			t.Rmw = sc.rmw
-			if req.GetIncludeCounts() {
-				if info, ierr := s.runIn(ctx, sc, "topic", "info", t.GetName()); ierr == nil {
-					_, pubs, subs := parseROS2TopicInfo(info)
-					t.PublisherCount = pubs
-					t.SubscriberCount = subs
-				}
-			}
-			resp.Topics = append(resp.Topics, t)
 		}
+		if req.GetIncludeCounts() {
+			s.fillROS2TopicCounts(ctx, sc, topics)
+		}
+		resp.Topics = append(resp.Topics, topics...)
 	}
 	if !any && lastErr != nil {
 		return nil, lastErr
 	}
 	return resp, nil
+}
+
+// ros2TopicInfoConcurrency bounds how many `ros2 topic info` execs
+// fillROS2TopicCounts runs at once. Each exec pays a fixed cost (container
+// exec dispatch + sourcing setup.bash + a fresh rclpy process doing DDS
+// discovery, roughly ~1s), so fetching counts one topic at a time turns
+// `--all` into a multi-minute wait on devices with many topics. Kept well
+// under the containerd client's per-sidecar cap (ros2MaxConcurrentExecs=16)
+// so this fan-out can't starve other concurrent ROS 2 RPCs on the sidecar.
+const ros2TopicInfoConcurrency = 8
+
+// fillROS2TopicCounts fetches publisher/subscriber counts for each topic
+// concurrently and fills them in in place. A topic whose `topic info` exec
+// fails is left with zero counts, matching the prior sequential behavior.
+func (s *ROS2Service) fillROS2TopicCounts(ctx context.Context, sc ros2SC, topics []*agentpbv2.ROS2Topic) {
+	sem := make(chan struct{}, ros2TopicInfoConcurrency)
+	var wg sync.WaitGroup
+	for _, t := range topics {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(t *agentpbv2.ROS2Topic) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			info, ierr := s.runIn(ctx, sc, "topic", "info", t.GetName())
+			if ierr != nil {
+				return
+			}
+			_, pubs, subs := parseROS2TopicInfo(info)
+			t.PublisherCount = pubs
+			t.SubscriberCount = subs
+		}(t)
+	}
+	wg.Wait()
 }
 
 func (s *ROS2Service) GetTopicInfo(ctx context.Context, req *agentpbv2.GetROS2TopicInfoRequest) (*agentpbv2.GetROS2TopicInfoResponse, error) {

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,7 +32,9 @@ type fakeROS2Runtime struct {
 	outputs map[string]string
 	// execFn, when set, overrides the outputs map entirely.
 	execFn func(ctx context.Context, opts ROS2ExecOptions, stdout, stderr io.Writer) (int, error)
-	calls  []ROS2ExecOptions
+
+	mu    sync.Mutex // guards calls; ListTopics fans out concurrent ExecROS2 calls
+	calls []ROS2ExecOptions
 }
 
 func (f *fakeROS2Runtime) FindROS2Containers(context.Context) ([]ROS2Target, error) {
@@ -53,7 +56,9 @@ func (f *fakeROS2Runtime) StopROS2Sidecar(context.Context) error { return nil }
 func (f *fakeROS2Runtime) VerifyROS2Sidecar(context.Context) error { return f.verifyErr }
 
 func (f *fakeROS2Runtime) ExecROS2(ctx context.Context, opts ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
+	f.mu.Lock()
 	f.calls = append(f.calls, opts)
+	f.mu.Unlock()
 	if f.execFn != nil {
 		return f.execFn(ctx, opts, stdout, stderr)
 	}
@@ -241,6 +246,118 @@ func TestROS2Service_ListTopicsWithCounts(t *testing.T) {
 	topic := resp.GetTopics()[0]
 	if topic.GetPublisherCount() != 1 || topic.GetSubscriberCount() != 3 {
 		t.Errorf("counts = %d/%d, want 1/3", topic.GetPublisherCount(), topic.GetSubscriberCount())
+	}
+}
+
+// TestROS2Service_ListTopicsCountsRunConcurrently proves --all's per-topic
+// `topic info` execs are fanned out rather than run one at a time: with n
+// topics each taking a fixed simulated delay, a sequential implementation
+// would take n*delay, while the bounded-concurrency implementation should
+// finish in a small multiple of delay regardless of n.
+func TestROS2Service_ListTopicsCountsRunConcurrently(t *testing.T) {
+	const n = 24
+	const delay = 20 * time.Millisecond
+
+	var listOut strings.Builder
+	for i := range n {
+		fmt.Fprintf(&listOut, "/t%d [std_msgs/msg/String]\n", i)
+	}
+
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch {
+			case len(opts.Args) >= 2 && opts.Args[0] == "topic" && opts.Args[1] == "list":
+				io.WriteString(stdout, listOut.String())
+				return 0, nil
+			case len(opts.Args) >= 3 && opts.Args[0] == "topic" && opts.Args[1] == "info":
+				time.Sleep(delay)
+				fmt.Fprintf(stdout, "Type: std_msgs/msg/String\nPublisher count: 1\nSubscription count: 0\n")
+				return 0, nil
+			default:
+				return 1, nil
+			}
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	start := time.Now()
+	resp, err := svc.ListTopics(context.Background(), &agentpbv2.ListROS2TopicsRequest{IncludeCounts: true})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+	if len(resp.GetTopics()) != n {
+		t.Fatalf("got %d topics, want %d", len(resp.GetTopics()), n)
+	}
+
+	// Sequential execution would take n*delay = 480ms; bounded concurrency
+	// (width 8) needs only ceil(n/8) rounds ~= 60ms. Give generous slack for
+	// scheduling jitter while still failing if counts run one at a time.
+	if elapsed >= n*delay/2 {
+		t.Errorf("ListTopics(IncludeCounts) across %d topics took %v (>= %v); per-topic counts do not appear to run concurrently", n, elapsed, n*delay/2)
+	}
+}
+
+// TestROS2Service_ListTopicsCountsPreserveOrderAndTolerateErrors exercises the
+// concurrent fan-out with per-topic completion order scrambled (later topics
+// finish first) and one topic's `topic info` failing outright, verifying that
+// output order still matches `topic list` order and a failed lookup leaves
+// that topic's counts at zero rather than aborting the whole request.
+func TestROS2Service_ListTopicsCountsPreserveOrderAndTolerateErrors(t *testing.T) {
+	const n = 16
+	const failIdx = 3
+
+	var listOut strings.Builder
+	for i := range n {
+		fmt.Fprintf(&listOut, "/t%d [std_msgs/msg/String]\n", i)
+	}
+
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Distro: "humble"},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
+			switch {
+			case len(opts.Args) >= 2 && opts.Args[0] == "topic" && opts.Args[1] == "list":
+				io.WriteString(stdout, listOut.String())
+				return 0, nil
+			case len(opts.Args) >= 3 && opts.Args[0] == "topic" && opts.Args[1] == "info":
+				var idx int
+				fmt.Sscanf(opts.Args[2], "/t%d", &idx)
+				if idx == failIdx {
+					io.WriteString(stderr, "boom")
+					return 1, nil
+				}
+				// Reverse-order delay: earlier topics in list order finish
+				// last, so completion order is the opposite of list order.
+				time.Sleep(time.Duration(n-idx) * time.Millisecond)
+				fmt.Fprintf(stdout, "Type: std_msgs/msg/String\nPublisher count: %d\nSubscription count: 0\n", idx)
+				return 0, nil
+			default:
+				return 1, nil
+			}
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	resp, err := svc.ListTopics(context.Background(), &agentpbv2.ListROS2TopicsRequest{IncludeCounts: true})
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+	if len(resp.GetTopics()) != n {
+		t.Fatalf("got %d topics, want %d", len(resp.GetTopics()), n)
+	}
+	for i, topic := range resp.GetTopics() {
+		want := fmt.Sprintf("/t%d", i)
+		if topic.GetName() != want {
+			t.Fatalf("topics[%d].Name = %q, want %q (list order not preserved)", i, topic.GetName(), want)
+		}
+		wantPubs := int32(i)
+		if i == failIdx {
+			wantPubs = 0 // failed `topic info` leaves counts at zero
+		}
+		if topic.GetPublisherCount() != wantPubs {
+			t.Errorf("topics[%d].PublisherCount = %d, want %d", i, topic.GetPublisherCount(), wantPubs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `wendy device ros2 topics --all` fetched publisher/subscriber counts for each topic via a separate, sequential `ros2 topic info <name>` exec into the CLI sidecar. Each exec pays a fixed ~1s cost (container exec dispatch + sourcing `setup.bash` + a fresh rclpy process doing DDS discovery), so wall time scaled linearly with topic count — on a device with dozens of topics that turned into minutes.
- Confirmed live against `unitree-g1-nx.local`: plain `topics` (2 topics, no counts) took 3.4s; `topics --all` took 5.2s — roughly +0.9s per topic just from the added lookup.
- Fixed by fanning the per-topic `topic info` lookups out with bounded concurrency (8 at a time), under the containerd client's existing per-sidecar cap of 16 concurrent execs (`ros2MaxConcurrentExecs`, added for exactly this kind of fan-out but previously unused here). Topic order and the "leave counts at zero on a failed lookup" behavior are both preserved.

## Test plan
- [x] `go test ./internal/agent/services/... ./internal/cli/commands/... -race` — all pass
- [x] New test proving the fan-out is concurrent: 24 topics with a simulated per-call delay finish in ~60ms instead of the ~480ms a sequential loop would take
- [x] New test proving list order is preserved and a single failed `topic info` call doesn't corrupt other topics' counts, even with out-of-order completion
- [ ] Hardware verification on a device with many ROS 2 topics (only devices reachable during development had 1-2 topics each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01La3dehB9C2WeqHGuZ5AzpA