### PR TITLE
Stream mDNS device discovery to the picker on macOS (rework of #1570)

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2202,6 +2202,92 @@ func hideLocalProviders(excludes map[string]bool) map[string]bool {
 	return merged
 }
 
+// externalProviderPickerItem builds the picker row for a device discovered
+// through an external provider. wendy-lite devices are presented as merged
+// devices (like LAN discoveries) so they share the LAN row layout.
+func externalProviderPickerItem(prov providers.DeviceProvider, dev *models.ExternalDevice) tui.PickerItem {
+	if prov.Key() == "wendy-lite" {
+		return tui.PickerItem{
+			Name:         dev.DisplayName,
+			DedupKey:     dev.DisplayName,
+			Type:         dev.ConnectionType() + " (Lite)",
+			Address:      dev.ConnectionInfo["ip"],
+			AgentVersion: dev.AgentVersion,
+			OS:           dev.OS,
+			OSVersion:    dev.OSVersion,
+			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
+				DisplayName:     dev.DisplayName,
+				AgentVersion:    dev.AgentVersion,
+				OSVersion:       dev.OSVersion,
+				CPUArchitecture: dev.CPUArchitecture,
+				Externals:       []*models.ExternalDevice{dev},
+			}},
+		}
+	}
+	return tui.PickerItem{
+		Name:         dev.DisplayName,
+		Type:         prov.DisplayName(),
+		Address:      externalProviderAddress(dev.ProviderKey, dev.ID),
+		AgentVersion: dev.AgentVersion,
+		OS:           dev.OS,
+		OSVersion:    dev.OSVersion,
+		DedupKey:     dev.DisplayName,
+		SortKey:      externalProviderSortKey(prov.Key(), dev.DisplayName),
+		Hint:         externalProviderPickerHint(prov.Key()),
+		Value:        &pickerEntry{externalDevice: dev, provider: prov},
+	}
+}
+
+// providerPollDelay returns how long to wait before the next DiscoverDevices
+// poll given how long the previous scan took: the remainder of the 3s cycle,
+// but never less than 500ms between scans.
+func providerPollDelay(elapsed time.Duration) time.Duration {
+	delay := 3*time.Second - elapsed
+	if delay < 500*time.Millisecond {
+		delay = 500 * time.Millisecond
+	}
+	return delay
+}
+
+// discoverProviderForPicker feeds picker items for prov until ctx is done.
+// Providers implementing providers.ContinuousDiscoverer are consumed as a
+// stream; otherwise DiscoverDevices is polled on a 3-second cadence measured
+// from the start of each scan (with a 500ms minimum gap, so slow scans don't
+// stretch the period). If the stream fails to start or closes while the
+// picker is still open, discovery falls back to polling.
+func discoverProviderForPicker(ctx context.Context, prov providers.DeviceProvider, send func([]tui.PickerItem)) {
+	if cd, ok := prov.(providers.ContinuousDiscoverer); ok {
+		if ch, err := cd.DiscoverDevicesContinuous(ctx); err == nil {
+			for dev := range ch {
+				send([]tui.PickerItem{externalProviderPickerItem(prov, &dev)})
+			}
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}
+
+	for {
+		start := time.Now()
+		devices, err := prov.DiscoverDevices(ctx)
+		if err == nil {
+			var items []tui.PickerItem
+			for i := range devices {
+				items = append(items, externalProviderPickerItem(prov, &devices[i]))
+			}
+			if len(items) > 0 {
+				send(items)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(providerPollDelay(time.Since(start))):
+		}
+	}
+}
+
 // pickDevice runs an interactive TUI that discovers devices across all
 // transports and providers, then lets the user select one.
 // LAN discovery runs continuously so devices that come online after the
@@ -2311,62 +2397,15 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 		}
 	}()
 
-	// Continuous provider discovery — re-scan every 3 seconds.
+	// Continuous provider discovery — streamed when the provider supports it,
+	// otherwise re-scanned on a 3-second cadence.
 	for _, prov := range providers.AvailableProviders() {
 		if excludeProviders[prov.Key()] {
 			continue
 		}
-		prov := prov
-		go func() {
-			for {
-				devices, err := prov.DiscoverDevices(discoverCtx)
-				if err == nil && len(devices) > 0 {
-					var items []tui.PickerItem
-					for i := range devices {
-						if prov.Key() == "wendy-lite" {
-							items = append(items, tui.PickerItem{
-								Name:         devices[i].DisplayName,
-								DedupKey:     devices[i].DisplayName,
-								Type:         devices[i].ConnectionType() + " (Lite)",
-								Address:      devices[i].ConnectionInfo["ip"],
-								AgentVersion: devices[i].AgentVersion,
-								OS:           devices[i].OS,
-								OSVersion:    devices[i].OSVersion,
-								Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
-									DisplayName:     devices[i].DisplayName,
-									AgentVersion:    devices[i].AgentVersion,
-									OSVersion:       devices[i].OSVersion,
-									CPUArchitecture: devices[i].CPUArchitecture,
-									Externals:       []*models.ExternalDevice{&devices[i]},
-								}},
-							})
-						} else {
-							items = append(items, tui.PickerItem{
-								Name:         devices[i].DisplayName,
-								Type:         prov.DisplayName(),
-								Address:      externalProviderAddress(devices[i].ProviderKey, devices[i].ID),
-								AgentVersion: devices[i].AgentVersion,
-								OS:           devices[i].OS,
-								OSVersion:    devices[i].OSVersion,
-								DedupKey:     devices[i].DisplayName,
-								SortKey:      externalProviderSortKey(prov.Key(), devices[i].DisplayName),
-								Hint:         externalProviderPickerHint(prov.Key()),
-								Value:        &pickerEntry{externalDevice: &devices[i], provider: prov},
-							})
-						}
-					}
-					if len(items) > 0 {
-						p.Send(tui.PickerAddMsg{Items: items})
-					}
-				}
-
-				select {
-				case <-discoverCtx.Done():
-					return
-				case <-time.After(3 * time.Second):
-				}
-			}
-		}()
+		go discoverProviderForPicker(discoverCtx, prov, func(items []tui.PickerItem) {
+			p.Send(tui.PickerAddMsg{Items: items})
+		})
 	}
 
 	// Continuous Bluetooth discovery — re-scan every 5 seconds.

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -10,11 +10,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -1023,6 +1025,235 @@ func TestHideLocalProviders(t *testing.T) {
 			if got[k] {
 				t.Errorf("hideLocalProviders(nil)[%q] = true with opt-in set; want false", k)
 			}
+		}
+	})
+}
+
+// ── discoverProviderForPicker ───────────────────────────────────────
+
+// fakeProvider is a minimal DeviceProvider for exercising the picker
+// discovery loop.
+type fakeProvider struct {
+	key           string
+	devices       []models.ExternalDevice
+	discoverCalls atomic.Int32
+}
+
+func (p *fakeProvider) Key() string                             { return p.key }
+func (p *fakeProvider) DisplayName() string                     { return "Fake" }
+func (p *fakeProvider) IsAvailable(context.Context) bool        { return true }
+func (p *fakeProvider) CheckRequirements(context.Context) error { return nil }
+func (p *fakeProvider) DiscoverDevices(context.Context) ([]models.ExternalDevice, error) {
+	p.discoverCalls.Add(1)
+	return p.devices, nil
+}
+func (p *fakeProvider) SupportedBuildTypes() []string { return nil }
+func (p *fakeProvider) CanBuild(string) bool          { return false }
+func (p *fakeProvider) Build(context.Context, models.ExternalDevice, string, string, string, bool) (*providers.BuiltApp, error) {
+	return nil, errors.New("not implemented")
+}
+func (p *fakeProvider) Run(context.Context, *providers.BuiltApp, bool, chan<- providers.RunOutput) error {
+	return errors.New("not implemented")
+}
+func (p *fakeProvider) Stop(context.Context, *providers.BuiltApp) error {
+	return errors.New("not implemented")
+}
+func (p *fakeProvider) GetDeviceInfo(context.Context, models.ExternalDevice) (*providers.ProviderDeviceInfo, error) {
+	return nil, nil
+}
+
+// fakeContinuousProvider additionally implements ContinuousDiscoverer.
+type fakeContinuousProvider struct {
+	fakeProvider
+	ch  chan models.ExternalDevice
+	err error
+}
+
+func (p *fakeContinuousProvider) DiscoverDevicesContinuous(context.Context) (<-chan models.ExternalDevice, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.ch, nil
+}
+
+var (
+	_ providers.DeviceProvider       = (*fakeProvider)(nil)
+	_ providers.ContinuousDiscoverer = (*fakeContinuousProvider)(nil)
+)
+
+// runDiscoverProviderForPicker starts the discovery loop in a goroutine and
+// returns a channel of items sent to the picker plus a done channel closed
+// when the loop returns.
+func runDiscoverProviderForPicker(ctx context.Context, prov providers.DeviceProvider) (<-chan tui.PickerItem, <-chan struct{}) {
+	got := make(chan tui.PickerItem, 16)
+	done := make(chan struct{})
+	go func() {
+		discoverProviderForPicker(ctx, prov, func(items []tui.PickerItem) {
+			for _, item := range items {
+				got <- item
+			}
+		})
+		close(done)
+	}()
+	return got, done
+}
+
+func awaitPickerItem(t *testing.T, got <-chan tui.PickerItem, wantName string) {
+	t.Helper()
+	select {
+	case item := <-got:
+		if item.Name != wantName {
+			t.Fatalf("picker item name = %q, want %q", item.Name, wantName)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for picker item %q", wantName)
+	}
+}
+
+func awaitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discoverProviderForPicker did not return after ctx cancel")
+	}
+}
+
+func TestProviderPollDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		{"instant scan waits full cycle", 0, 3 * time.Second},
+		{"scan time counts toward the cycle", 1 * time.Second, 2 * time.Second},
+		{"remainder below minimum gap is clamped", 2600 * time.Millisecond, 500 * time.Millisecond},
+		{"scan as long as the cycle", 3 * time.Second, 500 * time.Millisecond},
+		{"scan longer than the cycle", 10 * time.Second, 500 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := providerPollDelay(tt.elapsed); got != tt.want {
+				t.Fatalf("providerPollDelay(%v) = %v, want %v", tt.elapsed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverProviderForPickerStreamsContinuous(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prov := &fakeContinuousProvider{
+		fakeProvider: fakeProvider{key: "fake"},
+		ch:           make(chan models.ExternalDevice),
+	}
+	got, done := runDiscoverProviderForPicker(ctx, prov)
+
+	prov.ch <- models.ExternalDevice{ID: "fake:1", DisplayName: "one", ProviderKey: "fake"}
+	awaitPickerItem(t, got, "one")
+	prov.ch <- models.ExternalDevice{ID: "fake:2", DisplayName: "two", ProviderKey: "fake"}
+	awaitPickerItem(t, got, "two")
+
+	// Cancel then close the stream, as a real implementation would on ctx
+	// cancellation; the loop must return without falling back to polling.
+	cancel()
+	close(prov.ch)
+	awaitDone(t, done)
+
+	if n := prov.discoverCalls.Load(); n != 0 {
+		t.Fatalf("DiscoverDevices called %d times; streaming path should not poll", n)
+	}
+}
+
+func TestDiscoverProviderForPickerPollingFallback(t *testing.T) {
+	polled := []models.ExternalDevice{{ID: "fake:1", DisplayName: "polled", ProviderKey: "fake"}}
+
+	tests := []struct {
+		name string
+		prov providers.DeviceProvider
+	}{
+		{"provider without continuous support", &fakeProvider{key: "fake", devices: polled}},
+		{"continuous start error", &fakeContinuousProvider{
+			fakeProvider: fakeProvider{key: "fake", devices: polled},
+			err:          errors.New("stream unavailable"),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			got, done := runDiscoverProviderForPicker(ctx, tt.prov)
+			awaitPickerItem(t, got, "polled")
+			cancel()
+			awaitDone(t, done)
+		})
+	}
+}
+
+func TestDiscoverProviderForPickerStreamDeathFallsBackToPolling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prov := &fakeContinuousProvider{
+		fakeProvider: fakeProvider{
+			key:     "fake",
+			devices: []models.ExternalDevice{{ID: "fake:1", DisplayName: "polled", ProviderKey: "fake"}},
+		},
+		ch: make(chan models.ExternalDevice),
+	}
+	got, done := runDiscoverProviderForPicker(ctx, prov)
+
+	// Stream dies while the picker is still open: polling must take over.
+	close(prov.ch)
+	awaitPickerItem(t, got, "polled")
+	cancel()
+	awaitDone(t, done)
+}
+
+func TestExternalProviderPickerItem(t *testing.T) {
+	t.Run("wendy-lite devices become merged devices", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		dev := models.ExternalDevice{
+			ID:              "wendy-lite:board",
+			DisplayName:     "Lite Board",
+			ProviderKey:     "wendy-lite",
+			AgentVersion:    "1.2.3",
+			CPUArchitecture: "riscv",
+			ConnectionInfo:  map[string]string{"type": "LAN", "ip": "10.0.0.9"},
+		}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if item.Type != "LAN (Lite)" {
+			t.Errorf("Type = %q, want %q", item.Type, "LAN (Lite)")
+		}
+		if item.Address != "10.0.0.9" {
+			t.Errorf("Address = %q, want %q", item.Address, "10.0.0.9")
+		}
+		entry, ok := item.Value.(*pickerEntry)
+		if !ok || entry.mergedDevice == nil {
+			t.Fatalf("Value = %#v, want *pickerEntry with mergedDevice", item.Value)
+		}
+		if len(entry.mergedDevice.Externals) != 1 || entry.mergedDevice.Externals[0].ID != dev.ID {
+			t.Errorf("mergedDevice.Externals = %#v, want the source device", entry.mergedDevice.Externals)
+		}
+	})
+
+	t.Run("other providers keep provider row layout", func(t *testing.T) {
+		prov := &fakeProvider{key: "fake"}
+		dev := models.ExternalDevice{ID: "fake:1", DisplayName: "Dev", ProviderKey: "fake"}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if item.Type != "Fake" {
+			t.Errorf("Type = %q, want %q", item.Type, "Fake")
+		}
+		entry, ok := item.Value.(*pickerEntry)
+		if !ok || entry.externalDevice == nil {
+			t.Fatalf("Value = %#v, want *pickerEntry with externalDevice", item.Value)
+		}
+		if entry.provider != providers.DeviceProvider(prov) {
+			t.Errorf("entry.provider = %#v, want the source provider", entry.provider)
 		}
 	})
 }

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -64,41 +64,130 @@ func (p *MicroWendyProvider) DiscoverDevices(ctx context.Context) ([]models.Exte
 
 	var devices []models.ExternalDevice
 	for _, svc := range services {
-		displayName := svc.InstanceName
-		if displayName == "" {
-			displayName = svc.Hostname
-		}
-		devices = append(devices, models.ExternalDevice{
-			ID:          fmt.Sprintf("wendy-lite:%s", svc.Hostname),
-			DisplayName: displayName,
-			ProviderKey: p.Key(),
-			ConnectionInfo: map[string]string{
-				"type":     "LAN",
-				"name":     svc.TXTRecords["name"],
-				"hostname": svc.Hostname,
-				"ip":       svc.IPAddress,
-				"port":     fmt.Sprintf("%d", svc.Port),
-				"mtls":     fmt.Sprintf("%t", svc.TXTRecords["mtls"] == "true"),
-			},
-			IsWendyDevice: true,
-		})
+		devices = append(devices, p.mdnsExternalDevice(svc))
 	}
-
 	for _, dev := range sd.Devices() {
-		devices = append(devices, models.ExternalDevice{
-			ID:          fmt.Sprintf("wendy-lite:%s", dev.Port),
-			DisplayName: dev.DisplayName,
-			ProviderKey: p.Key(),
-			ConnectionInfo: map[string]string{
-				"type":       "USB",
-				"name":       dev.Name,
-				"serialPort": dev.Port,
-			},
-			IsWendyDevice: true,
-		})
+		devices = append(devices, p.serialExternalDevice(dev))
 	}
 
 	return devices, nil
+}
+
+// mdnsExternalDevice maps a resolved _wendy-lite._tcp mDNS service to an
+// ExternalDevice.
+func (p *MicroWendyProvider) mdnsExternalDevice(svc discovery.MDNSService) models.ExternalDevice {
+	displayName := svc.InstanceName
+	if displayName == "" {
+		displayName = svc.Hostname
+	}
+	return models.ExternalDevice{
+		ID:          fmt.Sprintf("wendy-lite:%s", svc.Hostname),
+		DisplayName: displayName,
+		ProviderKey: p.Key(),
+		ConnectionInfo: map[string]string{
+			"type":     "LAN",
+			"name":     svc.TXTRecords["name"],
+			"hostname": svc.Hostname,
+			"ip":       svc.IPAddress,
+			"port":     fmt.Sprintf("%d", svc.Port),
+			"mtls":     fmt.Sprintf("%t", svc.TXTRecords["mtls"] == "true"),
+		},
+		IsWendyDevice: true,
+	}
+}
+
+// serialExternalDevice maps a serial-port Wendy Lite device to an ExternalDevice.
+func (p *MicroWendyProvider) serialExternalDevice(dev discovery.SerialDevice) models.ExternalDevice {
+	return models.ExternalDevice{
+		ID:          fmt.Sprintf("wendy-lite:%s", dev.Port),
+		DisplayName: dev.DisplayName,
+		ProviderKey: p.Key(),
+		ConnectionInfo: map[string]string{
+			"type":       "USB",
+			"name":       dev.Name,
+			"serialPort": dev.Port,
+		},
+		IsWendyDevice: true,
+	}
+}
+
+// DiscoverDevicesContinuous streams wendy-lite devices as they are found:
+// mDNS services via continuous browsing and serial devices via the background
+// serial scanner. Continuous mDNS browsing is only available on macOS; on
+// other platforms this returns an error and callers fall back to polling
+// DiscoverDevices.
+func (p *MicroWendyProvider) DiscoverDevicesContinuous(ctx context.Context) (<-chan models.ExternalDevice, error) {
+	svcCh, err := discovery.BrowseMDNSServicesContinuous(ctx, microWendyServiceType)
+	if err != nil {
+		return nil, err
+	}
+
+	sd := discovery.GetSerialDiscovery()
+	sd.StartScan(3 * time.Second)
+
+	// Coalesce serial snapshots into a capacity-1 channel: the listener must
+	// never block (it runs under SerialDiscovery's notify lock), and only the
+	// latest snapshot matters. notify() serializes listener calls, so the
+	// drain-then-send below never races with itself.
+	serialUpdates := make(chan []discovery.SerialDevice, 1)
+	listenerID := sd.AddListener(func(devices []discovery.SerialDevice) {
+		select {
+		case serialUpdates <- devices:
+		default:
+			select {
+			case <-serialUpdates:
+			default:
+			}
+			serialUpdates <- devices
+		}
+	})
+
+	ch := make(chan models.ExternalDevice, 16)
+	go func() {
+		defer close(ch)
+		defer sd.RemoveListener(listenerID)
+		defer sd.StopScan()
+
+		send := func(dev models.ExternalDevice) bool {
+			select {
+			case ch <- dev:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
+		// Emit serial devices already known before the listener registered.
+		for _, dev := range sd.Devices() {
+			if !send(p.serialExternalDevice(dev)) {
+				return
+			}
+		}
+
+		for {
+			select {
+			case svc, ok := <-svcCh:
+				if !ok {
+					// Browse stream died; closing ch lets the consumer fall
+					// back to polling.
+					return
+				}
+				if !send(p.mdnsExternalDevice(svc)) {
+					return
+				}
+			case snap := <-serialUpdates:
+				for _, dev := range snap {
+					if !send(p.serialExternalDevice(dev)) {
+						return
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
 }
 
 func (p *MicroWendyProvider) SupportedBuildTypes() []string {

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -124,6 +124,16 @@ type ImageBuilder interface {
 	BuildFromImage(device models.ExternalDevice, product, imageName string) *BuiltApp
 }
 
+// ContinuousDiscoverer is optionally implemented by providers that can stream
+// discovered devices as they appear, instead of being polled via DiscoverDevices.
+type ContinuousDiscoverer interface {
+	// DiscoverDevicesContinuous starts continuous discovery and returns a
+	// channel that receives each device as it is found. The channel stays
+	// open until ctx is cancelled (or the stream fails), then is closed.
+	// Implementations may re-send a device; consumers deduplicate.
+	DiscoverDevicesContinuous(ctx context.Context) (<-chan models.ExternalDevice, error)
+}
+
 // TypedBuilder is optionally implemented by providers that can disambiguate
 // between multiple buildable markers in the same project using the caller's
 // resolved build type (e.g. "docker" vs "compose"). When the build type is

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -5,6 +5,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"time"
 )
@@ -44,6 +45,49 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	}
 
 	return services, nil
+}
+
+// BrowseMDNSServicesContinuous browses for serviceType and streams each newly
+// discovered service, resolved, to the returned channel. It runs until ctx is
+// cancelled or the browse stops; the channel is closed either way, and a
+// consumer that sees it close while still interested falls back to polling.
+// Instances that fail to resolve are skipped, matching BrowseMDNSServices.
+// Consumers signal they are done by cancelling ctx.
+func BrowseMDNSServicesContinuous(ctx context.Context, serviceType string) (<-chan MDNSService, error) {
+	ch := make(chan MDNSService, 16)
+
+	go func() {
+		defer close(ch)
+
+		seen := make(map[string]bool)
+
+		// Resolving inside the callback blocks the browse socket pump for up to
+		// the resolve timeout, matching discoverLANContinuous; mDNSResponder
+		// queues further browse replies meanwhile.
+		if err := dnssdBrowseStream(ctx, serviceType, func(inst browseResult) {
+			key := inst.instanceName + "%" + inst.interfaceName
+			if seen[key] {
+				return
+			}
+			seen[key] = true
+
+			resolveCtx, resolveCancel := context.WithTimeout(ctx, 2*time.Second)
+			svc, err := resolveMDNSService(resolveCtx, inst, serviceType)
+			resolveCancel()
+			if err != nil {
+				return
+			}
+
+			select {
+			case ch <- svc:
+			case <-ctx.Done():
+			}
+		}); err != nil && ctx.Err() == nil {
+			log.Printf("discovery: continuous mDNS browse for %s stopped: %v", serviceType, err)
+		}
+	}()
+
+	return ch, nil
 }
 
 // resolveMDNSService resolves a browse result into an MDNSService.

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -97,8 +97,12 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 		return MDNSService{}, err
 	}
 
+	// Through the resolver rather than net.LookupHost, which ignores ctx: this
+	// runs inside the browse callback on the streaming path, so a lookup that
+	// hangs stalls the socket pump and stops discovery for every other device.
+	// DefaultResolver keeps the system resolver, which .local names need.
 	ipAddr := ""
-	if addrs, lookupErr := net.LookupHost(hostname); lookupErr == nil {
+	if addrs, lookupErr := net.DefaultResolver.LookupHost(ctx, hostname); lookupErr == nil {
 		ipAddr = preferIPv4Addr(addrs)
 	}
 

--- a/go/internal/shared/discovery/mdns_darwin_test.go
+++ b/go/internal/shared/discovery/mdns_darwin_test.go
@@ -1,0 +1,88 @@
+//go:build darwin
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestBrowseMDNSServicesContinuousStreamsLateArrival is the property the picker
+// depends on: a service that appears *after* the browse is already open still
+// reaches the consumer, without waiting for a rescan. Registering only once the
+// stream is running is what separates streaming from polling — a polling
+// implementation would pass a test that registered up front.
+func TestBrowseMDNSServicesContinuousStreamsLateArrival(t *testing.T) {
+	// Its own service type so a browse cannot pick up real devices, and a pid in
+	// the instance name so concurrent test binaries do not collide and trigger
+	// mDNSResponder's conflict renaming.
+	const serviceType = "_wendy-streamtest._tcp"
+	instance := fmt.Sprintf("wendy-streamtest-%d", os.Getpid())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ch, err := BrowseMDNSServicesContinuous(ctx, serviceType)
+	if err != nil {
+		t.Fatalf("BrowseMDNSServicesContinuous: %v", err)
+	}
+
+	want := map[string]string{"name": "Stream Test Board", "mtls": "true"}
+	stop, err := dnssdRegister(instance, serviceType, 51235, want)
+	if err != nil {
+		t.Skipf("cannot register an mDNS service (is mDNSResponder reachable?): %v", err)
+	}
+	t.Cleanup(stop)
+
+	var got MDNSService
+	deadline := time.After(20 * time.Second)
+	for got.InstanceName != instance {
+		select {
+		case svc, ok := <-ch:
+			if !ok {
+				t.Fatal("stream closed before the registered service arrived")
+			}
+			got = svc
+		case <-deadline:
+			t.Fatal("registered service did not arrive on the stream")
+		}
+	}
+
+	if got.Port != 51235 {
+		t.Errorf("Port = %d, want 51235", got.Port)
+	}
+	if got.Hostname == "" {
+		t.Error("resolved service has an empty hostname")
+	}
+	// A TXT value with a space, which is what the old display-output parser had
+	// to recover by unescaping.
+	for k, v := range want {
+		if got.TXTRecords[k] != v {
+			t.Errorf("TXT[%q] = %q, want %q", k, got.TXTRecords[k], v)
+		}
+	}
+
+	// The same instance must not be streamed twice: the picker relies on dedup
+	// to avoid a row per browse reply (mDNSResponder repeats them per interface).
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for svc := range ch {
+			if svc.InstanceName == instance {
+				t.Errorf("instance %q streamed more than once", instance)
+			}
+		}
+	}()
+
+	// Cancelling must close the channel — the picker's signal to fall back to
+	// polling, and what stops this goroutine.
+	cancel()
+	select {
+	case <-drained:
+	case <-time.After(10 * time.Second):
+		t.Fatal("stream did not close after ctx cancellation")
+	}
+}

--- a/go/internal/shared/discovery/mdns_linux.go
+++ b/go/internal/shared/discovery/mdns_linux.go
@@ -5,6 +5,7 @@ package discovery
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -27,6 +28,14 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 		return browseMDNSAvahi(ctx, serviceType, timeout)
 	}
 	return browseMDNSHashicorp(ctx, serviceType, timeout)
+}
+
+// BrowseMDNSServicesContinuous streams newly discovered mDNS services of the
+// given type as they appear. Only macOS has a native streaming primitive
+// (dns-sd); on Linux this returns errors.ErrUnsupported so callers fall back
+// to polling BrowseMDNSServices.
+func BrowseMDNSServicesContinuous(_ context.Context, _ string) (<-chan MDNSService, error) {
+	return nil, fmt.Errorf("continuous mDNS browsing: %w", errors.ErrUnsupported)
 }
 
 // browseMDNSAvahi uses avahi-browse to discover services.

--- a/go/internal/shared/discovery/mdns_windows.go
+++ b/go/internal/shared/discovery/mdns_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// BrowseMDNSServicesContinuous streams newly discovered mDNS services of the
+// given type as they appear. Only macOS has a native streaming primitive
+// (dns-sd); on Windows this returns errors.ErrUnsupported so callers fall
+// back to polling BrowseMDNSServices.
+func BrowseMDNSServicesContinuous(_ context.Context, _ string) (<-chan MDNSService, error) {
+	return nil, fmt.Errorf("continuous mDNS browsing: %w", errors.ErrUnsupported)
+}


### PR DESCRIPTION
Reworks #1570 on top of #1555. Same feature, rebased onto a `main` where darwin mDNS no longer shells out to `dns-sd`.

#1570 branched from `d7b862c58` and was written the same afternoon #1555 merged, so it never saw it. The two overlap in `discovery_darwin.go` and `mdns_darwin.go`, and the conflict is not textual: four of its six commits refactor machinery that #1555 deleted.

## What carried over

Both feature commits, authorship preserved:

- **`ContinuousDiscoverer`** — an optional interface letting a provider push discovered devices over a channel. The picker streams when a provider implements it and falls back to polling otherwise, including when the stream fails to start or closes while the picker is open. Cherry-picked clean; #1555 touched none of these files.
- **wendy-lite streaming on macOS** — `MicroWendyProvider` implements it via a new `BrowseMDNSServicesContinuous`. Serial devices stream too, via listener snapshots coalesced into the same channel. Linux and Windows return `errors.ErrUnsupported`, keeping the polling fallback there.

The polling cadence fix rides along: the fallback now measures 3s from scan start rather than sleeping 3s after the scan returns, so a slow wendy-lite browse no longer stretches the effective period to ~6s.

## What was dropped

#1570's first four commits — `parseBrowseLine`, `dnssdResolveService`/`resolvedService`, `dnssdBrowseStream` as owner of the `dns-sd -B` process, and the regrouping into `mdns_darwin.go`. No replacement commit, because #1555 already landed each outcome under a different name:

| #1570 | already on `main` |
| --- | --- |
| `dnssdResolveService` unifying the two resolve loops | `dnssdResolveInstance` |
| `dnssdBrowseStream` owning the browse lifecycle | `dnssdBrowseStream` (callback, no process) |
| generic machinery grouped in `mdns_darwin.go` | grouped in `dnssd_darwin.go` |
| TXT parsing unified across the two copies | `parseTXTRecord` over the wire format |

`parseBrowseLine` and `parseDNSSDTXT` have nothing left to parse — browse replies arrive as structured callback arguments, not stdout. #1570's process-leak fix is also moot: it covered orderly exit, which is the case WDY-1831 established doesn't matter, since any live `dns-sd` is reparented to launchd when the CLI dies however carefully the parent unwinds.

`discovery_darwin.go` and `discovery_darwin_test.go` therefore leave the PR entirely, and only `BrowseMDNSServicesContinuous` needed rewriting — ~35 lines on the callback `dnssdBrowseStream`, mirroring `discoverLANContinuous`.

## Behaviour change worth flagging

On darwin `BrowseMDNSServicesContinuous` now always returns a nil error. `dnssdBrowseStream` delivers by callback for the lifetime of the context, so there is no start-up step that can fail separately; a browse that never starts or stops early closes the channel instead, and is logged. The signature keeps its error for the Linux/Windows `ErrUnsupported` case, and the picker already treats a closed channel as "fall back to polling" (`TestDiscoverProviderForPickerStreamDeathFallsBackToPolling`).

## Added here

- **A test for `BrowseMDNSServicesContinuous`**, the one piece of the streaming path with no coverage. It registers the service only *after* the browse is open, so a polling implementation cannot pass it, and asserts the late arrival reaches the consumer, that an instance is not streamed twice, and that cancelling closes the channel.
- **A ctx-bound address lookup.** `resolveMDNSService` took its hostname to an address through `net.LookupHost`, which ignores the context it was given. Tolerable while resolution only ran under polling, where a slow lookup delays one scan — but streaming calls it from inside the browse callback, which owns the daemon socket pump, so a hanging lookup stops discovery for every other device. Now `net.DefaultResolver.LookupHost(ctx, …)`: same code path with ctx threaded, keeping the system resolver that `.local` names depend on.

## Copilot review on #1570

- **`&dev` aliasing in the stream loop** — not a bug. `go.mod` is `go 1.26.5`, so loop variables are per-iteration; verified distinct addresses.
- **`strings.Contains(line, "Add")` misclassifying an instance named "Addison"** — moot. #1555 replaced the line scrape with a `flags & kDNSServiceFlagsAdd` test, which no instance name can fool.
- **`net.LookupHost` ignoring ctx** — real, and fixed here.

## Verification

Against a Raspberry Pi 4 and a Jetson AGX Thor on the LAN:

- both devices streamed at +0.01s, each exactly once over a 20s window, TXT values with spaces intact
- `discover --json` byte-identical to a `main` build, with one device and with two
- five concurrent pollers for 30s sampled twice a second: peak of zero `dns-sd` processes
- `.local` resolution still populates `IPAddress` on both the streaming and polling paths after the resolver change
- full suite green under `-race`; vet and gofmt clean; Windows cross-build of discovery/providers/commands clean

Not covered: the `MicroWendyProvider` glue and the serial/USB half need an ESP32 wendy-lite board, which nothing on the LAN advertises — both test devices are WendyOS, which goes through `discoverLANContinuous`. The picker loop itself is covered by unit tests.
