### PR TITLE
fix(cli): paginate ListOrganizations so the org picker shows every org

### DIFF
--- a/go/internal/cli/commands/org_picker.go
+++ b/go/internal/cli/commands/org_picker.go
@@ -20,6 +20,16 @@ import (
 // so unit tests can stub it without a live cloud connection.
 var listOrgsFromCloud = listOrgsFromCloudImpl
 
+// orgPageSize is the explicit page size sent to ListOrganizations. The server
+// applies a small default (20) when the request omits a limit, which silently
+// truncated the org picker to the 20 oldest orgs (WDY: orgs past the first page
+// were unreachable — see listOrgsFromCloudImpl).
+const orgPageSize = 200
+
+// orgPageCap bounds the pagination loop so a server that keeps returning full
+// pages cannot spin forever.
+const orgPageCap = 50
+
 func listOrgsFromCloudImpl(ctx context.Context, auth *config.AuthConfig) ([]*cloudpb.Organization, error) {
 	conn, err := dialCloudGRPC(auth)
 	if err != nil {
@@ -28,23 +38,38 @@ func listOrgsFromCloudImpl(ctx context.Context, auth *config.AuthConfig) ([]*clo
 	defer conn.Close()
 
 	client := cloudpb.NewOrganizationServiceClient(conn)
-	stream, err := client.ListOrganizations(cloudContext(ctx, auth), &cloudpb.ListOrganizationsRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("listing organizations: %w", err)
-	}
 
+	// The RPC is paginated: it streams one page per call and honours
+	// offset/limit. Keep requesting pages until one comes back short (or empty),
+	// otherwise only the first page of orgs ever reaches the picker.
 	var orgs []*cloudpb.Organization
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
+	offset := int32(0)
+	limit := int32(orgPageSize)
+	for page := 0; page < orgPageCap; page++ {
+		req := &cloudpb.ListOrganizationsRequest{Offset: &offset, Limit: &limit}
+		stream, err := client.ListOrganizations(cloudContext(ctx, auth), req)
+		if err != nil {
+			return nil, fmt.Errorf("listing organizations: %w", err)
+		}
+
+		received := int32(0)
+		for {
+			resp, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("receiving organizations: %w", err)
+			}
+			if org := resp.GetOrganization(); org != nil {
+				received++
+				orgs = append(orgs, org)
+			}
+		}
+		if received < limit {
 			break
 		}
-		if err != nil {
-			return nil, fmt.Errorf("receiving organizations: %w", err)
-		}
-		if org := resp.GetOrganization(); org != nil {
-			orgs = append(orgs, org)
-		}
+		offset += received
 	}
 	return orgs, nil
 }

--- a/go/internal/cli/commands/org_picker_pagination_test.go
+++ b/go/internal/cli/commands/org_picker_pagination_test.go
@@ -1,0 +1,125 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// fakeOrgService mimics the cloud's ListOrganizations: it pages, and applies a
+// small default page size when the request omits a limit — the behaviour that
+// silently truncated the org picker to the 20 oldest orgs.
+type fakeOrgService struct {
+	cloudpb.UnimplementedOrganizationServiceServer
+
+	total          int
+	defaultLimit   int32
+	maxLimit       int32
+	requestedPages []struct{ offset, limit int32 }
+}
+
+func (s *fakeOrgService) ListOrganizations(req *cloudpb.ListOrganizationsRequest, stream grpc.ServerStreamingServer[cloudpb.ListOrganizationsResponse]) error {
+	offset := req.GetOffset()
+	limit := req.GetLimit()
+	if limit <= 0 {
+		limit = s.defaultLimit
+	}
+	if limit > s.maxLimit {
+		limit = s.maxLimit
+	}
+	s.requestedPages = append(s.requestedPages, struct{ offset, limit int32 }{offset, limit})
+
+	for i := offset; i < offset+limit && int(i) < s.total; i++ {
+		// Org IDs start at 2, matching production (1 is reserved).
+		id := i + 2
+		err := stream.Send(&cloudpb.ListOrganizationsResponse{
+			Organization: &cloudpb.Organization{Id: id, Name: fmt.Sprintf("Org %d", id)},
+			Total:        int32(s.total),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func startFakeOrgServer(t *testing.T, svc *fakeOrgService) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	cloudpb.RegisterOrganizationServiceServer(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// TestListOrgsFromCloudPaginates guards against the picker showing only the
+// first server page: orgs past the default page size must still be returned.
+func TestListOrgsFromCloudPaginates(t *testing.T) {
+	svc := &fakeOrgService{total: 51, defaultLimit: 20, maxLimit: 1000}
+	addr := startFakeOrgServer(t, svc)
+
+	auth := &config.AuthConfig{
+		CloudGRPC:    addr, // not :443 -> dialed insecurely, no certs needed on the wire
+		Certificates: []config.CertificateInfo{{OrganizationID: 2, UserID: "test-user"}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	orgs, err := listOrgsFromCloudImpl(ctx, auth)
+	if err != nil {
+		t.Fatalf("listOrgsFromCloudImpl: %v", err)
+	}
+	if len(orgs) != svc.total {
+		t.Fatalf("got %d orgs, want %d (pagination dropped orgs past the first page)", len(orgs), svc.total)
+	}
+	if got := orgs[len(orgs)-1].GetId(); got != int32(svc.total+1) {
+		t.Errorf("last org id = %d, want %d", got, svc.total+1)
+	}
+	for _, p := range svc.requestedPages {
+		if p.limit <= 0 {
+			t.Errorf("request sent no limit (offset=%d); the server default would truncate the list", p.offset)
+		}
+	}
+}
+
+// TestListOrgsFromCloudCapsPageRequests ensures a server that keeps returning
+// full pages cannot spin the pagination loop forever.
+func TestListOrgsFromCloudCapsPageRequests(t *testing.T) {
+	// maxLimit below the client page size makes every page look "full" to a
+	// naive loop; the cap must stop it.
+	svc := &fakeOrgService{total: 1_000_000, defaultLimit: 20, maxLimit: orgPageSize}
+	addr := startFakeOrgServer(t, svc)
+
+	auth := &config.AuthConfig{
+		CloudGRPC:    addr,
+		Certificates: []config.CertificateInfo{{OrganizationID: 2, UserID: "test-user"}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	orgs, err := listOrgsFromCloudImpl(ctx, auth)
+	if err != nil {
+		t.Fatalf("listOrgsFromCloudImpl: %v", err)
+	}
+	if want := orgPageSize * orgPageCap; len(orgs) != want {
+		t.Fatalf("got %d orgs, want %d (page cap not enforced)", len(orgs), want)
+	}
+	if len(svc.requestedPages) != orgPageCap {
+		t.Errorf("made %d page requests, want cap of %d", len(svc.requestedPages), orgPageCap)
+	}
+}


### PR DESCRIPTION
## Problem

`wendy device enroll` on a fresh machine could not find the `WendyBox-Enmax` org — the picker's list stopped at org ID 22.

`listOrgsFromCloud` called `ListOrganizations` with an empty `ListOrganizationsRequest`. That RPC is paginated (`offset` / `limit`), and the server applies a **default limit of 20** when the request omits one. So every org picker — `device enroll`, `os install --pre-enroll`, `auth list-orgs` — showed only the 20 oldest organizations, with nothing in the UI indicating the list was truncated.

On production that hides 31 of 51 orgs, including:

| ID | Org |
|---|---|
| 75 | WendyBox-Enmax |
| 76 | Wendy Studio |
| 77 | Wendy Labs CI |

An org past the first page simply cannot be selected. The documented workaround (`wendy auth list-orgs` to set a default) hits the same truncated list, so there is no way out from the CLI.

## Fix

Request pages explicitly and loop until a short page comes back:

- page size 200 (`orgPageSize`)
- bounded by `orgPageCap` (50 pages) so a server that keeps returning full pages cannot spin the loop forever

The picker itself needed no change — `PickerTableHeight` already sizes the table to the window, so 51 rows scroll fine.

## Verification

- Against live prod (`cloud.wendy.dev`), `listOrgsFromCloud` now returns **51** orgs instead of 20, including `75 WendyBox-Enmax`, `76 Wendy Studio`, `77 Wendy Labs CI`.
- New `org_picker_pagination_test.go` stands up a fake `OrganizationService` that reproduces the server's 20-per-page default. `TestListOrgsFromCloudPaginates` returns 20/51 without this fix; `TestListOrgsFromCloudCapsPageRequests` pins the page cap.
- `gofmt`, `go vet`, and the full `internal/cli/commands` suite pass.

## Follow-up, not in this PR

`ListOrganizations` returns **every** org in the cloud, not just those the caller belongs to — this account holds certificates for orgs 2, 9 and 75, yet all 51 come back with names and domains (every row renders `Credentials ✗`). Any authenticated user can enumerate every customer organization. That is a server-side membership filter in the cloud repo; happy to file it separately.

Separately, `wendy auth list-orgs` has no non-interactive path — it fails with `picker: could not open a new TTY` even under `--json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
