### PR TITLE
fix(e2e): update stale help-text assertions after a60370c49

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothConnectTests.swift
@@ -19,7 +19,7 @@ struct `'wendy cloud device bluetooth connect'` {
                 #expect(result.status.isSuccess)
                 #expect(result.stdout.contains("Connect to a Bluetooth peripheral"))
                 #expect(
-                    result.stdout.contains("wendy cloud device bluetooth connect [address] [flags]")
+                    result.stdout.contains("wendy cloud device bluetooth connect <address> [flags]")
                 )
                 #expect(result.stdout.contains("--pair"))
                 #expect(result.stdout.contains("--trust"))

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothDisconnectTests.swift
@@ -20,7 +20,7 @@ struct `'wendy cloud device bluetooth disconnect'` {
                 #expect(result.stdout.contains("Disconnect a Bluetooth peripheral"))
                 #expect(
                     result.stdout.contains(
-                        "wendy cloud device bluetooth disconnect [address] [flags]"
+                        "wendy cloud device bluetooth disconnect <address> [flags]"
                     )
                 )
                 #expect(result.stdout.contains("--device"))

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceBluetoothForgetTests.swift
@@ -19,7 +19,7 @@ struct `'wendy cloud device bluetooth forget'` {
                 #expect(result.status.isSuccess)
                 #expect(result.stdout.contains("Forget a paired Bluetooth peripheral"))
                 #expect(
-                    result.stdout.contains("wendy cloud device bluetooth forget [address] [flags]")
+                    result.stdout.contains("wendy cloud device bluetooth forget <address> [flags]")
                 )
                 #expect(result.stdout.contains("--device"))
                 #expect(result.stderr == "")

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudRunTests.swift
@@ -8,9 +8,10 @@ struct `'wendy cloud run'` {
     /**
      Displays usage for `wendy cloud run`. The output includes the command
      synopsis, local flags, inherited global flags, and concise
-     descriptions. Help exits successfully, writes to stdout, emits no
-     stderr, and leaves configuration, cache, project, cloud, and device
-     state untouched.
+     descriptions. Help exits successfully and writes to stdout. Because the
+     command is deprecated, cobra also emits a deprecation notice to stderr
+     even under `--help`; configuration, cache, project, cloud, and device
+     state are otherwise left untouched.
      */
     @Test
     func `prints command help`() async throws {
@@ -25,7 +26,7 @@ struct `'wendy cloud run'` {
                 #expect(result.stdout.contains("--user-args"))
                 #expect(result.stdout.contains("--prefix"))
                 #expect(result.stdout.contains("--device"))
-                #expect(result.stderr == "")
+                #expect(result.stderr.contains("Command \"run\" is deprecated, use 'wendy run' instead"))
             }
         }
     }

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothConnectTests.swift
@@ -18,7 +18,7 @@ struct `'wendy device bluetooth connect'` {
             try await cli.sh("wendy device bluetooth connect --help") { result in
                 #expect(result.status.isSuccess)
                 #expect(result.stdout.contains("Connect to a Bluetooth peripheral"))
-                #expect(result.stdout.contains("wendy device bluetooth connect [address] [flags]"))
+                #expect(result.stdout.contains("wendy device bluetooth connect <address> [flags]"))
                 #expect(result.stdout.contains("--pair"))
                 #expect(result.stdout.contains("--trust"))
                 #expect(result.stdout.contains("--device"))

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothDisconnectTests.swift
@@ -19,7 +19,7 @@ struct `'wendy device bluetooth disconnect'` {
                 #expect(result.status.isSuccess)
                 #expect(result.stdout.contains("Disconnect a Bluetooth peripheral"))
                 #expect(
-                    result.stdout.contains("wendy device bluetooth disconnect [address] [flags]")
+                    result.stdout.contains("wendy device bluetooth disconnect <address> [flags]")
                 )
                 #expect(result.stdout.contains("--device"))
                 #expect(result.stderr == "")

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceBluetoothForgetTests.swift
@@ -18,7 +18,7 @@ struct `'wendy device bluetooth forget'` {
             try await cli.sh("wendy device bluetooth forget --help") { result in
                 #expect(result.status.isSuccess)
                 #expect(result.stdout.contains("Forget a paired Bluetooth peripheral"))
-                #expect(result.stdout.contains("wendy device bluetooth forget [address] [flags]"))
+                #expect(result.stdout.contains("wendy device bluetooth forget <address> [flags]"))
                 #expect(result.stdout.contains("--device"))
                 #expect(result.stderr == "")
             }


### PR DESCRIPTION
## Summary
- `a60370c49` changed `bluetooth connect/disconnect/forget` from `[address]` (optional-looking) to `<address>` (correctly required) and set cobra's `Deprecated` field on `cloud run`, but didn't update the corresponding Swift E2E tests — breaking `Swift E2E Tests` on `main` (e.g. run 30961060793 for #1555) with 7 failing tests, all in `--help` assertions.
- Updates the 6 bluetooth `[address]` → `<address>` assertions (`cloud device bluetooth` + `device bluetooth`, connect/disconnect/forget).
- Updates `wendy cloud run --help`'s test: cobra prints the deprecation notice to stderr even under `--help` (it runs before the help short-circuit), so the test now expects that line on stderr instead of asserting stderr is empty.

## Test plan
- [x] Built the CLI from this branch and ran `wendy device bluetooth connect --help`, `wendy cloud device bluetooth forget --help`, and `wendy cloud run --help` directly — output matches the new assertions exactly (confirmed the deprecation notice lands on stderr, not stdout).
- [ ] CI: `Swift E2E Tests` should go green on this PR.

https://claude.ai/code/session_015MEivUovquc1hkKjWnjNG8