### PR TITLE
fix(cli): add --host-info for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,14 +56,15 @@ body:
     id: version
     attributes:
       label: Versions
-      description: Output of `wendy version` (and agent version if relevant)
+      description: Output of `wendy --version` (and agent version if relevant)
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: host-os
     attributes:
-      label: Host OS
-      placeholder: macOS 15.2 (Apple Silicon), Ubuntu 24.04, Windows 11
+      label: Host information
+      description: Output of `wendy --host-info`. If your CLI does not support this flag, provide your OS name, version, and architecture manually.
+      render: shell
     validations:
       required: true
   - type: textarea

--- a/go/internal/cli/commands/host_info.go
+++ b/go/internal/cli/commands/host_info.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+)
+
+func formatDarwinOSVersion(productVersion string) string {
+	productVersion = strings.TrimSpace(productVersion)
+	if productVersion == "" {
+		return ""
+	}
+	return "macOS " + productVersion
+}
+
+func parseLinuxOSRelease(data []byte) string {
+	values := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(key)] = unquoteOSReleaseValue(value)
+	}
+
+	if prettyName := strings.TrimSpace(values["PRETTY_NAME"]); prettyName != "" {
+		return prettyName
+	}
+	name := strings.TrimSpace(values["NAME"])
+	version := strings.TrimSpace(values["VERSION"])
+	if version == "" {
+		version = strings.TrimSpace(values["VERSION_ID"])
+	}
+	return strings.TrimSpace(name + " " + version)
+}
+
+func unquoteOSReleaseValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	if value[0] == '\'' && value[len(value)-1] == '\'' {
+		return value[1 : len(value)-1]
+	}
+	if value[0] == '"' && value[len(value)-1] == '"' {
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			return unquoted
+		}
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+func formatWindowsOSVersion(productName, displayVersion, buildNumber string) string {
+	productName = strings.TrimSpace(productName)
+	displayVersion = strings.TrimSpace(displayVersion)
+	buildNumber = strings.TrimSpace(buildNumber)
+
+	build, _ := strconv.Atoi(strings.SplitN(buildNumber, ".", 2)[0])
+	if productName == "" {
+		switch {
+		case build >= 22000:
+			productName = "Windows 11"
+		case build >= 10240:
+			productName = "Windows 10"
+		default:
+			productName = "Windows"
+		}
+	} else if build >= 22000 {
+		// Windows 11 may report a Windows 10 product name through this
+		// compatibility registry key. The build number is authoritative.
+		productName = strings.Replace(productName, "Windows 10", "Windows 11", 1)
+	}
+
+	result := productName
+	if displayVersion != "" && !strings.Contains(result, displayVersion) {
+		result += " " + displayVersion
+	}
+	if buildNumber != "" {
+		result += " (build " + buildNumber + ")"
+	}
+	return result
+}

--- a/go/internal/cli/commands/host_info_darwin.go
+++ b/go/internal/cli/commands/host_info_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package commands
+
+import "os/exec"
+
+func hostOSVersion() string {
+	output, err := exec.Command("/usr/bin/sw_vers", "-productVersion").Output()
+	if err != nil {
+		return ""
+	}
+	return formatDarwinOSVersion(string(output))
+}

--- a/go/internal/cli/commands/host_info_linux.go
+++ b/go/internal/cli/commands/host_info_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package commands
+
+import "os"
+
+func hostOSVersion() string {
+	for _, path := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if version := parseLinuxOSRelease(data); version != "" {
+				return version
+			}
+		}
+	}
+	return ""
+}

--- a/go/internal/cli/commands/host_info_other.go
+++ b/go/internal/cli/commands/host_info_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux && !windows
+
+package commands
+
+func hostOSVersion() string {
+	return ""
+}

--- a/go/internal/cli/commands/host_info_test.go
+++ b/go/internal/cli/commands/host_info_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import "testing"
+
+func TestFormatDarwinOSVersion(t *testing.T) {
+	if got := formatDarwinOSVersion("15.6.1\n"); got != "macOS 15.6.1" {
+		t.Fatalf("formatDarwinOSVersion() = %q; want %q", got, "macOS 15.6.1")
+	}
+	if got := formatDarwinOSVersion("  "); got != "" {
+		t.Fatalf("formatDarwinOSVersion(empty) = %q; want empty", got)
+	}
+}
+
+func TestParseLinuxOSRelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "pretty name",
+			content: "NAME=Ubuntu\nVERSION_ID=24.04\nPRETTY_NAME=\"Ubuntu 24.04.3 LTS\"\n",
+			want:    "Ubuntu 24.04.3 LTS",
+		},
+		{
+			name:    "name and version fallback",
+			content: "NAME='Arch Linux'\nVERSION_ID=rolling\n",
+			want:    "Arch Linux rolling",
+		},
+		{
+			name:    "ignores comments and malformed lines",
+			content: "# comment\nnot-a-pair\n",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseLinuxOSRelease([]byte(tt.content)); got != tt.want {
+				t.Fatalf("parseLinuxOSRelease() = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatWindowsOSVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		productName    string
+		displayVersion string
+		buildNumber    string
+		want           string
+	}{
+		{
+			name:           "windows 11 compatibility product name",
+			productName:    "Windows 10 Pro",
+			displayVersion: "24H2",
+			buildNumber:    "26100",
+			want:           "Windows 11 Pro 24H2 (build 26100)",
+		},
+		{
+			name:           "windows 10",
+			productName:    "Windows 10 Enterprise",
+			displayVersion: "22H2",
+			buildNumber:    "19045",
+			want:           "Windows 10 Enterprise 22H2 (build 19045)",
+		},
+		{
+			name:        "minimal fallback",
+			buildNumber: "",
+			want:        "Windows",
+		},
+		{
+			name:           "windows 11 fallback from build",
+			displayVersion: "23H2",
+			buildNumber:    "22631",
+			want:           "Windows 11 23H2 (build 22631)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatWindowsOSVersion(tt.productName, tt.displayVersion, tt.buildNumber)
+			if got != tt.want {
+				t.Fatalf("formatWindowsOSVersion() = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/host_info_windows.go
+++ b/go/internal/cli/commands/host_info_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package commands
+
+import "golang.org/x/sys/windows/registry"
+
+func hostOSVersion() string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer key.Close()
+
+	productName, _, _ := key.GetStringValue("ProductName")
+	displayVersion, _, _ := key.GetStringValue("DisplayVersion")
+	if displayVersion == "" {
+		displayVersion, _, _ = key.GetStringValue("ReleaseId")
+	}
+	buildNumber, _, _ := key.GetStringValue("CurrentBuildNumber")
+	return formatWindowsOSVersion(productName, displayVersion, buildNumber)
+}

--- a/go/internal/cli/commands/info.go
+++ b/go/internal/cli/commands/info.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
@@ -14,29 +15,44 @@ func newInfoCmd() *cobra.Command {
 		Use:   "info",
 		Short: "Display CLI version and system information",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			info := map[string]string{
-				"version":   version.Version,
-				"os":        runtime.GOOS,
-				"arch":      runtime.GOARCH,
-				"goVersion": runtime.Version(),
-			}
-
-			if jsonOutput {
-				data, err := json.MarshalIndent(info, "", "  ")
-				if err != nil {
-					return err
-				}
-				fmt.Println(string(data))
-				return nil
-			}
-
-			fmt.Printf("Wendy CLI\n")
-			fmt.Printf("  Version:    %s\n", info["version"])
-			fmt.Printf("  OS:         %s\n", info["os"])
-			fmt.Printf("  Arch:       %s\n", info["arch"])
-			fmt.Printf("  Go Version: %s\n", info["goVersion"])
-			return nil
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return writeCLIInfo(cmd, jsonOutput)
 		},
 	}
+}
+
+// writeCLIInfo emits the local, non-identifying diagnostics shared by the
+// backwards-compatible `wendy info` command and the `wendy --host-info` flag.
+func writeCLIInfo(cmd *cobra.Command, asJSON bool) error {
+	info := map[string]string{
+		"version":   version.Version,
+		"os":        runtime.GOOS,
+		"osVersion": hostOSVersion(),
+		"arch":      runtime.GOARCH,
+		"goVersion": runtime.Version(),
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		return err
+	}
+
+	osVersion := info["osVersion"]
+	if osVersion == "" {
+		osVersion = "unknown"
+	}
+	lines := []string{
+		"Wendy CLI",
+		fmt.Sprintf("  Version:    %s", info["version"]),
+		fmt.Sprintf("  OS:         %s", info["os"]),
+		fmt.Sprintf("  OS Version: %s", osVersion),
+		fmt.Sprintf("  Arch:       %s", info["arch"]),
+		fmt.Sprintf("  Go Version: %s", info["goVersion"]),
+	}
+	_, err := fmt.Fprintln(cmd.OutOrStdout(), strings.Join(lines, "\n"))
+	return err
 }

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -23,6 +23,7 @@ func NewRootCmd() *cobra.Command {
 	// firstRun records whether this invocation showed the first-run analytics
 	// notice in PreRunE, so PostRunE can avoid stacking another prompt on top.
 	var firstRun bool
+	var hostInfo bool
 
 	root := &cobra.Command{
 		Use:           "wendy",
@@ -30,7 +31,20 @@ func NewRootCmd() *cobra.Command {
 		Long:          "Wendy is a CLI for developing and deploying edge computing applications to WendyOS devices.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if hostInfo {
+				return writeCLIInfo(cmd, jsonOutput)
+			}
+			return cmd.Help()
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// The root is runnable only to support one-shot informational flags.
+			// Keep bare `wendy` and those flags free from configuration, provider,
+			// analytics, update-check, and completion-prompt side effects.
+			if cmd.Parent() == nil {
+				return nil
+			}
+
 			// Skip heavy init for commands that don't need device/cloud setup.
 			// __usb-setup and __t234-write run as root under sudo; skipping init
 			// avoids config/analytics writes (and an update check) as root, and
@@ -87,6 +101,10 @@ func NewRootCmd() *cobra.Command {
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Parent() == nil {
+				return nil
+			}
+
 			// Surface a throttled tip about `wendy project optimize` after a
 			// successful build/run (no-op for other commands and in CI).
 			maybeShowOptimizeTip(cmd)
@@ -106,6 +124,7 @@ func NewRootCmd() *cobra.Command {
 
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname")
+	root.Flags().BoolVar(&hostInfo, "host-info", false, "Display CLI version and host system information")
 
 	// Render the top-level command groups in the deliberate order below rather
 	// than alphabetically, so e.g. "project" lists before "device".

--- a/go/internal/cli/commands/root_test.go
+++ b/go/internal/cli/commands/root_test.go
@@ -54,6 +54,81 @@ func TestRootCommand_VersionFlag(t *testing.T) {
 	}
 }
 
+func TestRootCommand_HostInfoFlag(t *testing.T) {
+	root := NewRootCmd()
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"--host-info"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{"Wendy CLI", "Version:", "OS:", "OS Version:", "Arch:", "Go Version:"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("host info output missing %q: %q", want, output)
+		}
+	}
+}
+
+func TestRootCommand_HostInfoJSON(t *testing.T) {
+	root := NewRootCmd()
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"--host-info", "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{`"version":`, `"os":`, `"osVersion":`, `"arch":`, `"goVersion":`} {
+		if !strings.Contains(output, want) {
+			t.Errorf("JSON host info output missing %q: %q", want, output)
+		}
+	}
+}
+
+func TestRootCommand_BareInvocationStillPrintsHelp(t *testing.T) {
+	root := NewRootCmd()
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Usage:") {
+		t.Fatalf("bare invocation should print help, got: %q", output)
+	}
+	if strings.Contains(output, "Go Version:") {
+		t.Fatalf("bare invocation printed host info instead of help: %q", output)
+	}
+}
+
+func TestRootCommand_HostInfoFlagIsRootLocal(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"run", "--host-info"})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --host-info") {
+		t.Fatalf("wendy run --host-info error = %v; want unknown flag", err)
+	}
+}
+
+func TestRootCommand_UnknownRootArgumentStillFails(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"banana"})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unknown command "banana" for "wendy"`) {
+		t.Fatalf("wendy banana error = %v; want unknown-command error", err)
+	}
+}
+
 func TestRootCommand_JSONFlag(t *testing.T) {
 	root := NewRootCmd()
 
@@ -87,6 +162,7 @@ func TestRootCommand_Help(t *testing.T) {
 		"Cloud",
 		"Settings",
 		"Flags",
+		"--host-info",
 	}
 	for _, text := range expectedTexts {
 		if !strings.Contains(strings.ToLower(output), strings.ToLower(text)) {


### PR DESCRIPTION
## Summary

- correct the bug-report template to request wendy --version
- add a root-local wendy --host-info diagnostic with CLI, OS release, architecture, and Go runtime details
- preserve the hidden wendy info command, add osVersion to its JSON, and keep diagnostics free of identifying host data
- make the issue form host field multiline with a manual fallback for older CLIs

## Testing

- go test ./go/internal/cli/... ./go/cmd/wendy
- go vet ./go/internal/cli/... ./go/cmd/wendy
- Windows amd64 cross-build
- parsed all GitHub Issue Form YAML and ran git diff --check
- built and ran wendy --host-info on macOS arm64