### PR TITLE
fix(os install): reorder Jetson flash-mode picker and correct its transport label

### DIFF
--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -587,14 +587,15 @@ func shouldPromptFlashMode(deviceType, installMode string, rootfsOnlyExplicit bo
 		interactive
 }
 
-// chooseT234FlashMode prompts the user to pick between full USB recovery
-// (firmware + OS) and OS-image-only imaging, returning rootfsOnly=true for the
-// image-only choice. A cancelled picker surfaces ErrUserCancelled, which the
-// top-level command maps to a clean exit.
+// chooseT234FlashMode prompts the user to pick between OS-image-only imaging
+// and a full recovery flash (firmware + OS), returning rootfsOnly=true for the
+// image-only choice. Image-only is listed first because it is the common case;
+// a full flash needs the device jumpered into recovery mode. A cancelled picker
+// surfaces ErrUserCancelled, which the top-level command maps to a clean exit.
 func chooseT234FlashMode() (rootfsOnly bool, err error) {
 	choice, err := pickFromItems("Select flash mode", []tui.PickerItem{
-		{Name: "Full flash over USB", Description: "Updates boot firmware + OS (device in recovery mode)", Value: "full"},
 		{Name: "OS image only (no firmware update)", Description: "Write to an NVMe/SD drive attached to this computer", Value: "rootfs"},
+		{Name: "Full flash over UART", Description: "Updates boot firmware + OS (device in recovery mode)", Value: "full"},
 	})
 	if err != nil {
 		return false, err // ErrUserCancelled propagates unchanged


### PR DESCRIPTION
## What

The `wendy os install` flash-mode picker (Jetson Orin targets, including the Orin Nano) presented:

1. `Full flash over USB` — updates boot firmware + OS
2. `OS image only (no firmware update)` — write to an NVMe/SD drive

Two problems: the transport in the first label is UART, not USB, and the full flash was the first (highlighted) entry even though writing the OS image to the NVMe/SD drive is the common case.

## Change

Swap the two entries so the OS-image-only option is first, and relabel the other one `Full flash over UART`. Values, descriptions, and the rest of the flow are untouched, so `--rootfs-only` / `--storage` behaviour and every non-interactive path are unchanged.

## Testing

`go test ./internal/cli/...` passes (full CLI suite).