### PR TITLE
VoiceAssistant: Pi 3/4/5 support, voice-controlled volume tools, device auto-detect

### DIFF
--- a/Examples/VoiceAssistant/.env.example
+++ b/Examples/VoiceAssistant/.env.example
@@ -1,0 +1,26 @@
+# Copy this file to .env and fill in your key. The .env file is gitignored and
+# its values are injected at deploy time — never baked into the image.
+OPENAI_API_KEY=sk-your-key-here
+
+# ALSA devices. Leave unset to auto-detect the first USB card (recommended);
+# find names with `wendy device audio list`.
+#AUDIO_INPUT_DEVICE=plughw:CARD=Device,DEV=0
+#AUDIO_OUTPUT_DEVICE=plughw:CARD=Device,DEV=0
+
+# Speaker volume applied once at startup (0-100, `off` to disable). Default 70.
+#STARTUP_VOLUME_PERCENT=70
+
+# Half-duplex echo protection for hardware without echo cancellation.
+# Setting this to true disables barge-in/interruption.
+#MUTE_INPUT_DURING_PLAYBACK=true
+
+# Model, voice, and behavior.
+#OPENAI_REALTIME_MODEL=gpt-realtime-2.1
+#OPENAI_VOICE=marin
+#ASSISTANT_INSTRUCTIONS=You are a helpful voice assistant.
+
+# Audio tuning. The Realtime API expects 24 kHz mono PCM16.
+#AUDIO_SAMPLE_RATE=24000
+#AUDIO_CHUNK_MS=100
+
+#LOG_LEVEL=INFO

--- a/Examples/VoiceAssistant/README.md
+++ b/Examples/VoiceAssistant/README.md
@@ -1,107 +1,119 @@
 # Realtime Voice Assistant
 
 A Raspberry Pi / WendyOS demo that streams microphone audio to OpenAI's
-Realtime API and plays the spoken response through a separately selectable
-speaker. It uses the GA Realtime WebSocket interface, `gpt-realtime-2.1`,
-semantic voice activity detection, and 24 kHz mono PCM16 audio in both
-directions.
+Realtime API and plays the spoken response through a speaker. It uses the GA
+Realtime WebSocket interface, `gpt-realtime-2.1`, semantic voice activity
+detection, and 24 kHz mono PCM16 audio in both directions.
+
+Interruption/barge-in is enabled by default: speak over the assistant and it
+stops immediately, truncating the unheard part of its reply. The assistant can
+also control its own speaker volume — say "set the volume to 30 percent" or
+"turn it up a bit" and it adjusts the ALSA mixer through Realtime function
+tools.
 
 ## Hardware
 
-- A WendyOS device (the example command uses `pi4`)
-- A microphone visible to ALSA
-- A speaker visible to ALSA; USB, HDMI, or the Pi audio jack can be selected
+- A WendyOS device — Raspberry Pi 3, 4, and 5 are all supported
+- A microphone and speaker visible to ALSA (a USB speakerphone covers both)
 - Internet access from the device
 
 Keep the mic away from the speaker for the cleanest turn detection. The mic
 stays live while the assistant speaks so the user can interrupt it. Hardware
 echo cancellation is strongly recommended to prevent the speaker from
-interrupting itself.
+interrupting itself — USB conference speakerphones (e.g. Anker PowerConf) have
+it built in. Without it, set `MUTE_INPUT_DURING_PLAYBACK=true` for half-duplex
+operation (this disables interruption).
 
-## 1. Find the ALSA devices
+### Raspberry Pi model notes
 
-```sh
-wendy device audio list --device wendyos-pi4.local
-```
+| Model | Audio out | Microphone |
+| --- | --- | --- |
+| Pi 5 | USB or HDMI (no 3.5 mm jack) | USB |
+| Pi 3 / 4 | USB, HDMI, or 3.5 mm jack (output only) | USB |
 
-Choose the capture and playback identifiers shown by the command. ALSA names
-typically look like `plughw:CARD=Device,DEV=0`. If the desired devices are
-already the WendyOS defaults, leave both variables unset.
+No Pi has an analog audio input, so the microphone is always USB (or a HAT).
+ALSA card *numbers* can change across boots as USB devices enumerate, so
+prefer the stable name form `plughw:CARD=<name>,DEV=<n>` — the app's
+auto-detection (below) does this for you.
 
-On the `pi4` inspected while building this demo, card 2 is a USB Speaker Phone
-with both capture and playback, while cards 0 and 1 are HDMI playback devices.
-For that current wiring, start with:
+## 1. Pick the ALSA devices (optional)
 
-```sh
-export AUDIO_INPUT_DEVICE='plughw:2,0'
-export AUDIO_OUTPUT_DEVICE='plughw:2,0'  # or plughw:0,0 for HDMI
-```
+By default the app auto-detects the first USB sound card for both capture and
+playback and falls back to the ALSA `default` device. If that is what you want,
+skip this step.
 
-Use `plughw` rather than `hw` so ALSA can convert a device's native sample rate
-to the API's 24 kHz PCM stream when necessary.
-
-For other hardware, substitute the card names reported by the list command:
+To choose devices yourself, list them:
 
 ```sh
-export AUDIO_INPUT_DEVICE='plughw:CARD=Microphone,DEV=0'
-export AUDIO_OUTPUT_DEVICE='plughw:CARD=Speaker,DEV=0'
+wendy device audio list --device <hostname>.local
 ```
 
-You can validate the microphone before deploying:
+and export the identifiers before deploying:
 
 ```sh
-wendy device audio monitor --device wendyos-pi4.local
+export AUDIO_INPUT_DEVICE='plughw:CARD=Device,DEV=0'
+export AUDIO_OUTPUT_DEVICE='plughw:CARD=Device,DEV=0'  # or an HDMI card
 ```
+
+Use `plughw` rather than `hw` so ALSA can convert a device's native sample
+rate to the API's 24 kHz PCM stream when necessary. You can validate the
+microphone before deploying with `wendy device audio monitor`.
 
 ## 2. Supply the API key and deploy
 
-Create an API key in the OpenAI dashboard. Copy the example environment file,
-then replace its placeholder key:
+Create an API key in the OpenAI dashboard, then:
 
 ```sh
 cp .env.example .env
-# Edit .env, then:
-./run.sh --device wendyos-pi4.local
+# Edit .env to add your key, then:
+set -a; source .env; set +a
+wendy run --device <hostname>.local
 ```
 
-The helper loads `.env`, runs the newer Wendy CLI source in this repository,
-and forces the registry deployment path with `--chunking off`. This is
-necessary because the currently installed CLI and Pi agent (`2026.07.27`)
-predate environment propagation on the chunk-diff deployment path, completed
-on `2026.07.29`. The older registry path already supports injected environment
-variables. The `.env` file is gitignored, and the key is injected at deployment
-time rather than stored in the repository or container image.
-
-With a newer installed Wendy CLI, the equivalent manual flow is:
-
-```sh
-set -a
-source .env
-set +a
-wendy run --chunking off --device wendyos-pi4.local
-```
+`./run.sh --device <hostname>.local` does the same `.env` loading for you.
+The `.env` file is gitignored; the key is injected at deployment time rather
+than stored in the repository or container image.
 
 When the log says `Ready — listening for your voice`, speak normally. Semantic
-VAD ends the turn automatically and the reply plays through
-`AUDIO_OUTPUT_DEVICE`. Press Ctrl-C to stop the attached log stream.
+VAD ends the turn automatically and the reply plays through the selected
+speaker. Press Ctrl-C to stop the attached log stream.
+
+## Volume
+
+At startup the app sets the speaker to `STARTUP_VOLUME_PERCENT` (default 70%)
+— WendyOS does not persist a volume across reinstalls, so a fresh device could
+otherwise be silent or very quiet. Set it to `off` to leave the mixer alone.
+
+While the assistant is running, just ask it: "set the volume to 30 percent",
+"turn it up", "how loud are you?". These are Realtime function tools backed by
+`amixer` inside the container.
+
+You can also drive volume manually with the interactive TUI on the host:
+
+```sh
+wendy device audio --device <hostname>.local
+# ↑/↓ select · enter set default · ←/→ volume · q quit
+```
+
+Agents older than the 2026-08 volume support don't implement `SetAudioVolume`;
+the TUI will say so — update the agent (or push a dev build with
+`wendy device push-agent`).
 
 ## Configuration
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `OPENAI_API_KEY` | required | OpenAI API credential |
-| `AUDIO_INPUT_DEVICE` | `plughw:2,0` | ALSA capture PCM |
-| `AUDIO_OUTPUT_DEVICE` | `plughw:2,0` | ALSA playback PCM |
+| `AUDIO_INPUT_DEVICE` | auto-detect (first USB card, else `default`) | ALSA capture PCM |
+| `AUDIO_OUTPUT_DEVICE` | auto-detect (first USB card, else `default`) | ALSA playback PCM |
+| `STARTUP_VOLUME_PERCENT` | `70` | Speaker volume applied once at startup; `off` disables |
 | `OPENAI_REALTIME_MODEL` | `gpt-realtime-2.1` | Realtime model |
 | `OPENAI_VOICE` | `marin` | Assistant voice |
 | `ASSISTANT_INSTRUCTIONS` | concise voice assistant | System instructions |
 | `MUTE_INPUT_DURING_PLAYBACK` | `false` | Set to `true` for half-duplex echo protection (disables interruption) |
+| `AUDIO_SAMPLE_RATE` | `24000` | PCM sample rate in Hz (the API expects 24 kHz) |
 | `AUDIO_CHUNK_MS` | `100` | Microphone packet duration |
 | `LOG_LEVEL` | `INFO` | Python log level |
-
-Interruption/barge-in is enabled by default. Set
-`MUTE_INPUT_DURING_PLAYBACK=true` only when a device has no echo cancellation
-and speaker feedback is worse than losing interruption support.
 
 ## Local checks
 
@@ -131,6 +143,14 @@ OpenAI's semantic VAD creates each response. Returned
 so there are no temporary audio files. When semantic VAD detects speech during
 a reply, the app drops queued speaker audio and truncates the unheard portion
 of the assistant message in the Realtime conversation.
+
+Volume control is Realtime tool calling: the session registers `set_volume`,
+`adjust_volume`, and `get_volume` function tools. When the model decides to
+call one, the finished `function_call` item arrives with its arguments, the
+app runs `amixer` against the playback card (the `audio` entitlement mounts
+`/dev/snd` into the container), sends the result back as a
+`function_call_output` item, and asks for a spoken confirmation with
+`response.create` — unless the user is already talking again.
 
 This follows OpenAI's current [Realtime WebSocket
 guide](https://developers.openai.com/api/docs/guides/realtime-websocket) and

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -22,7 +22,7 @@ BYTES_PER_SAMPLE = 2  # signed PCM16
 
 # "card 2: Device [USB Audio Device], device 0: USB Audio [USB Audio]"
 _ALSA_CARD_LINE = re.compile(
-    r"^card (\d+): (\S+) \[(.+?)\], device (\d+):", re.MULTILINE
+    r"^card (\d+): (\S+) \[(.+?)\], device (\d+): (.*)$", re.MULTILINE
 )
 
 
@@ -39,6 +39,7 @@ class AlsaCard:
     name: str
     description: str
     device: int
+    device_description: str = ""
 
 
 def parse_alsa_cards(listing: str) -> list[AlsaCard]:
@@ -56,15 +57,20 @@ def parse_alsa_cards(listing: str) -> list[AlsaCard]:
                 name=match.group(2),
                 description=match.group(3),
                 device=int(match.group(4)),
+                device_description=match.group(5),
             )
         )
     return cards
 
 
 def pick_alsa_device(cards: list[AlsaCard]) -> str | None:
-    """Pick the first USB card, addressed by CARD name (stable across reboots)."""
+    """Pick the first USB card, addressed by CARD name (stable across reboots).
+
+    The card description is the product string and often lacks "usb"
+    (e.g. "Anker PowerConf S330"), but snd-usb-audio always names the device
+    "USB Audio" — so match against both columns."""
     for card in cards:
-        if "usb" in card.description.lower():
+        if "usb" in f"{card.description} {card.device_description}".lower():
             return f"plughw:CARD={card.name},DEV={card.device}"
     return None
 
@@ -221,7 +227,13 @@ class AlsaMixer:
             self.parse_controls(await self._amixer("scontrols"))
         )
         for control in controls:
-            volume = self.parse_playback_volume(await self._amixer("sget", control))
+            try:
+                output = await self._amixer("sget", control)
+            except RuntimeError:
+                # A control that cannot be queried is skipped, not fatal —
+                # keeps USB and board-specific codecs usable (Go agent parity).
+                continue
+            volume = self.parse_playback_volume(output)
             if volume is not None:
                 self._control = control
                 return control, volume
@@ -459,13 +471,18 @@ class VoiceAssistant:
         percent = self.config.startup_volume_percent
         if percent is None or self._startup_volume_done:
             return
-        self._startup_volume_done = True
         try:
             applied = await mixer.set_volume(percent)
         except Exception as exc:
+            # Don't latch: USB devices can enumerate late, so retry next session.
             LOG.warning("Could not set startup volume: %s", exc)
             return
-        LOG.info("Startup volume set to %d%%", applied)
+        self._startup_volume_done = True
+        LOG.info(
+            "Startup volume set to %d%% (card %s)",
+            applied,
+            getattr(mixer, "card", "unknown"),
+        )
 
     async def run_session(self) -> None:
         # A dropped connection can happen mid-response. Never carry playback
@@ -476,6 +493,7 @@ class VoiceAssistant:
         self.assistant_speaking.clear()
         self._reset_playback_state()
         self.interrupted_item_id = None
+        self.user_speaking = False
         self.transcript_parts.clear()
         url = (
             "wss://api.openai.com/v1/realtime?model="
@@ -492,9 +510,10 @@ class VoiceAssistant:
         output_device = self.config.output_device or await detect_device("aplay")
 
         card = card_from_device(output_device)
-        if card is None:
-            # An explicit but unparsable device (e.g. "default"): fall back to
-            # whatever playback card auto-detection can name.
+        if card is None and self.config.output_device:
+            # An explicit but unparsable device (e.g. "default" via asound.conf):
+            # bind the mixer to whatever playback card auto-detection can name.
+            # Note this card may differ from the one actually playing.
             card = card_from_device(await detect_device("aplay"))
         if card is None:
             self.mixer = None
@@ -629,8 +648,11 @@ class VoiceAssistant:
             if name == "set_volume":
                 applied = await self.mixer.set_volume(int(arguments["percent"]))
             elif name == "adjust_volume":
+                direction = arguments["direction"]
+                if direction not in ("up", "down"):
+                    raise ValueError(f"direction must be 'up' or 'down', got {direction!r}")
                 applied = await self.mixer.adjust_volume(
-                    arguments["direction"], step=int(arguments.get("step", 10))
+                    direction, step=int(arguments.get("step", 10))
                 )
             elif name == "get_volume":
                 applied = await self.mixer.get_volume()

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -8,6 +8,7 @@ import base64
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -19,6 +20,11 @@ from websockets.asyncio.client import connect
 LOG = logging.getLogger("voice-assistant")
 BYTES_PER_SAMPLE = 2  # signed PCM16
 
+# "card 2: Device [USB Audio Device], device 0: USB Audio [USB Audio]"
+_ALSA_CARD_LINE = re.compile(
+    r"^card (\d+): (\S+) \[(.+?)\], device (\d+):", re.MULTILINE
+)
+
 
 def _env_bool(name: str, default: bool) -> bool:
     value = os.getenv(name)
@@ -28,19 +34,105 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 @dataclass(frozen=True)
+class AlsaCard:
+    number: int
+    name: str
+    description: str
+    device: int
+
+
+def parse_alsa_cards(listing: str) -> list[AlsaCard]:
+    """Parse `arecord -l` / `aplay -l` output, keeping the first device per card."""
+    cards: list[AlsaCard] = []
+    seen: set[int] = set()
+    for match in _ALSA_CARD_LINE.finditer(listing):
+        number = int(match.group(1))
+        if number in seen:
+            continue
+        seen.add(number)
+        cards.append(
+            AlsaCard(
+                number=number,
+                name=match.group(2),
+                description=match.group(3),
+                device=int(match.group(4)),
+            )
+        )
+    return cards
+
+
+def pick_alsa_device(cards: list[AlsaCard]) -> str | None:
+    """Pick the first USB card, addressed by CARD name (stable across reboots)."""
+    for card in cards:
+        if "usb" in card.description.lower():
+            return f"plughw:CARD={card.name},DEV={card.device}"
+    return None
+
+
+async def _run_command(*args: str) -> tuple[int, str]:
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    output, _ = await process.communicate()
+    return process.returncode or 0, output.decode(errors="replace")
+
+
+async def detect_device(binary: str, run: Any = None) -> str:
+    """Auto-select an ALSA PCM by listing hardware with `arecord -l`/`aplay -l`."""
+    run = run or _run_command
+    returncode, output = await run(binary, "-l")
+    device = pick_alsa_device(parse_alsa_cards(output)) if returncode == 0 else None
+    if device is None:
+        LOG.info("No USB card found via `%s -l`; using ALSA default", binary)
+        return "default"
+    LOG.info("Auto-detected %s device %s", "capture" if binary == "arecord" else "playback", device)
+    return device
+
+
+def card_from_device(device: str) -> str | None:
+    """Extract the amixer -c argument (card index or id) from an ALSA PCM name."""
+    _, _, rest = device.partition(":")
+    if rest.startswith("CARD="):
+        return rest[len("CARD=") :].split(",")[0] or None
+    digits = rest.split(",")[0]
+    return digits if digits.isdigit() else None
+
+
+@dataclass(frozen=True)
 class Config:
     api_key: str
     model: str = "gpt-realtime-2.1"
     voice: str = "marin"
     instructions: str = (
         "You are a friendly voice assistant running on an edge device. "
-        "Be conversational, helpful, and concise. Reply in the language the user speaks."
+        "Be conversational, helpful, and concise. Reply in the language the user speaks. "
+        "You can change your own speaker volume with the provided tools when asked."
     )
-    input_device: str = "plughw:2,0"
-    output_device: str = "plughw:2,0"
+    input_device: str | None = None  # None -> auto-detect
+    output_device: str | None = None  # None -> auto-detect
     sample_rate: int = 24_000
     chunk_ms: int = 100
     mute_input_during_playback: bool = False
+    startup_volume_percent: int | None = 70
+
+    @staticmethod
+    def _parse_startup_volume(raw: str | None) -> int | None:
+        raw = (raw or "").strip()
+        if not raw:
+            return 70
+        if raw.lower() in {"off", "false", "no", "none", "disabled"}:
+            return None
+        try:
+            percent = int(raw)
+        except ValueError as exc:
+            raise ValueError(
+                "STARTUP_VOLUME_PERCENT must be an integer 0-100 or 'off'"
+            ) from exc
+        if not 0 <= percent <= 100:
+            raise ValueError("STARTUP_VOLUME_PERCENT must be between 0 and 100")
+        return percent
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -60,11 +152,14 @@ class Config:
             model=os.getenv("OPENAI_REALTIME_MODEL", "gpt-realtime-2.1"),
             voice=os.getenv("OPENAI_VOICE", "marin"),
             instructions=os.getenv("ASSISTANT_INSTRUCTIONS", cls.instructions),
-            input_device=os.getenv("AUDIO_INPUT_DEVICE", "plughw:2,0"),
-            output_device=os.getenv("AUDIO_OUTPUT_DEVICE", "plughw:2,0"),
+            input_device=os.getenv("AUDIO_INPUT_DEVICE", "").strip() or None,
+            output_device=os.getenv("AUDIO_OUTPUT_DEVICE", "").strip() or None,
             sample_rate=sample_rate,
             chunk_ms=chunk_ms,
             mute_input_during_playback=_env_bool("MUTE_INPUT_DURING_PLAYBACK", False),
+            startup_volume_percent=cls._parse_startup_volume(
+                os.getenv("STARTUP_VOLUME_PERCENT")
+            ),
         )
 
     @property
@@ -73,11 +168,97 @@ class Config:
         return samples * BYTES_PER_SAMPLE
 
 
+class AlsaMixer:
+    """Playback volume control via `amixer`, mirroring the wendy-agent logic:
+    order simple controls by preference, use the first one that reports a
+    playback percentage, and always re-parse amixer's own output so callers
+    see the actual (quantized) volume ALSA applied."""
+
+    PREFERRED = ("Master", "PCM", "Speaker", "Headphone")
+    _CONTROL = re.compile(r"^Simple mixer control '(.+)',\d+$", re.MULTILINE)
+    _PLAYBACK_VOLUME = re.compile(r"\[(\d{1,3})%\]")
+
+    def __init__(self, card: str, run: Any = None) -> None:
+        self.card = card
+        # The runner receives only the amixer subcommand and its arguments,
+        # matching the agent's injectable amixerRun test seam.
+        self._run = run or (lambda *args: _run_command("amixer", "-c", card, *args))
+        self._control: str | None = None
+
+    @staticmethod
+    def parse_controls(output: str) -> list[str]:
+        return AlsaMixer._CONTROL.findall(output)
+
+    @classmethod
+    def order_controls(cls, controls: list[str]) -> list[str]:
+        preferred_rank = {name.lower(): i for i, name in enumerate(cls.PREFERRED)}
+        fallback = len(preferred_rank)
+        return sorted(
+            controls,
+            key=lambda name: (preferred_rank.get(name.lower(), fallback),),
+        )
+
+    @classmethod
+    def parse_playback_volume(cls, output: str) -> int | None:
+        for line in output.splitlines():
+            if "Playback" not in line:
+                continue
+            match = cls._PLAYBACK_VOLUME.search(line)
+            if match and int(match.group(1)) <= 100:
+                return int(match.group(1))
+        return None
+
+    async def _amixer(self, *args: str) -> str:
+        returncode, output = await self._run(*args)
+        if returncode != 0:
+            raise RuntimeError(
+                f"amixer -c {self.card} {' '.join(args)} failed: {output.strip()}"
+            )
+        return output
+
+    async def resolve_control(self) -> tuple[str, int]:
+        controls = self.order_controls(
+            self.parse_controls(await self._amixer("scontrols"))
+        )
+        for control in controls:
+            volume = self.parse_playback_volume(await self._amixer("sget", control))
+            if volume is not None:
+                self._control = control
+                return control, volume
+        raise RuntimeError(
+            f"no playback volume control found on ALSA card {self.card}"
+        )
+
+    async def get_volume(self) -> int:
+        if self._control is None:
+            return (await self.resolve_control())[1]
+        volume = self.parse_playback_volume(await self._amixer("sget", self._control))
+        if volume is None:
+            raise RuntimeError(f"control '{self._control}' lost its playback volume")
+        return volume
+
+    async def set_volume(self, percent: int) -> int:
+        percent = max(0, min(100, percent))
+        if self._control is None:
+            await self.resolve_control()
+        assert self._control is not None
+        output = await self._amixer("sset", self._control, f"{percent}%", "unmute")
+        applied = self.parse_playback_volume(output)
+        return applied if applied is not None else percent
+
+    async def adjust_volume(self, direction: str, step: int = 10) -> int:
+        current = await self.get_volume()
+        delta = step if direction == "up" else -step
+        return await self.set_volume(current + delta)
+
+
 class AlsaAudio:
     """Owns one arecord process and one aplay process."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, input_device: str, output_device: str) -> None:
         self.config = config
+        self.input_device = input_device
+        self.output_device = output_device
         self.capture: asyncio.subprocess.Process | None = None
         self.playback: asyncio.subprocess.Process | None = None
 
@@ -85,7 +266,7 @@ class AlsaAudio:
         common = [
             "-q",
             "-D",
-            self.config.input_device,
+            self.input_device,
             "-t",
             "raw",
             "-f",
@@ -109,7 +290,7 @@ class AlsaAudio:
         playback_args = [
             "-q",
             "-D",
-            self.config.output_device,
+            self.output_device,
             "-t",
             "raw",
             "-f",
@@ -188,6 +369,56 @@ class VoiceAssistant:
         self.interrupted_item_id: str | None = None
         self.playback_done_task: asyncio.Task[None] | None = None
         self.transcript_parts: list[str] = []
+        self._startup_volume_done = False
+        self.mixer: Any | None = None
+        self.user_speaking = False
+
+    @staticmethod
+    def tool_specs() -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "name": "set_volume",
+                "description": (
+                    "Set the speaker output volume to an absolute percentage. "
+                    "Use for requests like 'set the volume to 30 percent'."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "percent": {"type": "integer", "minimum": 0, "maximum": 100}
+                    },
+                    "required": ["percent"],
+                },
+            },
+            {
+                "type": "function",
+                "name": "adjust_volume",
+                "description": (
+                    "Nudge the speaker volume up or down. Use for relative "
+                    "requests like 'turn it up a bit' or 'quieter please'."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "direction": {"type": "string", "enum": ["up", "down"]},
+                        "step": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 10,
+                        },
+                    },
+                    "required": ["direction"],
+                },
+            },
+            {
+                "type": "function",
+                "name": "get_volume",
+                "description": "Report the current speaker output volume percentage.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ]
 
     def session_update_event(self) -> dict[str, Any]:
         return {
@@ -197,6 +428,8 @@ class VoiceAssistant:
                 "model": self.config.model,
                 "output_modalities": ["audio"],
                 "instructions": self.config.instructions,
+                "tools": self.tool_specs(),
+                "tool_choice": "auto",
                 "audio": {
                     "input": {
                         "format": {
@@ -220,6 +453,20 @@ class VoiceAssistant:
             },
         }
 
+    async def apply_startup_volume(self, mixer: Any) -> None:
+        """Set a known output volume once per process; WendyOS has no boot-time
+        volume init, so a fresh device may otherwise be silent or very quiet."""
+        percent = self.config.startup_volume_percent
+        if percent is None or self._startup_volume_done:
+            return
+        self._startup_volume_done = True
+        try:
+            applied = await mixer.set_volume(percent)
+        except Exception as exc:
+            LOG.warning("Could not set startup volume: %s", exc)
+            return
+        LOG.info("Startup volume set to %d%%", applied)
+
     async def run_session(self) -> None:
         # A dropped connection can happen mid-response. Never carry playback
         # gating or transcript fragments into the replacement session.
@@ -239,13 +486,34 @@ class VoiceAssistant:
             "OpenAI-Safety-Identifier": "wendy-voice-assistant-demo",
         }
 
+        # Devices can enumerate late or renumber across reconnects, so resolve
+        # them at the start of every session rather than once at startup.
+        input_device = self.config.input_device or await detect_device("arecord")
+        output_device = self.config.output_device or await detect_device("aplay")
+
+        card = card_from_device(output_device)
+        if card is None:
+            # An explicit but unparsable device (e.g. "default"): fall back to
+            # whatever playback card auto-detection can name.
+            card = card_from_device(await detect_device("aplay"))
+        if card is None:
+            self.mixer = None
+            LOG.warning(
+                "No ALSA card resolved from %s; volume control disabled", output_device
+            )
+        else:
+            self.mixer = AlsaMixer(card)
+            await self.apply_startup_volume(self.mixer)
+
         LOG.info(
-            "Opening Realtime session (%s); mic=%s speaker=%s",
+            "Opening Realtime session (%s); mic=%s%s speaker=%s%s",
             self.config.model,
-            self.config.input_device,
-            self.config.output_device,
+            input_device,
+            "" if self.config.input_device else " (auto)",
+            output_device,
+            "" if self.config.output_device else " (auto)",
         )
-        async with AlsaAudio(self.config) as audio:
+        async with AlsaAudio(self.config, input_device, output_device) as audio:
             async with connect(
                 url,
                 additional_headers=headers,
@@ -289,12 +557,21 @@ class VoiceAssistant:
         if event_type == "session.updated":
             LOG.info("Ready — listening for your voice.")
         elif event_type == "input_audio_buffer.speech_started":
+            self.user_speaking = True
             if self.assistant_speaking.is_set():
                 await self.interrupt_response(websocket, audio)
             else:
                 LOG.info("Listening…")
         elif event_type == "input_audio_buffer.speech_stopped":
+            self.user_speaking = False
             LOG.info("Thinking…")
+        elif event_type == "response.output_item.done":
+            # Function-call arguments arrive complete on the finished item, so
+            # there is no need to assemble response.function_call_arguments.*
+            # deltas.
+            item = event.get("item", {})
+            if item.get("type") == "function_call" and websocket is not None:
+                await self.handle_tool_call(item, websocket)
         elif event_type == "response.output_audio.delta":
             item_id = event.get("item_id")
             if item_id and item_id == self.interrupted_item_id:
@@ -339,6 +616,52 @@ class VoiceAssistant:
                 f"Realtime API error ({error.get('code', 'unknown')}): "
                 f"{error.get('message', error)}"
             )
+
+    async def execute_tool(self, name: str, arguments_json: str) -> dict[str, Any]:
+        """Run one volume tool; always returns a JSON-safe payload, never raises —
+        a hardware failure must not kill the session."""
+        if self.mixer is None:
+            return {"error": "volume control is unavailable on this audio device"}
+        try:
+            arguments = json.loads(arguments_json) if arguments_json.strip() else {}
+            if not isinstance(arguments, dict):
+                raise ValueError("arguments must be a JSON object")
+            if name == "set_volume":
+                applied = await self.mixer.set_volume(int(arguments["percent"]))
+            elif name == "adjust_volume":
+                applied = await self.mixer.adjust_volume(
+                    arguments["direction"], step=int(arguments.get("step", 10))
+                )
+            elif name == "get_volume":
+                applied = await self.mixer.get_volume()
+            else:
+                return {"error": f"unknown tool: {name}"}
+            return {"volume_percent": applied}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    async def handle_tool_call(self, item: dict[str, Any], websocket: Any) -> None:
+        name = item.get("name", "")
+        result = await self.execute_tool(name, item.get("arguments", ""))
+        LOG.info("Tool %s(%s) -> %s", name, item.get("arguments", ""), result)
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": item.get("call_id"),
+                        "output": json.dumps(result),
+                    },
+                }
+            )
+        )
+        if self.user_speaking:
+            # The output is in the conversation; the model's next turn will see
+            # it. Forcing a response now would race semantic VAD's turn taking.
+            LOG.info("User is speaking; deferring the spoken tool result")
+            return
+        await websocket.send(json.dumps({"type": "response.create"}))
 
     async def interrupt_response(self, websocket: Any | None, audio: AlsaAudio) -> None:
         now = time.monotonic()

--- a/Examples/VoiceAssistant/run.sh
+++ b/Examples/VoiceAssistant/run.sh
@@ -1,30 +1,20 @@
 #!/usr/bin/env bash
+# Convenience wrapper: load .env, then deploy with `wendy run`.
 set -euo pipefail
 
 demo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-env_file="$demo_dir/.env"
-wendy_package="$demo_dir/../../go/cmd/wendy"
 
-if [[ -f "$env_file" ]]; then
+if [[ -f "$demo_dir/.env" ]]; then
   set -a
-  # shellcheck disable=SC1090
-  source "$env_file"
+  # shellcheck disable=SC1091
+  source "$demo_dir/.env"
   set +a
 fi
 
 if [[ -z "${OPENAI_API_KEY:-}" ]]; then
-  echo "OPENAI_API_KEY is missing; add it to $env_file" >&2
+  echo "OPENAI_API_KEY is missing; copy .env.example to .env and add your key" >&2
   exit 2
 fi
 
-# Defaults for the USB Speaker Phone currently attached to pi4. Values in
-# .env still win, so input and output can be routed to separate ALSA devices.
-export AUDIO_INPUT_DEVICE="${AUDIO_INPUT_DEVICE:-plughw:2,0}"
-export AUDIO_OUTPUT_DEVICE="${AUDIO_OUTPUT_DEVICE:-plughw:2,0}"
-export MUTE_INPUT_DURING_PLAYBACK="${MUTE_INPUT_DURING_PLAYBACK:-false}"
-
-# The system CLI predates wendy.json env expansion, while the Pi's agent
-# predates env propagation on the chunk-diff deploy path. The repository CLI
-# plus the older registry path works with both versions without baking the API
-# key into the image or exposing it as a command-line argument.
-exec go run "$wendy_package" run --prefix "$demo_dir" --chunking off "$@"
+cd "$demo_dir"
+exec wendy run "$@"

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -5,7 +5,81 @@ import os
 import unittest
 from unittest.mock import patch
 
-from app import Config, VoiceAssistant
+import app
+from app import (
+    AlsaMixer,
+    Config,
+    VoiceAssistant,
+    card_from_device,
+    parse_alsa_cards,
+    pick_alsa_device,
+)
+
+APLAY_L_PI = """\
+**** List of PLAYBACK Hardware Devices ****
+card 0: vc4hdmi0 [vc4-hdmi-0], device 0: MAI PCM i2s-hifi-0 [MAI PCM i2s-hifi-0]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 1: vc4hdmi1 [vc4-hdmi-1], device 0: MAI PCM i2s-hifi-0 [MAI PCM i2s-hifi-0]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: Device [USB Audio Device], device 0: USB Audio [USB Audio]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+"""
+
+ARECORD_L_PI = """\
+**** List of CAPTURE Hardware Devices ****
+card 2: Device [USB Audio Device], device 0: USB Audio [USB Audio]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+"""
+
+SCONTROLS_USB = """\
+Simple mixer control 'Mic',0
+Simple mixer control 'Speaker',0
+"""
+
+SGET_SPEAKER_57 = """\
+Simple mixer control 'Speaker',0
+  Capabilities: pvolume pswitch
+  Playback channels: Front Left - Front Right
+  Limits: Playback 0 - 151
+  Front Left: Playback 86 [57%] [-19.42dB] [on]
+  Front Right: Playback 86 [57%] [-19.42dB] [on]
+"""
+
+SGET_MIC_CAPTURE_ONLY = """\
+Simple mixer control 'Mic',0
+  Capabilities: cvolume cswitch
+  Capture channels: Mono
+  Limits: Capture 0 - 16
+  Mono: Capture 12 [75%] [30.00dB] [on]
+"""
+
+SSET_SPEAKER_29 = """\
+Simple mixer control 'Speaker',0
+  Capabilities: pvolume pswitch
+  Playback channels: Front Left - Front Right
+  Limits: Playback 0 - 151
+  Front Left: Playback 44 [29%] [-32.34dB] [on]
+  Front Right: Playback 44 [29%] [-32.34dB] [on]
+"""
+
+
+class FakeAmixer:
+    """Injectable runner mimicking `amixer -c <card> <args...>`."""
+
+    def __init__(self, responses):
+        self.responses = responses  # first arg (subcommand) -> callable(args) or (rc, out)
+        self.calls = []
+
+    async def __call__(self, *args):
+        self.calls.append(args)
+        response = self.responses[args[0]]
+        if callable(response):
+            return response(args)
+        return response
 
 
 class FakeAudio:
@@ -49,9 +123,114 @@ class ConfigTests(unittest.TestCase):
     def test_audio_chunk_is_100ms_of_pcm16_by_default(self):
         config = Config(api_key="test")
         self.assertEqual(config.chunk_bytes, 4_800)
-        self.assertEqual(config.input_device, "plughw:2,0")
-        self.assertEqual(config.output_device, "plughw:2,0")
+        self.assertIsNone(config.input_device)
+        self.assertIsNone(config.output_device)
         self.assertFalse(config.mute_input_during_playback)
+
+    def test_startup_volume_defaults_to_70(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test"}, clear=True):
+            self.assertEqual(Config.from_env().startup_volume_percent, 70)
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test", "STARTUP_VOLUME_PERCENT": ""},
+            clear=True,
+        ):
+            self.assertEqual(Config.from_env().startup_volume_percent, 70)
+
+    def test_startup_volume_off_disables_normalization(self):
+        for value in ("off", "OFF", "false", "no", "none", "disabled"):
+            with patch.dict(
+                os.environ,
+                {"OPENAI_API_KEY": "test", "STARTUP_VOLUME_PERCENT": value},
+                clear=True,
+            ):
+                self.assertIsNone(Config.from_env().startup_volume_percent)
+
+    def test_startup_volume_out_of_range_is_rejected(self):
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test", "STARTUP_VOLUME_PERCENT": "150"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(ValueError, "STARTUP_VOLUME_PERCENT"):
+                Config.from_env()
+
+    def test_unset_audio_devices_mean_auto_detect(self):
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test", "AUDIO_INPUT_DEVICE": ""},
+            clear=True,
+        ):
+            config = Config.from_env()
+        self.assertIsNone(config.input_device)
+        self.assertIsNone(config.output_device)
+
+
+class AlsaDetectionTests(unittest.TestCase):
+    def test_parse_alsa_cards_reads_number_name_description_and_first_device(self):
+        cards = parse_alsa_cards(APLAY_L_PI)
+        self.assertEqual([card.number for card in cards], [0, 1, 2])
+        self.assertEqual(cards[2].name, "Device")
+        self.assertEqual(cards[2].device, 0)
+        self.assertIn("USB Audio Device", cards[2].description)
+
+    def test_parse_alsa_cards_keeps_first_device_per_card(self):
+        listing = (
+            "**** List of PLAYBACK Hardware Devices ****\n"
+            "card 0: Headset [USB Headset], device 2: USB Audio [USB Audio]\n"
+            "card 0: Headset [USB Headset], device 3: USB Audio [USB Audio #1]\n"
+        )
+        cards = parse_alsa_cards(listing)
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].device, 2)
+
+    def test_parse_alsa_cards_of_empty_listing(self):
+        self.assertEqual(parse_alsa_cards(""), [])
+        self.assertEqual(parse_alsa_cards("no soundcards found...\n"), [])
+
+    def test_pick_alsa_device_prefers_first_usb_card_with_stable_name(self):
+        self.assertEqual(
+            pick_alsa_device(parse_alsa_cards(APLAY_L_PI)),
+            "plughw:CARD=Device,DEV=0",
+        )
+        self.assertEqual(
+            pick_alsa_device(parse_alsa_cards(ARECORD_L_PI)),
+            "plughw:CARD=Device,DEV=0",
+        )
+
+    def test_pick_alsa_device_without_usb_card_returns_none(self):
+        hdmi_only = (
+            "**** List of PLAYBACK Hardware Devices ****\n"
+            "card 0: vc4hdmi0 [vc4-hdmi-0], device 0: MAI PCM i2s-hifi-0 [MAI PCM]\n"
+        )
+        self.assertIsNone(pick_alsa_device(parse_alsa_cards(hdmi_only)))
+        self.assertIsNone(pick_alsa_device([]))
+
+    def test_detect_device_returns_usb_pick_or_default(self):
+        async def check():
+            async def usb_runner(*args):
+                return 0, ARECORD_L_PI
+
+            async def hdmi_runner(*args):
+                return 0, "card 0: vc4hdmi0 [vc4-hdmi-0], device 0: MAI [MAI]\n"
+
+            async def failing_runner(*args):
+                return 1, "arecord: device_list:274: no soundcards found..."
+
+            self.assertEqual(
+                await app.detect_device("arecord", run=usb_runner),
+                "plughw:CARD=Device,DEV=0",
+            )
+            self.assertEqual(await app.detect_device("aplay", run=hdmi_runner), "default")
+            self.assertEqual(await app.detect_device("aplay", run=failing_runner), "default")
+
+        asyncio.run(check())
+
+    def test_card_from_device_forms(self):
+        self.assertEqual(card_from_device("plughw:2,0"), "2")
+        self.assertEqual(card_from_device("hw:2,0"), "2")
+        self.assertEqual(card_from_device("plughw:CARD=Device,DEV=0"), "Device")
+        self.assertIsNone(card_from_device("default"))
 
     def test_empty_mute_env_uses_interruptible_default(self):
         with patch.dict(
@@ -73,6 +252,241 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(turn_detection["type"], "semantic_vad")
         self.assertTrue(turn_detection["interrupt_response"])
         self.assertNotIn("secret", repr(event))
+
+
+class AlsaMixerTests(unittest.IsolatedAsyncioTestCase):
+    def test_parse_controls_reads_simple_mixer_control_names(self):
+        self.assertEqual(AlsaMixer.parse_controls(SCONTROLS_USB), ["Mic", "Speaker"])
+        self.assertEqual(AlsaMixer.parse_controls(""), [])
+
+    def test_order_controls_puts_preferred_playback_controls_first(self):
+        self.assertEqual(
+            AlsaMixer.order_controls(["Mic", "Speaker", "PCM"]),
+            ["PCM", "Speaker", "Mic"],
+        )
+        self.assertEqual(
+            AlsaMixer.order_controls(["mic", "master"]),
+            ["master", "mic"],
+        )
+
+    def test_parse_playback_volume_only_accepts_playback_lines(self):
+        self.assertEqual(AlsaMixer.parse_playback_volume(SGET_SPEAKER_57), 57)
+        self.assertIsNone(AlsaMixer.parse_playback_volume(SGET_MIC_CAPTURE_ONLY))
+        self.assertIsNone(
+            AlsaMixer.parse_playback_volume("Front Left: Playback 200 [101%] [on]")
+        )
+
+    async def test_resolve_control_skips_controls_without_playback_volume(self):
+        runner = FakeAmixer(
+            {
+                "scontrols": (0, SCONTROLS_USB),
+                "sget": lambda args: (0, SGET_MIC_CAPTURE_ONLY)
+                if args[1] == "Mic"
+                else (0, SGET_SPEAKER_57),
+            }
+        )
+        mixer = AlsaMixer("Device", run=runner)
+        self.assertEqual(await mixer.resolve_control(), ("Speaker", 57))
+        # Mic sorts after Speaker (preferred), so only Speaker is probed.
+        self.assertEqual(await mixer.get_volume(), 57)
+
+    async def test_set_volume_unmutes_and_returns_quantized_actual(self):
+        runner = FakeAmixer(
+            {
+                "scontrols": (0, SCONTROLS_USB),
+                "sget": (0, SGET_SPEAKER_57),
+                "sset": (0, SSET_SPEAKER_29),
+            }
+        )
+        mixer = AlsaMixer("2", run=runner)
+        self.assertEqual(await mixer.set_volume(30), 29)
+        self.assertIn(("sset", "Speaker", "30%", "unmute"), runner.calls)
+
+    async def test_adjust_volume_steps_and_clamps(self):
+        runner = FakeAmixer(
+            {
+                "scontrols": (0, SCONTROLS_USB),
+                "sget": (0, SGET_SPEAKER_57),
+                "sset": lambda args: (
+                    0,
+                    SSET_SPEAKER_29.replace("[29%]", f"[{args[2].rstrip('%')}%]"),
+                ),
+            }
+        )
+        mixer = AlsaMixer("2", run=runner)
+        self.assertEqual(await mixer.adjust_volume("up"), 67)
+        self.assertEqual(await mixer.adjust_volume("down", step=100), 0)
+
+    async def test_mixer_errors_raise_runtime_error(self):
+        runner = FakeAmixer({"scontrols": (1, "Invalid card number")})
+        mixer = AlsaMixer("9", run=runner)
+        with self.assertRaises(RuntimeError):
+            await mixer.set_volume(50)
+
+
+class FakeMixer:
+    def __init__(self, fail=False, volume=57):
+        self.fail = fail
+        self.volume = volume
+        self.set_calls = []
+        self.adjust_calls = []
+
+    async def set_volume(self, percent):
+        if self.fail:
+            raise RuntimeError("no playback volume control found")
+        self.set_calls.append(percent)
+        self.volume = percent
+        return percent
+
+    async def get_volume(self):
+        if self.fail:
+            raise RuntimeError("no playback volume control found")
+        return self.volume
+
+    async def adjust_volume(self, direction, step=10):
+        self.adjust_calls.append((direction, step))
+        self.volume += step if direction == "up" else -step
+        return self.volume
+
+    async def resolve_control(self):
+        return ("Speaker", self.volume)
+
+
+class StartupVolumeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_startup_volume_applied_once_per_process(self):
+        assistant = VoiceAssistant(Config(api_key="test"))
+        mixer = FakeMixer()
+        await assistant.apply_startup_volume(mixer)
+        await assistant.apply_startup_volume(mixer)
+        self.assertEqual(mixer.set_calls, [70])
+
+    async def test_startup_volume_disabled_never_touches_mixer(self):
+        assistant = VoiceAssistant(
+            Config(api_key="test", startup_volume_percent=None)
+        )
+        mixer = FakeMixer()
+        await assistant.apply_startup_volume(mixer)
+        self.assertEqual(mixer.set_calls, [])
+
+    async def test_startup_volume_failure_is_nonfatal(self):
+        assistant = VoiceAssistant(Config(api_key="test"))
+        with self.assertLogs("voice-assistant", level="WARNING"):
+            await assistant.apply_startup_volume(FakeMixer(fail=True))
+
+
+def _function_call_done(name, arguments, call_id="call_1"):
+    return {
+        "type": "response.output_item.done",
+        "item": {
+            "type": "function_call",
+            "name": name,
+            "call_id": call_id,
+            "arguments": arguments,
+        },
+    }
+
+
+class ToolTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.assistant = VoiceAssistant(Config(api_key="test"))
+        self.assistant.mixer = FakeMixer()
+        self.audio = FakeAudio()
+        self.websocket = FakeWebSocket()
+
+    def test_session_update_registers_volume_tools(self):
+        session = self.assistant.session_update_event()["session"]
+        self.assertEqual(session["tool_choice"], "auto")
+        names = [tool["name"] for tool in session["tools"]]
+        self.assertEqual(names, ["set_volume", "adjust_volume", "get_volume"])
+        for tool in session["tools"]:
+            self.assertEqual(tool["type"], "function")
+            self.assertIn("parameters", tool)
+
+    async def test_set_volume_tool_roundtrip(self):
+        await self.assistant.handle_event(
+            _function_call_done("set_volume", json.dumps({"percent": 25})),
+            self.audio,
+            self.websocket,
+        )
+        self.assertEqual(self.assistant.mixer.set_calls, [25])
+        output_event, response_event = self.websocket.sent
+        self.assertEqual(output_event["type"], "conversation.item.create")
+        item = output_event["item"]
+        self.assertEqual(item["type"], "function_call_output")
+        self.assertEqual(item["call_id"], "call_1")
+        self.assertEqual(json.loads(item["output"]), {"volume_percent": 25})
+        self.assertEqual(response_event, {"type": "response.create"})
+
+    async def test_adjust_and_get_volume_tools(self):
+        await self.assistant.handle_event(
+            _function_call_done("adjust_volume", json.dumps({"direction": "up"})),
+            self.audio,
+            self.websocket,
+        )
+        self.assertEqual(self.assistant.mixer.adjust_calls, [("up", 10)])
+        await self.assistant.handle_event(
+            _function_call_done("get_volume", "{}", call_id="call_2"),
+            self.audio,
+            self.websocket,
+        )
+        outputs = [
+            json.loads(event["item"]["output"])
+            for event in self.websocket.sent
+            if event["type"] == "conversation.item.create"
+        ]
+        self.assertEqual(outputs, [{"volume_percent": 67}, {"volume_percent": 67}])
+
+    async def test_tool_reply_suppressed_while_user_speaking(self):
+        self.assistant.user_speaking = True
+        await self.assistant.handle_event(
+            _function_call_done("set_volume", json.dumps({"percent": 25})),
+            self.audio,
+            self.websocket,
+        )
+        types = [event["type"] for event in self.websocket.sent]
+        self.assertEqual(types, ["conversation.item.create"])
+
+    async def test_speech_events_track_user_speaking(self):
+        await self.assistant.handle_event(
+            {"type": "input_audio_buffer.speech_started"}, self.audio, self.websocket
+        )
+        self.assertTrue(self.assistant.user_speaking)
+        await self.assistant.handle_event(
+            {"type": "input_audio_buffer.speech_stopped"}, self.audio, self.websocket
+        )
+        self.assertFalse(self.assistant.user_speaking)
+
+    async def test_tool_errors_become_error_payloads(self):
+        self.assistant.mixer = FakeMixer(fail=True)
+        await self.assistant.handle_event(
+            _function_call_done("set_volume", json.dumps({"percent": 25})),
+            self.audio,
+            self.websocket,
+        )
+        self.assistant.mixer = None
+        await self.assistant.handle_event(
+            _function_call_done("get_volume", "{}", call_id="call_2"),
+            self.audio,
+            self.websocket,
+        )
+        await self.assistant.handle_event(
+            _function_call_done("set_volume", "not json", call_id="call_3"),
+            self.audio,
+            self.websocket,
+        )
+        await self.assistant.handle_event(
+            _function_call_done("unknown_tool", "{}", call_id="call_4"),
+            self.audio,
+            self.websocket,
+        )
+        outputs = [
+            json.loads(event["item"]["output"])
+            for event in self.websocket.sent
+            if event["type"] == "conversation.item.create"
+        ]
+        self.assertEqual(len(outputs), 4)
+        for output in outputs:
+            self.assertIn("error", output)
 
 
 class EventTests(unittest.IsolatedAsyncioTestCase):

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -188,6 +188,27 @@ class AlsaDetectionTests(unittest.TestCase):
         self.assertEqual(parse_alsa_cards(""), [])
         self.assertEqual(parse_alsa_cards("no soundcards found...\n"), [])
 
+    def test_pick_alsa_device_finds_usb_named_only_in_device_column(self):
+        # snd-usb-audio always names the device "USB Audio", but the card
+        # description bracket is the product string, which often lacks "usb".
+        listing = (
+            "**** List of PLAYBACK Hardware Devices ****\n"
+            "card 0: vc4hdmi0 [vc4-hdmi-0], device 0: MAI PCM i2s-hifi-0 [MAI PCM]\n"
+            "card 2: S330 [Anker PowerConf S330], device 0: USB Audio [USB Audio]\n"
+        )
+        self.assertEqual(
+            pick_alsa_device(parse_alsa_cards(listing)),
+            "plughw:CARD=S330,DEV=0",
+        )
+        yeti = (
+            "**** List of CAPTURE Hardware Devices ****\n"
+            "card 1: Microphone [Yeti Stereo Microphone], device 0: USB Audio [USB Audio]\n"
+        )
+        self.assertEqual(
+            pick_alsa_device(parse_alsa_cards(yeti)),
+            "plughw:CARD=Microphone,DEV=0",
+        )
+
     def test_pick_alsa_device_prefers_first_usb_card_with_stable_name(self):
         self.assertEqual(
             pick_alsa_device(parse_alsa_cards(APLAY_L_PI)),
@@ -277,18 +298,41 @@ class AlsaMixerTests(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_resolve_control_skips_controls_without_playback_volume(self):
+        # Non-preferred names keep the original order, so the capture-only
+        # control is probed first and must be skipped.
+        scontrols = (
+            "Simple mixer control 'Mic',0\n"
+            "Simple mixer control 'Custom',0\n"
+        )
         runner = FakeAmixer(
             {
-                "scontrols": (0, SCONTROLS_USB),
+                "scontrols": (0, scontrols),
                 "sget": lambda args: (0, SGET_MIC_CAPTURE_ONLY)
                 if args[1] == "Mic"
                 else (0, SGET_SPEAKER_57),
             }
         )
         mixer = AlsaMixer("Device", run=runner)
+        self.assertEqual(await mixer.resolve_control(), ("Custom", 57))
+        self.assertIn(("sget", "Mic"), runner.calls)
+
+    async def test_resolve_control_skips_controls_whose_sget_fails(self):
+        # Go parity: a failing sget on one control must not abort resolution
+        # (audio_service.go continues to the next control).
+        scontrols = (
+            "Simple mixer control 'Master',0\n"
+            "Simple mixer control 'Speaker',0\n"
+        )
+        runner = FakeAmixer(
+            {
+                "scontrols": (0, scontrols),
+                "sget": lambda args: (1, "amixer: Mixer attach error")
+                if args[1] == "Master"
+                else (0, SGET_SPEAKER_57),
+            }
+        )
+        mixer = AlsaMixer("Device", run=runner)
         self.assertEqual(await mixer.resolve_control(), ("Speaker", 57))
-        # Mic sorts after Speaker (preferred), so only Speaker is probed.
-        self.assertEqual(await mixer.get_volume(), 57)
 
     async def test_set_volume_unmutes_and_returns_quantized_actual(self):
         runner = FakeAmixer(
@@ -373,6 +417,15 @@ class StartupVolumeTests(unittest.IsolatedAsyncioTestCase):
         with self.assertLogs("voice-assistant", level="WARNING"):
             await assistant.apply_startup_volume(FakeMixer(fail=True))
 
+    async def test_startup_volume_retries_after_failure(self):
+        # USB devices can enumerate late; only a successful set should latch.
+        assistant = VoiceAssistant(Config(api_key="test"))
+        with self.assertLogs("voice-assistant", level="WARNING"):
+            await assistant.apply_startup_volume(FakeMixer(fail=True))
+        mixer = FakeMixer()
+        await assistant.apply_startup_volume(mixer)
+        self.assertEqual(mixer.set_calls, [70])
+
 
 def _function_call_done(name, arguments, call_id="call_1"):
     return {
@@ -455,6 +508,16 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             {"type": "input_audio_buffer.speech_stopped"}, self.audio, self.websocket
         )
         self.assertFalse(self.assistant.user_speaking)
+
+    async def test_adjust_volume_rejects_invalid_direction(self):
+        await self.assistant.handle_event(
+            _function_call_done("adjust_volume", json.dumps({"direction": "sideways"})),
+            self.audio,
+            self.websocket,
+        )
+        self.assertEqual(self.assistant.mixer.adjust_calls, [])
+        output = json.loads(self.websocket.sent[0]["item"]["output"])
+        self.assertIn("error", output)
 
     async def test_tool_errors_become_error_payloads(self):
         self.assistant.mixer = FakeMixer(fail=True)

--- a/Examples/VoiceAssistant/wendy.json
+++ b/Examples/VoiceAssistant/wendy.json
@@ -1,6 +1,6 @@
 {
   "appId": "sh.wendy.examples.voiceassistant",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "platform": "linux",
   "entitlements": [
     {
@@ -19,6 +19,7 @@
     "AUDIO_OUTPUT_DEVICE": "${AUDIO_OUTPUT_DEVICE}",
     "ASSISTANT_INSTRUCTIONS": "${ASSISTANT_INSTRUCTIONS}",
     "MUTE_INPUT_DURING_PLAYBACK": "${MUTE_INPUT_DURING_PLAYBACK}",
+    "STARTUP_VOLUME_PERCENT": "${STARTUP_VOLUME_PERCENT}",
     "AUDIO_SAMPLE_RATE": "${AUDIO_SAMPLE_RATE}",
     "AUDIO_CHUNK_MS": "${AUDIO_CHUNK_MS}",
     "LOG_LEVEL": "${LOG_LEVEL}"


### PR DESCRIPTION
## Summary

Upgrades the Realtime voice example added in #1566 to be the definitive "OpenAI Realtime Voice on Raspberry Pi" demo:

- **ALSA device auto-detection** — picks the first USB sound card by stable `plughw:CARD=<name>,DEV=<n>` form (matching "usb" in both the card description and device columns, so Anker PowerConf/Yeti-style product names work), falling back to `default`. Explicit `AUDIO_INPUT_DEVICE`/`AUDIO_OUTPUT_DEVICE` still override. Devices re-resolve every session so late USB enumeration and reboot renumbering are handled.
- **Voice-controlled volume** — registers `set_volume`/`adjust_volume`/`get_volume` function tools with `gpt-realtime-2.1`; tool calls run `amixer` in-container (the `audio` entitlement mounts `/dev/snd` rw), mirroring the agent's mixer-control resolution from #1566 (preference-ordered scontrols, Playback-percentage probe, `sset N% unmute`, quantized actual reported back). Tool replies defer `response.create` while the user is speaking so they don't race semantic VAD.
- **Startup volume normalization** — `STARTUP_VOLUME_PERCENT` (default 70, `off` disables) applied once per process since WendyOS has no boot-time volume init; latches only on success so late-enumerating USB retries.
- **Fixes** — adds the missing `.env.example` the README referenced; simplifies `run.sh` (the `go run`/`--chunking off` workaround was for CLI/agent bugs fixed 2026-07-29); README gains a Pi 3/4/5 hardware matrix, volume/tool docs, `wendy device audio` TUI notes, and the missing `AUDIO_SAMPLE_RATE` config row.

## Testing

- 41 unit tests (pure fakes, no hardware/network): ALSA listing/mixer parsers with Pi-realistic fixtures, tool round-trips asserting the wire events, interruption/suppression interplay, config parsing edge cases. `python3 -m unittest discover -s tests -v`
- **On-device verified on a Pi 5 (WendyOS 0.18.1 + dev agent)** with a USB conference speakerphone: auto-detect picked `plughw:CARD=Phone,DEV=0`, startup volume applied (`70% (card Phone)`), live conversation, repeated clean barge-ins (`cancelled: turn_detected` + truncation), and `set_volume({"percent":80})` → audible change with spoken confirmation.
- Not exercised live: `adjust_volume`/`get_volume` voice paths (unit-tested), Pi 3/4 hardware (not on hand — covered by device-agnostic auto-detection + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT4CDZ82TGMPYCHsaQqwzh