### PR TITLE
docs: add vanity redirects for installation guides

### DIFF
--- a/.github/workflows/fumadocs.yml
+++ b/.github/workflows/fumadocs.yml
@@ -340,6 +340,73 @@ jobs:
             grep -q "WendyOS Docs" "${response_file}"
           done <<< "${DEPLOY_PATHS}"
 
+      - name: Deploy vanity redirects
+        if: >-
+          needs.build.outputs.is_release_deploy == 'true' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          DOCS_BUCKET: wendy-docs-public
+        run: |
+          set -euo pipefail
+
+          # Short vanity paths served from the bucket root, e.g.
+          # https://docs.wendy.dev/pi -> the Raspberry Pi 5 install guide.
+          # Slugs must never collide with deploy path prefixes
+          # (latest, latest-nightly, release-*, branch-*).
+          declare -A REDIRECTS=(
+            [pi]="https://docs.wendy.dev/latest/installation/wendyos-raspberry-pi-5/"
+            [thor]="https://docs.wendy.dev/latest/installation/wendyos-nvidia-jetson-agx-thor/"
+            [jetson]="https://docs.wendy.dev/latest/installation/wendyos-nvidia-jetson-orin-nano/"
+            [jetson-orin]="https://docs.wendy.dev/latest/installation/wendyos-nvidia-jetson-orin-nano/"
+            [jetson-orin-nano]="https://docs.wendy.dev/latest/installation/wendyos-nvidia-jetson-orin-nano/"
+          )
+
+          workdir="$(mktemp -d)"
+          for slug in "${!REDIRECTS[@]}"; do
+            target="${REDIRECTS[${slug}]}"
+            if [[ ! "${slug}" =~ ^[a-z0-9][a-z0-9-]{0,60}$ ]]; then
+              echo "::error::Unsupported vanity redirect slug: ${slug}"
+              exit 1
+            fi
+            case "${slug}" in
+              latest|latest-nightly|release-*|branch-*)
+                echo "::error::Vanity redirect slug collides with deploy paths: ${slug}"
+                exit 1
+                ;;
+            esac
+            if [[ ! "${target}" =~ ^https://docs\.wendy\.dev/[a-z0-9][a-z0-9./_-]{0,200}$ ]]; then
+              echo "::error::Unsupported vanity redirect target: ${target}"
+              exit 1
+            fi
+
+            mkdir -p "${workdir}/${slug}"
+            cat > "${workdir}/${slug}/index.html" <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=${target}">
+          <link rel="canonical" href="${target}">
+          <title>Redirecting to WendyOS Docs</title>
+          </head>
+          <body>
+          <p>Redirecting to <a href="${target}">${target}</a>&hellip;</p>
+          </body>
+          </html>
+          HTML
+
+            gcloud storage cp "${workdir}/${slug}/index.html" \
+              "gs://${DOCS_BUCKET}/${slug}/index.html" \
+              --cache-control="public, max-age=300" \
+              --quiet \
+              --project="${GCP_PROJECT_ID}"
+
+            response_file="$(mktemp)"
+            curl -fsS --max-time 30 -o "${response_file}" "https://docs.wendy.dev/${slug}/"
+            grep -qF "${target}" "${response_file}"
+          done
+
       - name: Delete expired branch previews
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -119,9 +119,9 @@ bucket root by the `Deploy vanity redirects` step in
 
 | Path | Target |
 |---|---|
-| `/pi` | `latest/installation/wendyos-raspberry-pi-5/` |
-| `/thor` | `latest/installation/wendyos-nvidia-jetson-agx-thor/` |
-| `/jetson`, `/jetson-orin`, `/jetson-orin-nano` | `latest/installation/wendyos-nvidia-jetson-orin-nano/` |
+| `/pi` | `/latest/installation/wendyos-raspberry-pi-5/` |
+| `/thor` | `/latest/installation/wendyos-nvidia-jetson-agx-thor/` |
+| `/jetson`, `/jetson-orin`, `/jetson-orin-nano` | `/latest/installation/wendyos-nvidia-jetson-orin-nano/` |
 
 Add new entries to the `REDIRECTS` map in that workflow step. Slugs must not
 collide with deploy path prefixes (`latest`, `latest-nightly`, `release-*`,

--- a/go/internal/cli/assets/docs/development/docs-site.md
+++ b/go/internal/cli/assets/docs/development/docs-site.md
@@ -111,6 +111,22 @@ docs host.
 
 Branch-preview objects under `branch-*` are cleaned up by CI after 30 days.
 
+### Vanity redirects
+
+Short marketing paths are served as static redirect pages uploaded to the
+bucket root by the `Deploy vanity redirects` step in
+`.github/workflows/fumadocs.yml` (main-branch pushes and release deploys only):
+
+| Path | Target |
+|---|---|
+| `/pi` | `latest/installation/wendyos-raspberry-pi-5/` |
+| `/thor` | `latest/installation/wendyos-nvidia-jetson-agx-thor/` |
+| `/jetson`, `/jetson-orin`, `/jetson-orin-nano` | `latest/installation/wendyos-nvidia-jetson-orin-nano/` |
+
+Add new entries to the `REDIRECTS` map in that workflow step. Slugs must not
+collide with deploy path prefixes (`latest`, `latest-nightly`, `release-*`,
+`branch-*`).
+
 ## Release Notifications
 
 The release workflow adds docs links to Discord notifications:


### PR DESCRIPTION
## Summary

Adds short vanity URLs on docs.wendy.dev that redirect to the installation guides:

| Path | Target |
|---|---|
| `/pi` | `/latest/installation/wendyos-raspberry-pi-5/` |
| `/thor` | `/latest/installation/wendyos-nvidia-jetson-agx-thor/` |
| `/jetson`, `/jetson-orin`, `/jetson-orin-nano` | `/latest/installation/wendyos-nvidia-jetson-orin-nano/` |

## How

The docs site is a static Next.js export served straight from the `wendy-docs-public` GCS bucket, so Next.js `redirects()` can't work and the load balancer is managed out-of-band. Instead, a new **Deploy vanity redirects** step in `.github/workflows/fumadocs.yml` uploads a meta-refresh + canonical-link `<slug>/index.html` page for each entry to the bucket root.

- Runs only on main-branch pushes and release deploys — never PR previews.
- Validates each slug (`^[a-z0-9][a-z0-9-]{0,60}$`), rejects collisions with deploy path prefixes (`latest`, `latest-nightly`, `release-*`, `branch-*`), and validates targets against `^https://docs\.wendy\.dev/...`.
- Verifies each redirect with a post-upload curl + content check, matching the existing deploy verification pattern.
- GCS website config already 301s `/<slug>` → `/<slug>/index.html` (same behavior as `/latest`), so both `/pi` and `/pi/` work.

Documented in `go/internal/cli/assets/docs/development/docs-site.md` (Hosting → Vanity redirects).

## Testing

- `python3 -c 'yaml.safe_load(...)'` — workflow YAML parses.
- Extracted the step's script from the YAML and ran it end-to-end with stubbed `gcloud`/`curl` — all five redirect pages generate with correct targets, validation and verification pass.
- Confirmed all three target pages return 200 on docs.wendy.dev today.