### PR TITLE
Surface a friendly error when a Mac agent's registry refuses pushes

### DIFF
--- a/go/internal/cli/commands/buildprogress.go
+++ b/go/internal/cli/commands/buildprogress.go
@@ -48,6 +48,11 @@ func runAppleContainerBuildWithProgress(ctx context.Context, dir, imageName, pla
 // failures are always surfaced to the user (no fallback rebuild follows).
 func dumpRawAlways(error) bool { return true }
 
+// dumpRawUnlessRegistryUnavailable suppresses the raw buildx replay when the
+// failure was converted to the friendly "no registry on the Mac agent" error —
+// the retried-EOF spam would bury the actionable message.
+func dumpRawUnlessRegistryUnavailable(err error) bool { return !isRegistryUnavailable(err) }
+
 // runBuildWithProgress runs build, rendering its buildx output as a clean live
 // step list (interactive) or concise per-step lines (non-interactive). The raw
 // buildx output is retained and printed if the build fails AND

--- a/go/internal/cli/commands/buildprogress_test.go
+++ b/go/internal/cli/commands/buildprogress_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -190,5 +191,19 @@ func TestShouldDumpChunkDiffBuildLog(t *testing.T) {
 		if got := shouldDumpChunkDiffBuildLog(c.chunking)(c.err); got != c.want {
 			t.Errorf("shouldDumpChunkDiffBuildLog(%q)(%v) = %v, want %v", c.chunking, c.err, got, c.want)
 		}
+	}
+}
+
+func TestDumpRawUnlessRegistryUnavailable(t *testing.T) {
+	friendly := &registryUnavailableError{host: "mac.local", dialErr: errors.New("connection refused")}
+	if dumpRawUnlessRegistryUnavailable(friendly) {
+		t.Error("raw dump not suppressed for a bare registryUnavailableError")
+	}
+	wrapped := fmt.Errorf("building service web: %w", friendly)
+	if dumpRawUnlessRegistryUnavailable(wrapped) {
+		t.Error("raw dump not suppressed for a wrapped registryUnavailableError")
+	}
+	if !dumpRawUnlessRegistryUnavailable(errors.New("plain build failure")) {
+		t.Error("raw dump suppressed for an unrelated error")
 	}
 }

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -794,8 +794,8 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		// Compose builds run sequentially, so they share the local cache dir
 		// (empty cache key) — no concurrent cache-export race to isolate.
 		composeBuildTitle := fmt.Sprintf("Building service %s for %s...", name, tui.Value(platform))
-		if err := runBuildWithProgress(ctx, composeBuildTitle, dumpRawAlways, func(stream, logw io.Writer) error {
-			return buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, "", stream, logw)
+		if err := runBuildWithProgress(ctx, composeBuildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
+			return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, "", stream, logw)
 		}); err != nil {
 			return fmt.Errorf("building service %s: %w", name, err)
 		}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/espidftoolchain"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/swifttoolchain"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -605,7 +606,7 @@ func injectDebugpy(ctx context.Context, registryAddr, registryImage, platform st
 		return fmt.Errorf("writing debugpy Dockerfile: %w", err)
 	}
 
-	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, "", streamOutput, streamOutput, useMTLS)
+	return buildAndPushImage(ctx, tmpDir, registryAddr, registryImage, platform, "", buildArgs, "", streamOutput, streamOutput, useMTLS, nil)
 }
 
 func generatePythonDockerfile(dir string, debug bool) (string, error) {
@@ -1400,7 +1401,9 @@ func buildxLocalCacheDir(userCache, cacheKey string) string {
 	return dir
 }
 
-func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+// dialErr, when non-nil, exposes the registry proxy's most recent failure to
+// reach the device registry; a refused dial short-circuits the retry loop.
+func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool, dialErr func() error) error {
 	// Serialize against other wendy processes: the buildx builder is shared, and
 	// reconfiguring or restarting it mid-build kills a concurrent build (#1017).
 	// Concurrent builds within this process share the lock via reference counting.
@@ -1551,10 +1554,14 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 			return nil
 		}
 		lastErr = err
-		// Don't retry on cancellation, on the final attempt, or for errors that
-		// don't look like a transient registry/push hiccup (a real build failure
-		// would just fail again and waste time).
-		if ctx.Err() != nil || attempt >= maxBuildPushAttempts || !isTransientPushError(capture.String()) {
+		var lastDial error
+		if dialErr != nil {
+			lastDial = dialErr()
+		}
+		if !shouldRetryPush(ctx.Err(), attempt, capture.String(), lastDial) {
+			if isDialRefused(lastDial) {
+				fmt.Fprintf(logOutput, "[buildx] device registry refused the connection; not retrying\n")
+			}
 			break
 		}
 		backoff := buildPushRetryBackoff(attempt)
@@ -1571,6 +1578,20 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 // maxBuildPushAttempts bounds how many times a fused buildx build+push is retried
 // on a transient registry/push failure (WDY-1690).
 const maxBuildPushAttempts = 3
+
+// shouldRetryPush decides whether a failed buildx build+push attempt is worth
+// retrying. Cancellation, the final attempt, and non-transient output never
+// retry; neither does a registry that actively refused the proxy's dial —
+// nothing is listening there, so every retry would fail identically.
+func shouldRetryPush(ctxErr error, attempt int, output string, dialErr error) bool {
+	if ctxErr != nil || attempt >= maxBuildPushAttempts {
+		return false
+	}
+	if isDialRefused(dialErr) {
+		return false
+	}
+	return isTransientPushError(output)
+}
 
 // buildPushRetryBackoff returns the wait before retry N+1 (2s, 4s). The tunnel
 // recovers quickly once concurrent push pressure drops, so a short linear backoff
@@ -1610,14 +1631,14 @@ func (c *capturingWriter) Write(p []byte) (int, error) {
 
 func (c *capturingWriter) String() string { return string(c.buf) }
 
-func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool) error {
+func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAddr, registryImage, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, useMTLS bool, dialErr func() error) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
 	}
 	switch normalized {
 	case imageBuilderDocker:
-		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS)
+		return buildAndPushImage(ctx, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS, dialErr)
 	case imageBuilderAppleContainer:
 		return buildAndPushImageWithAppleContainer(ctx, dir, registryImage, platform, dockerfile, buildArgs, streamOutput, logOutput, useMTLS)
 	default:
@@ -1625,12 +1646,12 @@ func buildAndPushImageWithBuilder(ctx context.Context, builder, dir, registryAdd
 	}
 }
 
-func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
 	if _, err := normalizeImageBuilder(builder); err != nil {
 		return err
 	}
 	if imageBuilderWasExplicit(builder) {
-		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
+		return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, agentOS, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 	}
 	if shouldAutoAttemptAppleContainerBuilder() {
 		// Apple Container builds don't use buildx, so the local-cache key never
@@ -1640,21 +1661,26 @@ func buildAndPushImageForAgent(ctx context.Context, conn *grpcclient.AgentConnec
 		// require Apple Container and get the startup prompt.
 		if err := checkAppleContainerBuilder(ctx); err != nil {
 			logAppleContainerFallback(logOutput, err)
-		} else if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
+		} else if err := buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, agentOS, imageBuilderAppleContainer, dir, repo, platform, dockerfile, buildArgs, "", streamOutput, logOutput); err == nil {
 			return nil
+		} else if isRegistryUnavailable(err) {
+			// The device registry refuses connections; the Docker fallback pushes
+			// to the same registry and would fail identically — surface the
+			// actionable error instead of burning a full rebuild.
+			return err
 		} else {
 			logAppleContainerFallback(logOutput, err)
 		}
 	}
-	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
+	return buildAndPushImageForAgentWithBuilder(ctx, conn, regPort, agentOS, imageBuilderDocker, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
 }
 
-func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
+func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
 		return err
 	}
-	registryAddr, cleanup, useMTLS, err := resolveRegistryForImageBuilder(ctx, conn, regPort, normalized)
+	registryAddr, cleanup, useMTLS, dialErr, err := resolveRegistryForImageBuilder(ctx, conn, regPort, normalized)
 	if err != nil {
 		return err
 	}
@@ -1662,7 +1688,10 @@ func buildAndPushImageForAgentWithBuilder(ctx context.Context, conn *grpcclient.
 
 	registryImage := fmt.Sprintf("%s/%s:latest", registryAddr, strings.ToLower(repo))
 	cliLogln("Building and pushing image with %s for %s...", imageBuilderDisplayName(normalized), platform)
-	return buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS)
+	if err := buildAndPushImageWithBuilder(ctx, normalized, dir, registryAddr, registryImage, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, useMTLS, dialErr); err != nil {
+		return maybeRegistryUnavailable(agentOS, conn.Host, dialErr, err)
+	}
+	return nil
 }
 
 func buildAndPushImageWithAppleContainer(ctx context.Context, dir, registryImage, platform, dockerfile string, buildArgs map[string]string, streamOutput, logOutput io.Writer, useMTLS bool) error {
@@ -1893,19 +1922,19 @@ func appleContainerTmpAlias(path string) (string, bool) {
 	return candidate, true
 }
 
-func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentConnection, port int, builder string) (registryAddr string, cleanup func(), useMTLS bool, err error) {
+func resolveRegistryForImageBuilder(ctx context.Context, conn *grpcclient.AgentConnection, port int, builder string) (registryAddr string, cleanup func(), useMTLS bool, dialErr func() error, err error) {
 	normalized, err := normalizeImageBuilder(builder)
 	if err != nil {
-		return "", nil, false, err
+		return "", nil, false, nil, err
 	}
 	switch normalized {
 	case imageBuilderDocker:
-		registryAddr, cleanup, err = resolveRegistryForAgent(ctx, conn, port)
-		return registryAddr, cleanup, conn.IsMTLS, err
+		registryAddr, cleanup, dialErr, err = resolveRegistryForAgent(ctx, conn, port)
+		return registryAddr, cleanup, conn.IsMTLS, dialErr, err
 	case imageBuilderAppleContainer:
 		return resolveRegistryForAppleContainer(ctx, conn, port)
 	default:
-		return "", nil, false, fmt.Errorf("unsupported image builder %q", normalized)
+		return "", nil, false, nil, fmt.Errorf("unsupported image builder %q", normalized)
 	}
 }
 
@@ -1935,8 +1964,10 @@ func registryHost(host string, port int) string {
 // the address is link-local or a routable LAN IP.
 //
 // The returned cleanup function MUST be called when the build is complete to
-// stop the proxy and release the port.
-func resolveRegistry(ctx context.Context, host string, port int) (registryAddr string, cleanup func(), err error) {
+// stop the proxy and release the port. dialErr reports the proxy's most recent
+// failure to reach the device registry (nil when there is no proxy or the last
+// attempt succeeded); it is non-nil on every nil-error return.
+func resolveRegistry(ctx context.Context, host string, port int) (registryAddr string, cleanup func(), dialErr func() error, err error) {
 	resolved := resolveRegistryIP(host)
 
 	// On Linux, buildkitd uses host networking (--driver-opt network=host) and
@@ -1947,7 +1978,7 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 		if strings.Contains(addr, ":") && !strings.HasPrefix(addr, "[") {
 			addr = "[" + addr + "]"
 		}
-		return fmt.Sprintf("%s:%d", addr, port), func() {}, nil
+		return fmt.Sprintf("%s:%d", addr, port), func() {}, func() error { return nil }, nil
 	}
 
 	// On macOS, buildkitd runs inside the Colima VM and cannot reach LAN devices
@@ -1967,11 +1998,11 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 	// Bind loopback only; the Docker VM forwards host.docker.internal to it.
 	proxy, err := startRegistryProxy(ctx, registryProxyListenAddr, target)
 	if err != nil {
-		return "", nil, fmt.Errorf("starting registry proxy: %w", err)
+		return "", nil, nil, fmt.Errorf("starting registry proxy: %w", err)
 	}
 
 	registryAddr = fmt.Sprintf("host.docker.internal:%d", proxy.Port())
-	return registryAddr, proxy.Close, nil
+	return registryAddr, proxy.Close, proxy.LastDialError, nil
 }
 
 // ensureBuildxBuilderMu serializes builder creation so that concurrent service
@@ -1979,27 +2010,38 @@ func resolveRegistry(ctx context.Context, host string, port int) (registryAddr s
 // caller would fail with "existing instance for … but no append mode".
 var ensureBuildxBuilderMu sync.Mutex
 
-// dockerRegistryProxyAddrs caches one proxy address per AgentConnection. The
+// registryProxyEntry is the cached result of resolving a device registry for
+// one AgentConnection: the stable proxy address plus the proxy's dial-error
+// accessor, so every build sharing the proxy can also inspect why pushes
+// through it are failing (e.g. a Mac agent with no container runtime).
+type registryProxyEntry struct {
+	addr    string
+	dialErr func() error
+}
+
+// dockerRegistryProxyAddrs caches one proxy entry per AgentConnection. The
 // proxy is allocated once (port 0 → OS-assigned) and reused for all pushes on
 // that connection, so the buildx builder config never changes between concurrent
 // builds and no builder teardown races can kill an in-flight push.
 var (
 	dockerRegistryProxyCacheMu sync.Mutex
-	dockerRegistryProxyAddrs   = map[*grpcclient.AgentConnection]string{}
+	dockerRegistryProxyAddrs   = map[*grpcclient.AgentConnection]registryProxyEntry{}
 )
 
 // resolveRegistryForAgent determines how Docker buildx should reach the
 // agent's registry. The proxy is started once per connection and cached so
 // concurrent pushes to the same device share a stable host:port address.
-func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), err error) {
+// dialErr reports the shared proxy's most recent failure to reach the device
+// registry; it is non-nil on every nil-error return.
+func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), dialErr func() error, err error) {
 	// Hold the lock for the entire operation so concurrent callers block rather
 	// than each starting their own proxy. Proxy creation is just a local
 	// net.Listen call, so the lock is held only briefly.
 	dockerRegistryProxyCacheMu.Lock()
 	defer dockerRegistryProxyCacheMu.Unlock()
 
-	if addr, ok := dockerRegistryProxyAddrs[conn]; ok {
-		return addr, func() {}, nil
+	if entry, ok := dockerRegistryProxyAddrs[conn]; ok {
+		return entry.addr, func() {}, entry.dialErr, nil
 	}
 
 	// Start a proxy tied to context.Background so it outlives this push and is
@@ -2008,9 +2050,9 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 	var stopProxy func()
 
 	if conn.RegistryDialer == nil {
-		addr, stopProxy, err = resolveRegistry(context.Background(), conn.Host, port)
+		addr, stopProxy, dialErr, err = resolveRegistry(context.Background(), conn.Host, port)
 		if err != nil {
-			return "", nil, err
+			return "", nil, nil, err
 		}
 	} else {
 		// Bind loopback only; the Docker VM forwards host.docker.internal to it.
@@ -2018,9 +2060,10 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 			return conn.RegistryDialer(ctx, port)
 		})
 		if proxyErr != nil {
-			return "", nil, fmt.Errorf("starting cloud registry proxy: %w", proxyErr)
+			return "", nil, nil, fmt.Errorf("starting cloud registry proxy: %w", proxyErr)
 		}
 		stopProxy = proxy.Close
+		dialErr = proxy.LastDialError
 		if runtime.GOOS == "linux" {
 			addr = fmt.Sprintf("127.0.0.1:%d", proxy.Port())
 		} else {
@@ -2028,7 +2071,7 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 		}
 	}
 
-	dockerRegistryProxyAddrs[conn] = addr
+	dockerRegistryProxyAddrs[conn] = registryProxyEntry{addr: addr, dialErr: dialErr}
 	conn.ExtraClosers = append(conn.ExtraClosers, closeFunc(func() {
 		dockerRegistryProxyCacheMu.Lock()
 		delete(dockerRegistryProxyAddrs, conn)
@@ -2036,7 +2079,7 @@ func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnecti
 		stopProxy()
 	}))
 
-	return addr, func() {}, nil
+	return addr, func() {}, dialErr, nil
 }
 
 // resolveRegistryForSwift is like resolveRegistry but for the Swift container
@@ -2201,21 +2244,21 @@ func tlsClientDialer(certPEM, keyPEM, caPEM string, dial func(context.Context) (
 	}, nil
 }
 
-func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, err error) {
+func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, dialErr func() error, err error) {
 	if conn.RegistryDialer != nil || conn.IsMTLS {
-		registryAddr, appleUseMTLS, cleanup, _, err := resolveRegistryForSwiftAgent(ctx, conn, port)
+		registryAddr, appleUseMTLS, cleanup, proxyDialErr, err := resolveRegistryForSwiftAgent(ctx, conn, port)
 		if err != nil {
-			return "", nil, false, err
+			return "", nil, false, nil, err
 		}
 		if appleUseMTLS {
 			cleanup()
-			return "", nil, false, fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry over this connection; use --builder docker")
+			return "", nil, false, nil, fmt.Errorf("Apple Container builder cannot push directly to an mTLS registry over this connection; use --builder docker")
 		}
 		if !registryAddrUsesLoopback(registryAddr) {
 			cleanup()
-			return "", nil, false, fmt.Errorf("Apple Container builder expected loopback registry proxy, got %q", registryAddr)
+			return "", nil, false, nil, fmt.Errorf("Apple Container builder expected loopback registry proxy, got %q", registryAddr)
 		}
-		return registryAddr, cleanup, false, nil
+		return registryAddr, cleanup, false, proxyDialErr, nil
 	}
 
 	targetHost := resolveRegistryIP(conn.Host)
@@ -2225,9 +2268,49 @@ func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.Agen
 	target := net.JoinHostPort(targetHost, strconv.Itoa(port))
 	proxy, proxyErr := startRegistryProxy(ctx, "127.0.0.1:0", target)
 	if proxyErr != nil {
-		return "", nil, false, fmt.Errorf("starting Apple Container registry proxy: %w", proxyErr)
+		return "", nil, false, nil, fmt.Errorf("starting Apple Container registry proxy: %w", proxyErr)
 	}
-	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, false, nil
+	return fmt.Sprintf("127.0.0.1:%d", proxy.Port()), proxy.Close, false, proxy.LastDialError, nil
+}
+
+// registryUnavailableError is a build/push failure reinterpreted as "the Mac
+// agent has no reachable container registry": the registry proxy recorded a
+// refused dial, meaning nothing was listening on the device's registry port.
+type registryUnavailableError struct {
+	host    string
+	dialErr error
+}
+
+func (e *registryUnavailableError) Error() string {
+	return fmt.Sprintf("the Mac agent at %s isn't running a container registry (%v); "+
+		"install Docker, OrbStack, or Apple's `container` CLI on the Mac — or update the "+
+		"Wendy agent there if a container runtime is already installed — to run Linux/WendyOS "+
+		"apps on it, or set \"platform\": \"darwin\" in wendy.json to run this app natively on "+
+		"the Mac instead", e.host, e.dialErr)
+}
+
+func (e *registryUnavailableError) Unwrap() error { return e.dialErr }
+
+func isRegistryUnavailable(err error) bool {
+	var r *registryUnavailableError
+	return errors.As(err, &r)
+}
+
+// maybeRegistryUnavailable reinterprets a build/push failure as "no registry on
+// the Mac agent" when the registry proxy recorded a refused dial. Darwin-only:
+// a Mac agent only runs a container registry when it found a Linux container
+// backend at startup (or is too old to serve the LAN listener at all), whereas
+// a WendyOS/Linux device always ships its container runtime as part of the OS —
+// a refused connection there is an actual fault, not a missing optional
+// dependency.
+func maybeRegistryUnavailable(agentOS, host string, dialErr func() error, buildErr error) error {
+	if !strings.EqualFold(agentOS, appconfig.PlatformDarwin) || dialErr == nil {
+		return buildErr
+	}
+	if de := dialErr(); isDialRefused(de) {
+		return &registryUnavailableError{host: host, dialErr: de}
+	}
+	return buildErr
 }
 
 // isDialRefused reports whether err looks like a TCP dial that was actively
@@ -2453,8 +2536,8 @@ func (p *registryProxy) recordDialErr(err error) {
 	p.mu.Unlock()
 }
 
-// LastDialError returns the most recent error encountered while reaching the
-// proxy's target, or nil if every connection so far has reached it.
+// LastDialError returns the error from the most recent attempt to reach the
+// proxy's target, or nil if that attempt succeeded (or none was made yet).
 func (p *registryProxy) LastDialError() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -2488,6 +2571,10 @@ func (p *registryProxy) forward(ctx context.Context, client net.Conn) {
 		p.recordDialErr(err)
 		return
 	}
+	// Clear any earlier failure so LastDialError reflects the latest attempt:
+	// a transient refusal during builder bootstrap must not misclassify a later
+	// healthy push as "registry unavailable".
+	p.recordDialErr(nil)
 	defer remote.Close()
 
 	done := make(chan struct{}, 2)

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -82,6 +83,7 @@ func TestBuildAndPushImageWithAppleContainerUsesContainerCLI(t *testing.T) {
 		io.Discard,
 		io.Discard,
 		false,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("buildAndPushImageWithBuilder: %v", err)
@@ -1311,9 +1313,12 @@ func TestResolveRegistryForAgentUsesConnectionDialer(t *testing.T) {
 		},
 	}
 
-	registryAddr, cleanup, err := resolveRegistryForAgent(ctx, conn, 5000)
+	registryAddr, cleanup, dialErr, err := resolveRegistryForAgent(ctx, conn, 5000)
 	if err != nil {
 		t.Fatalf("resolveRegistryForAgent: %v", err)
+	}
+	if dialErr == nil {
+		t.Fatal("resolveRegistryForAgent returned nil dialErr accessor")
 	}
 	defer cleanup()
 
@@ -1756,6 +1761,208 @@ func TestMTLSRegistryHTTPProxy_RecordsDialError(t *testing.T) {
 	if !isDialRefused(dialErr) {
 		t.Errorf("LastDialError = %v; want a connection-refused error", dialErr)
 	}
+}
+
+func TestMaybeRegistryUnavailable(t *testing.T) {
+	refused := fmt.Errorf("dial tcp 192.168.1.20:5555: connect: %w", syscall.ECONNREFUSED)
+	buildErr := errors.New("docker buildx build failed: exit status 1")
+
+	t.Run("darwin refused converts", func(t *testing.T) {
+		err := maybeRegistryUnavailable("darwin", "wendys-mac.local", func() error { return refused }, buildErr)
+		if !isRegistryUnavailable(err) {
+			t.Fatalf("err = %v; want registryUnavailableError", err)
+		}
+		msg := err.Error()
+		for _, want := range []string{
+			"wendys-mac.local",
+			"isn't running a container registry",
+			"update the",
+			`"platform": "darwin"`,
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("message %q missing %q", msg, want)
+			}
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			t.Error("friendly error does not unwrap to the dial error")
+		}
+	})
+	t.Run("linux refused passes through", func(t *testing.T) {
+		if err := maybeRegistryUnavailable("linux", "device.local", func() error { return refused }, buildErr); err != buildErr {
+			t.Fatalf("err = %v; want original build error", err)
+		}
+	})
+	t.Run("darwin nil accessor passes through", func(t *testing.T) {
+		if err := maybeRegistryUnavailable("darwin", "device.local", nil, buildErr); err != buildErr {
+			t.Fatalf("err = %v; want original build error", err)
+		}
+	})
+	t.Run("darwin non-refused dial error passes through", func(t *testing.T) {
+		timeout := errors.New("dial tcp: i/o timeout")
+		if err := maybeRegistryUnavailable("darwin", "device.local", func() error { return timeout }, buildErr); err != buildErr {
+			t.Fatalf("err = %v; want original build error", err)
+		}
+	})
+}
+
+func TestRegistryProxy_ClearsDialErrorOnSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dials atomic.Int32
+	proxy, err := startRegistryProxyWithDialer(ctx, "127.0.0.1:0", func(context.Context) (net.Conn, error) {
+		if dials.Add(1) == 1 {
+			return nil, fmt.Errorf("dial tcp: connect: %w", syscall.ECONNREFUSED)
+		}
+		proxySide, remoteSide := net.Pipe()
+		go func() {
+			buf := make([]byte, 4)
+			n, err := remoteSide.Read(buf)
+			if err == nil && n > 0 {
+				_, _ = remoteSide.Write(buf[:n])
+			}
+		}()
+		return proxySide, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	addr := "127.0.0.1:" + strconv.Itoa(proxy.Port())
+
+	// First connection: dial fails, error recorded.
+	c1, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	_, _ = c1.Read(buf) // proxy closes the conn on dial failure
+	c1.Close()
+	waitFor(t, "refused dial recorded", func() bool { return isDialRefused(proxy.LastDialError()) })
+
+	// Second connection succeeds: the recorded error must clear.
+	c2, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if _, err := c2.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c2.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "dial error cleared after success", func() bool { return proxy.LastDialError() == nil })
+}
+
+// waitFor polls cond every 10ms until it holds, failing the test after 2s.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestResolveRegistryForAgent_DialErrAccessorAndCacheHit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	refused := fmt.Errorf("broker tunnel: connect: %w", syscall.ECONNREFUSED)
+	conn := &grpcclient.AgentConnection{
+		Host: "refusing-device",
+		RegistryDialer: func(context.Context, int) (net.Conn, error) {
+			return nil, refused
+		},
+	}
+
+	addr1, cleanup1, dialErr1, err := resolveRegistryForAgent(ctx, conn, 5555)
+	if err != nil {
+		t.Fatalf("resolveRegistryForAgent: %v", err)
+	}
+	defer cleanup1()
+	if dialErr1 == nil {
+		t.Fatal("nil dialErr accessor on first resolve")
+	}
+	if got := dialErr1(); got != nil {
+		t.Fatalf("dialErr before any connection = %v; want nil", got)
+	}
+
+	_, port, err := net.SplitHostPort(addr1)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr1, err)
+	}
+	c, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	_, _ = c.Read(buf)
+	c.Close()
+	waitFor(t, "refused dial visible via accessor", func() bool { return isDialRefused(dialErr1()) })
+
+	// Cache hit: same address, and the accessor still reports the failure.
+	addr2, cleanup2, dialErr2, err := resolveRegistryForAgent(ctx, conn, 5555)
+	if err != nil {
+		t.Fatalf("resolveRegistryForAgent (cache hit): %v", err)
+	}
+	defer cleanup2()
+	if addr2 != addr1 {
+		t.Fatalf("cache hit addr = %q; want %q", addr2, addr1)
+	}
+	if dialErr2 == nil || !isDialRefused(dialErr2()) {
+		t.Fatal("cache hit accessor does not report the recorded refusal")
+	}
+}
+
+func TestResolveRegistryForAppleContainer_RecordsDialRefused(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Reserve then release a port so dialing it is refused.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadPort, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln.Close()
+
+	conn := &grpcclient.AgentConnection{Host: "127.0.0.1"}
+	addr, cleanup, useMTLS, dialErr, err := resolveRegistryForAppleContainer(ctx, conn, deadPort)
+	if err != nil {
+		t.Fatalf("resolveRegistryForAppleContainer: %v", err)
+	}
+	defer cleanup()
+	if useMTLS {
+		t.Fatal("plain-LAN branch returned useMTLS = true")
+	}
+	if dialErr == nil {
+		t.Fatal("nil dialErr accessor")
+	}
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	_, _ = c.Read(buf)
+	c.Close()
+	waitFor(t, "refused dial recorded", func() bool { return isDialRefused(dialErr()) })
 }
 
 func TestFindIPv4ViaNeighborTable_UnknownAddress(t *testing.T) {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -315,7 +315,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	failed, buildErr := buildServicesParallel(ctx, conn, regPort, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, opts.maxConcurrency)
+	failed, buildErr := buildServicesParallel(ctx, conn, regPort, agentOS, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, opts.maxConcurrency)
 	if buildErr != nil {
 		return buildErr
 	}
@@ -461,6 +461,7 @@ func buildServicesParallel(
 	ctx context.Context,
 	conn *grpcclient.AgentConnection,
 	regPort int,
+	agentOS string,
 	cwd, appID string,
 	services map[string]*appconfig.ServiceConfig,
 	platform string,
@@ -563,7 +564,7 @@ func buildServicesParallel(
 				// Pass the per-service repo as the build's cache key so each concurrent
 				// build gets its own isolated local buildx cache dir (WDY-1689); sharing
 				// one dir corrupts BuildKit's cache-export ingest store under concurrency.
-				err = buildServiceImage(ctx, conn, regPort, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOutW)
+				err = buildServiceImage(ctx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOutW)
 			}
 			dur := time.Since(start)
 
@@ -603,7 +604,9 @@ func buildServicesParallel(
 	for r := range results {
 		if r.err != nil {
 			failed[r.name] = r.err
-			if r.log != "" {
+			// Skip the raw replay for the friendly "no registry on the Mac agent"
+			// error — the retried-push spam would bury the actionable message.
+			if r.log != "" && !isRegistryUnavailable(r.err) {
 				fmt.Fprintf(os.Stderr, "\n[%s] build log:\n%s", r.name, r.log)
 			}
 		}

--- a/go/internal/cli/commands/pushretry_test.go
+++ b/go/internal/cli/commands/pushretry_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
+)
 
 func TestIsTransientPushError(t *testing.T) {
 	transient := []string{
@@ -72,6 +76,33 @@ func TestResolveBuildConcurrency(t *testing.T) {
 	for _, tt := range tests {
 		if got := resolveBuildConcurrency(tt.buildCount, tt.override); got != tt.want {
 			t.Errorf("resolveBuildConcurrency(%d, %d) = %d, want %d", tt.buildCount, tt.override, got, tt.want)
+		}
+	}
+}
+
+func TestShouldRetryPush(t *testing.T) {
+	transientOut := `unexpected EOF`
+	buildFailOut := `ERROR: failed to solve: process "/bin/sh -c go build" did not complete successfully: exit code: 1`
+	refused := fmt.Errorf("dial tcp 192.168.1.20:5555: connect: connection refused")
+
+	tests := []struct {
+		name    string
+		ctxErr  error
+		attempt int
+		output  string
+		dialErr error
+		want    bool
+	}{
+		{"transient output retries", nil, 1, transientOut, nil, true},
+		{"refused dial never retries", nil, 1, transientOut, refused, false},
+		{"non-transient output does not retry", nil, 1, buildFailOut, nil, false},
+		{"cancelled context does not retry", context.Canceled, 1, transientOut, nil, false},
+		{"final attempt does not retry", nil, maxBuildPushAttempts, transientOut, nil, false},
+		{"non-refused dial error still retries transient", nil, 1, transientOut, fmt.Errorf("dial tcp: i/o timeout"), true},
+	}
+	for _, tt := range tests {
+		if got := shouldRetryPush(tt.ctxErr, tt.attempt, tt.output, tt.dialErr); got != tt.want {
+			t.Errorf("%s: shouldRetryPush = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1576,9 +1576,14 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// Single-service build: no concurrency, so keep the shared local cache dir
 	// (empty cache key) for cross-run cache reuse.
 	buildTitle := fmt.Sprintf("Building and pushing image for %s...", tui.Value(platform))
-	if err := runBuildWithProgress(ctx, buildTitle, dumpRawAlways, func(stream, logw io.Writer) error {
-		return buildAndPushImageForAgent(ctx, conn, regPort, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
+	if err := runBuildWithProgress(ctx, buildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
+		return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
 	}); err != nil {
+		if isRegistryUnavailable(err) {
+			// Return the friendly error bare (matching the Swift path above) —
+			// the "building and pushing image" prefix adds nothing to it.
+			return err
+		}
 		return fmt.Errorf("building and pushing image: %w", err)
 	}
 

--- a/go/internal/cli/commands/stress_test.go
+++ b/go/internal/cli/commands/stress_test.go
@@ -121,7 +121,7 @@ func TestBuildServicesParallelStress(t *testing.T) {
 	built := map[string]int{}
 	orig := buildServiceImage
 	defer func() { buildServiceImage = orig }()
-	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, repo, _, _ string, _ map[string]string, _ string, _, _ io.Writer) error {
+	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, repo, _, _ string, _ map[string]string, _ string, _, _ io.Writer) error {
 		name := repoToName(repo)
 		mu.Lock()
 		built[name]++
@@ -134,7 +134,7 @@ func TestBuildServicesParallelStress(t *testing.T) {
 
 	maxConc := 1 + r.Intn(8)
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, root, appID, services, "linux/arm64", nil, "docker", skip, maxConc)
+		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", skip, maxConc)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}


### PR DESCRIPTION
## Problem

Deploying a Dockerfile/Python app to a Mac agent whose registry refuses connections (no container runtime installed, or an agent that predates the LAN registry listener) burned three "transient registry/push error" retries and dumped ~300 lines of raw buildx EOF spam. The Swift-build path already had a friendly explanation for this exact case via the registry proxy's `LastDialError`; the docker-buildx path discarded that accessor.

## Fix

- Thread a `dialErr func() error` accessor through `resolveRegistry` / `resolveRegistryForAgent` (the per-connection cache now stores `{addr, dialErr}`) / `resolveRegistryForImageBuilder` / `resolveRegistryForAppleContainer`.
- Clear the proxy's recorded dial error on a successful dial, so a transient bootstrap refusal can't misclassify a later healthy push.
- At the single choke point all three docker-push callers converge on (`buildAndPushImageForAgentWithBuilder`), convert refused-dial failures on **darwin agents only** into a typed `registryUnavailableError` telling the user to install Docker/OrbStack/Apple `container` — or update the Wendy agent — or set `platform: "darwin"`. Linux devices keep raw errors (they always ship a runtime; refused there is a real fault).
- Short-circuit the push retry loop on a refused dial (`shouldRetryPush`) — retrying a port with nothing listening can never succeed.
- Suppress the raw buildx replay (and multibuild's per-service log replay) when the friendly error fires so it isn't buried.
- Return the friendly error directly from the Apple Container auto-attempt instead of burning a doomed Docker fallback rebuild.

## Verification

- New unit tests: `TestShouldRetryPush`, `TestMaybeRegistryUnavailable`, `TestDumpRawUnlessRegistryUnavailable`, `TestRegistryProxy_ClearsDialErrorOnSuccess`, `TestResolveRegistryForAgent_DialErrAccessorAndCacheHit`, `TestResolveRegistryForAppleContainer_RecordsDialRefused`; full `internal/cli` suite green; `gofmt` clean.
- Live-verified against a real headless Mac mini (provisioned agent without the registry listener): `wendy run` in Examples/HelloPython now fails in a single attempt with the actionable message and no EOF spam, for both the docker and apple-container builder paths.

Companion agent-side fix (makes LAN deploys actually work): #1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)