### PR TITLE
camera view: offer GStreamer install via Homebrew on macOS

### DIFF
--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -216,7 +216,7 @@ func playVideoWithGStreamer(ctx context.Context, stream videoStream) error {
 	}
 	codec := first.GetCodec()
 
-	gstPath, err := resolveGSTLaunch()
+	gstPath, err := ensureGSTLaunch(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/camera_gst.go
+++ b/go/internal/cli/commands/camera_gst.go
@@ -1,9 +1,14 @@
 package commands
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
 // gstLaunchFallbackPathsFn indirects gstLaunchFallbackPaths so tests can stub
@@ -27,4 +32,71 @@ func resolveGSTLaunch() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%s not found; install GStreamer or use --stdout to pipe raw video", gstLaunchName)
+}
+
+// brewLookPathFn resolves the "brew" binary; indirected so tests can stub it
+// without depending on whether Homebrew is actually installed.
+var brewLookPathFn = exec.LookPath
+
+// installGStreamerFn runs `brew install gstreamer`; indirected so tests can
+// stub it without invoking Homebrew.
+var installGStreamerFn = installGStreamerViaBrew
+
+// ensureGSTLaunch resolves gst-launch-1.0 like resolveGSTLaunch, but on an
+// interactive macOS session where it's missing, offers to install GStreamer
+// via Homebrew first. Non-interactive runs, non-macOS hosts, and hosts
+// without Homebrew fall straight through to resolveGSTLaunch's plain "not
+// found" error instead of prompting.
+func ensureGSTLaunch(ctx context.Context) (string, error) {
+	return ensureGSTLaunchForHostOS(ctx, runtime.GOOS)
+}
+
+func ensureGSTLaunchForHostOS(ctx context.Context, hostOS string) (string, error) {
+	path, err := resolveGSTLaunch()
+	if err == nil {
+		return path, nil
+	}
+	if hostOS != "darwin" || !isInteractiveTerminalFn() {
+		return "", err
+	}
+	if _, lookErr := brewLookPathFn("brew"); lookErr != nil {
+		return "", err
+	}
+	if !confirmFn("GStreamer is required to view the camera and was not found. Install it now with `brew install gstreamer`?") {
+		return "", err
+	}
+	if instErr := installGStreamerFn(ctx); instErr != nil {
+		return "", fmt.Errorf("installing GStreamer via Homebrew: %w", instErr)
+	}
+	return resolveGSTLaunch()
+}
+
+// installGStreamerViaBrew runs `brew install gstreamer` behind a spinner
+// instead of streaming Homebrew's own log output; the captured output is
+// printed only if the install fails.
+func installGStreamerViaBrew(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "brew", "install", "gstreamer")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	s := tui.NewSpinner("Installing GStreamer via Homebrew...")
+	p := tui.NewProgressProgram(s)
+	go func() {
+		p.Send(tui.SpinnerDoneMsg{Err: cmd.Run()})
+	}()
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+	model, ok := finalModel.(tui.SpinnerModel)
+	if !ok {
+		return fmt.Errorf("TUI error: unexpected model type %T", finalModel)
+	}
+	if _, installErr := model.Result(); installErr != nil {
+		os.Stderr.Write(out.Bytes())
+		return installErr
+	}
+	return nil
 }

--- a/go/internal/cli/commands/camera_gst.go
+++ b/go/internal/cli/commands/camera_gst.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -66,7 +67,7 @@ func ensureGSTLaunchForHostOS(ctx context.Context, hostOS string) (string, error
 		return "", err
 	}
 	if instErr := installGStreamerFn(ctx); instErr != nil {
-		if instErr == ErrUserCancelled {
+		if errors.Is(instErr, ErrUserCancelled) {
 			return "", instErr
 		}
 		return "", fmt.Errorf("installing GStreamer via Homebrew: %w", instErr)
@@ -125,3 +126,4 @@ func installGStreamerViaBrew(ctx context.Context) error {
 		return runErr
 	}
 	return nil
+}

--- a/go/internal/cli/commands/camera_gst.go
+++ b/go/internal/cli/commands/camera_gst.go
@@ -78,28 +78,50 @@ func ensureGSTLaunchForHostOS(ctx context.Context, hostOS string) (string, error
 // instead of streaming Homebrew's own log output; the captured output is
 // printed only if the install fails.
 func installGStreamerViaBrew(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, "brew", "install", "gstreamer")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
+	cmd.Stdin = nil
 
-	s := tui.NewSpinner("Installing GStreamer via Homebrew...")
-	p := tui.NewProgressProgram(s)
+	prog := tui.NewProgressProgram(tui.NewSpinner("Installing GStreamer via Homebrew..."))
+
+	var (
+		runErr error
+		doneCh = make(chan struct{})
+	)
 	go func() {
-		p.Send(tui.SpinnerDoneMsg{Err: cmd.Run()})
+		defer close(doneCh)
+		runErr = cmd.Run()
+		// Keep spinner teardown quiet; callers handle the returned error/output.
+		prog.Send(tui.SpinnerDoneMsg{})
 	}()
 
-	finalModel, err := p.Run()
+	finalModel, err := prog.Run()
 	if err != nil {
-		return fmt.Errorf("TUI error: %w", err)
+		cancel()
+		<-doneCh
+		return fmt.Errorf("spinner TUI: %w", err)
 	}
-	model, ok := finalModel.(tui.SpinnerModel)
+
+	sm, ok := finalModel.(tui.SpinnerModel)
 	if !ok {
-		return fmt.Errorf("TUI error: unexpected model type %T", finalModel)
+		cancel()
+		<-doneCh
+		return fmt.Errorf("spinner TUI: unexpected model type %T", finalModel)
 	}
-	if _, installErr := model.Result(); installErr != nil {
-		os.Stderr.Write(out.Bytes())
-		return installErr
+	if !sm.Done() {
+		cancel()
+		<-doneCh
+		return ErrUserCancelled
+	}
+
+	<-doneCh
+	if runErr != nil {
+		_, _ = os.Stderr.Write(out.Bytes())
+		return runErr
 	}
 	return nil
-}

--- a/go/internal/cli/commands/camera_gst.go
+++ b/go/internal/cli/commands/camera_gst.go
@@ -66,6 +66,9 @@ func ensureGSTLaunchForHostOS(ctx context.Context, hostOS string) (string, error
 		return "", err
 	}
 	if instErr := installGStreamerFn(ctx); instErr != nil {
+		if instErr == ErrUserCancelled {
+			return "", instErr
+		}
 		return "", fmt.Errorf("installing GStreamer via Homebrew: %w", instErr)
 	}
 	return resolveGSTLaunch()

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -144,6 +144,7 @@ func TestPlaybackPipelineArgs_VP8LeakyQueueBeforeDecoder(t *testing.T) {
 func TestPlayVideoWithGStreamer_MissingGStreamer(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
 	stubGSTFallback(t, nil)       // no install-location fallbacks either
+	stubNonInteractive(t)         // no install prompt for the missing binary
 
 	stream := &mockVideoStream{frames: []*agentpb.VideoFrame{{Data: []byte{0x00}, Codec: agentpb.VideoCodec_VIDEO_CODEC_H264}}}
 	err := playVideoWithGStreamer(context.Background(), stream)
@@ -158,6 +159,7 @@ func TestPlayVideoWithGStreamer_MissingGStreamer(t *testing.T) {
 func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // empty dir — no executables on PATH
 	stubGSTFallback(t, nil)       // no install-location fallbacks either
+	stubNonInteractive(t)         // no install prompt for the missing binary
 
 	remoteErr := status.Error(codes.Unimplemented, "Camera streaming is currently not supported by Wendy Agent for Mac.")
 	stream := &mockVideoStream{err: remoteErr}
@@ -209,6 +211,162 @@ func stubGSTFallback(t *testing.T, paths []string) {
 	prev := gstLaunchFallbackPathsFn
 	gstLaunchFallbackPathsFn = func() []string { return paths }
 	t.Cleanup(func() { gstLaunchFallbackPathsFn = prev })
+}
+
+// stubNonInteractive forces isInteractiveTerminalFn to report a non-TTY
+// session for the duration of the test, so tests exercising a missing
+// gst-launch-1.0 never trigger the macOS install prompt.
+func stubNonInteractive(t *testing.T) {
+	t.Helper()
+	prev := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = prev })
+}
+
+func TestEnsureGSTLaunch_FoundSkipsPrompt(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	bin := filepath.Join(dir, gstLaunchName)
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("writing fake binary: %v", err)
+	}
+	stubGSTFallback(t, []string{bin})
+	stubConfirmFn(t, func(string) bool {
+		t.Fatal("must not prompt when gst-launch-1.0 is already resolvable")
+		return false
+	})
+
+	got, err := ensureGSTLaunchForHostOS(context.Background(), "darwin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != bin {
+		t.Errorf("got %q, want %q", got, bin)
+	}
+}
+
+func TestEnsureGSTLaunch_NonDarwinSkipsPrompt(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	stubGSTFallback(t, nil)
+	stubConfirmFn(t, func(string) bool {
+		t.Fatal("must not prompt on a non-macOS host")
+		return false
+	})
+
+	if _, err := ensureGSTLaunchForHostOS(context.Background(), "linux"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestEnsureGSTLaunch_NonInteractiveSkipsPrompt(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	stubGSTFallback(t, nil)
+	stubNonInteractive(t)
+	stubConfirmFn(t, func(string) bool {
+		t.Fatal("must not prompt in a non-interactive session")
+		return false
+	})
+
+	if _, err := ensureGSTLaunchForHostOS(context.Background(), "darwin"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestEnsureGSTLaunch_NoBrewSkipsPrompt(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	stubGSTFallback(t, nil)
+	stubInteractive(t)
+	stubBrewLookPath(t, func(string) (string, error) { return "", errors.New("brew not found") })
+	stubConfirmFn(t, func(string) bool {
+		t.Fatal("must not prompt when Homebrew is not installed")
+		return false
+	})
+
+	if _, err := ensureGSTLaunchForHostOS(context.Background(), "darwin"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestEnsureGSTLaunch_DeclinedInstallReturnsNotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	stubGSTFallback(t, nil)
+	stubInteractive(t)
+	stubBrewLookPath(t, func(string) (string, error) { return "/opt/homebrew/bin/brew", nil })
+	stubConfirmFn(t, func(string) bool { return false })
+	stubInstallGStreamer(t, func(context.Context) error {
+		t.Fatal("must not install when the user declines")
+		return nil
+	})
+
+	if _, err := ensureGSTLaunchForHostOS(context.Background(), "darwin"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestEnsureGSTLaunch_AcceptedInstallResolvesAfterwards(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	bin := filepath.Join(dir, gstLaunchName)
+	stubGSTFallback(t, []string{bin})
+	stubInteractive(t)
+	stubBrewLookPath(t, func(string) (string, error) { return "/opt/homebrew/bin/brew", nil })
+	stubConfirmFn(t, func(string) bool { return true })
+	stubInstallGStreamer(t, func(context.Context) error {
+		// Simulate a successful `brew install gstreamer` placing the binary.
+		return os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755)
+	})
+
+	got, err := ensureGSTLaunchForHostOS(context.Background(), "darwin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != bin {
+		t.Errorf("got %q, want %q", got, bin)
+	}
+}
+
+func TestEnsureGSTLaunch_InstallFailureIsWrapped(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	stubGSTFallback(t, nil)
+	stubInteractive(t)
+	stubBrewLookPath(t, func(string) (string, error) { return "/opt/homebrew/bin/brew", nil })
+	stubConfirmFn(t, func(string) bool { return true })
+	stubInstallGStreamer(t, func(context.Context) error { return errors.New("brew install failed") })
+
+	_, err := ensureGSTLaunchForHostOS(context.Background(), "darwin")
+	if err == nil || !strings.Contains(err.Error(), "installing GStreamer via Homebrew") {
+		t.Fatalf("expected wrapped install error, got: %v", err)
+	}
+}
+
+// stubInteractive forces isInteractiveTerminalFn to report an interactive TTY
+// session for the duration of the test.
+func stubInteractive(t *testing.T) {
+	t.Helper()
+	prev := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return true }
+	t.Cleanup(func() { isInteractiveTerminalFn = prev })
+}
+
+func stubConfirmFn(t *testing.T, fn func(string) bool) {
+	t.Helper()
+	prev := confirmFn
+	confirmFn = fn
+	t.Cleanup(func() { confirmFn = prev })
+}
+
+func stubBrewLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := brewLookPathFn
+	brewLookPathFn = fn
+	t.Cleanup(func() { brewLookPathFn = prev })
+}
+
+func stubInstallGStreamer(t *testing.T, fn func(context.Context) error) {
+	t.Helper()
+	prev := installGStreamerFn
+	installGStreamerFn = fn
+	t.Cleanup(func() { installGStreamerFn = prev })
 }
 
 func TestResolveGSTLaunch_FoundViaFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- `wendy device camera view` previously failed outright with a plain "gst-launch-1.0 not found" error on macOS hosts missing GStreamer.
- On an interactive macOS session, missing GStreamer now prompts `[Y/n]` to run `brew install gstreamer` automatically.
- The install runs behind a spinner instead of streaming Homebrew's own log output; the captured output is printed only if the install fails.
- Non-macOS hosts, non-interactive sessions, and machines without Homebrew fall through to the original "not found" error unchanged.

## Test plan
- [x] `go test ./internal/cli/commands/...` (full package, including 8 new tests covering found/no-prompt, non-darwin, non-interactive, no-brew, declined, accepted+resolves, and install-failure-wrapped paths)
- [ ] Manual: run `wendy device camera view` on a macOS host without GStreamer installed and confirm the prompt/spinner/install flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRibTwS8xAb4f17E9Ae7Xk