### PR TITLE
feat(examples): VoiceAssistant internet-backed answers (weather + web search tools)

### DIFF
--- a/Examples/VoiceAssistant/.env.example
+++ b/Examples/VoiceAssistant/.env.example
@@ -23,4 +23,10 @@ OPENAI_API_KEY=sk-your-key-here
 #AUDIO_SAMPLE_RATE=24000
 #AUDIO_CHUNK_MS=100
 
+# Web search runs through the OpenAI Responses API on the same key, so each
+# search bills normally. Set to false to remove the tool entirely. Weather
+# lookups use the free, keyless Open-Meteo API and are always available.
+#WEB_SEARCH_ENABLED=true
+#OPENAI_SEARCH_MODEL=gpt-5-mini
+
 #LOG_LEVEL=INFO

--- a/Examples/VoiceAssistant/README.md
+++ b/Examples/VoiceAssistant/README.md
@@ -9,7 +9,9 @@ Interruption/barge-in is enabled by default: speak over the assistant and it
 stops immediately, truncating the unheard part of its reply. The assistant can
 also control its own speaker volume — say "set the volume to 30 percent" or
 "turn it up a bit" and it adjusts the ALSA mixer through Realtime function
-tools.
+tools. It can answer questions that need live data too: weather anywhere via
+the free Open-Meteo API, and anything else current (news, scores, prices)
+via OpenAI web search.
 
 ## Hardware
 
@@ -99,6 +101,23 @@ Agents older than the 2026-08 volume support don't implement `SetAudioVolume`;
 the TUI will say so — update the agent (or push a dev build with
 `wendy device push-agent`).
 
+## Weather and web search
+
+Ask "what's the weather in Tokyo?" or "will it rain in Portland this
+weekend?" and the assistant calls a `get_weather` function tool backed by the
+free, keyless [Open-Meteo](https://open-meteo.com) API — current conditions
+plus a 3-day forecast, in celsius or fahrenheit as the conversation implies.
+
+For anything else that needs the live internet — "what's in the news today?",
+"who won the Giants game?", "what's the bitcoin price?" — the assistant calls
+a `web_search` tool. The Realtime API has no built-in web search, so the app
+forwards the query to the OpenAI Responses API (`/v1/responses`) with its
+built-in `web_search` tool enabled, using the same `OPENAI_API_KEY`, and
+speaks the short text answer. Each search bills one Responses API call
+(`OPENAI_SEARCH_MODEL`, default `gpt-5-mini`) on top of the Realtime session;
+set `WEB_SEARCH_ENABLED=false` to remove the tool entirely. Weather lookups
+are free and unaffected by the toggle.
+
 ## Configuration
 
 | Variable | Default | Purpose |
@@ -113,6 +132,8 @@ the TUI will say so — update the agent (or push a dev build with
 | `MUTE_INPUT_DURING_PLAYBACK` | `false` | Set to `true` for half-duplex echo protection (disables interruption) |
 | `AUDIO_SAMPLE_RATE` | `24000` | PCM sample rate in Hz (the API expects 24 kHz) |
 | `AUDIO_CHUNK_MS` | `100` | Microphone packet duration |
+| `WEB_SEARCH_ENABLED` | `true` | Set to `false` to remove the paid `web_search` tool |
+| `OPENAI_SEARCH_MODEL` | `gpt-5-mini` | Responses API model used for web searches |
 | `LOG_LEVEL` | `INFO` | Python log level |
 
 ## Local checks
@@ -144,13 +165,18 @@ so there are no temporary audio files. When semantic VAD detects speech during
 a reply, the app drops queued speaker audio and truncates the unheard portion
 of the assistant message in the Realtime conversation.
 
-Volume control is Realtime tool calling: the session registers `set_volume`,
-`adjust_volume`, and `get_volume` function tools. When the model decides to
-call one, the finished `function_call` item arrives with its arguments, the
-app runs `amixer` against the playback card (the `audio` entitlement mounts
-`/dev/snd` into the container), sends the result back as a
-`function_call_output` item, and asks for a spoken confirmation with
-`response.create` — unless the user is already talking again.
+Tool calling drives everything beyond conversation: the session registers
+`set_volume`, `adjust_volume`, `get_volume`, `get_weather`, and `web_search`
+function tools. When the model decides to call one, the finished
+`function_call` item arrives with its arguments and the app executes it —
+`amixer` against the playback card for volume (the `audio` entitlement mounts
+`/dev/snd` into the container), a geocode-then-forecast pair of Open-Meteo
+requests for weather, or a Responses API call with OpenAI's built-in
+`web_search` tool for searches. The result goes back as a
+`function_call_output` item followed by `response.create` for a spoken reply
+— unless the user is already talking again. Tool calls run as concurrent
+asyncio tasks (HTTP requests on worker threads), so the event loop keeps
+draining and barge-in stays responsive even mid-search.
 
 This follows OpenAI's current [Realtime WebSocket
 guide](https://developers.openai.com/api/docs/guides/realtime-websocket) and

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -893,7 +893,10 @@ class VoiceAssistant:
             "input": query,
             "instructions": (
                 "Answer for a voice assistant: 1-3 short spoken sentences, "
-                "current as of today, no markdown or URLs."
+                "current as of today, no markdown or URLs. Never ask "
+                "clarifying questions — this is a one-shot search, so pick "
+                "the most likely interpretation of the query, search, and "
+                "answer with concrete facts."
             ),
             "tools": [{"type": "web_search"}],
         }

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -10,15 +10,80 @@ import logging
 import os
 import re
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlencode, urlsplit
 
 from websockets.asyncio.client import connect
 
 
 LOG = logging.getLogger("voice-assistant")
 BYTES_PER_SAMPLE = 2  # signed PCM16
+
+GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
+FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+
+# WMO weather interpretation codes as reported by Open-Meteo.
+_WMO_WEATHER_CODES = {
+    0: "clear sky",
+    1: "mainly clear",
+    2: "partly cloudy",
+    3: "overcast",
+    45: "fog",
+    48: "depositing rime fog",
+    51: "light drizzle",
+    53: "moderate drizzle",
+    55: "dense drizzle",
+    56: "light freezing drizzle",
+    57: "dense freezing drizzle",
+    61: "light rain",
+    63: "moderate rain",
+    65: "heavy rain",
+    66: "light freezing rain",
+    67: "heavy freezing rain",
+    71: "light snow",
+    73: "moderate snow",
+    75: "heavy snow",
+    77: "snow grains",
+    80: "light rain showers",
+    81: "moderate rain showers",
+    82: "violent rain showers",
+    85: "light snow showers",
+    86: "heavy snow showers",
+    95: "thunderstorm",
+    96: "thunderstorm with light hail",
+    99: "thunderstorm with heavy hail",
+}
+
+
+def describe_weather_code(code: int | None) -> str:
+    """Spoken-friendly text for a WMO weather interpretation code."""
+    return _WMO_WEATHER_CODES.get(code, "unknown conditions")
+
+
+# "(...[site](url)...)" citation groups, then any leftover inline [text](url).
+_CITATION_GROUP = re.compile(r"\s*\((?:\[[^\]]+\]\([^)\s]+\)(?:,\s*)?)+\)")
+_MARKDOWN_LINK = re.compile(r"\[([^\]]*)\]\([^)\s]*\)")
+
+
+def strip_citations(text: str) -> str:
+    """Drop web-search citation annotations — URLs are noise when spoken."""
+    return _MARKDOWN_LINK.sub(r"\1", _CITATION_GROUP.sub("", text))
+
+
+def extract_output_text(data: dict[str, Any]) -> str:
+    """Concatenate the output_text content of an OpenAI Responses API payload."""
+    parts: list[str] = []
+    for item in data.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content in item.get("content") or []:
+            if isinstance(content, dict) and content.get("type") == "output_text":
+                parts.append(content.get("text", ""))
+    return "".join(parts)
 
 # "card 2: Device [USB Audio Device], device 0: USB Audio [USB Audio]"
 _ALSA_CARD_LINE = re.compile(
@@ -75,6 +140,46 @@ def pick_alsa_device(cards: list[AlsaCard]) -> str | None:
     return None
 
 
+def _http_json_sync(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Blocking HTTPS JSON call. Raises RuntimeError with a concise message on
+    failure — never echoing request headers, which carry the API key."""
+    host = urlsplit(url).hostname or url
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Content-Type", "application/json")
+    for name, value in (headers or {}).items():
+        request.add_header(name, value)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(200).decode(errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} from {host}: {detail}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"could not reach {host}: {exc}") from exc
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{host} returned invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{host} returned unexpected {type(parsed).__name__} JSON")
+    return parsed
+
+
+async def http_json(url: str, **kwargs: Any) -> dict[str, Any]:
+    """Run the blocking HTTP call on a worker thread so the event loop (audio
+    pump, barge-in) never stalls. Cancellation cannot stop the thread mid-
+    request; a cancelled tool task simply discards the result."""
+    return await asyncio.to_thread(_http_json_sync, url, **kwargs)
+
+
 async def _run_command(*args: str) -> tuple[int, str]:
     process = await asyncio.create_subprocess_exec(
         *args,
@@ -114,7 +219,9 @@ class Config:
     instructions: str = (
         "You are a friendly voice assistant running on an edge device. "
         "Be conversational, helpful, and concise. Reply in the language the user speaks. "
-        "You can change your own speaker volume with the provided tools when asked."
+        "You can change your own speaker volume, look up the current weather and "
+        "forecast anywhere, and search the web for up-to-date information with "
+        "the provided tools."
     )
     input_device: str | None = None  # None -> auto-detect
     output_device: str | None = None  # None -> auto-detect
@@ -122,6 +229,8 @@ class Config:
     chunk_ms: int = 100
     mute_input_during_playback: bool = False
     startup_volume_percent: int | None = 70
+    search_model: str = "gpt-5-mini"
+    web_search_enabled: bool = True
 
     @staticmethod
     def _parse_startup_volume(raw: str | None) -> int | None:
@@ -166,6 +275,8 @@ class Config:
             startup_volume_percent=cls._parse_startup_volume(
                 os.getenv("STARTUP_VOLUME_PERCENT")
             ),
+            search_model=os.getenv("OPENAI_SEARCH_MODEL", "").strip() or "gpt-5-mini",
+            web_search_enabled=_env_bool("WEB_SEARCH_ENABLED", True),
         )
 
     @property
@@ -384,10 +495,11 @@ class VoiceAssistant:
         self._startup_volume_done = False
         self.mixer: Any | None = None
         self.user_speaking = False
+        self.http_json = http_json
+        self.tool_tasks: set[asyncio.Task[None]] = set()
 
-    @staticmethod
-    def tool_specs() -> list[dict[str, Any]]:
-        return [
+    def tool_specs(self) -> list[dict[str, Any]]:
+        specs: list[dict[str, Any]] = [
             {
                 "type": "function",
                 "name": "set_volume",
@@ -430,7 +542,62 @@ class VoiceAssistant:
                 "description": "Report the current speaker output volume percentage.",
                 "parameters": {"type": "object", "properties": {}},
             },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": (
+                    "Get the current weather and a 3-day forecast for a named "
+                    "place. Fast and free — always use this for weather "
+                    "questions instead of web_search."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": (
+                                "City or place name, e.g. 'Berlin' or "
+                                "'Portland, Oregon'"
+                            ),
+                        },
+                        "units": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                            "description": (
+                                "Temperature unit the user expects (fahrenheit "
+                                "for US locations). Default celsius."
+                            ),
+                        },
+                    },
+                    "required": ["location"],
+                },
+            },
         ]
+        if self.config.web_search_enabled:
+            specs.append(
+                {
+                    "type": "function",
+                    "name": "web_search",
+                    "description": (
+                        "Search the live web for current information: news, "
+                        "sports scores, prices, or facts you are not sure "
+                        "about. Slower and costs money — never use it for "
+                        "weather (use get_weather) or for things you already "
+                        "know."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "A concise search query",
+                            }
+                        },
+                        "required": ["query"],
+                    },
+                }
+            )
+        return specs
 
     def session_update_event(self) -> dict[str, Any]:
         return {
@@ -486,10 +653,14 @@ class VoiceAssistant:
 
     async def run_session(self) -> None:
         # A dropped connection can happen mid-response. Never carry playback
-        # gating or transcript fragments into the replacement session.
+        # gating, transcript fragments, or in-flight tool calls into the
+        # replacement session.
         if self.playback_done_task is not None:
             self.playback_done_task.cancel()
             self.playback_done_task = None
+        for task in list(self.tool_tasks):
+            task.cancel()
+        self.tool_tasks.clear()
         self.assistant_speaking.clear()
         self._reset_playback_state()
         self.interrupted_item_id = None
@@ -590,7 +761,12 @@ class VoiceAssistant:
             # deltas.
             item = event.get("item", {})
             if item.get("type") == "function_call" and websocket is not None:
-                await self.handle_tool_call(item, websocket)
+                # Run the tool concurrently: a slow network fetch must not stall
+                # this receive loop, or barge-in (speech_started) would go
+                # unnoticed until the fetch finished.
+                task = asyncio.create_task(self.handle_tool_call(item, websocket))
+                self.tool_tasks.add(task)
+                task.add_done_callback(self._finish_tool_task)
         elif event_type == "response.output_audio.delta":
             item_id = event.get("item_id")
             if item_id and item_id == self.interrupted_item_id:
@@ -636,15 +812,127 @@ class VoiceAssistant:
                 f"{error.get('message', error)}"
             )
 
+    async def get_weather(
+        self, location: str, units: str = "celsius"
+    ) -> dict[str, Any]:
+        location = location.strip()
+        if not location:
+            raise ValueError("location is required")
+        if units not in ("celsius", "fahrenheit"):
+            raise ValueError(f"units must be 'celsius' or 'fahrenheit', got {units!r}")
+        query = urlencode(
+            {"name": location, "count": 1, "language": "en", "format": "json"}
+        )
+        geocoded = await self.http_json(f"{GEOCODING_URL}?{query}")
+        places = geocoded.get("results") or []
+        if not places:
+            return {"error": f"no location found matching {location!r}"}
+        place = places[0]
+        params: dict[str, Any] = {
+            "latitude": place.get("latitude"),
+            "longitude": place.get("longitude"),
+            "current": (
+                "temperature_2m,apparent_temperature,relative_humidity_2m,"
+                "weather_code,wind_speed_10m,is_day"
+            ),
+            "daily": (
+                "weather_code,temperature_2m_max,temperature_2m_min,"
+                "precipitation_probability_max"
+            ),
+            "forecast_days": 3,
+            "timezone": "auto",
+        }
+        if units == "fahrenheit":
+            params["temperature_unit"] = "fahrenheit"
+            params["wind_speed_unit"] = "mph"
+        forecast = await self.http_json(f"{FORECAST_URL}?{urlencode(params)}")
+        current = forecast.get("current") or {}
+        daily = forecast.get("daily") or {}
+
+        def column(key: str, index: int) -> Any:
+            values = daily.get(key) or []
+            return values[index] if index < len(values) else None
+
+        # "Berlin, Berlin, Germany" reads badly aloud: city-states repeat the
+        # name in admin1, so keep only distinct parts.
+        location_parts: list[str] = []
+        for part in (place.get("name"), place.get("admin1"), place.get("country")):
+            if part and str(part) not in location_parts:
+                location_parts.append(str(part))
+        return {
+            "location": ", ".join(location_parts),
+            "units": units,
+            "current": {
+                "temperature": current.get("temperature_2m"),
+                "feels_like": current.get("apparent_temperature"),
+                "humidity_percent": current.get("relative_humidity_2m"),
+                "wind_speed": current.get("wind_speed_10m"),
+                "conditions": describe_weather_code(current.get("weather_code")),
+            },
+            "daily": [
+                {
+                    "date": date,
+                    "high": column("temperature_2m_max", i),
+                    "low": column("temperature_2m_min", i),
+                    "conditions": describe_weather_code(column("weather_code", i)),
+                    "precipitation_chance_percent": column(
+                        "precipitation_probability_max", i
+                    ),
+                }
+                for i, date in enumerate(daily.get("time") or [])
+            ],
+        }
+
+    async def web_search(self, query: str) -> dict[str, Any]:
+        query = query.strip()
+        if not query:
+            raise ValueError("query is required")
+        LOG.info("Searching the web: %s", query)
+        body: dict[str, Any] = {
+            "model": self.config.search_model,
+            "input": query,
+            "instructions": (
+                "Answer for a voice assistant: 1-3 short spoken sentences, "
+                "current as of today, no markdown or URLs."
+            ),
+            "tools": [{"type": "web_search"}],
+        }
+        if self.config.search_model.startswith("gpt-5"):
+            body["reasoning"] = {"effort": "low"}
+        data = await self.http_json(
+            OPENAI_RESPONSES_URL,
+            method="POST",
+            headers={"Authorization": f"Bearer {self.config.api_key}"},
+            body=body,
+            timeout=45,
+        )
+        answer = strip_citations(extract_output_text(data)).strip()
+        if not answer:
+            raise RuntimeError(
+                f"web search returned no answer (status: {data.get('status', 'unknown')})"
+            )
+        return {"answer": answer}
+
     async def execute_tool(self, name: str, arguments_json: str) -> dict[str, Any]:
-        """Run one volume tool; always returns a JSON-safe payload, never raises —
-        a hardware failure must not kill the session."""
-        if self.mixer is None:
-            return {"error": "volume control is unavailable on this audio device"}
+        """Run one tool; always returns a JSON-safe payload, never raises — a
+        hardware or network failure must not kill the session."""
         try:
             arguments = json.loads(arguments_json) if arguments_json.strip() else {}
             if not isinstance(arguments, dict):
                 raise ValueError("arguments must be a JSON object")
+            if name == "get_weather":
+                return await self.get_weather(
+                    str(arguments.get("location", "")),
+                    units=str(arguments.get("units") or "celsius"),
+                )
+            if name == "web_search":
+                if not self.config.web_search_enabled:
+                    return {"error": "web search is disabled on this device"}
+                return await self.web_search(str(arguments.get("query", "")))
+            if name not in ("set_volume", "adjust_volume", "get_volume"):
+                return {"error": f"unknown tool: {name}"}
+            if self.mixer is None:
+                return {"error": "volume control is unavailable on this audio device"}
             if name == "set_volume":
                 applied = await self.mixer.set_volume(int(arguments["percent"]))
             elif name == "adjust_volume":
@@ -654,13 +942,17 @@ class VoiceAssistant:
                 applied = await self.mixer.adjust_volume(
                     direction, step=int(arguments.get("step", 10))
                 )
-            elif name == "get_volume":
-                applied = await self.mixer.get_volume()
             else:
-                return {"error": f"unknown tool: {name}"}
+                applied = await self.mixer.get_volume()
             return {"volume_percent": applied}
         except Exception as exc:
             return {"error": str(exc)}
+
+    def _finish_tool_task(self, task: asyncio.Task[None]) -> None:
+        self.tool_tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            # execute_tool never raises; this is a websocket send failure.
+            LOG.warning("Tool result was not delivered: %s", task.exception())
 
     async def handle_tool_call(self, item: dict[str, Any], websocket: Any) -> None:
         name = item.get("name", "")

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -892,11 +892,14 @@ class VoiceAssistant:
             "model": self.config.search_model,
             "input": query,
             "instructions": (
-                "Answer for a voice assistant: 1-3 short spoken sentences, "
-                "current as of today, no markdown or URLs. Never ask "
-                "clarifying questions — this is a one-shot search, so pick "
-                "the most likely interpretation of the query, search, and "
-                "answer with concrete facts."
+                "You are a silent search backend for a voice assistant; the "
+                "assistant has already acknowledged the user. Reply with 1-3 "
+                "short spoken-style sentences of concrete facts, current as "
+                "of today. Start directly with the facts — no greetings, "
+                "acknowledgements, or lead-ins like 'Got it' or 'Here's "
+                "what's going on'. No markdown or URLs. Never ask clarifying "
+                "questions — this is a one-shot search, so pick the most "
+                "likely interpretation of the query, search, and answer."
             ),
             "tools": [{"type": "web_search"}],
         }

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -821,6 +821,9 @@ class WebSearchToolTests(WebToolTestCase):
         self.assertEqual(body["input"], "giants score")
         self.assertEqual(body["tools"], [{"type": "web_search"}])
         self.assertEqual(body["reasoning"], {"effort": "low"})
+        # Live finding: without this the model answers broad queries with
+        # clarifying questions instead of searching, looping the user.
+        self.assertIn("Never ask clarifying questions", body["instructions"])
 
     async def test_web_search_omits_reasoning_for_non_gpt5_models(self):
         self.assistant = VoiceAssistant(

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -821,9 +821,12 @@ class WebSearchToolTests(WebToolTestCase):
         self.assertEqual(body["input"], "giants score")
         self.assertEqual(body["tools"], [{"type": "web_search"}])
         self.assertEqual(body["reasoning"], {"effort": "low"})
-        # Live finding: without this the model answers broad queries with
-        # clarifying questions instead of searching, looping the user.
+        # Live findings: without these the model answers broad queries with
+        # clarifying questions instead of searching (looping the user), and
+        # opens with acknowledgements that double up on the realtime model's
+        # own spoken lead-in.
         self.assertIn("Never ask clarifying questions", body["instructions"])
+        self.assertIn("Start directly with the facts", body["instructions"])
 
     async def test_web_search_omits_reasoning_for_non_gpt5_models(self):
         self.assistant = VoiceAssistant(

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -11,6 +11,9 @@ from app import (
     Config,
     VoiceAssistant,
     card_from_device,
+    describe_weather_code,
+    extract_output_text,
+    strip_citations,
     parse_alsa_cards,
     pick_alsa_device,
 )
@@ -102,6 +105,74 @@ class FakeWebSocket:
         self.sent.append(json.loads(message))
 
 
+class FakeFetch:
+    """Injectable stand-in for app.http_json, keyed by URL prefix."""
+
+    def __init__(self, responses):
+        self.responses = responses  # url prefix -> dict, Exception, or callable
+        self.calls = []
+
+    async def __call__(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        for prefix, response in self.responses.items():
+            if url.startswith(prefix):
+                if isinstance(response, Exception):
+                    raise response
+                if callable(response):
+                    return response(url, kwargs)
+                return response
+        raise AssertionError(f"unexpected fetch: {url}")
+
+
+async def _drain_tools(assistant):
+    while assistant.tool_tasks:
+        await asyncio.gather(*list(assistant.tool_tasks), return_exceptions=True)
+
+
+GEOCODE_BERLIN = {
+    "results": [
+        {
+            "name": "Berlin",
+            "latitude": 52.52,
+            "longitude": 13.41,
+            "country": "Germany",
+            "admin1": "Berlin",
+        }
+    ]
+}
+
+FORECAST_BERLIN = {
+    "current": {
+        "temperature_2m": 18.3,
+        "apparent_temperature": 17.1,
+        "relative_humidity_2m": 65,
+        "weather_code": 61,
+        "wind_speed_10m": 12.5,
+        "is_day": 1,
+    },
+    "daily": {
+        "time": ["2026-08-05", "2026-08-06", "2026-08-07"],
+        "weather_code": [61, 3, 0],
+        "temperature_2m_max": [21.0, 24.5, 26.1],
+        "temperature_2m_min": [14.2, 15.0, 16.3],
+        "precipitation_probability_max": [80, 20, 5],
+    },
+}
+
+RESPONSES_ANSWER = {
+    "status": "completed",
+    "output": [
+        {"type": "web_search_call", "id": "ws_1", "status": "completed"},
+        {
+            "type": "message",
+            "content": [
+                {"type": "output_text", "text": "The Giants won 4-2 last night."}
+            ],
+        },
+    ],
+}
+
+
 class OneChunkAudio:
     def __init__(self, chunk):
         self.chunk = chunk
@@ -154,6 +225,28 @@ class ConfigTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(ValueError, "STARTUP_VOLUME_PERCENT"):
                 Config.from_env()
+
+    def test_search_config_defaults(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test"}, clear=True):
+            config = Config.from_env()
+        self.assertEqual(config.search_model, "gpt-5-mini")
+        self.assertTrue(config.web_search_enabled)
+        self.assertIn("weather", config.instructions)
+        self.assertIn("search the web", config.instructions)
+
+    def test_search_config_overrides(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test",
+                "OPENAI_SEARCH_MODEL": "gpt-4.1-mini",
+                "WEB_SEARCH_ENABLED": "false",
+            },
+            clear=True,
+        ):
+            config = Config.from_env()
+        self.assertEqual(config.search_model, "gpt-4.1-mini")
+        self.assertFalse(config.web_search_enabled)
 
     def test_unset_audio_devices_mean_auto_detect(self):
         with patch.dict(
@@ -427,6 +520,60 @@ class StartupVolumeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mixer.set_calls, [70])
 
 
+class WebHelperTests(unittest.TestCase):
+    def test_describe_weather_code_maps_known_and_unknown_codes(self):
+        self.assertEqual(describe_weather_code(0), "clear sky")
+        self.assertEqual(describe_weather_code(61), "light rain")
+        self.assertEqual(describe_weather_code(999), "unknown conditions")
+        self.assertEqual(describe_weather_code(None), "unknown conditions")
+
+    def test_extract_output_text_concatenates_message_output_text(self):
+        payload = {
+            "status": "completed",
+            "output": [
+                {"type": "web_search_call", "id": "ws_1", "status": "completed"},
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "It is sunny."},
+                        {"type": "output_text", "text": " High of 20."},
+                    ],
+                },
+            ],
+        }
+        self.assertEqual(extract_output_text(payload), "It is sunny. High of 20.")
+
+    def test_extract_output_text_of_empty_or_tool_only_payloads(self):
+        self.assertEqual(extract_output_text({}), "")
+        self.assertEqual(
+            extract_output_text({"output": [{"type": "web_search_call"}]}), ""
+        )
+
+    def test_strip_citations_removes_web_search_annotations(self):
+        # Live web_search answers embed citations despite the no-URLs
+        # instruction; they must not reach the spoken reply.
+        annotated = (
+            "The rate is 3.50% to 3.75%. "
+            "([federalreserve.gov](https://www.federalreserve.gov/a?utm_source=openai))"
+            "\n\nReserves pay 3.65%. "
+            "([a.com](https://a.com/x), [b.org](https://b.org/y))"
+        )
+        self.assertEqual(
+            strip_citations(annotated),
+            "The rate is 3.50% to 3.75%.\n\nReserves pay 3.65%.",
+        )
+
+    def test_strip_citations_unwraps_inline_links_and_keeps_plain_text(self):
+        self.assertEqual(
+            strip_citations("See [the Fed](https://fed.gov) for details."),
+            "See the Fed for details.",
+        )
+        self.assertEqual(
+            strip_citations("Plain text (with an aside) stays."),
+            "Plain text (with an aside) stays.",
+        )
+
+
 def _function_call_done(name, arguments, call_id="call_1"):
     return {
         "type": "response.output_item.done",
@@ -446,14 +593,26 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
         self.audio = FakeAudio()
         self.websocket = FakeWebSocket()
 
-    def test_session_update_registers_volume_tools(self):
+    def test_session_update_registers_tools(self):
         session = self.assistant.session_update_event()["session"]
         self.assertEqual(session["tool_choice"], "auto")
         names = [tool["name"] for tool in session["tools"]]
-        self.assertEqual(names, ["set_volume", "adjust_volume", "get_volume"])
+        self.assertEqual(
+            names,
+            ["set_volume", "adjust_volume", "get_volume", "get_weather", "web_search"],
+        )
         for tool in session["tools"]:
             self.assertEqual(tool["type"], "function")
             self.assertIn("parameters", tool)
+
+    def test_web_search_tool_omitted_when_disabled(self):
+        assistant = VoiceAssistant(Config(api_key="test", web_search_enabled=False))
+        names = [
+            tool["name"]
+            for tool in assistant.session_update_event()["session"]["tools"]
+        ]
+        self.assertNotIn("web_search", names)
+        self.assertIn("get_weather", names)
 
     async def test_set_volume_tool_roundtrip(self):
         await self.assistant.handle_event(
@@ -461,6 +620,7 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         self.assertEqual(self.assistant.mixer.set_calls, [25])
         output_event, response_event = self.websocket.sent
         self.assertEqual(output_event["type"], "conversation.item.create")
@@ -476,12 +636,14 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         self.assertEqual(self.assistant.mixer.adjust_calls, [("up", 10)])
         await self.assistant.handle_event(
             _function_call_done("get_volume", "{}", call_id="call_2"),
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         outputs = [
             json.loads(event["item"]["output"])
             for event in self.websocket.sent
@@ -496,6 +658,7 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         types = [event["type"] for event in self.websocket.sent]
         self.assertEqual(types, ["conversation.item.create"])
 
@@ -515,6 +678,7 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         self.assertEqual(self.assistant.mixer.adjust_calls, [])
         output = json.loads(self.websocket.sent[0]["item"]["output"])
         self.assertIn("error", output)
@@ -542,6 +706,7 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
             self.audio,
             self.websocket,
         )
+        await _drain_tools(self.assistant)
         outputs = [
             json.loads(event["item"]["output"])
             for event in self.websocket.sent
@@ -550,6 +715,201 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(outputs), 4)
         for output in outputs:
             self.assertIn("error", output)
+
+
+class WebToolTestCase(unittest.IsolatedAsyncioTestCase):
+    """Shared harness driving tools through handle_event like the live app."""
+
+    def setUp(self):
+        self.assistant = VoiceAssistant(Config(api_key="test"))
+        self.assistant.mixer = FakeMixer()
+        self.audio = FakeAudio()
+        self.websocket = FakeWebSocket()
+
+    async def call_tool(self, name, arguments):
+        await self.assistant.handle_event(
+            _function_call_done(name, json.dumps(arguments)),
+            self.audio,
+            self.websocket,
+        )
+        await _drain_tools(self.assistant)
+        outputs = [
+            json.loads(event["item"]["output"])
+            for event in self.websocket.sent
+            if event["type"] == "conversation.item.create"
+        ]
+        self.assertEqual(len(outputs), 1)
+        return outputs[0]
+
+
+class WeatherToolTests(WebToolTestCase):
+    def use_fetch(self, geocode=GEOCODE_BERLIN, forecast=FORECAST_BERLIN):
+        fetch = FakeFetch({app.GEOCODING_URL: geocode, app.FORECAST_URL: forecast})
+        self.assistant.http_json = fetch
+        return fetch
+
+    async def test_get_weather_reports_current_and_daily_conditions(self):
+        fetch = self.use_fetch()
+        output = await self.call_tool("get_weather", {"location": "Berlin"})
+        self.assertEqual(output["location"], "Berlin, Germany")
+        self.assertEqual(output["units"], "celsius")
+        self.assertEqual(output["current"]["temperature"], 18.3)
+        self.assertEqual(output["current"]["conditions"], "light rain")
+        self.assertEqual(len(output["daily"]), 3)
+        self.assertEqual(output["daily"][0]["date"], "2026-08-05")
+        self.assertEqual(output["daily"][0]["high"], 21.0)
+        self.assertEqual(output["daily"][0]["precipitation_chance_percent"], 80)
+        geocode_url, forecast_url = (call[0] for call in fetch.calls)
+        self.assertIn("name=Berlin", geocode_url)
+        self.assertIn("latitude=52.52", forecast_url)
+        self.assertNotIn("temperature_unit", forecast_url)
+
+    async def test_get_weather_fahrenheit_switches_units(self):
+        fetch = self.use_fetch()
+        output = await self.call_tool(
+            "get_weather", {"location": "Berlin", "units": "fahrenheit"}
+        )
+        self.assertEqual(output["units"], "fahrenheit")
+        forecast_url = fetch.calls[1][0]
+        self.assertIn("temperature_unit=fahrenheit", forecast_url)
+        self.assertIn("wind_speed_unit=mph", forecast_url)
+
+    async def test_get_weather_unknown_location_is_a_soft_error(self):
+        fetch = self.use_fetch(geocode={"results": []})
+        output = await self.call_tool("get_weather", {"location": "Atlantis"})
+        self.assertIn("Atlantis", output["error"])
+        self.assertEqual(len(fetch.calls), 1)  # forecast never requested
+
+    async def test_get_weather_http_failure_becomes_error_payload(self):
+        self.assistant.http_json = FakeFetch(
+            {app.GEOCODING_URL: RuntimeError("HTTP 500 from geocoding-api.open-meteo.com")}
+        )
+        output = await self.call_tool("get_weather", {"location": "Berlin"})
+        self.assertIn("HTTP 500", output["error"])
+
+    async def test_get_weather_works_without_a_mixer(self):
+        # Network tools must not be blocked by the volume-control guard.
+        self.assistant.mixer = None
+        self.use_fetch()
+        output = await self.call_tool("get_weather", {"location": "Berlin"})
+        self.assertNotIn("error", output)
+
+    async def test_get_weather_rejects_bad_arguments(self):
+        fetch = self.use_fetch()
+        output = await self.call_tool(
+            "get_weather", {"location": "Berlin", "units": "kelvin"}
+        )
+        self.assertIn("units", output["error"])
+        self.websocket.sent.clear()
+        output = await self.call_tool("get_weather", {})
+        self.assertIn("location", output["error"])
+        self.assertEqual(fetch.calls, [])
+
+
+class WebSearchToolTests(WebToolTestCase):
+    async def test_web_search_posts_query_and_returns_answer(self):
+        fetch = FakeFetch({app.OPENAI_RESPONSES_URL: RESPONSES_ANSWER})
+        self.assistant.http_json = fetch
+        output = await self.call_tool("web_search", {"query": "giants score"})
+        self.assertEqual(output, {"answer": "The Giants won 4-2 last night."})
+        url, kwargs = fetch.calls[0]
+        self.assertEqual(url, app.OPENAI_RESPONSES_URL)
+        self.assertEqual(kwargs["method"], "POST")
+        self.assertEqual(kwargs["headers"], {"Authorization": "Bearer test"})
+        body = kwargs["body"]
+        self.assertEqual(body["model"], "gpt-5-mini")
+        self.assertEqual(body["input"], "giants score")
+        self.assertEqual(body["tools"], [{"type": "web_search"}])
+        self.assertEqual(body["reasoning"], {"effort": "low"})
+
+    async def test_web_search_omits_reasoning_for_non_gpt5_models(self):
+        self.assistant = VoiceAssistant(
+            Config(api_key="test", search_model="gpt-4.1-mini")
+        )
+        fetch = FakeFetch({app.OPENAI_RESPONSES_URL: RESPONSES_ANSWER})
+        self.assistant.http_json = fetch
+        await self.call_tool("web_search", {"query": "giants score"})
+        body = fetch.calls[0][1]["body"]
+        self.assertEqual(body["model"], "gpt-4.1-mini")
+        self.assertNotIn("reasoning", body)
+
+    async def test_web_search_answer_is_stripped_of_citations(self):
+        annotated = {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "It is 3.65%. ([fed.gov](https://fed.gov/x))",
+                        }
+                    ],
+                }
+            ],
+        }
+        self.assistant.http_json = FakeFetch({app.OPENAI_RESPONSES_URL: annotated})
+        output = await self.call_tool("web_search", {"query": "rate"})
+        self.assertEqual(output, {"answer": "It is 3.65%."})
+
+    async def test_web_search_empty_answer_becomes_error_payload(self):
+        self.assistant.http_json = FakeFetch(
+            {app.OPENAI_RESPONSES_URL: {"status": "incomplete", "output": []}}
+        )
+        output = await self.call_tool("web_search", {"query": "giants score"})
+        self.assertIn("incomplete", output["error"])
+
+    async def test_web_search_http_failure_becomes_error_payload(self):
+        self.assistant.http_json = FakeFetch(
+            {app.OPENAI_RESPONSES_URL: RuntimeError("HTTP 429 from api.openai.com")}
+        )
+        output = await self.call_tool("web_search", {"query": "giants score"})
+        self.assertIn("HTTP 429", output["error"])
+
+    async def test_web_search_disabled_never_fetches(self):
+        self.assistant = VoiceAssistant(
+            Config(api_key="test", web_search_enabled=False)
+        )
+        fetch = FakeFetch({app.OPENAI_RESPONSES_URL: RESPONSES_ANSWER})
+        self.assistant.http_json = fetch
+        output = await self.call_tool("web_search", {"query": "giants score"})
+        self.assertIn("disabled", output["error"])
+        self.assertEqual(fetch.calls, [])
+
+
+class ToolConcurrencyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_slow_tool_call_does_not_block_events_and_defers_reply(self):
+        assistant = VoiceAssistant(Config(api_key="test"))
+        audio = FakeAudio()
+        websocket = FakeWebSocket()
+        gate = asyncio.Event()
+
+        async def slow_fetch(url, **kwargs):
+            await gate.wait()
+            return GEOCODE_BERLIN if url.startswith(app.GEOCODING_URL) else FORECAST_BERLIN
+
+        assistant.http_json = slow_fetch
+        await asyncio.wait_for(
+            assistant.handle_event(
+                _function_call_done("get_weather", json.dumps({"location": "Berlin"})),
+                audio,
+                websocket,
+            ),
+            timeout=1.0,
+        )
+        # The fetch is still in flight: nothing sent, one task pending.
+        self.assertEqual(websocket.sent, [])
+        self.assertEqual(len(assistant.tool_tasks), 1)
+        # The user barges in while the tool is running...
+        await assistant.handle_event(
+            {"type": "input_audio_buffer.speech_started"}, audio, websocket
+        )
+        gate.set()
+        await _drain_tools(assistant)
+        # ...so the output lands in the conversation without forcing a response.
+        types = [event["type"] for event in websocket.sent]
+        self.assertEqual(types, ["conversation.item.create"])
+        self.assertEqual(assistant.tool_tasks, set())
 
 
 class EventTests(unittest.IsolatedAsyncioTestCase):

--- a/Examples/VoiceAssistant/wendy.json
+++ b/Examples/VoiceAssistant/wendy.json
@@ -1,6 +1,6 @@
 {
   "appId": "sh.wendy.examples.voiceassistant",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "platform": "linux",
   "entitlements": [
     {
@@ -22,6 +22,8 @@
     "STARTUP_VOLUME_PERCENT": "${STARTUP_VOLUME_PERCENT}",
     "AUDIO_SAMPLE_RATE": "${AUDIO_SAMPLE_RATE}",
     "AUDIO_CHUNK_MS": "${AUDIO_CHUNK_MS}",
+    "WEB_SEARCH_ENABLED": "${WEB_SEARCH_ENABLED}",
+    "OPENAI_SEARCH_MODEL": "${OPENAI_SEARCH_MODEL}",
     "LOG_LEVEL": "${LOG_LEVEL}"
   }
 }


### PR DESCRIPTION
Stacked on #1574.

The Realtime voice assistant answered "I can't do that" to anything needing live data. This adds two function tools following the existing volume-tool pattern, so it can answer "what's the weather in Berlin?" and "what's in the news today?".

## Why function tools (and not native web search / MCP)

- The Realtime API has **no built-in `web_search`** — that tool is Responses-API-only (OpenAI staff confirmed sessions hang if you try).
- The Realtime API's native remote-MCP support has OpenAI's cloud call the MCP server, so only **publicly hosted** HTTP MCP servers work — an MCP running on the device is unreachable.

## What's new

- **`get_weather`** — free, keyless Open-Meteo geocode → current conditions + 3-day forecast, celsius/fahrenheit chosen by the model from conversation. Unresolvable places return a soft error so the model asks the user to rephrase.
- **`web_search`** — forwards the query to the OpenAI Responses API with its built-in `web_search` tool on the same `OPENAI_API_KEY` (default `gpt-5-mini`; `OPENAI_SEARCH_MODEL` to override) and returns a short spoken-style answer with citation links stripped. `WEB_SEARCH_ENABLED=false` removes the paid tool entirely; weather is unaffected.
- **Concurrency**: tool calls now run as asyncio tasks (stdlib `urllib` on worker threads — no new dependencies), so the event receive loop keeps draining during multi-second fetches and barge-in stays responsive; a barge-in mid-fetch defers `response.create` via the existing `user_speaking` suppression.
- The mixer-`None` guard now only applies to volume tools, so network tools work on devices without a resolvable ALSA card.
- `wendy.json` → 0.3.0 with the two new env passthroughs; README + `.env.example` updated.

## Live findings fixed during on-device testing

- **Clarification loop** (4aa4707): the inner search model answered broad queries with clarifying questions instead of searching; the realtime model relayed/retried each one — six billed calls before an answer. Instructions now forbid clarifying questions (one-shot search, most likely interpretation).
- **Double acknowledgement** (da20411): the inner model opened with its own "Got it…" on top of the realtime model's spoken acknowledgement. Instructions now frame the call as a silent backend that starts directly with the facts. Both prompt phrases are pinned by test assertions.

## Testing

- 62 unit tests (21 new), TDD'd — includes a concurrency test proving a slow fetch doesn't block the event loop and defers the spoken reply when the user barges in.
- Live-verified on a Pi 5 (`wendyos-wild-snipe.local`, WendyOS 0.18.1) by speaking to the device: `get_weather` end-to-end (model inferred fahrenheit from phrasing, spoken 65°F SF answer with 3-day forecast), `web_search` end-to-end (one search → spoken headline summary), and `set_volume` regression after the `execute_tool` restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)