### PR TITLE
feat(cli): add wendy report-bug, wire into crash-report fallback

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something isn't working with the wendy CLI, wendy-agent, or WendyOS
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more detail you can give, the faster we can fix it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what actually happened?
+      placeholder: I ran `wendy run` and expected the app to deploy, but instead...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Flash WendyOS with `wendy os install`
+        2. Plug in the device over USB-C
+        3. Run `wendy run` in the sample app directory
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - wendy CLI
+        - wendy-agent
+        - WendyOS image / flashing
+        - USB-C host mode / discovery
+        - App runtime (containerd / entitlements)
+        - Docs
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Target hardware
+      options:
+        - NVIDIA Jetson Orin Nano
+        - NVIDIA Jetson AGX Orin
+        - NVIDIA Jetson Thor
+        - Raspberry Pi 5
+        - Generic Linux machine
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: Output of `wendy --version` (and agent version if relevant)
+    validations:
+      required: true
+  - type: textarea
+    id: host-os
+    attributes:
+      label: Host information
+      description: Run 'wendy report-bug' to open a pre-filled report, or paste your OS name, version, and architecture manually.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any CLI output, agent logs, or error messages. This will be formatted as code automatically.
+      render: shell

--- a/go/internal/cli/commands/crashflow.go
+++ b/go/internal/cli/commands/crashflow.go
@@ -110,7 +110,11 @@ func MaybeRunCrashReport(ctx context.Context, executed *cobra.Command, err error
 func reportCrashLocally(cmd *cobra.Command, out io.Writer, info platforminfo.Info, bundle crashreport.Bundle, localFile string) {
 	fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", localFile)
 	rawURL := reportBugURL(info, &bundle, localFile)
-	if !maybeOpenReportBugURL(cmd, rawURL) {
+	switch maybeOpenReportBugURL(cmd, rawURL) {
+	case reportBugOpened:
+	case reportBugOpenFailed:
+		fmt.Fprintln(out, "Could not open the browser automatically. Open a bug report:", rawURL)
+	default: // reportBugNoGH
 		fmt.Fprintln(out, "Open a bug report:", rawURL)
 	}
 }

--- a/go/internal/cli/commands/crashflow.go
+++ b/go/internal/cli/commands/crashflow.go
@@ -100,8 +100,19 @@ func MaybeRunCrashReport(ctx context.Context, executed *cobra.Command, err error
 		}
 		return
 	}
-	fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", res.LocalFile)
-	fmt.Fprintln(out, "Attach it to an issue at https://github.com/wendylabsinc/wendyos/issues")
+	reportCrashLocally(executed, out, info, bundle, res.LocalFile)
+}
+
+// reportCrashLocally is the cloud-unavailable fallback: point the user at a
+// pre-filled GitHub issue (the same mechanism as `wendy report-bug`) carrying
+// the redacted bundle's error summary and the local report path, instead of
+// the previous dead-end "attach it to an issue" instruction.
+func reportCrashLocally(cmd *cobra.Command, out io.Writer, info platforminfo.Info, bundle crashreport.Bundle, localFile string) {
+	fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", localFile)
+	rawURL := reportBugURL(info, &bundle, localFile)
+	if !maybeOpenReportBugURL(cmd, rawURL) {
+		fmt.Fprintln(out, "Open a bug report:", rawURL)
+	}
 }
 
 func printTail(out io.Writer, header string, lines []string) {

--- a/go/internal/cli/commands/crashflow_test.go
+++ b/go/internal/cli/commands/crashflow_test.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
 	"github.com/wendylabsinc/wendy/go/internal/cli/diag"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
 )
 
 func TestMaybeRunCrashReportSkipsRecoverable(t *testing.T) {
@@ -80,6 +83,48 @@ func TestMaybeRunCrashReportNotSuppressedProceeds(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "unrecoverable failure") {
 		t.Errorf("expected output to contain %q, got %q", "unrecoverable failure", buf.String())
+	}
+}
+
+func TestReportCrashLocallyOpensBrowserWhenGHPresent(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var out bytes.Buffer
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "boom"}
+
+	reportCrashLocally(cmd, &out, info, bundle, "/tmp/report.json")
+
+	if !strings.Contains(out.String(), "/tmp/report.json") {
+		t.Errorf("out = %q, want it to mention the local file", out.String())
+	}
+	if openedURL == "" || !strings.Contains(openedURL, "issues/new?") {
+		t.Errorf("openBrowser called with %q, want a bug_report.yml issue URL", openedURL)
+	}
+}
+
+func TestReportCrashLocallyPrintsURLWhenGHMissing(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var out bytes.Buffer
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "boom"}
+
+	reportCrashLocally(cmd, &out, info, bundle, "/tmp/report.json")
+
+	if !strings.Contains(out.String(), "Open a bug report:") {
+		t.Errorf("out = %q, want the manual fallback line", out.String())
+	}
+	if !strings.Contains(out.String(), "issues/new?") {
+		t.Errorf("out = %q, want the report URL", out.String())
 	}
 }
 

--- a/go/internal/cli/commands/crashflow_test.go
+++ b/go/internal/cli/commands/crashflow_test.go
@@ -108,6 +108,27 @@ func TestReportCrashLocallyOpensBrowserWhenGHPresent(t *testing.T) {
 	}
 }
 
+func TestReportCrashLocallyPrintsURLWhenOpenBrowserFails(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	openBrowser = func(string) error { return fmt.Errorf("no display") }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var out bytes.Buffer
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "boom"}
+
+	reportCrashLocally(cmd, &out, info, bundle, "/tmp/report.json")
+
+	if !strings.Contains(out.String(), "Could not open the browser automatically") {
+		t.Errorf("out = %q, want the open-failed fallback message", out.String())
+	}
+	if !strings.Contains(out.String(), "issues/new?") {
+		t.Errorf("out = %q, want the report URL", out.String())
+	}
+}
+
 func TestReportCrashLocallyPrintsURLWhenGHMissing(t *testing.T) {
 	origLookPath := lookPath
 	t.Cleanup(func() { lookPath = origLookPath })

--- a/go/internal/cli/commands/crashflow_test.go
+++ b/go/internal/cli/commands/crashflow_test.go
@@ -13,11 +13,22 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
 	"github.com/wendylabsinc/wendy/go/internal/cli/diag"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/env"
 	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
 )
 
+// clearCIEnv unsets every CI-detection env var (not just "CI") so tests run
+// correctly under real CI systems, which set vars like GITHUB_ACTIONS that
+// env.IsCI() also checks.
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range env.CIEnvVars {
+		t.Setenv(key, "")
+	}
+}
+
 func TestMaybeRunCrashReportSkipsRecoverable(t *testing.T) {
-	t.Setenv("CI", "") // ensure not classified as CI
+	clearCIEnv(t)
 	t.Setenv("WENDY_CRASHREPORT", "true")
 	MaybeRunCrashReport(context.Background(), &cobra.Command{Use: "wendy"},
 		fmt.Errorf("plain recoverable error"), "other")
@@ -37,7 +48,7 @@ func TestMaybeRunCrashReportSuppressed(t *testing.T) {
 	analyticsEnabledFn = func() bool { return true }
 	isInteractiveTerminalFn = func() bool { return true }
 
-	t.Setenv("CI", "")
+	clearCIEnv(t)
 	t.Setenv("WENDY_CRASHREPORT", "true")
 	t.Setenv("HOME", t.TempDir())
 	_ = config.Save(&config.Config{CrashReport: &config.CrashReportConfig{Suppressed: true}})
@@ -69,7 +80,7 @@ func TestMaybeRunCrashReportNotSuppressedProceeds(t *testing.T) {
 	analyticsEnabledFn = func() bool { return true }
 	isInteractiveTerminalFn = func() bool { return true }
 
-	t.Setenv("CI", "")
+	clearCIEnv(t)
 	t.Setenv("WENDY_CRASHREPORT", "true")
 	t.Setenv("HOME", t.TempDir())
 	_ = config.Save(&config.Config{CrashReport: &config.CrashReportConfig{Suppressed: false}})

--- a/go/internal/cli/commands/report_bug.go
+++ b/go/internal/cli/commands/report_bug.go
@@ -53,19 +53,31 @@ func truncateForURL(s string, max int) string {
 // depending on the real PATH.
 var lookPath = exec.LookPath
 
+// reportBugOpenResult distinguishes why maybeOpenReportBugURL did not
+// successfully open a browser, so callers can give the user accurate
+// guidance instead of assuming gh is missing.
+type reportBugOpenResult int
+
+const (
+	reportBugOpened reportBugOpenResult = iota
+	reportBugNoGH
+	reportBugOpenFailed
+)
+
 // maybeOpenReportBugURL opens rawURL in the browser when gh is on PATH (used
 // only as a signal that this is an interactive developer machine — gh's own
-// issue-create machinery is never invoked). Returns whether it succeeded;
-// callers own the fallback message for the false case.
-func maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) bool {
+// issue-create machinery is never invoked). Returns which of the three
+// outcomes occurred; callers own the fallback message for the non-opened
+// cases, which differ (gh missing vs. gh present but the open itself failed).
+func maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) reportBugOpenResult {
 	if _, err := lookPath("gh"); err != nil {
-		return false
+		return reportBugNoGH
 	}
 	if err := openBrowser(rawURL); err != nil {
-		return false
+		return reportBugOpenFailed
 	}
 	fmt.Fprintln(cmd.ErrOrStderr(), "Opening a pre-filled bug report in your browser...")
-	return true
+	return reportBugOpened
 }
 
 // newReportBugCmd builds the hidden `wendy report-bug` command: it opens a
@@ -80,16 +92,24 @@ func newReportBugCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			info := platforminfo.Collect()
 			rawURL := reportBugURL(info, nil, "")
-			if maybeOpenReportBugURL(cmd, rawURL) {
+			switch maybeOpenReportBugURL(cmd, rawURL) {
+			case reportBugOpened:
+				return nil
+			case reportBugOpenFailed:
+				out := cmd.OutOrStdout()
+				fmt.Fprintln(out, "Could not open the browser automatically. Open this link to file a report:")
+				fmt.Fprintln(out, rawURL)
+				fmt.Fprintln(out)
+				fmt.Fprintln(out, info.Block())
+				return nil
+			default: // reportBugNoGH
+				out := cmd.OutOrStdout()
+				fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com, or open this link to file a report:")
+				fmt.Fprintln(out, rawURL)
+				fmt.Fprintln(out)
+				fmt.Fprintln(out, info.Block())
 				return nil
 			}
-
-			out := cmd.OutOrStdout()
-			fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com, or open this link to file a report:")
-			fmt.Fprintln(out, rawURL)
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, info.Block())
-			return nil
 		},
 	}
 }

--- a/go/internal/cli/commands/report_bug.go
+++ b/go/internal/cli/commands/report_bug.go
@@ -67,3 +67,29 @@ func maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) bool {
 	fmt.Fprintln(cmd.ErrOrStderr(), "Opening a pre-filled bug report in your browser...")
 	return true
 }
+
+// newReportBugCmd builds the hidden `wendy report-bug` command: it opens a
+// pre-filled GitHub issue in the browser when `gh` is on PATH, or prints the
+// URL (plus the platform info block) as a fallback otherwise.
+func newReportBugCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "report-bug",
+		Short:  "Open a pre-filled GitHub bug report",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			info := platforminfo.Collect()
+			rawURL := reportBugURL(info, nil, "")
+			if maybeOpenReportBugURL(cmd, rawURL) {
+				return nil
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com, or open this link to file a report:")
+			fmt.Fprintln(out, rawURL)
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, info.Block())
+			return nil
+		},
+	}
+}

--- a/go/internal/cli/commands/report_bug.go
+++ b/go/internal/cli/commands/report_bug.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
+)
+
+// reportBugIssueURL is the GitHub "new issue" endpoint for this repo. Keep the
+// path casing exact — GitHub's own links use it and some proxies are case
+// sensitive.
+const reportBugIssueURL = "https://github.com/wendylabsinc/WendyOS/issues/new"
+
+// reportBugURL builds a GitHub issue-form URL that pre-fills bug_report.yml's
+// Versions and Host information fields via GitHub's documented per-field
+// query-param prefill (field id as the parameter name). When bundle is
+// non-nil (the automatic crash-report path), it also fills a short
+// What-happened summary and, when localFile is set, a pointer to the
+// locally-saved report file instead of the raw log tail. Component and
+// Target hardware are never inferable, so they're left for the user to pick
+// from the form's dropdowns.
+func reportBugURL(info platforminfo.Info, bundle *crashreport.Bundle, localFile string) string {
+	q := url.Values{}
+	q.Set("template", "bug_report.yml")
+	q.Set("version", info.CLIVersion)
+	q.Set("host-os", info.Block())
+
+	if bundle != nil {
+		q.Set("what-happened", truncateForURL(bundle.ErrorClass+": "+bundle.ErrorChain, 500))
+		if localFile != "" {
+			q.Set("logs", "Full redacted diagnostic bundle saved locally at "+localFile+" — attach it here.")
+		}
+	}
+
+	return reportBugIssueURL + "?" + q.Encode()
+}
+
+// truncateForURL shortens s to at most max runes (appending "…") so a single
+// query value can't blow past practical URL-length limits.
+func truncateForURL(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}
+
+// lookPath is a seam so tests can simulate gh being present or absent without
+// depending on the real PATH.
+var lookPath = exec.LookPath
+
+// maybeOpenReportBugURL opens rawURL in the browser when gh is on PATH (used
+// only as a signal that this is an interactive developer machine — gh's own
+// issue-create machinery is never invoked). Returns whether it succeeded;
+// callers own the fallback message for the false case.
+func maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) bool {
+	if _, err := lookPath("gh"); err != nil {
+		return false
+	}
+	if err := openBrowser(rawURL); err != nil {
+		return false
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), "Opening a pre-filled bug report in your browser...")
+	return true
+}

--- a/go/internal/cli/commands/report_bug_template_test.go
+++ b/go/internal/cli/commands/report_bug_template_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// TestBugReportTemplateFieldIDsMatchReportBugURL is a guard-rail: reportBugURL
+// (report_bug.go) hardcodes the query-param names "version", "host-os",
+// "what-happened", and "logs" to match bug_report.yml's form field ids, so
+// GitHub's per-field URL prefill actually lands in the right boxes. Nothing
+// else catches a drift between the two — if someone renames a field id in
+// the YAML (or in reportBugURL) without updating the other, the prefill
+// silently does nothing for that field. This test reads the raw YAML bytes
+// and checks the ids it depends on are still present, without adding a YAML
+// parsing dependency.
+func TestBugReportTemplateFieldIDsMatchReportBugURL(t *testing.T) {
+	const templatePath = "../../../../.github/ISSUE_TEMPLATE/bug_report.yml"
+
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", templatePath, err)
+	}
+
+	idRe := regexp.MustCompile(`(?m)^\s*id:\s*(\S+)\s*$`)
+	matches := idRe.FindAllSubmatch(data, -1)
+	ids := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		ids[string(m[1])] = true
+	}
+
+	// These are the exact field ids reportBugURL targets via GitHub's
+	// per-field query-param prefill. "template" is deliberately excluded: it
+	// is GitHub's own template-selector query param, not a form field id
+	// declared in this YAML.
+	want := []string{"version", "host-os", "what-happened", "logs"}
+	for _, id := range want {
+		if !ids[id] {
+			t.Errorf("bug_report.yml is missing field id %q, which reportBugURL depends on for prefill", id)
+		}
+	}
+}

--- a/go/internal/cli/commands/report_bug_test.go
+++ b/go/internal/cli/commands/report_bug_test.go
@@ -89,8 +89,8 @@ func TestMaybeOpenReportBugURLGHPresentSucceeds(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 
-	if !maybeOpenReportBugURL(cmd, "https://example.com/issue") {
-		t.Fatal("expected true when gh is present and openBrowser succeeds")
+	if got := maybeOpenReportBugURL(cmd, "https://example.com/issue"); got != reportBugOpened {
+		t.Fatalf("expected reportBugOpened when gh is present and openBrowser succeeds, got %v", got)
 	}
 	if openedURL != "https://example.com/issue" {
 		t.Errorf("openBrowser called with %q, want the report URL", openedURL)
@@ -106,8 +106,8 @@ func TestMaybeOpenReportBugURLGHMissing(t *testing.T) {
 	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
 
 	cmd := &cobra.Command{Use: "wendy"}
-	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
-		t.Fatal("expected false when gh is missing")
+	if got := maybeOpenReportBugURL(cmd, "https://example.com/issue"); got != reportBugNoGH {
+		t.Fatalf("expected reportBugNoGH when gh is missing, got %v", got)
 	}
 }
 
@@ -118,8 +118,8 @@ func TestMaybeOpenReportBugURLOpenBrowserFails(t *testing.T) {
 	openBrowser = func(string) error { return fmt.Errorf("no display") }
 
 	cmd := &cobra.Command{Use: "wendy"}
-	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
-		t.Fatal("expected false when openBrowser fails")
+	if got := maybeOpenReportBugURL(cmd, "https://example.com/issue"); got != reportBugOpenFailed {
+		t.Fatalf("expected reportBugOpenFailed when openBrowser fails, got %v", got)
 	}
 }
 
@@ -169,6 +169,34 @@ func TestReportBugCmdGHPresentOpensBrowser(t *testing.T) {
 	}
 	if stdout.String() != "" {
 		t.Errorf("expected no stdout output when gh succeeds, got %q", stdout.String())
+	}
+}
+
+func TestReportBugCmdGHPresentButOpenBrowserFails(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	openBrowser = func(string) error { return fmt.Errorf("no display") }
+
+	cmd := newReportBugCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Could not open the browser automatically") {
+		t.Errorf("output = %q, want the open-failed fallback message", out)
+	}
+	if strings.Contains(out, "`gh` CLI not found") {
+		t.Errorf("output = %q, must not claim gh is missing when it is present", out)
+	}
+	if !strings.Contains(out, "issues/new?") {
+		t.Errorf("output = %q, want the fallback URL", out)
 	}
 }
 

--- a/go/internal/cli/commands/report_bug_test.go
+++ b/go/internal/cli/commands/report_bug_test.go
@@ -122,3 +122,70 @@ func TestMaybeOpenReportBugURLOpenBrowserFails(t *testing.T) {
 		t.Fatal("expected false when openBrowser fails")
 	}
 }
+
+func TestReportBugCmdGHMissingPrintsFallback(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := newReportBugCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "`gh` CLI not found") {
+		t.Errorf("output = %q, want the gh-missing fallback message", out)
+	}
+	if !strings.Contains(out, "issues/new?") {
+		t.Errorf("output = %q, want the fallback URL", out)
+	}
+}
+
+func TestReportBugCmdGHPresentOpensBrowser(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := newReportBugCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if openedURL == "" || !strings.Contains(openedURL, "issues/new?") {
+		t.Errorf("openBrowser called with %q, want a bug_report.yml issue URL", openedURL)
+	}
+	if stdout.String() != "" {
+		t.Errorf("expected no stdout output when gh succeeds, got %q", stdout.String())
+	}
+}
+
+func TestReportBugCmdRejectsArgs(t *testing.T) {
+	cmd := newReportBugCmd()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for a stray positional argument")
+	}
+}
+
+func TestReportBugCmdIsHidden(t *testing.T) {
+	cmd := newReportBugCmd()
+	if !cmd.Hidden {
+		t.Error("report-bug must be Hidden so it doesn't appear in `wendy --help`")
+	}
+}

--- a/go/internal/cli/commands/report_bug_test.go
+++ b/go/internal/cli/commands/report_bug_test.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
+)
+
+func TestReportBugURLManualNoBundle(t *testing.T) {
+	info := platforminfo.Info{CLIVersion: "1.2.3", DevOS: "darwin", DevOSVersion: "15.2", DevArch: "arm64"}
+	got := reportBugURL(info, nil, "")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	if u.Scheme != "https" || u.Host != "github.com" || u.Path != "/wendylabsinc/WendyOS/issues/new" {
+		t.Fatalf("unexpected URL base: %q", got)
+	}
+	q := u.Query()
+	if q.Get("template") != "bug_report.yml" {
+		t.Errorf("template = %q, want bug_report.yml", q.Get("template"))
+	}
+	if q.Get("version") != "1.2.3" {
+		t.Errorf("version = %q, want 1.2.3", q.Get("version"))
+	}
+	if !strings.Contains(q.Get("host-os"), "darwin") {
+		t.Errorf("host-os = %q, want it to mention darwin", q.Get("host-os"))
+	}
+	if q.Get("what-happened") != "" {
+		t.Errorf("what-happened should be unset for a nil bundle, got %q", q.Get("what-happened"))
+	}
+	if q.Get("logs") != "" {
+		t.Errorf("logs should be unset for a nil bundle, got %q", q.Get("logs"))
+	}
+}
+
+func TestReportBugURLWithBundleAndLocalFile(t *testing.T) {
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "exit status 1"}
+	got := reportBugURL(info, &bundle, "/tmp/wendy-crashreport-abc/report.json")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	q := u.Query()
+	if want := "docker_build_failed: exit status 1"; q.Get("what-happened") != want {
+		t.Errorf("what-happened = %q, want %q", q.Get("what-happened"), want)
+	}
+	if !strings.Contains(q.Get("logs"), "/tmp/wendy-crashreport-abc/report.json") {
+		t.Errorf("logs = %q, want it to mention the local file", q.Get("logs"))
+	}
+}
+
+func TestReportBugURLTruncatesLongErrorChain(t *testing.T) {
+	info := platforminfo.Info{}
+	bundle := crashreport.Bundle{ErrorClass: "x", ErrorChain: strings.Repeat("a", 1000)}
+	got := reportBugURL(info, &bundle, "")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	whatHappened := u.Query().Get("what-happened")
+	if rc := len([]rune(whatHappened)); rc > 501 { // 500 + the "…" rune
+		t.Errorf("what-happened not truncated: %d runes", rc)
+	}
+	if !strings.HasSuffix(whatHappened, "…") {
+		t.Errorf("what-happened = %q, want a truncation ellipsis", whatHappened)
+	}
+}
+
+func TestMaybeOpenReportBugURLGHPresentSucceeds(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	if !maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected true when gh is present and openBrowser succeeds")
+	}
+	if openedURL != "https://example.com/issue" {
+		t.Errorf("openBrowser called with %q, want the report URL", openedURL)
+	}
+	if !strings.Contains(stderr.String(), "Opening a pre-filled bug report") {
+		t.Errorf("stderr = %q, want the opening message", stderr.String())
+	}
+}
+
+func TestMaybeOpenReportBugURLGHMissing(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected false when gh is missing")
+	}
+}
+
+func TestMaybeOpenReportBugURLOpenBrowserFails(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	openBrowser = func(string) error { return fmt.Errorf("no display") }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected false when openBrowser fails")
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -173,6 +173,7 @@ func NewRootCmd() *cobra.Command {
 	tourCmd.Hidden = true
 	mcpCmd := newMCPCmd()
 	mcpCmd.Hidden = true
+	reportBugCmd := newReportBugCmd()
 	completionCmd := newCompletionCmd()
 	completionCmd.Hidden = true
 	// Keep a valid group on the (hidden) completion command so the help/
@@ -234,6 +235,7 @@ func NewRootCmd() *cobra.Command {
 		discoverCmd,
 		osCmd,
 		infoCmd,
+		reportBugCmd,
 		utilsCmd,
 		tourCmd,
 		mcpCmd,

--- a/specs/2026-08-04-report-bug-command-design.md
+++ b/specs/2026-08-04-report-bug-command-design.md
@@ -1,0 +1,168 @@
+# `wendy report-bug` + automatic GitHub issue prefill — design
+
+Date: 2026-08-04
+Status: approved (brainstorming)
+Builds on `specs/2026-06-28-platform-diagnostics-crash-reporting-design.md` and
+`specs/2026-07-04-anonymous-crash-reporting-cli-notifications-design.md` (PR #1228). Supersedes the
+`--host-info` flag proposed in PR #1563 (`max/fix-issue-template-host-info`, still open) — that PR's
+`host_info_*.go` files duplicate work `platforminfo` already does on this branch and should not be
+merged; #1563 should be closed once this ships, keeping only its `bug_report.yml` wording fix.
+
+## Context
+
+PR #1563 added a root `wendy --host-info` flag that prints CLI/OS/arch/Go diagnostics for the GitHub
+bug report form, and pointed `bug_report.yml`'s "Host information" field at it. Two problems:
+
+- It duplicates `platforminfo.Collect()` / `.Block()`, which PR #1228 already built for the crash
+  banner and crash-report bundles (dev OS, OS version, arch, kernel).
+- It still leaves the user to copy-paste output into a browser by hand. #1228's crash-report flow
+  already hits this exact wall: when `crashreport.SubmitHTTP` fails (cloud unavailable), it falls back
+  to a local JSON file and tells the user to "attach it to an issue" — a dead end that no one follows
+  through on in practice.
+
+`gh` (the GitHub CLI) can turn both of these into one step: build the issue title/body and let `gh`
+open a prefilled compose page in the browser. This design adds a `report-bug` hidden command for
+manual use, and wires the same body-builder into `MaybeRunCrashReport`'s cloud-unavailable branch so
+the flow "spawns automatically" right where a report currently goes nowhere.
+
+## Goals
+
+1. A hidden `wendy report-bug` command that collects local diagnostics (reusing `platforminfo`) and,
+   when `gh` is installed, opens a prefilled GitHub issue compose page mirroring `bug_report.yml`'s
+   sections.
+2. When `gh` is missing, print the diagnostic block plus a manual issue-creation link — no dead end.
+3. Wire the same body-builder into #1228's `MaybeRunCrashReport`: when cloud submission fails after
+   the user has already consented to send a report, automatically open a prefilled issue (with the
+   actual redacted bundle contents, not placeholders) instead of just printing instructions.
+4. Fix `bug_report.yml`'s "Host information" field to reference `report-bug` instead of `--host-info`,
+   and carry over #1563's `wendy version` → `wendy --version` typo fix.
+
+## Non-goals
+
+- Submitting the issue automatically without the user looking at it first — `gh issue create --web`
+  always opens an editable compose page; nothing is filed without the user pressing submit in the
+  browser.
+- Reimplementing OS-specific browser-opening — `gh issue create --web` already does this reliably
+  cross-platform, which is the main reason to shell out to `gh` rather than opening a URL ourselves.
+- Any change to `--host-info` on `main` or to #1228's existing consent/redaction/submission logic —
+  only the cloud-unavailable branch's *output* changes.
+
+## Architecture
+
+```
+wendy report-bug (manual)                MaybeRunCrashReport (#1228, automatic)
+        │                                            │
+        ▼                                            ▼
+platforminfo.Collect()                    (already have: bundle from crashreport.Build)
+        │                                            │
+        ▼                                            ▼
+        └──────────────► reportBugBody(info, bundle*) ◄──────────────┘
+                                   │
+                                   ▼
+                     exec.LookPath("gh") found?
+                          │             │
+                         yes            no
+                          │             │
+                          ▼             ▼
+              gh issue create      print diagnostic block +
+              --repo wendylabsinc/WendyOS   issues/new?template=bug_report.yml
+              --title <t> --body <b> --web       (manual fallback)
+```
+
+`bundle*` is nil for the manual `report-bug` path (no error context exists) and populated for the
+automatic path (error class, severity, chain, log tail already collected by the existing crash flow).
+
+## Components
+
+### 1. `reportBugBody(info platforminfo.Info, bundle *crashreport.Bundle) (title, body string)`
+
+New function in `go/internal/cli/commands/report_bug.go`. Builds markdown mirroring
+`bug_report.yml`'s field labels as `###` headers:
+
+- `What happened?`, `Steps to reproduce`, `Component`, `Target hardware` — placeholder prompt text
+  (e.g. `_Describe what happened here._`) when `bundle == nil`; when `bundle != nil`, `What happened?`
+  is pre-filled with `bundle.ErrorChain` and a `_(auto-filled from the failure that triggered this
+  report; edit as needed)_` note, the rest stay placeholders (component/hardware aren't inferable).
+- `Versions` — `info.CLIVersion`.
+- `Host information` — `info.Block()`.
+- `Relevant logs or output` — omitted when `bundle == nil`; filled with `bundle.LogTail` (and
+  `bundle.BuildOutputTail` when present) otherwise.
+
+Title: `"bug: <short summary>"` placeholder for manual use; `"bug: " + bundle.ErrorClass` for the
+automatic path.
+
+Pure function, no I/O — fully unit-testable against fixed `Info`/`Bundle` values.
+
+### 2. `openPrefilledIssue(cmd *cobra.Command, title, body string) bool`
+
+- Looks up `gh` via a package-level `lookGH = exec.LookPath` seam (swappable in tests).
+- If found: runs `gh issue create --repo wendylabsinc/WendyOS --title <title> --body <body> --web`,
+  streaming its stderr through so the user sees `gh`'s own "Opening in your browser." message. Returns
+  `true` on success.
+- If not found, or `gh` errors: returns `false` and does nothing else — callers own the fallback
+  message, since the manual and automatic call sites want different wording.
+
+### 3. `wendy report-bug` (`newReportBugCmd`, hidden, added to root.go's hidden-command block)
+
+```
+info := platforminfo.Collect()
+title, body := reportBugBody(info, nil)
+if !openPrefilledIssue(cmd, title, body) {
+    fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com for a pre-filled report.")
+    fmt.Fprintln(out, "")
+    fmt.Fprintln(out, info.Block())
+    fmt.Fprintln(out, "")
+    fmt.Fprintln(out, "Open a bug report: https://github.com/wendylabsinc/WendyOS/issues/new?template=bug_report.yml")
+}
+```
+
+### 4. `crashflow.go` change (PR #1228 branch)
+
+In `MaybeRunCrashReport`, replace:
+
+```go
+fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", res.LocalFile)
+fmt.Fprintln(out, "Attach it to an issue at https://github.com/wendylabsinc/wendyos/issues")
+```
+
+with:
+
+```go
+fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", res.LocalFile)
+title, body := reportBugBody(info, &bundle)
+if !openPrefilledIssue(executed, title, body) {
+    fmt.Fprintln(out, "Attach it to an issue at https://github.com/wendylabsinc/WendyOS/issues/new?template=bug_report.yml")
+}
+```
+
+No new consent prompt: the user already answered "Send this report?" yes; this is what "sending"
+degrades to when the cloud path is unavailable.
+
+### 5. `bug_report.yml`
+
+- `version` field description: `wendy version` → `wendy --version` (carried over from #1563).
+- `host-os` field description: replace the `--host-info` reference with:
+  `Run 'wendy report-bug' to open a pre-filled report, or paste your OS name, version, and architecture manually.`
+
+## Testing
+
+- `report_bug_body_test.go`: table tests for `reportBugBody` — nil bundle (placeholders) vs populated
+  bundle (error chain/log tail filled in), asserting exact section presence/absence.
+- `report_bug_test.go`: `lookGH` stubbed to simulate gh-present/gh-absent/gh-error; asserts the correct
+  fallback text and that the constructed `gh` argv matches expectations (via a stubbed exec runner,
+  not a real subprocess).
+- Update existing `crashflow_test.go` cloud-unavailable case for the new call, using the same `lookGH`
+  stub.
+- `go test ./go/internal/cli/...`, `go vet ./go/internal/cli/...`.
+- Manual: run `wendy report-bug` locally with and without `gh` on PATH; confirm the browser opens with
+  the expected sections pre-filled and nothing is submitted without pressing the button.
+
+## Open questions / follow-ups
+
+- `gh issue create --web --title/--body` on a form-only repo bypasses the YAML form UI (GitHub treats
+  it as a plain issue with the given body) rather than pre-filling individual form fields. This is
+  intentional here — it's the reliable, documented behavior versus relying on per-field query-param
+  prefill, which is undocumented for `gh`'s flag surface. Worth revisiting if GitHub/gh add first-class
+  form-field prefill support.
+- #1563 should be closed by its author (`max`) once this lands, keeping only the `bug_report.yml`
+  wording fix folded in here.

--- a/specs/2026-08-04-report-bug-command-design.md
+++ b/specs/2026-08-04-report-bug-command-design.md
@@ -20,30 +20,44 @@ bug report form, and pointed `bug_report.yml`'s "Host information" field at it. 
   to a local JSON file and tells the user to "attach it to an issue" — a dead end that no one follows
   through on in practice.
 
-`gh` (the GitHub CLI) can turn both of these into one step: build the issue title/body and let `gh`
-open a prefilled compose page in the browser. This design adds a `report-bug` hidden command for
-manual use, and wires the same body-builder into `MaybeRunCrashReport`'s cloud-unavailable branch so
-the flow "spawns automatically" right where a report currently goes nowhere.
+GitHub issue forms (the YAML-based templates like `bug_report.yml`) support pre-filling individual
+fields via URL query parameters matching each field's `id` (documented:
+https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue#creating-an-issue-from-a-url-query).
+This repo also already has a tested, cross-platform `openBrowser(url string) error` seam
+(`go/internal/cli/commands/open_browser.go`, backed by `browseropen.Open`, used by `wendy utils
+open-browser`). Combined, these mean we can build a properly-prefilled issue-form URL and open it
+without shelling out to `gh` at all. `gh`'s presence is used only as a signal that this is an
+interactive developer machine (not a headless/SSH/CI-like session) worth auto-opening a browser on —
+not as the mechanism that does the filling or opening.
+
+This design adds a `report-bug` hidden command for manual use, and wires the same URL-builder into
+`MaybeRunCrashReport`'s cloud-unavailable branch so the flow "spawns automatically" right where a
+report currently goes nowhere.
 
 ## Goals
 
 1. A hidden `wendy report-bug` command that collects local diagnostics (reusing `platforminfo`) and,
-   when `gh` is installed, opens a prefilled GitHub issue compose page mirroring `bug_report.yml`'s
-   sections.
-2. When `gh` is missing, print the diagnostic block plus a manual issue-creation link — no dead end.
-3. Wire the same body-builder into #1228's `MaybeRunCrashReport`: when cloud submission fails after
-   the user has already consented to send a report, automatically open a prefilled issue (with the
-   actual redacted bundle contents, not placeholders) instead of just printing instructions.
+   when `gh` is installed, opens a pre-filled GitHub issue-form URL in the browser (via the existing
+   `openBrowser` seam) with `bug_report.yml`'s Versions and Host information fields filled in.
+2. When `gh` is missing, print the diagnostic block plus the same URL as a manual link — no auto-open,
+   no dead end.
+3. Wire the same URL-builder into #1228's `MaybeRunCrashReport`: when cloud submission fails after the
+   user has already consented to send a report, automatically open a pre-filled issue (Versions, Host
+   information, a short auto-filled "What happened", and a pointer to the locally-saved report file for
+   the full log tail) instead of just printing instructions.
 4. Fix `bug_report.yml`'s "Host information" field to reference `report-bug` instead of `--host-info`,
    and carry over #1563's `wendy version` → `wendy --version` typo fix.
 
 ## Non-goals
 
-- Submitting the issue automatically without the user looking at it first — `gh issue create --web`
-  always opens an editable compose page; nothing is filed without the user pressing submit in the
-  browser.
-- Reimplementing OS-specific browser-opening — `gh issue create --web` already does this reliably
-  cross-platform, which is the main reason to shell out to `gh` rather than opening a URL ourselves.
+- Submitting the issue automatically without the user looking at it first — this only ever opens an
+  editable compose page; nothing is filed without the user pressing submit in the browser.
+- Shelling out to `gh issue create` — `gh`'s own `--title`/`--body` flags bypass individual form fields
+  in favor of one combined body blob, which is a worse fill than the URL-query-param approach. `gh` is
+  used only via `exec.LookPath` as a presence check.
+- Cramming full log tails into the URL — browsers/servers cap request-target length (~8KB is a common
+  practical ceiling); the automatic path links to the already-saved local report file instead of trying
+  to inline hundreds of log lines as a query parameter.
 - Any change to `--host-info` on `main` or to #1228's existing consent/redaction/submission logic —
   only the cloud-unavailable branch's *output* changes.
 
@@ -53,66 +67,71 @@ the flow "spawns automatically" right where a report currently goes nowhere.
 wendy report-bug (manual)                MaybeRunCrashReport (#1228, automatic)
         │                                            │
         ▼                                            ▼
-platforminfo.Collect()                    (already have: bundle from crashreport.Build)
+platforminfo.Collect()                    (already have: bundle, res.LocalFile)
         │                                            │
         ▼                                            ▼
-        └──────────────► reportBugBody(info, bundle*) ◄──────────────┘
+        └──────────────► reportBugURL(info, bundle*, localFile) ◄──────────────┘
                                    │
                                    ▼
-                     exec.LookPath("gh") found?
+                       lookGH() found on PATH?
                           │             │
                          yes            no
                           │             │
                           ▼             ▼
-              gh issue create      print diagnostic block +
-              --repo wendylabsinc/WendyOS   issues/new?template=bug_report.yml
-              --title <t> --body <b> --web       (manual fallback)
+                openBrowser(url)   print diagnostic block + url
+              "Opening a pre-filled    (manual fallback, no
+               bug report in your       auto-open)
+               browser..."
 ```
 
-`bundle*` is nil for the manual `report-bug` path (no error context exists) and populated for the
-automatic path (error class, severity, chain, log tail already collected by the existing crash flow).
+`bundle*`/`localFile` are empty for the manual `report-bug` path (no error context exists) and
+populated for the automatic path (bundle from `crashreport.Build`, `localFile` from
+`crashreport.Result.LocalFile`).
 
 ## Components
 
-### 1. `reportBugBody(info platforminfo.Info, bundle *crashreport.Bundle) (title, body string)`
+### 1. `reportBugURL(info platforminfo.Info, bundle *crashreport.Bundle, localFile string) string`
 
-New function in `go/internal/cli/commands/report_bug.go`. Builds markdown mirroring
-`bug_report.yml`'s field labels as `###` headers:
+New function in `go/internal/cli/commands/report_bug.go`. Builds:
 
-- `What happened?`, `Steps to reproduce`, `Component`, `Target hardware` — placeholder prompt text
-  (e.g. `_Describe what happened here._`) when `bundle == nil`; when `bundle != nil`, `What happened?`
-  is pre-filled with `bundle.ErrorChain` and a `_(auto-filled from the failure that triggered this
-  report; edit as needed)_` note, the rest stay placeholders (component/hardware aren't inferable).
-- `Versions` — `info.CLIVersion`.
-- `Host information` — `info.Block()`.
-- `Relevant logs or output` — omitted when `bundle == nil`; filled with `bundle.LogTail` (and
-  `bundle.BuildOutputTail` when present) otherwise.
+`https://github.com/wendylabsinc/WendyOS/issues/new?template=bug_report.yml&<query>`
 
-Title: `"bug: <short summary>"` placeholder for manual use; `"bug: " + bundle.ErrorClass` for the
-automatic path.
+where `<query>` is built with `net/url.Values`, field ids matching `bug_report.yml`:
 
-Pure function, no I/O — fully unit-testable against fixed `Info`/`Bundle` values.
+- `version` — `info.CLIVersion`.
+- `host-os` — `info.Block()`.
+- `what-happened` — omitted when `bundle == nil` (manual path leaves it for the user to fill in from
+  the form itself); when `bundle != nil`, set to `bundle.ErrorClass + ": " + bundle.ErrorChain`,
+  truncated to 500 characters with a `…` suffix if longer (`truncate(s string, max int) string`
+  helper).
+- `logs` — omitted when `bundle == nil`; when `bundle != nil` and `localFile != ""`, set to
+  `"Full redacted diagnostic bundle saved locally at " + localFile + " — attach it here."` (never the
+  raw log tail — see Non-goals on URL length).
+- `component`, `hardware` — never set; not inferable from either path, left for the user to pick from
+  the form's dropdowns.
 
-### 2. `openPrefilledIssue(cmd *cobra.Command, title, body string) bool`
+All values are URL-encoded by `url.Values.Encode()`. Pure function, no I/O — fully unit-testable
+against fixed `Info`/`Bundle` values asserting the decoded query string.
 
-- Looks up `gh` via a package-level `lookGH = exec.LookPath` seam (swappable in tests).
-- If found: runs `gh issue create --repo wendylabsinc/WendyOS --title <title> --body <body> --web`,
-  streaming its stderr through so the user sees `gh`'s own "Opening in your browser." message. Returns
-  `true` on success.
-- If not found, or `gh` errors: returns `false` and does nothing else — callers own the fallback
-  message, since the manual and automatic call sites want different wording.
+### 2. `maybeOpenReportBugURL(cmd *cobra.Command, url string) bool`
+
+- Looks up `gh` via a package-level `lookGH = func() (string, error) { return exec.LookPath("gh") }`
+  seam (swappable in tests).
+- If found: calls `openBrowser(url)` (existing seam from `open_browser.go`), prints `"Opening a
+  pre-filled bug report in your browser..."` to `cmd.ErrOrStderr()`, returns `true`.
+- If `gh` not found, or `openBrowser` errors: returns `false` and does nothing else — callers own the
+  fallback message, since the manual and automatic call sites want different wording.
 
 ### 3. `wendy report-bug` (`newReportBugCmd`, hidden, added to root.go's hidden-command block)
 
-```
+```go
 info := platforminfo.Collect()
-title, body := reportBugBody(info, nil)
-if !openPrefilledIssue(cmd, title, body) {
-    fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com for a pre-filled report.")
+url := reportBugURL(info, nil, "")
+if !maybeOpenReportBugURL(cmd, url) {
+    fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com, or open this link to file a report:")
+    fmt.Fprintln(out, url)
     fmt.Fprintln(out, "")
     fmt.Fprintln(out, info.Block())
-    fmt.Fprintln(out, "")
-    fmt.Fprintln(out, "Open a bug report: https://github.com/wendylabsinc/WendyOS/issues/new?template=bug_report.yml")
 }
 ```
 
@@ -129,9 +148,9 @@ with:
 
 ```go
 fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", res.LocalFile)
-title, body := reportBugBody(info, &bundle)
-if !openPrefilledIssue(executed, title, body) {
-    fmt.Fprintln(out, "Attach it to an issue at https://github.com/wendylabsinc/WendyOS/issues/new?template=bug_report.yml")
+url := reportBugURL(info, &bundle, res.LocalFile)
+if !maybeOpenReportBugURL(executed, url) {
+    fmt.Fprintln(out, "Open a bug report:", url)
 }
 ```
 
@@ -146,23 +165,19 @@ degrades to when the cloud path is unavailable.
 
 ## Testing
 
-- `report_bug_body_test.go`: table tests for `reportBugBody` — nil bundle (placeholders) vs populated
-  bundle (error chain/log tail filled in), asserting exact section presence/absence.
-- `report_bug_test.go`: `lookGH` stubbed to simulate gh-present/gh-absent/gh-error; asserts the correct
-  fallback text and that the constructed `gh` argv matches expectations (via a stubbed exec runner,
-  not a real subprocess).
-- Update existing `crashflow_test.go` cloud-unavailable case for the new call, using the same `lookGH`
-  stub.
+- `report_bug_url_test.go`: table tests for `reportBugURL` — nil bundle (only version/host-os set) vs
+  populated bundle (+ what-happened, + logs pointing at localFile), asserting the decoded query string
+  via `url.ParseQuery`. Includes a case for the 500-char truncation.
+- `report_bug_test.go`: `lookGH` and `openBrowser` stubbed to simulate gh-present/gh-absent/
+  openBrowser-error; asserts the correct stdout/stderr text in each case (following the pattern in
+  `open_browser_test.go`).
+- Update existing `crashflow_test.go` cloud-unavailable case for the new call, using the same stubs.
 - `go test ./go/internal/cli/...`, `go vet ./go/internal/cli/...`.
 - Manual: run `wendy report-bug` locally with and without `gh` on PATH; confirm the browser opens with
-  the expected sections pre-filled and nothing is submitted without pressing the button.
+  Versions/Host information pre-filled in their actual form fields and nothing is submitted without
+  pressing the button.
 
 ## Open questions / follow-ups
 
-- `gh issue create --web --title/--body` on a form-only repo bypasses the YAML form UI (GitHub treats
-  it as a plain issue with the given body) rather than pre-filling individual form fields. This is
-  intentional here — it's the reliable, documented behavior versus relying on per-field query-param
-  prefill, which is undocumented for `gh`'s flag surface. Worth revisiting if GitHub/gh add first-class
-  form-field prefill support.
 - #1563 should be closed by its author (`max`) once this lands, keeping only the `bug_report.yml`
   wording fix folded in here.

--- a/specs/2026-08-04-report-bug-command-plan.md
+++ b/specs/2026-08-04-report-bug-command-plan.md
@@ -1,0 +1,691 @@
+# `wendy report-bug` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a hidden `wendy report-bug` command that opens a pre-filled GitHub bug-report form, and wire the same mechanism into PR #1228's crash-report flow so it fires automatically when cloud submission is unavailable.
+
+**Architecture:** A pure URL-builder (`reportBugURL`) fills `bug_report.yml`'s Versions/Host information (and, when triggered by a crash, a short error summary + local-file pointer) via GitHub's documented per-field query-param prefill. A small opener (`maybeOpenReportBugURL`) auto-opens that URL via the repo's existing `openBrowser` seam only when `gh` is on PATH (a "this is a dev machine" signal, not the opening mechanism itself); otherwise it's printed for manual use. `wendy report-bug` and `crashflow.go`'s cloud-unavailable branch both call the same two functions.
+
+**Tech Stack:** Go 1.26, Cobra, the existing `platforminfo`/`crashreport`/`browseropen` packages in `go/internal/...`.
+
+## Global Constraints
+
+- Repo/module: `github.com/wendylabsinc/wendy`; CLI commands live in `go/internal/cli/commands` (package `commands`).
+- Base branch for all work: `jo/report-bug` (already checked out in this worktree, branched from `origin/jo/platform-diagnostics-crash-reporting`, i.e. PR #1228).
+- Issue URL base: `https://github.com/wendylabsinc/WendyOS/issues/new` — always keep this exact host/path/casing.
+- Never shell out to `gh issue create`; `gh`'s only role is an `exec.LookPath("gh")` presence check.
+- Never add a new consent prompt in `crashflow.go` — the automatic path only fires after the existing "Send this report?" consent already returned yes and cloud submission failed.
+- Never inline full log tails into the URL — cap any single query value at 500 runes via `truncateForURL`; the automatic path points at the already-saved local report file instead of embedding the log tail.
+- Reuse the existing `openBrowser` package var (`go/internal/cli/commands/auth.go:646`, backed by `browseropen.Open`) — do not write new OS-specific browser-opening code.
+- Test seams follow the existing save/restore pattern (see `go/internal/cli/commands/open_browser_test.go`): save the package var, `t.Cleanup` to restore it, reassign for the test.
+- `report-bug` is `Hidden: true` on its `cobra.Command`, takes no args (`cobra.NoArgs`), and is added to `root.go`'s hidden-command block — it must not appear in `wendy --help`.
+
+---
+
+### Task 1: Core helpers — `reportBugURL` and `maybeOpenReportBugURL`
+
+**Files:**
+- Create: `go/internal/cli/commands/report_bug.go`
+- Test: `go/internal/cli/commands/report_bug_test.go`
+
+**Interfaces:**
+- Consumes: `platforminfo.Info` (fields `CLIVersion`, `.Block()` — from `go/internal/shared/platforminfo/platforminfo.go`), `crashreport.Bundle` (fields `ErrorClass`, `ErrorChain` — from `go/internal/cli/crashreport/bundle.go`), the existing package-level `openBrowser func(string) error` var (`go/internal/cli/commands/auth.go:646`).
+- Produces: `reportBugURL(info platforminfo.Info, bundle *crashreport.Bundle, localFile string) string`, `maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) bool`, and the package-level `lookPath` var — all consumed by Task 2 and Task 3.
+
+- [ ] **Step 1: Write the failing tests for `reportBugURL`**
+
+```go
+// go/internal/cli/commands/report_bug_test.go
+package commands
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
+)
+
+func TestReportBugURLManualNoBundle(t *testing.T) {
+	info := platforminfo.Info{CLIVersion: "1.2.3", DevOS: "darwin", DevOSVersion: "15.2", DevArch: "arm64"}
+	got := reportBugURL(info, nil, "")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	if u.Scheme != "https" || u.Host != "github.com" || u.Path != "/wendylabsinc/WendyOS/issues/new" {
+		t.Fatalf("unexpected URL base: %q", got)
+	}
+	q := u.Query()
+	if q.Get("template") != "bug_report.yml" {
+		t.Errorf("template = %q, want bug_report.yml", q.Get("template"))
+	}
+	if q.Get("version") != "1.2.3" {
+		t.Errorf("version = %q, want 1.2.3", q.Get("version"))
+	}
+	if !strings.Contains(q.Get("host-os"), "darwin") {
+		t.Errorf("host-os = %q, want it to mention darwin", q.Get("host-os"))
+	}
+	if q.Get("what-happened") != "" {
+		t.Errorf("what-happened should be unset for a nil bundle, got %q", q.Get("what-happened"))
+	}
+	if q.Get("logs") != "" {
+		t.Errorf("logs should be unset for a nil bundle, got %q", q.Get("logs"))
+	}
+}
+
+func TestReportBugURLWithBundleAndLocalFile(t *testing.T) {
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "exit status 1"}
+	got := reportBugURL(info, &bundle, "/tmp/wendy-crashreport-abc/report.json")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	q := u.Query()
+	if want := "docker_build_failed: exit status 1"; q.Get("what-happened") != want {
+		t.Errorf("what-happened = %q, want %q", q.Get("what-happened"), want)
+	}
+	if !strings.Contains(q.Get("logs"), "/tmp/wendy-crashreport-abc/report.json") {
+		t.Errorf("logs = %q, want it to mention the local file", q.Get("logs"))
+	}
+}
+
+func TestReportBugURLTruncatesLongErrorChain(t *testing.T) {
+	info := platforminfo.Info{}
+	bundle := crashreport.Bundle{ErrorClass: "x", ErrorChain: strings.Repeat("a", 1000)}
+	got := reportBugURL(info, &bundle, "")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("invalid URL %q: %v", got, err)
+	}
+	whatHappened := u.Query().Get("what-happened")
+	if rc := len([]rune(whatHappened)); rc > 501 { // 500 + the "…" rune
+		t.Errorf("what-happened not truncated: %d runes", rc)
+	}
+	if !strings.HasSuffix(whatHappened, "…") {
+		t.Errorf("what-happened = %q, want a truncation ellipsis", whatHappened)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportBugURL -v`
+Expected: FAIL — `undefined: reportBugURL` (the function doesn't exist yet).
+
+- [ ] **Step 3: Implement `reportBugURL` and `truncateForURL` only**
+
+`maybeOpenReportBugURL` is deliberately left out of this step — it gets its own red-green cycle in
+Steps 5-8 below.
+
+```go
+// go/internal/cli/commands/report_bug.go
+package commands
+
+import (
+	"net/url"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
+)
+
+// reportBugIssueURL is the GitHub "new issue" endpoint for this repo. Keep the
+// path casing exact — GitHub's own links use it and some proxies are case
+// sensitive.
+const reportBugIssueURL = "https://github.com/wendylabsinc/WendyOS/issues/new"
+
+// reportBugURL builds a GitHub issue-form URL that pre-fills bug_report.yml's
+// Versions and Host information fields via GitHub's documented per-field
+// query-param prefill (field id as the parameter name). When bundle is
+// non-nil (the automatic crash-report path), it also fills a short
+// What-happened summary and, when localFile is set, a pointer to the
+// locally-saved report file instead of the raw log tail. Component and
+// Target hardware are never inferable, so they're left for the user to pick
+// from the form's dropdowns.
+func reportBugURL(info platforminfo.Info, bundle *crashreport.Bundle, localFile string) string {
+	q := url.Values{}
+	q.Set("template", "bug_report.yml")
+	q.Set("version", info.CLIVersion)
+	q.Set("host-os", info.Block())
+
+	if bundle != nil {
+		q.Set("what-happened", truncateForURL(bundle.ErrorClass+": "+bundle.ErrorChain, 500))
+		if localFile != "" {
+			q.Set("logs", "Full redacted diagnostic bundle saved locally at "+localFile+" — attach it here.")
+		}
+	}
+
+	return reportBugIssueURL + "?" + q.Encode()
+}
+
+// truncateForURL shortens s to at most max runes (appending "…") so a single
+// query value can't blow past practical URL-length limits.
+func truncateForURL(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportBugURL -v`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Write the failing tests for `maybeOpenReportBugURL`**
+
+```go
+// append to go/internal/cli/commands/report_bug_test.go
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	// ...(keep existing imports)
+
+	"github.com/spf13/cobra"
+)
+
+func TestMaybeOpenReportBugURLGHPresentSucceeds(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	if !maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected true when gh is present and openBrowser succeeds")
+	}
+	if openedURL != "https://example.com/issue" {
+		t.Errorf("openBrowser called with %q, want the report URL", openedURL)
+	}
+	if !strings.Contains(stderr.String(), "Opening a pre-filled bug report") {
+		t.Errorf("stderr = %q, want the opening message", stderr.String())
+	}
+}
+
+func TestMaybeOpenReportBugURLGHMissing(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected false when gh is missing")
+	}
+}
+
+func TestMaybeOpenReportBugURLOpenBrowserFails(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	openBrowser = func(string) error { return fmt.Errorf("no display") }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	if maybeOpenReportBugURL(cmd, "https://example.com/issue") {
+		t.Fatal("expected false when openBrowser fails")
+	}
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `go test ./go/internal/cli/commands/... -run TestMaybeOpenReportBugURL -v`
+Expected: FAIL to compile — `undefined: maybeOpenReportBugURL` and `undefined: lookPath` (neither exists yet).
+
+- [ ] **Step 7: Implement `lookPath` and `maybeOpenReportBugURL`**
+
+Add to `go/internal/cli/commands/report_bug.go`: extend the import block with `"fmt"`, `"os/exec"`, and
+`"github.com/spf13/cobra"`, then append:
+
+```go
+// lookPath is a seam so tests can simulate gh being present or absent without
+// depending on the real PATH.
+var lookPath = exec.LookPath
+
+// maybeOpenReportBugURL opens rawURL in the browser when gh is on PATH (used
+// only as a signal that this is an interactive developer machine — gh's own
+// issue-create machinery is never invoked). Returns whether it succeeded;
+// callers own the fallback message for the false case.
+func maybeOpenReportBugURL(cmd *cobra.Command, rawURL string) bool {
+	if _, err := lookPath("gh"); err != nil {
+		return false
+	}
+	if err := openBrowser(rawURL); err != nil {
+		return false
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), "Opening a pre-filled bug report in your browser...")
+	return true
+}
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/cli/commands/... -run TestMaybeOpenReportBugURL -v`
+Expected: PASS (all three cases).
+
+- [ ] **Step 9: Run the full set of Task 1 tests together**
+
+Run: `go test ./go/internal/cli/commands/... -run 'TestReportBugURL|TestMaybeOpenReportBugURL' -v`
+Expected: PASS — 6 tests total.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add go/internal/cli/commands/report_bug.go go/internal/cli/commands/report_bug_test.go
+git commit -m "feat(cli): add reportBugURL + maybeOpenReportBugURL helpers"
+```
+
+---
+
+### Task 2: `wendy report-bug` command
+
+**Files:**
+- Modify: `go/internal/cli/commands/report_bug.go` (add `newReportBugCmd`)
+- Modify: `go/internal/cli/commands/root.go` (register the hidden command)
+- Modify: `go/internal/cli/commands/report_bug_test.go` (add command-level tests)
+
+**Interfaces:**
+- Consumes: `reportBugURL`, `maybeOpenReportBugURL`, `lookPath`, `openBrowser` (Task 1), `platforminfo.Collect()` (existing).
+- Produces: `newReportBugCmd() *cobra.Command`, consumed only by `root.go`'s `NewRootCmd`.
+
+- [ ] **Step 1: Write the failing command-level tests**
+
+```go
+// append to go/internal/cli/commands/report_bug_test.go
+func TestReportBugCmdGHMissingPrintsFallback(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := newReportBugCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "`gh` CLI not found") {
+		t.Errorf("output = %q, want the gh-missing fallback message", out)
+	}
+	if !strings.Contains(out, "issues/new?") {
+		t.Errorf("output = %q, want the fallback URL", out)
+	}
+}
+
+func TestReportBugCmdGHPresentOpensBrowser(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := newReportBugCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if openedURL == "" || !strings.Contains(openedURL, "issues/new?") {
+		t.Errorf("openBrowser called with %q, want a bug_report.yml issue URL", openedURL)
+	}
+	if stdout.String() != "" {
+		t.Errorf("expected no stdout output when gh succeeds, got %q", stdout.String())
+	}
+}
+
+func TestReportBugCmdRejectsArgs(t *testing.T) {
+	cmd := newReportBugCmd()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for a stray positional argument")
+	}
+}
+
+func TestReportBugCmdIsHidden(t *testing.T) {
+	cmd := newReportBugCmd()
+	if !cmd.Hidden {
+		t.Error("report-bug must be Hidden so it doesn't appear in `wendy --help`")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportBugCmd -v`
+Expected: FAIL with `undefined: newReportBugCmd`.
+
+- [ ] **Step 3: Implement `newReportBugCmd`**
+
+```go
+// append to go/internal/cli/commands/report_bug.go
+func newReportBugCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "report-bug",
+		Short:  "Open a pre-filled GitHub bug report",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			info := platforminfo.Collect()
+			rawURL := reportBugURL(info, nil, "")
+			if maybeOpenReportBugURL(cmd, rawURL) {
+				return nil
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "`gh` CLI not found — install it from https://cli.github.com, or open this link to file a report:")
+			fmt.Fprintln(out, rawURL)
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, info.Block())
+			return nil
+		},
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportBugCmd -v`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Register the command in `root.go`**
+
+In `go/internal/cli/commands/root.go`, add alongside the other hidden commands (near `tourCmd := newTourCmd()` / `mcpCmd := newMCPCmd()`, around line 172-175):
+
+```go
+	tourCmd := newTourCmd()
+	tourCmd.Hidden = true
+	mcpCmd := newMCPCmd()
+	mcpCmd.Hidden = true
+	reportBugCmd := newReportBugCmd()
+```
+
+(`newReportBugCmd` already sets `Hidden: true` itself, so no separate assignment is needed — this mirrors how `jsonCmd`/`authCmd` are declared just before their own `.Hidden = true` line elsewhere in this block; keep the ordering consistent with the surrounding declarations.)
+
+Then add `reportBugCmd` to the `root.AddCommand(...)` hidden-command list (around line 226-240), e.g. directly after `infoCmd,`:
+
+```go
+		infoCmd,
+		reportBugCmd,
+		utilsCmd,
+```
+
+- [ ] **Step 6: Verify the command is wired up end-to-end**
+
+Run: `go build ./go/... && go run ./go/cmd/wendy report-bug --help`
+Expected: prints cobra's help for `report-bug` (proving it's registered and runnable), and does NOT appear in `go run ./go/cmd/wendy --help`'s command list (proving `Hidden` took effect).
+
+- [ ] **Step 7: Run the full commands package test suite**
+
+Run: `go test ./go/internal/cli/commands/... -v 2>&1 | tail -60`
+Expected: PASS, no regressions in `root_test.go` or elsewhere from the new registration.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add go/internal/cli/commands/report_bug.go go/internal/cli/commands/report_bug_test.go go/internal/cli/commands/root.go
+git commit -m "feat(cli): add hidden wendy report-bug command"
+```
+
+---
+
+### Task 3: Wire the automatic fallback into `crashflow.go`
+
+**Files:**
+- Modify: `go/internal/cli/commands/crashflow.go:103-104` (replace the cloud-unavailable print block)
+- Modify: `go/internal/cli/commands/crashflow_test.go` (add tests for the extracted helper)
+
+**Interfaces:**
+- Consumes: `reportBugURL`, `maybeOpenReportBugURL` (Task 1); existing `platforminfo.Info`, `crashreport.Bundle` types; `crashreport.Result.LocalFile` (existing field, `go/internal/cli/crashreport/submit.go`).
+- Produces: `reportCrashLocally(cmd *cobra.Command, out io.Writer, info platforminfo.Info, bundle crashreport.Bundle, localFile string)`, called only from `MaybeRunCrashReport`.
+
+- [ ] **Step 1: Write the failing tests for `reportCrashLocally`**
+
+```go
+// append to go/internal/cli/commands/crashflow_test.go
+import (
+	"os/exec"
+	// ...(keep existing imports)
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/crashreport"
+	"github.com/wendylabsinc/wendy/go/internal/shared/platforminfo"
+)
+
+func TestReportCrashLocallyOpensBrowserWhenGHPresent(t *testing.T) {
+	origLookPath, origOpenBrowser := lookPath, openBrowser
+	t.Cleanup(func() { lookPath = origLookPath; openBrowser = origOpenBrowser })
+	lookPath = func(string) (string, error) { return "/usr/local/bin/gh", nil }
+	var openedURL string
+	openBrowser = func(u string) error { openedURL = u; return nil }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var out bytes.Buffer
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "boom"}
+
+	reportCrashLocally(cmd, &out, info, bundle, "/tmp/report.json")
+
+	if !strings.Contains(out.String(), "/tmp/report.json") {
+		t.Errorf("out = %q, want it to mention the local file", out.String())
+	}
+	if openedURL == "" || !strings.Contains(openedURL, "issues/new?") {
+		t.Errorf("openBrowser called with %q, want a bug_report.yml issue URL", openedURL)
+	}
+}
+
+func TestReportCrashLocallyPrintsURLWhenGHMissing(t *testing.T) {
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	cmd := &cobra.Command{Use: "wendy"}
+	var out bytes.Buffer
+	info := platforminfo.Info{CLIVersion: "1.2.3"}
+	bundle := crashreport.Bundle{ErrorClass: "docker_build_failed", ErrorChain: "boom"}
+
+	reportCrashLocally(cmd, &out, info, bundle, "/tmp/report.json")
+
+	if !strings.Contains(out.String(), "Open a bug report:") {
+		t.Errorf("out = %q, want the manual fallback line", out.String())
+	}
+	if !strings.Contains(out.String(), "issues/new?") {
+		t.Errorf("out = %q, want the report URL", out.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportCrashLocally -v`
+Expected: FAIL with `undefined: reportCrashLocally`.
+
+- [ ] **Step 3: Extract `reportCrashLocally` and update the call site**
+
+In `go/internal/cli/commands/crashflow.go`, replace lines 103-104:
+
+```go
+	fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", res.LocalFile)
+	fmt.Fprintln(out, "Attach it to an issue at https://github.com/wendylabsinc/wendyos/issues")
+```
+
+with:
+
+```go
+	reportCrashLocally(executed, out, info, bundle, res.LocalFile)
+```
+
+Then add the new function (e.g. directly below `MaybeRunCrashReport`, before `printTail`):
+
+```go
+// reportCrashLocally is the cloud-unavailable fallback: point the user at a
+// pre-filled GitHub issue (the same mechanism as `wendy report-bug`) carrying
+// the redacted bundle's error summary and the local report path, instead of
+// the previous dead-end "attach it to an issue" instruction.
+func reportCrashLocally(cmd *cobra.Command, out io.Writer, info platforminfo.Info, bundle crashreport.Bundle, localFile string) {
+	fmt.Fprintf(out, "\nCloud unavailable; report saved locally: %s\n", localFile)
+	rawURL := reportBugURL(info, &bundle, localFile)
+	if !maybeOpenReportBugURL(cmd, rawURL) {
+		fmt.Fprintln(out, "Open a bug report:", rawURL)
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/cli/commands/... -run TestReportCrashLocally -v`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Run the full crashflow test suite to confirm no regressions**
+
+Run: `go test ./go/internal/cli/commands/... -run TestMaybeRunCrashReport -v`
+Expected: PASS — `TestMaybeRunCrashReportSkipsRecoverable`, `TestMaybeRunCrashReportSuppressed`, `TestMaybeRunCrashReportNotSuppressedProceeds`, `TestCrashConsentPrompt` all still pass unchanged (none of them reach the cloud-unavailable branch, since they stop at the consent-prompt EOF).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/cli/commands/crashflow.go go/internal/cli/commands/crashflow_test.go
+git commit -m "fix(cli): open a pre-filled bug report when crash-report cloud submission is unavailable"
+```
+
+---
+
+### Task 4: `bug_report.yml` wording fix
+
+**Files:**
+- Create/Modify: `.github/ISSUE_TEMPLATE/bug_report.yml` (does not exist on this branch yet — `jo/platform-diagnostics-crash-reporting` predates its addition on `main`; bring the current `main` version over first, then edit)
+
+**Interfaces:**
+- None (YAML config, not Go code). No other task depends on this one.
+
+- [ ] **Step 1: Bring the current file over from `main`**
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+git show main:.github/ISSUE_TEMPLATE/bug_report.yml > .github/ISSUE_TEMPLATE/bug_report.yml
+```
+
+- [ ] **Step 2: Confirm the version/host-os block matches what this step expects to edit**
+
+Run: `sed -n '55,68p' .github/ISSUE_TEMPLATE/bug_report.yml`
+Expected output:
+
+```yaml
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: Output of `wendy version` (and agent version if relevant)
+    validations:
+      required: true
+  - type: input
+    id: host-os
+    attributes:
+      label: Host OS
+      placeholder: macOS 15.2 (Apple Silicon), Ubuntu 24.04, Windows 11
+    validations:
+      required: true
+```
+
+If the line numbers differ, locate the same block by searching for `id: version`.
+
+- [ ] **Step 3: Edit the block**
+
+Replace it with:
+
+```yaml
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: Output of `wendy --version` (and agent version if relevant)
+    validations:
+      required: true
+  - type: textarea
+    id: host-os
+    attributes:
+      label: Host information
+      description: Run 'wendy report-bug' to open a pre-filled report, or paste your OS name, version, and architecture manually.
+      render: shell
+    validations:
+      required: true
+```
+
+- [ ] **Step 4: Validate the YAML parses and the diff has no whitespace errors**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))" && echo "YAML OK"
+git diff --check
+```
+Expected: `YAML OK` printed, `git diff --check` produces no output (no trailing-whitespace/tab errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/bug_report.yml
+git commit -m "docs: point bug_report.yml at wendy --version and wendy report-bug"
+```
+
+Note for the eventual PR description: this branch had never picked up `main`'s addition of `bug_report.yml` (PR #1228 predates it), so this commit's diff will show the file as newly added rather than modified. When #1228/this branch is eventually rebased or merged against current `main`, expect a create/create conflict on this one file — resolve by keeping this branch's version (it is `main`'s version plus the two wording edits above).
+
+---
+
+### Task 5: Final verification
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run the full CLI test suite**
+
+Run: `go test ./go/internal/cli/... -v 2>&1 | tail -100`
+Expected: PASS, no failures or skips beyond any pre-existing ones unrelated to this change.
+
+- [ ] **Step 2: Run `go vet`**
+
+Run: `go vet ./go/internal/cli/...`
+Expected: no output (clean).
+
+- [ ] **Step 3: Build the CLI binary**
+
+Run: `go build -o /tmp/wendy-report-bug-check ./go/cmd/wendy`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Manual smoke test — gh present**
+
+Run: `/tmp/wendy-report-bug-check report-bug` (with `gh` on `PATH`)
+Expected: stderr prints "Opening a pre-filled bug report in your browser...", and the browser opens to a GitHub new-issue page with the Versions and Host information fields already filled in, nothing else.
+
+- [ ] **Step 5: Manual smoke test — gh absent**
+
+Run: `PATH=/usr/bin:/bin /tmp/wendy-report-bug-check report-bug` (a `PATH` without `gh`)
+Expected: stdout prints the "`gh` CLI not found" message, the issue URL, and the diagnostic block; nothing opens automatically.
+
+- [ ] **Step 6: Confirm `report-bug` stays hidden**
+
+Run: `/tmp/wendy-report-bug-check --help`
+Expected: `report-bug` does not appear in the command list.
+
+- [ ] **Step 7: Review the full diff before opening a PR**
+
+Run: `git diff origin/jo/platform-diagnostics-crash-reporting...HEAD --stat`
+Expected: only the files touched by Tasks 1-4 (`report_bug.go`, `report_bug_test.go`, `root.go`, `crashflow.go`, `crashflow_test.go`, `bug_report.yml`, plus the two spec docs from brainstorming/planning).


### PR DESCRIPTION
## Summary

- Adds a hidden `wendy report-bug` command that opens a GitHub issue pre-filled with CLI version and host diagnostics (reusing `platforminfo`, already on this branch), using GitHub's documented per-field URL query-param prefill for issue forms — no new host-info collection code, no shelling out to `gh issue create`.
- `gh`'s presence (`exec.LookPath`) gates whether the browser auto-opens (a proxy for "interactive dev machine"); without it, the command prints the diagnostics and the URL for manual use.
- Wires the same URL-builder into this branch's `MaybeRunCrashReport` (`crashflow.go`): when cloud crash-report submission fails after the user already consented to send a report, it now opens a pre-filled issue (with the redacted error summary + a pointer to the locally-saved report file) instead of the previous dead-end "attach it to an issue" message. No new consent prompt.
- Fixes `bug_report.yml`: `wendy version` → `wendy --version` typo, and points the Host information field at `wendy report-bug` (now a multi-line `textarea` instead of a single-line `input`, since the prefilled content is multi-line).

## Why this is based on #1228, not `main`

This branch reuses `platforminfo.Collect()`/`.Block()` and hooks directly into `crashflow.go`'s `MaybeRunCrashReport`, both of which live only on `jo/platform-diagnostics-crash-reporting` (#1228) and aren't on `main` yet. Supersedes #1563 (`max/fix-issue-template-host-info`), which added a separate `--host-info` flag duplicating this diagnostics collection — that PR should be closed in favor of this one, keeping only its `bug_report.yml` `--version` wording fix (carried over here).

Note: `bug_report.yml` doesn't exist yet on `jo/platform-diagnostics-crash-reporting` (added to `main` after that branch diverged), so this PR's diff shows it as newly added. Expect a create/create conflict when #1228 is eventually rebased/merged against current `main` — resolve by keeping this branch's version (main's content plus the two wording edits).

## Review notes

Went through brainstorming → design → plan → subagent-driven implementation (5 tasks) → whole-branch review → one fix round. The whole-branch review is clean after the fix round; residual items below were deliberately parked rather than fixed:

- The `gh`-gate applies to both the explicit command and the automatic crash-flow path by design (reviewer raised whether the explicit command should always try to open regardless of `gh`; kept as designed).
- I could not visually confirm GitHub actually renders the pre-filled form fields correctly (no browser access in this environment) — recommend opening the printed URL once before merging.
- A handful of Minor findings (naming, a `root_test.go` registration line, partial truncation-cap application, crash-path issue title prefill) are deferred, not blocking.

## Test plan

- [x] `go build ./go/...`
- [x] `go vet ./go/internal/cli/...`
- [x] `go test ./go/...` (whole module, green)
- [x] Manual: `report-bug` with/without `gh` on PATH — correct messages, `report-bug` absent from `wendy --help`
- [ ] Manual: open the printed/opened URL in a real browser once and confirm GitHub actually pre-fills Versions/Host information

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144H6SSDAYLKG3T5DWuFtVp