### PR TITLE
Stream mDNS device discovery to the picker on macOS

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2202,6 +2202,92 @@ func hideLocalProviders(excludes map[string]bool) map[string]bool {
 	return merged
 }
 
+// externalProviderPickerItem builds the picker row for a device discovered
+// through an external provider. wendy-lite devices are presented as merged
+// devices (like LAN discoveries) so they share the LAN row layout.
+func externalProviderPickerItem(prov providers.DeviceProvider, dev *models.ExternalDevice) tui.PickerItem {
+	if prov.Key() == "wendy-lite" {
+		return tui.PickerItem{
+			Name:         dev.DisplayName,
+			DedupKey:     dev.DisplayName,
+			Type:         dev.ConnectionType() + " (Lite)",
+			Address:      dev.ConnectionInfo["ip"],
+			AgentVersion: dev.AgentVersion,
+			OS:           dev.OS,
+			OSVersion:    dev.OSVersion,
+			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
+				DisplayName:     dev.DisplayName,
+				AgentVersion:    dev.AgentVersion,
+				OSVersion:       dev.OSVersion,
+				CPUArchitecture: dev.CPUArchitecture,
+				Externals:       []*models.ExternalDevice{dev},
+			}},
+		}
+	}
+	return tui.PickerItem{
+		Name:         dev.DisplayName,
+		Type:         prov.DisplayName(),
+		Address:      externalProviderAddress(dev.ProviderKey, dev.ID),
+		AgentVersion: dev.AgentVersion,
+		OS:           dev.OS,
+		OSVersion:    dev.OSVersion,
+		DedupKey:     dev.DisplayName,
+		SortKey:      externalProviderSortKey(prov.Key(), dev.DisplayName),
+		Hint:         externalProviderPickerHint(prov.Key()),
+		Value:        &pickerEntry{externalDevice: dev, provider: prov},
+	}
+}
+
+// providerPollDelay returns how long to wait before the next DiscoverDevices
+// poll given how long the previous scan took: the remainder of the 3s cycle,
+// but never less than 500ms between scans.
+func providerPollDelay(elapsed time.Duration) time.Duration {
+	delay := 3*time.Second - elapsed
+	if delay < 500*time.Millisecond {
+		delay = 500 * time.Millisecond
+	}
+	return delay
+}
+
+// discoverProviderForPicker feeds picker items for prov until ctx is done.
+// Providers implementing providers.ContinuousDiscoverer are consumed as a
+// stream; otherwise DiscoverDevices is polled on a 3-second cadence measured
+// from the start of each scan (with a 500ms minimum gap, so slow scans don't
+// stretch the period). If the stream fails to start or closes while the
+// picker is still open, discovery falls back to polling.
+func discoverProviderForPicker(ctx context.Context, prov providers.DeviceProvider, send func([]tui.PickerItem)) {
+	if cd, ok := prov.(providers.ContinuousDiscoverer); ok {
+		if ch, err := cd.DiscoverDevicesContinuous(ctx); err == nil {
+			for dev := range ch {
+				send([]tui.PickerItem{externalProviderPickerItem(prov, &dev)})
+			}
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}
+
+	for {
+		start := time.Now()
+		devices, err := prov.DiscoverDevices(ctx)
+		if err == nil {
+			var items []tui.PickerItem
+			for i := range devices {
+				items = append(items, externalProviderPickerItem(prov, &devices[i]))
+			}
+			if len(items) > 0 {
+				send(items)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(providerPollDelay(time.Since(start))):
+		}
+	}
+}
+
 // pickDevice runs an interactive TUI that discovers devices across all
 // transports and providers, then lets the user select one.
 // LAN discovery runs continuously so devices that come online after the
@@ -2311,62 +2397,15 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 		}
 	}()
 
-	// Continuous provider discovery — re-scan every 3 seconds.
+	// Continuous provider discovery — streamed when the provider supports it,
+	// otherwise re-scanned on a 3-second cadence.
 	for _, prov := range providers.AvailableProviders() {
 		if excludeProviders[prov.Key()] {
 			continue
 		}
-		prov := prov
-		go func() {
-			for {
-				devices, err := prov.DiscoverDevices(discoverCtx)
-				if err == nil && len(devices) > 0 {
-					var items []tui.PickerItem
-					for i := range devices {
-						if prov.Key() == "wendy-lite" {
-							items = append(items, tui.PickerItem{
-								Name:         devices[i].DisplayName,
-								DedupKey:     devices[i].DisplayName,
-								Type:         devices[i].ConnectionType() + " (Lite)",
-								Address:      devices[i].ConnectionInfo["ip"],
-								AgentVersion: devices[i].AgentVersion,
-								OS:           devices[i].OS,
-								OSVersion:    devices[i].OSVersion,
-								Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
-									DisplayName:     devices[i].DisplayName,
-									AgentVersion:    devices[i].AgentVersion,
-									OSVersion:       devices[i].OSVersion,
-									CPUArchitecture: devices[i].CPUArchitecture,
-									Externals:       []*models.ExternalDevice{&devices[i]},
-								}},
-							})
-						} else {
-							items = append(items, tui.PickerItem{
-								Name:         devices[i].DisplayName,
-								Type:         prov.DisplayName(),
-								Address:      externalProviderAddress(devices[i].ProviderKey, devices[i].ID),
-								AgentVersion: devices[i].AgentVersion,
-								OS:           devices[i].OS,
-								OSVersion:    devices[i].OSVersion,
-								DedupKey:     devices[i].DisplayName,
-								SortKey:      externalProviderSortKey(prov.Key(), devices[i].DisplayName),
-								Hint:         externalProviderPickerHint(prov.Key()),
-								Value:        &pickerEntry{externalDevice: &devices[i], provider: prov},
-							})
-						}
-					}
-					if len(items) > 0 {
-						p.Send(tui.PickerAddMsg{Items: items})
-					}
-				}
-
-				select {
-				case <-discoverCtx.Done():
-					return
-				case <-time.After(3 * time.Second):
-				}
-			}
-		}()
+		go discoverProviderForPicker(discoverCtx, prov, func(items []tui.PickerItem) {
+			p.Send(tui.PickerAddMsg{Items: items})
+		})
 	}
 
 	// Continuous Bluetooth discovery — re-scan every 5 seconds.

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -10,11 +10,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -1023,6 +1025,235 @@ func TestHideLocalProviders(t *testing.T) {
 			if got[k] {
 				t.Errorf("hideLocalProviders(nil)[%q] = true with opt-in set; want false", k)
 			}
+		}
+	})
+}
+
+// ── discoverProviderForPicker ───────────────────────────────────────
+
+// fakeProvider is a minimal DeviceProvider for exercising the picker
+// discovery loop.
+type fakeProvider struct {
+	key           string
+	devices       []models.ExternalDevice
+	discoverCalls atomic.Int32
+}
+
+func (p *fakeProvider) Key() string                             { return p.key }
+func (p *fakeProvider) DisplayName() string                     { return "Fake" }
+func (p *fakeProvider) IsAvailable(context.Context) bool        { return true }
+func (p *fakeProvider) CheckRequirements(context.Context) error { return nil }
+func (p *fakeProvider) DiscoverDevices(context.Context) ([]models.ExternalDevice, error) {
+	p.discoverCalls.Add(1)
+	return p.devices, nil
+}
+func (p *fakeProvider) SupportedBuildTypes() []string { return nil }
+func (p *fakeProvider) CanBuild(string) bool          { return false }
+func (p *fakeProvider) Build(context.Context, models.ExternalDevice, string, string, string, bool) (*providers.BuiltApp, error) {
+	return nil, errors.New("not implemented")
+}
+func (p *fakeProvider) Run(context.Context, *providers.BuiltApp, bool, chan<- providers.RunOutput) error {
+	return errors.New("not implemented")
+}
+func (p *fakeProvider) Stop(context.Context, *providers.BuiltApp) error {
+	return errors.New("not implemented")
+}
+func (p *fakeProvider) GetDeviceInfo(context.Context, models.ExternalDevice) (*providers.ProviderDeviceInfo, error) {
+	return nil, nil
+}
+
+// fakeContinuousProvider additionally implements ContinuousDiscoverer.
+type fakeContinuousProvider struct {
+	fakeProvider
+	ch  chan models.ExternalDevice
+	err error
+}
+
+func (p *fakeContinuousProvider) DiscoverDevicesContinuous(context.Context) (<-chan models.ExternalDevice, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.ch, nil
+}
+
+var (
+	_ providers.DeviceProvider       = (*fakeProvider)(nil)
+	_ providers.ContinuousDiscoverer = (*fakeContinuousProvider)(nil)
+)
+
+// runDiscoverProviderForPicker starts the discovery loop in a goroutine and
+// returns a channel of items sent to the picker plus a done channel closed
+// when the loop returns.
+func runDiscoverProviderForPicker(ctx context.Context, prov providers.DeviceProvider) (<-chan tui.PickerItem, <-chan struct{}) {
+	got := make(chan tui.PickerItem, 16)
+	done := make(chan struct{})
+	go func() {
+		discoverProviderForPicker(ctx, prov, func(items []tui.PickerItem) {
+			for _, item := range items {
+				got <- item
+			}
+		})
+		close(done)
+	}()
+	return got, done
+}
+
+func awaitPickerItem(t *testing.T, got <-chan tui.PickerItem, wantName string) {
+	t.Helper()
+	select {
+	case item := <-got:
+		if item.Name != wantName {
+			t.Fatalf("picker item name = %q, want %q", item.Name, wantName)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for picker item %q", wantName)
+	}
+}
+
+func awaitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discoverProviderForPicker did not return after ctx cancel")
+	}
+}
+
+func TestProviderPollDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		{"instant scan waits full cycle", 0, 3 * time.Second},
+		{"scan time counts toward the cycle", 1 * time.Second, 2 * time.Second},
+		{"remainder below minimum gap is clamped", 2600 * time.Millisecond, 500 * time.Millisecond},
+		{"scan as long as the cycle", 3 * time.Second, 500 * time.Millisecond},
+		{"scan longer than the cycle", 10 * time.Second, 500 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := providerPollDelay(tt.elapsed); got != tt.want {
+				t.Fatalf("providerPollDelay(%v) = %v, want %v", tt.elapsed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverProviderForPickerStreamsContinuous(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prov := &fakeContinuousProvider{
+		fakeProvider: fakeProvider{key: "fake"},
+		ch:           make(chan models.ExternalDevice),
+	}
+	got, done := runDiscoverProviderForPicker(ctx, prov)
+
+	prov.ch <- models.ExternalDevice{ID: "fake:1", DisplayName: "one", ProviderKey: "fake"}
+	awaitPickerItem(t, got, "one")
+	prov.ch <- models.ExternalDevice{ID: "fake:2", DisplayName: "two", ProviderKey: "fake"}
+	awaitPickerItem(t, got, "two")
+
+	// Cancel then close the stream, as a real implementation would on ctx
+	// cancellation; the loop must return without falling back to polling.
+	cancel()
+	close(prov.ch)
+	awaitDone(t, done)
+
+	if n := prov.discoverCalls.Load(); n != 0 {
+		t.Fatalf("DiscoverDevices called %d times; streaming path should not poll", n)
+	}
+}
+
+func TestDiscoverProviderForPickerPollingFallback(t *testing.T) {
+	polled := []models.ExternalDevice{{ID: "fake:1", DisplayName: "polled", ProviderKey: "fake"}}
+
+	tests := []struct {
+		name string
+		prov providers.DeviceProvider
+	}{
+		{"provider without continuous support", &fakeProvider{key: "fake", devices: polled}},
+		{"continuous start error", &fakeContinuousProvider{
+			fakeProvider: fakeProvider{key: "fake", devices: polled},
+			err:          errors.New("stream unavailable"),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			got, done := runDiscoverProviderForPicker(ctx, tt.prov)
+			awaitPickerItem(t, got, "polled")
+			cancel()
+			awaitDone(t, done)
+		})
+	}
+}
+
+func TestDiscoverProviderForPickerStreamDeathFallsBackToPolling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prov := &fakeContinuousProvider{
+		fakeProvider: fakeProvider{
+			key:     "fake",
+			devices: []models.ExternalDevice{{ID: "fake:1", DisplayName: "polled", ProviderKey: "fake"}},
+		},
+		ch: make(chan models.ExternalDevice),
+	}
+	got, done := runDiscoverProviderForPicker(ctx, prov)
+
+	// Stream dies while the picker is still open: polling must take over.
+	close(prov.ch)
+	awaitPickerItem(t, got, "polled")
+	cancel()
+	awaitDone(t, done)
+}
+
+func TestExternalProviderPickerItem(t *testing.T) {
+	t.Run("wendy-lite devices become merged devices", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		dev := models.ExternalDevice{
+			ID:              "wendy-lite:board",
+			DisplayName:     "Lite Board",
+			ProviderKey:     "wendy-lite",
+			AgentVersion:    "1.2.3",
+			CPUArchitecture: "riscv",
+			ConnectionInfo:  map[string]string{"type": "LAN", "ip": "10.0.0.9"},
+		}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if item.Type != "LAN (Lite)" {
+			t.Errorf("Type = %q, want %q", item.Type, "LAN (Lite)")
+		}
+		if item.Address != "10.0.0.9" {
+			t.Errorf("Address = %q, want %q", item.Address, "10.0.0.9")
+		}
+		entry, ok := item.Value.(*pickerEntry)
+		if !ok || entry.mergedDevice == nil {
+			t.Fatalf("Value = %#v, want *pickerEntry with mergedDevice", item.Value)
+		}
+		if len(entry.mergedDevice.Externals) != 1 || entry.mergedDevice.Externals[0].ID != dev.ID {
+			t.Errorf("mergedDevice.Externals = %#v, want the source device", entry.mergedDevice.Externals)
+		}
+	})
+
+	t.Run("other providers keep provider row layout", func(t *testing.T) {
+		prov := &fakeProvider{key: "fake"}
+		dev := models.ExternalDevice{ID: "fake:1", DisplayName: "Dev", ProviderKey: "fake"}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if item.Type != "Fake" {
+			t.Errorf("Type = %q, want %q", item.Type, "Fake")
+		}
+		entry, ok := item.Value.(*pickerEntry)
+		if !ok || entry.externalDevice == nil {
+			t.Fatalf("Value = %#v, want *pickerEntry with externalDevice", item.Value)
+		}
+		if entry.provider != providers.DeviceProvider(prov) {
+			t.Errorf("entry.provider = %#v, want the source provider", entry.provider)
 		}
 	})
 }

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -64,41 +64,130 @@ func (p *MicroWendyProvider) DiscoverDevices(ctx context.Context) ([]models.Exte
 
 	var devices []models.ExternalDevice
 	for _, svc := range services {
-		displayName := svc.InstanceName
-		if displayName == "" {
-			displayName = svc.Hostname
-		}
-		devices = append(devices, models.ExternalDevice{
-			ID:          fmt.Sprintf("wendy-lite:%s", svc.Hostname),
-			DisplayName: displayName,
-			ProviderKey: p.Key(),
-			ConnectionInfo: map[string]string{
-				"type":     "LAN",
-				"name":     svc.TXTRecords["name"],
-				"hostname": svc.Hostname,
-				"ip":       svc.IPAddress,
-				"port":     fmt.Sprintf("%d", svc.Port),
-				"mtls":     fmt.Sprintf("%t", svc.TXTRecords["mtls"] == "true"),
-			},
-			IsWendyDevice: true,
-		})
+		devices = append(devices, p.mdnsExternalDevice(svc))
 	}
-
 	for _, dev := range sd.Devices() {
-		devices = append(devices, models.ExternalDevice{
-			ID:          fmt.Sprintf("wendy-lite:%s", dev.Port),
-			DisplayName: dev.DisplayName,
-			ProviderKey: p.Key(),
-			ConnectionInfo: map[string]string{
-				"type":       "USB",
-				"name":       dev.Name,
-				"serialPort": dev.Port,
-			},
-			IsWendyDevice: true,
-		})
+		devices = append(devices, p.serialExternalDevice(dev))
 	}
 
 	return devices, nil
+}
+
+// mdnsExternalDevice maps a resolved _wendy-lite._tcp mDNS service to an
+// ExternalDevice.
+func (p *MicroWendyProvider) mdnsExternalDevice(svc discovery.MDNSService) models.ExternalDevice {
+	displayName := svc.InstanceName
+	if displayName == "" {
+		displayName = svc.Hostname
+	}
+	return models.ExternalDevice{
+		ID:          fmt.Sprintf("wendy-lite:%s", svc.Hostname),
+		DisplayName: displayName,
+		ProviderKey: p.Key(),
+		ConnectionInfo: map[string]string{
+			"type":     "LAN",
+			"name":     svc.TXTRecords["name"],
+			"hostname": svc.Hostname,
+			"ip":       svc.IPAddress,
+			"port":     fmt.Sprintf("%d", svc.Port),
+			"mtls":     fmt.Sprintf("%t", svc.TXTRecords["mtls"] == "true"),
+		},
+		IsWendyDevice: true,
+	}
+}
+
+// serialExternalDevice maps a serial-port Wendy Lite device to an ExternalDevice.
+func (p *MicroWendyProvider) serialExternalDevice(dev discovery.SerialDevice) models.ExternalDevice {
+	return models.ExternalDevice{
+		ID:          fmt.Sprintf("wendy-lite:%s", dev.Port),
+		DisplayName: dev.DisplayName,
+		ProviderKey: p.Key(),
+		ConnectionInfo: map[string]string{
+			"type":       "USB",
+			"name":       dev.Name,
+			"serialPort": dev.Port,
+		},
+		IsWendyDevice: true,
+	}
+}
+
+// DiscoverDevicesContinuous streams wendy-lite devices as they are found:
+// mDNS services via continuous browsing and serial devices via the background
+// serial scanner. Continuous mDNS browsing is only available on macOS; on
+// other platforms this returns an error and callers fall back to polling
+// DiscoverDevices.
+func (p *MicroWendyProvider) DiscoverDevicesContinuous(ctx context.Context) (<-chan models.ExternalDevice, error) {
+	svcCh, err := discovery.BrowseMDNSServicesContinuous(ctx, microWendyServiceType)
+	if err != nil {
+		return nil, err
+	}
+
+	sd := discovery.GetSerialDiscovery()
+	sd.StartScan(3 * time.Second)
+
+	// Coalesce serial snapshots into a capacity-1 channel: the listener must
+	// never block (it runs under SerialDiscovery's notify lock), and only the
+	// latest snapshot matters. notify() serializes listener calls, so the
+	// drain-then-send below never races with itself.
+	serialUpdates := make(chan []discovery.SerialDevice, 1)
+	listenerID := sd.AddListener(func(devices []discovery.SerialDevice) {
+		select {
+		case serialUpdates <- devices:
+		default:
+			select {
+			case <-serialUpdates:
+			default:
+			}
+			serialUpdates <- devices
+		}
+	})
+
+	ch := make(chan models.ExternalDevice, 16)
+	go func() {
+		defer close(ch)
+		defer sd.RemoveListener(listenerID)
+		defer sd.StopScan()
+
+		send := func(dev models.ExternalDevice) bool {
+			select {
+			case ch <- dev:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
+		// Emit serial devices already known before the listener registered.
+		for _, dev := range sd.Devices() {
+			if !send(p.serialExternalDevice(dev)) {
+				return
+			}
+		}
+
+		for {
+			select {
+			case svc, ok := <-svcCh:
+				if !ok {
+					// Browse stream died; closing ch lets the consumer fall
+					// back to polling.
+					return
+				}
+				if !send(p.mdnsExternalDevice(svc)) {
+					return
+				}
+			case snap := <-serialUpdates:
+				for _, dev := range snap {
+					if !send(p.serialExternalDevice(dev)) {
+						return
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
 }
 
 func (p *MicroWendyProvider) SupportedBuildTypes() []string {

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -124,6 +124,16 @@ type ImageBuilder interface {
 	BuildFromImage(device models.ExternalDevice, product, imageName string) *BuiltApp
 }
 
+// ContinuousDiscoverer is optionally implemented by providers that can stream
+// discovered devices as they appear, instead of being polled via DiscoverDevices.
+type ContinuousDiscoverer interface {
+	// DiscoverDevicesContinuous starts continuous discovery and returns a
+	// channel that receives each device as it is found. The channel stays
+	// open until ctx is cancelled (or the stream fails), then is closed.
+	// Implementations may re-send a device; consumers deduplicate.
+	DiscoverDevicesContinuous(ctx context.Context) (<-chan models.ExternalDevice, error)
+}
+
 // TypedBuilder is optionally implemented by providers that can disambiguate
 // between multiple buildable markers in the same project using the caller's
 // resolved build type (e.g. "docker" vs "compose"). When the build type is

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -62,6 +62,32 @@ type browseResult struct {
 	interfaceName string
 }
 
+// parseBrowseLine parses one line of dns-sd -B output. It returns ok=false
+// for lines that are not "Add" records or are too short to parse.
+func parseBrowseLine(line string) (browseResult, bool) {
+	if !strings.Contains(line, "Add") {
+		return browseResult{}, false
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 7 {
+		return browseResult{}, false
+	}
+	interfaceName := ""
+	if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
+		// Silently falls through with empty interfaceName when the
+		// interface disappears between browse and resolve; USB detection
+		// will be skipped for that device rather than returning an error.
+		if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
+			interfaceName = iface.Name
+		}
+	}
+	return browseResult{
+		instanceName:  strings.Join(fields[6:], " "),
+		domain:        fields[4],
+		interfaceName: interfaceName,
+	}, true
+}
+
 // dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
 // It uses a short settle timer: once the first result arrives, it waits up to
 // 500ms for more results before returning. This avoids waiting for the full timeout.
@@ -76,40 +102,14 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 	}
 
 	// Parse lines on a channel so we can select with a timer.
-	type parsedLine struct {
-		result browseResult
-		ok     bool
-	}
-	lineCh := make(chan parsedLine, 16)
+	lineCh := make(chan browseResult, 16)
 
 	go func() {
 		defer close(lineCh)
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.Contains(line, "Add") {
-				continue
-			}
-			fields := strings.Fields(line)
-			if len(fields) < 7 {
-				continue
-			}
-			interfaceName := ""
-			if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
-				// Silently falls through with empty interfaceName when the
-				// interface disappears between browse and resolve; USB detection
-				// will be skipped for that device rather than returning an error.
-				if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
-					interfaceName = iface.Name
-				}
-			}
-			lineCh <- parsedLine{
-				result: browseResult{
-					instanceName:  strings.Join(fields[6:], " "),
-					domain:        fields[4],
-					interfaceName: interfaceName,
-				},
-				ok: true,
+			if result, ok := parseBrowseLine(scanner.Text()); ok {
+				lineCh <- result
 			}
 		}
 	}()
@@ -126,15 +126,15 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
 			return results, nil
-		case pl, open := <-lineCh:
+		case result, open := <-lineCh:
 			if !open {
 				_ = cmd.Wait()
 				return results, nil
 			}
-			key := pl.result.instanceName + "%" + pl.result.interfaceName
-			if pl.ok && !seen[key] {
+			key := result.instanceName + "%" + result.interfaceName
+			if !seen[key] {
 				seen[key] = true
-				results = append(results, pl.result)
+				results = append(results, result)
 				// Reset settle timer: wait 500ms for more results.
 				settle = time.After(500 * time.Millisecond)
 			}
@@ -353,25 +353,9 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	seen := make(map[string]bool)
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.Contains(line, "Add") {
+		inst, ok := parseBrowseLine(scanner.Text())
+		if !ok {
 			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 7 {
-			continue
-		}
-
-		interfaceName := ""
-		if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
-			if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
-				interfaceName = iface.Name
-			}
-		}
-		inst := browseResult{
-			instanceName:  strings.Join(fields[6:], " "),
-			domain:        fields[4],
-			interfaceName: interfaceName,
 		}
 
 		key := inst.instanceName + "%" + inst.interfaceName

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -147,97 +147,23 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 	}
 }
 
-// dnssdResolve runs dns-sd -L to resolve an instance to hostname, port, and TXT records.
-// Returns as soon as the "can be reached at" line is parsed.
+// dnssdResolve resolves an instance via dns-sd -L and maps the result to a
+// wendy LANDevice, interpreting the wendy-specific TXT records.
 func dnssdResolve(ctx context.Context, inst browseResult, interfaceDisplayNames map[string]string, linkSpeeds map[string]string) (models.LANDevice, error) {
-	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, wendyServiceType, inst.domain)
-	stdout, err := cmd.StdoutPipe()
+	svc, err := dnssdResolveService(ctx, inst, wendyServiceType)
 	if err != nil {
 		return models.LANDevice{}, err
 	}
-	if err := cmd.Start(); err != nil {
-		return models.LANDevice{}, err
-	}
 
-	var hostname string
-	var port int
-	txtRecords := make(map[string]string)
-
-	// parseTXT extracts key=value pairs from a dns-sd TXT record line.
-	// dns-sd escapes spaces inside values as "\ "; we split on unescaped
-	// whitespace so that values like "Dynamic\ Cosmos" round-trip correctly.
-	parseTXT := func(line string) {
-		var fields []string
-		var cur strings.Builder
-		for i := 0; i < len(line); i++ {
-			if line[i] == '\\' && i+1 < len(line) && (line[i+1] == ' ' || line[i+1] == '\t') {
-				cur.WriteByte(line[i+1])
-				i++
-			} else if line[i] == ' ' || line[i] == '\t' {
-				if cur.Len() > 0 {
-					fields = append(fields, cur.String())
-					cur.Reset()
-				}
-			} else {
-				cur.WriteByte(line[i])
-			}
-		}
-		if cur.Len() > 0 {
-			fields = append(fields, cur.String())
-		}
-		for _, field := range fields {
-			if k, v, ok := strings.Cut(field, "="); ok {
-				txtRecords[k] = v
-			}
-		}
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if strings.Contains(line, "can be reached at") {
-			parts := strings.Fields(line)
-			for i, p := range parts {
-				if p == "at" && i+1 < len(parts) {
-					hostPort := parts[i+1]
-					h, p, err := net.SplitHostPort(hostPort)
-					if err == nil {
-						hostname = strings.TrimSuffix(h, ".")
-						fmt.Sscanf(p, "%d", &port)
-					}
-					break
-				}
-			}
-
-			// TXT records on the same line (some versions).
-			parseTXT(line)
-
-			// TXT records are typically on the next line indented with a space.
-			if scanner.Scan() {
-				parseTXT(scanner.Text())
-			}
-
-			_ = cmd.Process.Kill()
-			break
-		}
-	}
-
-	_ = cmd.Wait()
-
-	if hostname == "" {
-		return models.LANDevice{}, fmt.Errorf("could not resolve instance %q", inst.instanceName)
-	}
-
-	displayName := strings.TrimSuffix(hostname, ".local")
-	if dn, ok := txtRecords["displayname"]; ok {
+	displayName := strings.TrimSuffix(svc.hostname, ".local")
+	if dn, ok := svc.txtRecords["displayname"]; ok {
 		displayName = dn
 	}
 
 	id := ""
-	if v, ok := txtRecords["wendyosdevice"]; ok {
+	if v, ok := svc.txtRecords["wendyosdevice"]; ok {
 		id = v
-	} else if v, ok := txtRecords["id"]; ok {
+	} else if v, ok := svc.txtRecords["id"]; ok {
 		id = v
 	}
 	if id == "" {
@@ -247,13 +173,13 @@ func dnssdResolve(ctx context.Context, inst browseResult, interfaceDisplayNames 
 	dev := models.LANDevice{
 		ID:            id,
 		DisplayName:   displayName,
-		Hostname:      hostname,
-		Port:          port,
-		IsMTLS:        txtRecords["tls"] == "true",
+		Hostname:      svc.hostname,
+		Port:          svc.port,
+		IsMTLS:        svc.txtRecords["tls"] == "true",
 		InterfaceType: string(models.InterfaceLAN),
 		IsWendyDevice: true,
 	}
-	setAssetID(&dev, txtRecords)
+	setAssetID(&dev, svc.txtRecords)
 	setLANNetworkInterface(&dev, inst.interfaceName, interfaceDisplayNames[inst.interfaceName], darwinCachedInterfaceLinkSpeed(ctx, inst.interfaceName, linkSpeeds))
 	return dev, nil
 }

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -3,11 +3,8 @@
 package discovery
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"net"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -54,120 +51,6 @@ func discoverLAN(ctx context.Context, timeout time.Duration) ([]models.LANDevice
 	}
 
 	return devices, nil
-}
-
-type browseResult struct {
-	instanceName  string
-	domain        string
-	interfaceName string
-}
-
-// parseBrowseLine parses one line of dns-sd -B output. It returns ok=false
-// for lines that are not "Add" records or are too short to parse.
-func parseBrowseLine(line string) (browseResult, bool) {
-	if !strings.Contains(line, "Add") {
-		return browseResult{}, false
-	}
-	fields := strings.Fields(line)
-	if len(fields) < 7 {
-		return browseResult{}, false
-	}
-	interfaceName := ""
-	if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
-		// Silently falls through with empty interfaceName when the
-		// interface disappears between browse and resolve; USB detection
-		// will be skipped for that device rather than returning an error.
-		if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
-			interfaceName = iface.Name
-		}
-	}
-	return browseResult{
-		instanceName:  strings.Join(fields[6:], " "),
-		domain:        fields[4],
-		interfaceName: interfaceName,
-	}, true
-}
-
-// dnssdBrowseStream starts dns-sd -B for serviceType and streams each newly
-// discovered instance to the returned channel. Duplicate (instance, interface)
-// pairs are emitted only once. The channel is closed when ctx is cancelled or
-// the dns-sd process exits; the process is killed and reaped on all paths.
-// Consumers signal they are done by cancelling ctx.
-func dnssdBrowseStream(ctx context.Context, serviceType string) (<-chan browseResult, error) {
-	cmd := exec.CommandContext(ctx, "dns-sd", "-B", serviceType, "local")
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	ch := make(chan browseResult, 16)
-	go func() {
-		defer close(ch)
-		defer func() {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}()
-
-		seen := make(map[string]bool)
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			result, ok := parseBrowseLine(scanner.Text())
-			if !ok {
-				continue
-			}
-			key := result.instanceName + "%" + result.interfaceName
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-
-			select {
-			case ch <- result:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return ch, nil
-}
-
-// dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
-// It uses a short settle timer: once the first result arrives, it waits up to
-// 500ms for more results before returning. This avoids waiting for the full timeout.
-func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
-	streamCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	browseCh, err := dnssdBrowseStream(streamCtx, serviceType)
-	if err != nil {
-		return nil, err
-	}
-
-	var results []browseResult
-
-	// Wait up to the context deadline for the first result.
-	// Once we get one, use a short settle timer for additional results.
-	var settle <-chan time.Time
-	for {
-		select {
-		case <-ctx.Done():
-			return results, nil
-		case result, open := <-browseCh:
-			if !open {
-				return results, nil
-			}
-			results = append(results, result)
-			// Reset settle timer: wait 500ms for more results.
-			settle = time.After(500 * time.Millisecond)
-		case <-settle:
-			// No new results in 500ms, we're done.
-			return results, nil
-		}
-	}
 }
 
 // dnssdResolve resolves an instance via dns-sd -L and maps the result to a

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -88,10 +88,12 @@ func parseBrowseLine(line string) (browseResult, bool) {
 	}, true
 }
 
-// dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
-// It uses a short settle timer: once the first result arrives, it waits up to
-// 500ms for more results before returning. This avoids waiting for the full timeout.
-func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
+// dnssdBrowseStream starts dns-sd -B for serviceType and streams each newly
+// discovered instance to the returned channel. Duplicate (instance, interface)
+// pairs are emitted only once. The channel is closed when ctx is cancelled or
+// the dns-sd process exits; the process is killed and reaped on all paths.
+// Consumers signal they are done by cancelling ctx.
+func dnssdBrowseStream(ctx context.Context, serviceType string) (<-chan browseResult, error) {
 	cmd := exec.CommandContext(ctx, "dns-sd", "-B", serviceType, "local")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -101,21 +103,51 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 		return nil, err
 	}
 
-	// Parse lines on a channel so we can select with a timer.
-	lineCh := make(chan browseResult, 16)
-
+	ch := make(chan browseResult, 16)
 	go func() {
-		defer close(lineCh)
+		defer close(ch)
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+
+		seen := make(map[string]bool)
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			if result, ok := parseBrowseLine(scanner.Text()); ok {
-				lineCh <- result
+			result, ok := parseBrowseLine(scanner.Text())
+			if !ok {
+				continue
+			}
+			key := result.instanceName + "%" + result.interfaceName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			select {
+			case ch <- result:
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
 
+	return ch, nil
+}
+
+// dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
+// It uses a short settle timer: once the first result arrives, it waits up to
+// 500ms for more results before returning. This avoids waiting for the full timeout.
+func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	browseCh, err := dnssdBrowseStream(streamCtx, serviceType)
+	if err != nil {
+		return nil, err
+	}
+
 	var results []browseResult
-	seen := make(map[string]bool)
 
 	// Wait up to the context deadline for the first result.
 	// Once we get one, use a short settle timer for additional results.
@@ -123,25 +155,16 @@ func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error
 	for {
 		select {
 		case <-ctx.Done():
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
 			return results, nil
-		case result, open := <-lineCh:
+		case result, open := <-browseCh:
 			if !open {
-				_ = cmd.Wait()
 				return results, nil
 			}
-			key := result.instanceName + "%" + result.interfaceName
-			if !seen[key] {
-				seen[key] = true
-				results = append(results, result)
-				// Reset settle timer: wait 500ms for more results.
-				settle = time.After(500 * time.Millisecond)
-			}
+			results = append(results, result)
+			// Reset settle timer: wait 500ms for more results.
+			settle = time.After(500 * time.Millisecond)
 		case <-settle:
 			// No new results in 500ms, we're done.
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
 			return results, nil
 		}
 	}
@@ -267,29 +290,12 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 	interfaceDisplayNames := darwinInterfaceDisplayNameMap(ctx)
 	linkSpeeds := make(map[string]string)
 
-	cmd := exec.CommandContext(ctx, "dns-sd", "-B", wendyServiceType, "local")
-	stdout, err := cmd.StdoutPipe()
+	browseCh, err := dnssdBrowseStream(ctx, wendyServiceType)
 	if err != nil {
 		return
 	}
-	if err := cmd.Start(); err != nil {
-		return
-	}
 
-	seen := make(map[string]bool)
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		inst, ok := parseBrowseLine(scanner.Text())
-		if !ok {
-			continue
-		}
-
-		key := inst.instanceName + "%" + inst.interfaceName
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
+	for inst := range browseCh {
 		resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
 		dev, err := dnssdResolve(resolveCtx, inst, interfaceDisplayNames, linkSpeeds)
 		resolveCancel()
@@ -303,6 +309,4 @@ func discoverLANContinuous(ctx context.Context, ch chan<- models.LANDevice) {
 			return
 		}
 	}
-
-	_ = cmd.Wait()
 }

--- a/go/internal/shared/discovery/discovery_darwin_test.go
+++ b/go/internal/shared/discovery/discovery_darwin_test.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package discovery
+
+import "testing"
+
+func TestParseBrowseLine(t *testing.T) {
+	// Interface index 9999 never resolves, so interfaceName is deterministically
+	// empty regardless of the machine's network configuration.
+	tests := []struct {
+		name   string
+		line   string
+		want   browseResult
+		wantOK bool
+	}{
+		{
+			name:   "valid add line",
+			line:   "14:05:31.123  Add        3   9999 local.               _wendy._tcp.         wendy-device",
+			want:   browseResult{instanceName: "wendy-device", domain: "local.", interfaceName: ""},
+			wantOK: true,
+		},
+		{
+			name:   "multi-word instance name",
+			line:   "14:05:31.123  Add        3   9999 local.               _wendy._tcp.         Dynamic Cosmos",
+			want:   browseResult{instanceName: "Dynamic Cosmos", domain: "local.", interfaceName: ""},
+			wantOK: true,
+		},
+		{
+			name:   "remove line",
+			line:   "14:05:31.123  Rmv        2   9999 local.               _wendy._tcp.         wendy-device",
+			wantOK: false,
+		},
+		{
+			name:   "header line",
+			line:   "Timestamp     A/R    Flags  if Domain               Service Type         Instance Name",
+			wantOK: false,
+		},
+		{
+			name:   "too few fields",
+			line:   "14:05:31.123  Add        3   9999 local.",
+			wantOK: false,
+		},
+		{
+			name:   "empty line",
+			line:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseBrowseLine(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("parseBrowseLine(%q) ok = %v, want %v", tt.line, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("parseBrowseLine(%q) = %+v, want %+v", tt.line, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/shared/discovery/discovery_darwin_test.go
+++ b/go/internal/shared/discovery/discovery_darwin_test.go
@@ -2,7 +2,10 @@
 
 package discovery
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseBrowseLine(t *testing.T) {
 	// Interface index 9999 never resolves, so interfaceName is deterministically
@@ -55,6 +58,45 @@ func TestParseBrowseLine(t *testing.T) {
 			}
 			if ok && got != tt.want {
 				t.Errorf("parseBrowseLine(%q) = %+v, want %+v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDNSSDTXT(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want map[string]string
+	}{
+		{
+			name: "plain pairs",
+			line: " tls=true id=abc123",
+			want: map[string]string{"tls": "true", "id": "abc123"},
+		},
+		{
+			name: "escaped space in value",
+			line: ` displayname=Dynamic\ Cosmos tls=true`,
+			want: map[string]string{"displayname": "Dynamic Cosmos", "tls": "true"},
+		},
+		{
+			name: "tokens without equals are ignored",
+			line: "some noise displayname=wendy more noise",
+			want: map[string]string{"displayname": "wendy"},
+		},
+		{
+			name: "empty line",
+			line: "",
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := make(map[string]string)
+			parseDNSSDTXT(tt.line, got)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDNSSDTXT(%q) = %v, want %v", tt.line, got, tt.want)
 			}
 		})
 	}

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -49,15 +49,55 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	return services, nil
 }
 
-// resolveMDNSService runs dns-sd -L to resolve a browse result into an MDNSService.
-func resolveMDNSService(ctx context.Context, inst browseResult, serviceType string) (MDNSService, error) {
+// resolvedService is the raw result of a dns-sd -L resolve: exactly what the
+// SRV + TXT records provide. No IP address — resolving the hostname to an
+// address is the caller's concern.
+type resolvedService struct {
+	instanceName string
+	hostname     string
+	port         int
+	txtRecords   map[string]string
+}
+
+// parseDNSSDTXT extracts key=value pairs from a dns-sd TXT record line into txt.
+// dns-sd escapes spaces inside values as "\ "; we split on unescaped
+// whitespace so that values like "Dynamic\ Cosmos" round-trip correctly.
+func parseDNSSDTXT(line string, txt map[string]string) {
+	var fields []string
+	var cur strings.Builder
+	for i := 0; i < len(line); i++ {
+		if line[i] == '\\' && i+1 < len(line) && (line[i+1] == ' ' || line[i+1] == '\t') {
+			cur.WriteByte(line[i+1])
+			i++
+		} else if line[i] == ' ' || line[i] == '\t' {
+			if cur.Len() > 0 {
+				fields = append(fields, cur.String())
+				cur.Reset()
+			}
+		} else {
+			cur.WriteByte(line[i])
+		}
+	}
+	if cur.Len() > 0 {
+		fields = append(fields, cur.String())
+	}
+	for _, field := range fields {
+		if k, v, ok := strings.Cut(field, "="); ok {
+			txt[k] = v
+		}
+	}
+}
+
+// dnssdResolveService runs dns-sd -L to resolve a browse result to hostname,
+// port, and TXT records. Returns as soon as the "can be reached at" line is parsed.
+func dnssdResolveService(ctx context.Context, inst browseResult, serviceType string) (resolvedService, error) {
 	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, serviceType, inst.domain)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return MDNSService{}, err
+		return resolvedService{}, err
 	}
 	if err := cmd.Start(); err != nil {
-		return MDNSService{}, err
+		return resolvedService{}, err
 	}
 
 	var hostname string
@@ -82,16 +122,12 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 				}
 			}
 
+			// TXT records on the same line (some versions).
+			parseDNSSDTXT(line, txtRecords)
+
+			// TXT records are typically on the next line indented with a space.
 			if scanner.Scan() {
-				txtLine := scanner.Text()
-				if strings.HasPrefix(txtLine, " ") {
-					txtParts := strings.Fields(txtLine)
-					for _, field := range txtParts {
-						if k, v, ok := strings.Cut(field, "="); ok {
-							txtRecords[k] = v
-						}
-					}
-				}
+				parseDNSSDTXT(scanner.Text(), txtRecords)
 			}
 
 			_ = cmd.Process.Kill()
@@ -102,19 +138,35 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 	_ = cmd.Wait()
 
 	if hostname == "" {
-		return MDNSService{}, fmt.Errorf("could not resolve instance %q", inst.instanceName)
+		return resolvedService{}, fmt.Errorf("could not resolve instance %q", inst.instanceName)
+	}
+
+	return resolvedService{
+		instanceName: inst.instanceName,
+		hostname:     hostname,
+		port:         port,
+		txtRecords:   txtRecords,
+	}, nil
+}
+
+// resolveMDNSService resolves a browse result into an MDNSService, including
+// a best-effort IP address lookup for the resolved hostname.
+func resolveMDNSService(ctx context.Context, inst browseResult, serviceType string) (MDNSService, error) {
+	svc, err := dnssdResolveService(ctx, inst, serviceType)
+	if err != nil {
+		return MDNSService{}, err
 	}
 
 	ipAddr := ""
-	if addrs, lookupErr := net.LookupHost(hostname); lookupErr == nil {
+	if addrs, lookupErr := net.LookupHost(svc.hostname); lookupErr == nil {
 		ipAddr = preferIPv4Addr(addrs)
 	}
 
 	return MDNSService{
-		InstanceName: inst.instanceName,
-		Hostname:     hostname,
+		InstanceName: svc.instanceName,
+		Hostname:     svc.hostname,
 		IPAddress:    ipAddr,
-		Port:         port,
-		TXTRecords:   txtRecords,
+		Port:         svc.port,
+		TXTRecords:   svc.txtRecords,
 	}, nil
 }

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -50,6 +50,39 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	return services, nil
 }
 
+// BrowseMDNSServicesContinuous browses for serviceType and streams each newly
+// discovered service, resolved, to the returned channel. It runs until ctx is
+// cancelled or the underlying browse exits; the channel is closed when
+// browsing stops. Instances that fail to resolve are skipped, matching
+// BrowseMDNSServices. Consumers signal they are done by cancelling ctx.
+func BrowseMDNSServicesContinuous(ctx context.Context, serviceType string) (<-chan MDNSService, error) {
+	browseCh, err := dnssdBrowseStream(ctx, serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan MDNSService, 16)
+	go func() {
+		defer close(ch)
+		for inst := range browseCh {
+			resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
+			svc, err := resolveMDNSService(resolveCtx, inst, serviceType)
+			resolveCancel()
+			if err != nil {
+				continue
+			}
+
+			select {
+			case ch <- svc:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
 type browseResult struct {
 	instanceName  string
 	domain        string

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -47,6 +48,124 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	}
 
 	return services, nil
+}
+
+type browseResult struct {
+	instanceName  string
+	domain        string
+	interfaceName string
+}
+
+// parseBrowseLine parses one line of dns-sd -B output. It returns ok=false
+// for lines that are not "Add" records or are too short to parse.
+func parseBrowseLine(line string) (browseResult, bool) {
+	if !strings.Contains(line, "Add") {
+		return browseResult{}, false
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 7 {
+		return browseResult{}, false
+	}
+	interfaceName := ""
+	if interfaceIndex, err := strconv.Atoi(fields[3]); err == nil {
+		// Silently falls through with empty interfaceName when the
+		// interface disappears between browse and resolve; USB detection
+		// will be skipped for that device rather than returning an error.
+		if iface, ifaceErr := net.InterfaceByIndex(interfaceIndex); ifaceErr == nil {
+			interfaceName = iface.Name
+		}
+	}
+	return browseResult{
+		instanceName:  strings.Join(fields[6:], " "),
+		domain:        fields[4],
+		interfaceName: interfaceName,
+	}, true
+}
+
+// dnssdBrowseStream starts dns-sd -B for serviceType and streams each newly
+// discovered instance to the returned channel. Duplicate (instance, interface)
+// pairs are emitted only once. The channel is closed when ctx is cancelled or
+// the dns-sd process exits; the process is killed and reaped on all paths.
+// Consumers signal they are done by cancelling ctx.
+//
+// This function is intentionally generic mDNS browsing: keep it free of
+// anything wendy-specific (service types, TXT record interpretation, device
+// models) — callers layer that on top.
+func dnssdBrowseStream(ctx context.Context, serviceType string) (<-chan browseResult, error) {
+	cmd := exec.CommandContext(ctx, "dns-sd", "-B", serviceType, "local")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	ch := make(chan browseResult, 16)
+	go func() {
+		defer close(ch)
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+
+		seen := make(map[string]bool)
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			result, ok := parseBrowseLine(scanner.Text())
+			if !ok {
+				continue
+			}
+			key := result.instanceName + "%" + result.interfaceName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			select {
+			case ch <- result:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+// dnssdBrowse runs dns-sd -B and returns as soon as results stop arriving.
+// It uses a short settle timer: once the first result arrives, it waits up to
+// 500ms for more results before returning. This avoids waiting for the full timeout.
+func dnssdBrowse(ctx context.Context, serviceType string) ([]browseResult, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	browseCh, err := dnssdBrowseStream(streamCtx, serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []browseResult
+
+	// Wait up to the context deadline for the first result.
+	// Once we get one, use a short settle timer for additional results.
+	var settle <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return results, nil
+		case result, open := <-browseCh:
+			if !open {
+				return results, nil
+			}
+			results = append(results, result)
+			// Reset settle timer: wait 500ms for more results.
+			settle = time.After(500 * time.Millisecond)
+		case <-settle:
+			// No new results in 500ms, we're done.
+			return results, nil
+		}
+	}
 }
 
 // resolvedService is the raw result of a dns-sd -L resolve: exactly what the
@@ -90,6 +209,10 @@ func parseDNSSDTXT(line string, txt map[string]string) {
 
 // dnssdResolveService runs dns-sd -L to resolve a browse result to hostname,
 // port, and TXT records. Returns as soon as the "can be reached at" line is parsed.
+//
+// This function is intentionally generic mDNS resolution: keep it free of
+// anything wendy-specific (service types, TXT record interpretation, device
+// models) — callers layer that on top.
 func dnssdResolveService(ctx context.Context, inst browseResult, serviceType string) (resolvedService, error) {
 	cmd := exec.CommandContext(ctx, "dns-sd", "-L", inst.instanceName, serviceType, inst.domain)
 	stdout, err := cmd.StdoutPipe()

--- a/go/internal/shared/discovery/mdns_linux.go
+++ b/go/internal/shared/discovery/mdns_linux.go
@@ -5,6 +5,7 @@ package discovery
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -27,6 +28,14 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 		return browseMDNSAvahi(ctx, serviceType, timeout)
 	}
 	return browseMDNSHashicorp(ctx, serviceType, timeout)
+}
+
+// BrowseMDNSServicesContinuous streams newly discovered mDNS services of the
+// given type as they appear. Only macOS has a native streaming primitive
+// (dns-sd); on Linux this returns errors.ErrUnsupported so callers fall back
+// to polling BrowseMDNSServices.
+func BrowseMDNSServicesContinuous(_ context.Context, _ string) (<-chan MDNSService, error) {
+	return nil, fmt.Errorf("continuous mDNS browsing: %w", errors.ErrUnsupported)
 }
 
 // browseMDNSAvahi uses avahi-browse to discover services.

--- a/go/internal/shared/discovery/mdns_windows.go
+++ b/go/internal/shared/discovery/mdns_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// BrowseMDNSServicesContinuous streams newly discovered mDNS services of the
+// given type as they appear. Only macOS has a native streaming primitive
+// (dns-sd); on Windows this returns errors.ErrUnsupported so callers fall
+// back to polling BrowseMDNSServices.
+func BrowseMDNSServicesContinuous(_ context.Context, _ string) (<-chan MDNSService, error) {
+	return nil, fmt.Errorf("continuous mDNS browsing: %w", errors.ErrUnsupported)
+}


### PR DESCRIPTION
## Summary

Makes the device picker consume discovery results as a stream instead of polling, and refactors the darwin `dns-sd` machinery it builds on.

- **Picker streaming**: adds `providers.ContinuousDiscoverer`, an optional interface letting a provider push discovered devices over a channel. The picker uses the stream when available and falls back to polling otherwise (including when a stream fails to start or closes). The polling fallback now runs on a 3s cadence measured from scan start, so slow scans no longer stretch the effective rescan period.
- **wendy-lite streaming on macOS**: `MicroWendyProvider` implements the new interface via `BrowseMDNSServicesContinuous`, which streams each newly discovered service as it resolves. Serial devices stream too, via periodic re-scanning with listener snapshots coalesced into the same channel. Linux and Windows return `errors.ErrUnsupported`, keeping the polling fallback there.
- **darwin dns-sd cleanup**: unifies the duplicated `dns-sd -L` resolve loops into a shared `dnssdResolveService` (fixing drifted TXT parsing in the mdns copy), extracts `dnssdBrowseStream` as the single owner of the `dns-sd -B` lifecycle (fixing a process leak in `discoverLANContinuous`), and groups all wendy-agnostic dns-sd machinery in `mdns_darwin.go` with the layering rule documented.

## Test plan

- [ ] `go test ./go/internal/shared/discovery/... ./go/internal/cli/...` (new unit tests for browse-line parsing and the picker discovery loop)
- [ ] On macOS, open the device picker with a wendy-lite device on the LAN and verify it appears as soon as it resolves, without waiting for a poll cycle
- [ ] Plug in a USB board while the picker is open and verify it appears
- [ ] On Linux/Windows, verify the picker still discovers devices via polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)