### PR TITLE
fix(mcp): remove duplicate tool aliases, bound unbounded list tools

### DIFF
--- a/go/internal/cli/mcp/server_helpers_test.go
+++ b/go/internal/cli/mcp/server_helpers_test.go
@@ -124,15 +124,11 @@ func (s *mcpServer) callTool(ctx context.Context, name string, args map[string]a
 		return s.handleCloudDiscover(ctx, req)
 	case "cloud_connect":
 		return s.handleCloudConnect(ctx, req)
-	case "cloud_device_connect":
-		return s.handleCloudConnect(ctx, req)
 	case "cloud_enroll_device":
 		return s.handleCloudEnrollDevice(ctx, req)
 	case "cloud_tunnel":
 		return s.handleCloudTunnel(ctx, req)
 	case "run":
-		return s.handleRun(ctx, req)
-	case "cloud_run":
 		return s.handleRun(ctx, req)
 	default:
 		return mcpgo.NewToolResultError("unknown tool: " + name), nil

--- a/go/internal/cli/mcp/server_test.go
+++ b/go/internal/cli/mcp/server_test.go
@@ -51,10 +51,13 @@ func TestGuideResource_ReturnsText(t *testing.T) {
 	}
 }
 
-// TestFileSyncSync_NotRegistered locks in the removal of the dead filesync_sync
-// tool: it registers the same tool set Start() does and asserts the tool is
-// absent from the server's tool list.
-func TestFileSyncSync_NotRegistered(t *testing.T) {
+// TestDeadTools_NotRegistered locks in the removal of dead/duplicate tools:
+// it registers the same tool set Start() does and asserts each is absent
+// from the server's tool list. filesync_sync was removed as unused; cloud_run
+// and cloud_device_connect were removed as pure aliases of run and
+// cloud_connect (same handler, same schema) that only added tool-selection
+// noise for callers.
+func TestDeadTools_NotRegistered(t *testing.T) {
 	srv := server.NewMCPServer("t", "0")
 	s := New(&config.Config{}, nil)
 	s.registerStatusTools(srv)
@@ -69,7 +72,10 @@ func TestFileSyncSync_NotRegistered(t *testing.T) {
 	s.registerCloudTools(srv)
 	s.registerContainerMCPTools(context.Background(), srv) // no active connection; no-op
 
-	if _, ok := srv.ListTools()["filesync_sync"]; ok {
-		t.Fatal("filesync_sync should not be registered")
+	tools := srv.ListTools()
+	for _, name := range []string{"filesync_sync", "cloud_run", "cloud_device_connect"} {
+		if _, ok := tools[name]; ok {
+			t.Fatalf("%s should not be registered", name)
+		}
 	}
 }

--- a/go/internal/cli/mcp/tools_bluetooth.go
+++ b/go/internal/cli/mcp/tools_bluetooth.go
@@ -17,6 +17,7 @@ func (s *mcpServer) registerBluetoothTools(srv *server.MCPServer) {
 		mcpgo.WithNumber("timeout_seconds",
 			mcpgo.Description("Scan duration in seconds (default 5)"),
 		),
+		mcpgo.WithNumber("max_bytes", mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)")),
 	}
 	scanOpts = append(scanOpts, readOnly()...)
 	scanOpts = append(scanOpts, openWorld()...)
@@ -101,7 +102,7 @@ func (s *mcpServer) handleBluetoothScan(ctx context.Context, req mcpgo.CallToolR
 	for _, d := range seen {
 		devices = append(devices, d)
 	}
-	return okList("devices", devices), nil
+	return okListBounded("devices", devices, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleBluetoothConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_cloud.go
+++ b/go/internal/cli/mcp/tools_cloud.go
@@ -73,6 +73,7 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 		mcpgo.WithString("filter",
 			mcpgo.Description("Optional cloud-side asset filter"),
 		),
+		mcpgo.WithNumber("max_bytes", mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)")),
 	}
 	discoverOpts = append(discoverOpts, readOnly()...)
 	discoverOpts = append(discoverOpts, openWorld()...)
@@ -94,23 +95,6 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 	connectOpts = append(connectOpts, idempotent()...)
 	connectOpts = append(connectOpts, openWorld()...)
 	srv.AddTool(mcpgo.NewTool("cloud_connect", connectOpts...), s.handleCloudConnect)
-
-	deviceConnectOpts := []mcpgo.ToolOption{
-		mcpgo.WithDescription("Alias for cloud_connect; connects existing MCP device tools through the Wendy Cloud tunnel"),
-		mcpgo.WithString("device_name",
-			mcpgo.Description("Device name; optional only when exactly one cloud device is available"),
-		),
-		mcpgo.WithString("cloud_grpc",
-			mcpgo.Description("Cloud gRPC endpoint to use, e.g. cloud.wendy.dev:443 (optional when a default session is set via 'wendy auth use')"),
-		),
-		mcpgo.WithString("broker_url",
-			mcpgo.Description("Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)"),
-		),
-	}
-	deviceConnectOpts = append(deviceConnectOpts, mutating()...)
-	deviceConnectOpts = append(deviceConnectOpts, idempotent()...)
-	deviceConnectOpts = append(deviceConnectOpts, openWorld()...)
-	srv.AddTool(mcpgo.NewTool("cloud_device_connect", deviceConnectOpts...), s.handleCloudConnect)
 
 	enrollOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("Enroll the currently connected device with Wendy Cloud"),
@@ -191,47 +175,6 @@ func (s *mcpServer) registerCloudTools(srv *server.MCPServer) {
 	runOpts = append(runOpts, mutating()...)
 	runOpts = append(runOpts, openWorld()...)
 	srv.AddTool(mcpgo.NewTool("run", runOpts...), s.handleRun)
-
-	cloudRunOpts := []mcpgo.ToolOption{
-		mcpgo.WithDescription("Deprecated: use run instead. Run 'wendy cloud run' for a local project and return bounded command output. The project's wendy.json entitlements apply on the device; a denied entitlement returns error_code ENTITLEMENT_DENIED."),
-		mcpgo.WithString("project_path",
-			mcpgo.Required(),
-			mcpgo.Description("Project directory containing wendy.json"),
-		),
-		mcpgo.WithString("device_name",
-			mcpgo.Description("Cloud device name"),
-		),
-		mcpgo.WithString("cloud_grpc",
-			mcpgo.Description("Cloud gRPC endpoint to use, e.g. cloud.wendy.dev:443 (optional when a default session is set via 'wendy auth use')"),
-		),
-		mcpgo.WithString("broker_url",
-			mcpgo.Description("Tunnel broker host:port (default: cloud :443 endpoint, otherwise <cloud-host>:50052)"),
-		),
-		mcpgo.WithString("build_type",
-			mcpgo.Description("Build type: docker, swift, or python"),
-		),
-		mcpgo.WithString("product",
-			mcpgo.Description("Swift Package Manager product to build and run"),
-		),
-		mcpgo.WithBoolean("debug",
-			mcpgo.Description("Enable debug logging"),
-		),
-		mcpgo.WithBoolean("deploy",
-			mcpgo.Description("Create container but do not start it"),
-		),
-		mcpgo.WithBoolean("detach",
-			mcpgo.Description("Start container but do not stream logs (default true for MCP)"),
-		),
-		mcpgo.WithNumber("timeout_seconds",
-			mcpgo.Description("Maximum command runtime in seconds (default 300)"),
-		),
-		mcpgo.WithNumber("max_bytes",
-			mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)"),
-		),
-	}
-	cloudRunOpts = append(cloudRunOpts, mutating()...)
-	cloudRunOpts = append(cloudRunOpts, openWorld()...)
-	srv.AddTool(mcpgo.NewTool("cloud_run", cloudRunOpts...), s.handleRun)
 }
 
 func (s *mcpServer) handleCloudDiscover(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -247,7 +190,7 @@ func (s *mcpServer) handleCloudDiscover(ctx context.Context, req mcpgo.CallToolR
 	for _, a := range assets {
 		out = append(out, cloudAssetToMap(a))
 	}
-	return okList("devices", out), nil
+	return okListBounded("devices", out, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleCloudConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_cloud_test.go
+++ b/go/internal/cli/mcp/tools_cloud_test.go
@@ -118,6 +118,44 @@ func TestCloudDiscover_HasStructuredContent(t *testing.T) {
 	}
 }
 
+func TestCloudDiscover_MaxBytesTruncates(t *testing.T) {
+	assets := make([]*cloudpb.Asset, 0, 200)
+	for i := int32(0); i < 200; i++ {
+		assets = append(assets, &cloudpb.Asset{
+			Id:              i,
+			OrganizationId:  7,
+			Name:            "some-padding-device-name",
+			AssetType:       "device",
+			IsComputeDevice: true,
+		})
+	}
+	fake := &fakeCloudAssetServer{assets: assets}
+	addr := startFakeCloudAssetServer(t, fake)
+	srv := New(&config.Config{
+		Auth: []config.AuthConfig{{
+			CloudGRPC: addr,
+			Certificates: []config.CertificateInfo{{
+				OrganizationID: 7,
+			}},
+		}},
+	}, nil)
+
+	result, err := srv.callTool(context.Background(), "cloud_discover", map[string]any{"max_bytes": 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("truncation is not an error result: %v", result.Content)
+	}
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent has unexpected type %T", result.StructuredContent)
+	}
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
 func TestCloud_MultipleSessions_Code(t *testing.T) {
 	srv := New(&config.Config{
 		Auth: []config.AuthConfig{
@@ -160,17 +198,6 @@ func TestCloudDiscover_RequiresCloudGRPCWhenMultipleAuthSessionsExist(t *testing
 		},
 	}, nil)
 	result, err := srv.callTool(context.Background(), "cloud_discover", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !result.IsError {
-		t.Fatal("expected error result")
-	}
-}
-
-func TestCloudRun_RequiresProjectPath(t *testing.T) {
-	srv := New(&config.Config{}, nil)
-	result, err := srv.callTool(context.Background(), "cloud_run", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -15,6 +15,7 @@ func (s *mcpServer) registerDeviceTools(srv *server.MCPServer) {
 	listOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List wendy devices from config and known addresses. Pass scan=true to also run a live 3-second mDNS scan for devices on the local network."),
 		mcpgo.WithBoolean("scan", mcpgo.Description("If true, run a live mDNS scan (3 s) in addition to returning configured devices")),
+		mcpgo.WithNumber("max_bytes", mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)")),
 	}
 	listOpts = append(listOpts, readOnly()...)
 	listOpts = append(listOpts, openWorld()...)
@@ -98,7 +99,7 @@ func (s *mcpServer) handleDeviceList(ctx context.Context, req mcpgo.CallToolRequ
 		}
 	}
 
-	return okList("devices", devices), nil
+	return okListBounded("devices", devices, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleDeviceConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_device_test.go
+++ b/go/internal/cli/mcp/tools_device_test.go
@@ -172,6 +172,26 @@ func TestDeviceList_ScanTrue_IncludesScanResults(t *testing.T) {
 	}
 }
 
+func TestDeviceList_MaxBytesTruncates(t *testing.T) {
+	auth := make([]config.AuthConfig, 0, 50)
+	for i := 0; i < 50; i++ {
+		auth = append(auth, config.AuthConfig{CloudGRPC: "some-long-device-hostname-for-padding.local:50051"})
+	}
+	srv := New(&config.Config{Auth: auth}, nil)
+
+	result, err := srv.callTool(context.Background(), "device_list", map[string]any{"max_bytes": 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("truncation is not an error result: %v", result.Content)
+	}
+	sc := structuredMap(t, result)
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
 func TestDeviceConnect_CallsConnectFn(t *testing.T) {
 	fake := &fakeAgentServer{
 		versionResp: &agentpb.GetAgentVersionResponse{Version: "1.0.0"},

--- a/go/internal/cli/mcp/tools_hardware.go
+++ b/go/internal/cli/mcp/tools_hardware.go
@@ -14,6 +14,7 @@ func (s *mcpServer) registerHardwareTools(srv *server.MCPServer) {
 		mcpgo.WithString("category",
 			mcpgo.Description("Filter by category, e.g. gpu, usb, i2c, gpio, camera (optional)"),
 		),
+		mcpgo.WithNumber("max_bytes", mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)")),
 	}
 	capsOpts = append(capsOpts, readOnly()...)
 	capsOpts = append(capsOpts, localOnly()...)
@@ -45,5 +46,5 @@ func (s *mcpServer) handleHardwareCapabilities(ctx context.Context, req mcpgo.Ca
 		}
 		caps = append(caps, entry)
 	}
-	return okList("capabilities", caps), nil
+	return okListBounded("capabilities", caps, intParam(req, "max_bytes", 100000)), nil
 }

--- a/go/internal/cli/mcp/tools_hardware_provisioning_test.go
+++ b/go/internal/cli/mcp/tools_hardware_provisioning_test.go
@@ -159,6 +159,36 @@ func TestHardwareCapabilities_EmptyList(t *testing.T) {
 	}
 }
 
+func TestHardwareCapabilities_MaxBytesTruncates(t *testing.T) {
+	caps := make([]*agentpb.ListHardwareCapabilitiesResponse_HardwareCapability, 0, 200)
+	for i := 0; i < 200; i++ {
+		caps = append(caps, &agentpb.ListHardwareCapabilitiesResponse_HardwareCapability{
+			Category:    "gpu",
+			DevicePath:  "/dev/gpu0",
+			Description: "some padding description text",
+		})
+	}
+	fake := &fakeHWProvisioningOSServer{capabilities: caps}
+	conn := startFakeHWProvisioningServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "hardware_capabilities", map[string]any{"max_bytes": 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("truncation is not an error result: %v", result.Content)
+	}
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent has unexpected type %T", result.StructuredContent)
+	}
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
+	}
+}
+
 // --- Provisioning tests ---
 
 func TestProvisioningStatus_NotConnected(t *testing.T) {

--- a/go/internal/cli/mcp/tools_wifi.go
+++ b/go/internal/cli/mcp/tools_wifi.go
@@ -12,6 +12,7 @@ import (
 func (s *mcpServer) registerWiFiTools(srv *server.MCPServer) {
 	listOpts := []mcpgo.ToolOption{
 		mcpgo.WithDescription("List available WiFi networks visible to the connected device"),
+		mcpgo.WithNumber("max_bytes", mcpgo.Description("Maximum output size in bytes before the result is truncated (default 100000)")),
 	}
 	listOpts = append(listOpts, readOnly()...)
 	listOpts = append(listOpts, openWorld()...)
@@ -55,7 +56,7 @@ func (s *mcpServer) registerWiFiTools(srv *server.MCPServer) {
 	srv.AddTool(mcpgo.NewTool("wifi_known_networks", knownOpts...), s.handleWiFiKnownNetworks)
 }
 
-func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+func (s *mcpServer) handleWiFiList(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	conn := s.GetConn()
 	if conn == nil {
 		return errNotConnected(), nil
@@ -76,7 +77,7 @@ func (s *mcpServer) handleWiFiList(ctx context.Context, _ mcpgo.CallToolRequest)
 			"priority":     n.GetPriority(),
 		})
 	}
-	return okList("networks", networks), nil
+	return okListBounded("networks", networks, intParam(req, "max_bytes", 100000)), nil
 }
 
 func (s *mcpServer) handleWiFiConnect(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
+++ b/go/internal/cli/mcp/tools_wifi_bluetooth_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"testing"
 
@@ -148,6 +149,29 @@ func TestWiFiList_HasStructuredContent(t *testing.T) {
 	}
 	if _, ok := structuredMap(t, result)["networks"]; !ok {
 		t.Error("wifi_list envelope is missing the networks key")
+	}
+}
+
+func TestWiFiList_MaxBytesTruncates(t *testing.T) {
+	networks := make([]*agentpb.ListWiFiNetworksResponse_WiFiNetwork, 0, 200)
+	for i := 0; i < 200; i++ {
+		networks = append(networks, &agentpb.ListWiFiNetworksResponse_WiFiNetwork{Ssid: "some-padding-ssid-value"})
+	}
+	fake := &fakeWiFiBluetoothServer{wifiNetworks: networks}
+	conn := startFakeAgentWiFiServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "wifi_list", map[string]any{"max_bytes": 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("truncation is not an error result: %v", result.Content)
+	}
+	sc := structuredMap(t, result)
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
 	}
 }
 
@@ -305,6 +329,32 @@ func TestBluetoothScan_HasStructuredContent(t *testing.T) {
 	}
 	if _, ok := structuredMap(t, result)["devices"]; !ok {
 		t.Error("bluetooth_scan envelope is missing the devices key")
+	}
+}
+
+func TestBluetoothScan_MaxBytesTruncates(t *testing.T) {
+	peripherals := make([]*agentpb.DiscoveredBluetoothPeripheral, 0, 200)
+	for i := 0; i < 200; i++ {
+		peripherals = append(peripherals, &agentpb.DiscoveredBluetoothPeripheral{
+			Name:    "some-padding-peripheral-name",
+			Address: fmt.Sprintf("AA:BB:CC:DD:EE:%02X", i%256),
+		})
+	}
+	fake := &fakeWiFiBluetoothServer{btPeripherals: peripherals}
+	conn := startFakeAgentWiFiServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "bluetooth_scan", map[string]any{"timeout_seconds": 2, "max_bytes": 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("truncation is not an error result: %v", result.Content)
+	}
+	sc := structuredMap(t, result)
+	if sc["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", sc["truncated"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the MCP effectiveness review (#1413/#1414/#1415 hardening series). Two mechanical fixes to the `wendy mcp serve` tool surface (`internal/cli/mcp`):

- **Removed `cloud_run` and `cloud_device_connect`.** Both were pure aliases — identical schema, dispatching to the same handler as `run` and `cloud_connect` respectively — that only added tool-selection noise for an LLM caller with zero functional difference. `cloud_run`'s description already said "Deprecated: use run instead", but a deprecation note in a tool description doesn't reduce the tool-selection surface; removing the tool does. Locked the removal in via `TestDeadTools_NotRegistered` (extended from the existing `filesync_sync` pattern).
- **Bounded 5 previously-unbounded list tools**: `device_list`, `hardware_capabilities`, `wifi_list`, `bluetooth_scan`, `cloud_discover`. Every other list/stream tool in this package (telemetry, container, run) already goes through `okResultBounded`/`okListBounded` with a `max_bytes` param from the prior MCP hardening pass — these five were the exceptions. Added the same optional `max_bytes` param (default 100000) and reused the existing `okListBounded` helper, so a large WiFi scan, BT scan, or cloud asset list can't dump an unbounded payload into the calling model's context.

## Test plan

- `go build ./...` — clean
- `go vet ./internal/cli/mcp/...` — clean
- `go test ./internal/cli/mcp/...` — all pass, including 5 new truncation tests (one per bounded tool) and the extended not-registered test

🤖 Generated with [Claude Code](https://claude.com/claude-code)