### PR TITLE
Serve the Mac agent registry on the LAN with mTLS when provisioned

### DIFF
--- a/swift/WendyAgentCore/Package.swift
+++ b/swift/WendyAgentCore/Package.swift
@@ -50,6 +50,8 @@ let package = Package(
                 .product(name: "GRPCCore", package: "grpc-swift-2"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
             ],
             path: "Tests/WendyAgentTests",
             swiftSettings: swiftSettings
@@ -66,6 +68,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "X509", package: "swift-certificates"),
                 .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdTLS", package: "hummingbird"),
                 .target(name: "WendyAgentGRPC"),
                 .target(name: "WendyCloudGRPC"),
             ],

--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/AgentImageRegistry.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/AgentImageRegistry.swift
@@ -2,6 +2,8 @@ import Crypto
 import Foundation
 import HTTPTypes
 import Hummingbird
+import HummingbirdCore
+import HummingbirdTLS
 import Logging
 import NIOCore
 
@@ -14,14 +16,43 @@ import NIOCore
 /// server. The behavior contract is what matters here — routes, statuses,
 /// digest verification, and `Location` headers — verified end-to-end in
 /// Task 9.
+///
+/// One instance serves one listener. The agent runs two over a shared
+/// `BlobStore` (see `LocalRegistryRef`): a wildcard push listener (plain HTTP
+/// unprovisioned, TLS + client-cert verification provisioned) and a
+/// loopback-only plain-HTTP pull listener for the on-device container
+/// backends. Blob and manifest writes are digest-addressed and atomic, so two
+/// instances over one store directory are concurrent-safe; the in-memory
+/// chunked-upload sessions are per-instance, which is fine because only the
+/// push listener registers write routes.
 struct AgentImageRegistry: Sendable {
+    /// One listener's shape: where it binds, whether it terminates TLS, and
+    /// which route set it exposes.
+    struct ListenerConfiguration: Sendable {
+        enum Routes: Sendable {
+            /// Full OCI push+pull surface (uploads, manifest PUT, reads).
+            case pushAndPull
+            /// Read-only surface (blob/manifest GET+HEAD, /v2 check).
+            case pullOnly
+        }
+
+        var host: String
+        var port: Int
+        /// Non-nil terminates TLS with the device identity and verifies client
+        /// certificates; nil serves plain HTTP.
+        var tls: RegistryTLS.Configuration?
+        var routes: Routes
+        /// Short name ("push"/"pull") for log lines.
+        var label: String
+    }
+
     /// Maximum accepted blob size (container image layers can be several GiB).
     private static let maxBlobSize = 8 * 1024 * 1024 * 1024
     /// Maximum accepted manifest size (JSON, always small).
     private static let maxManifestSize = 16 * 1024 * 1024
 
     private let store: BlobStore
-    private let port: Int
+    private let configuration: ListenerConfiguration
     private let logger = Logger(label: "sh.wendy.agent.registry")
     private let uploads = UploadBuffers()
 
@@ -44,9 +75,9 @@ struct AgentImageRegistry: Sendable {
             as? String ?? "application/vnd.oci.image.manifest.v1+json"
     }
 
-    init(store: BlobStore, port: Int = 5555) {
+    init(store: BlobStore, configuration: ListenerConfiguration) {
         self.store = store
-        self.port = port
+        self.configuration = configuration
     }
 
     /// Accumulates in-progress chunked uploads keyed by upload UUID.
@@ -68,19 +99,100 @@ struct AgentImageRegistry: Sendable {
         }
     }
 
-    func run() async throws {
+    /// Builds the route table. Write routes (blob uploads, manifest PUT) are
+    /// registered only for `.pushAndPull` listeners; the pull listener exposes
+    /// just the read surface the container backends need.
+    func buildRouter() -> Router<BasicRequestContext> {
         let router = Router()
         router.addMiddleware {
             LogRequestsMiddleware(.info)
         }
         let store = self.store
-        let uploads = self.uploads
-        let maxBlobSize = Self.maxBlobSize
-        let maxManifestSize = Self.maxManifestSize
 
         router.get("/v2") { _, _ in
             Response(status: .ok)
         }
+
+        if case .pushAndPull = self.configuration.routes {
+            self.addWriteRoutes(to: router)
+        }
+
+        router.head("/v2/{repo}/blobs/{digest}") { _, context -> Response in
+            let digest = context.parameters.get("digest") ?? ""
+            guard BlobStore.isValidSHA256Digest(digest) else { return Response(status: .notFound) }
+            guard store.hasBlob(digest: digest) else { return Response(status: .notFound) }
+            return Response(
+                status: .ok,
+                headers: [
+                    .contentType: "application/octet-stream",
+                    Self.dockerContentDigest: digest,
+                ]
+            )
+        }
+
+        router.get("/v2/{repo}/blobs/{digest}") { _, context -> Response in
+            let digest = context.parameters.get("digest") ?? ""
+            guard BlobStore.isValidSHA256Digest(digest) else { return Response(status: .notFound) }
+            guard let data = store.readBlob(digest: digest) else {
+                return Response(status: .notFound)
+            }
+            return Response(
+                status: .ok,
+                headers: [
+                    .contentType: "application/octet-stream",
+                    Self.dockerContentDigest: digest,
+                ],
+                body: .init(byteBuffer: ByteBuffer(bytes: data))
+            )
+        }
+
+        router.head("/v2/{repo}/manifests/{reference}") { _, context -> Response in
+            let repo = context.parameters.get("repo") ?? ""
+            let reference = context.parameters.get("reference") ?? ""
+            guard BlobStore.isValidRepository(repo), BlobStore.isValidReference(reference) else {
+                return Response(status: .notFound)
+            }
+            guard let url = store.manifestURL(repository: repo, reference: reference),
+                let data = try? Data(contentsOf: url)
+            else { return Response(status: .notFound) }
+            return Response(
+                status: .ok,
+                headers: [
+                    .contentType: Self.manifestMediaType(data),
+                    Self.dockerContentDigest: Self.contentDigest(of: data),
+                ]
+            )
+        }
+
+        router.get("/v2/{repo}/manifests/{reference}") { _, context -> Response in
+            let repo = context.parameters.get("repo") ?? ""
+            let reference = context.parameters.get("reference") ?? ""
+            guard BlobStore.isValidRepository(repo), BlobStore.isValidReference(reference) else {
+                return Response(status: .notFound)
+            }
+            guard let url = store.manifestURL(repository: repo, reference: reference),
+                let data = try? Data(contentsOf: url)
+            else { return Response(status: .notFound) }
+            // Content-Type must echo the stored manifest's mediaType; default to OCI.
+            return Response(
+                status: .ok,
+                headers: [
+                    .contentType: Self.manifestMediaType(data),
+                    Self.dockerContentDigest: Self.contentDigest(of: data),
+                ],
+                body: .init(byteBuffer: ByteBuffer(bytes: data))
+            )
+        }
+
+        return router
+    }
+
+    /// Registers the push-side (write) routes: blob uploads and manifest PUT.
+    private func addWriteRoutes(to router: Router<BasicRequestContext>) {
+        let store = self.store
+        let uploads = self.uploads
+        let maxBlobSize = Self.maxBlobSize
+        let maxManifestSize = Self.maxManifestSize
 
         // Begin an upload session, or perform a monolithic push when `digest`
         // is supplied on the initial POST (the whole blob is the body).
@@ -139,35 +251,6 @@ struct AgentImageRegistry: Sendable {
             )
         }
 
-        router.head("/v2/{repo}/blobs/{digest}") { _, context -> Response in
-            let digest = context.parameters.get("digest") ?? ""
-            guard BlobStore.isValidSHA256Digest(digest) else { return Response(status: .notFound) }
-            guard store.hasBlob(digest: digest) else { return Response(status: .notFound) }
-            return Response(
-                status: .ok,
-                headers: [
-                    .contentType: "application/octet-stream",
-                    Self.dockerContentDigest: digest,
-                ]
-            )
-        }
-
-        router.get("/v2/{repo}/blobs/{digest}") { _, context -> Response in
-            let digest = context.parameters.get("digest") ?? ""
-            guard BlobStore.isValidSHA256Digest(digest) else { return Response(status: .notFound) }
-            guard let data = store.readBlob(digest: digest) else {
-                return Response(status: .notFound)
-            }
-            return Response(
-                status: .ok,
-                headers: [
-                    .contentType: "application/octet-stream",
-                    Self.dockerContentDigest: digest,
-                ],
-                body: .init(byteBuffer: ByteBuffer(bytes: data))
-            )
-        }
-
         router.put("/v2/{repo}/manifests/{reference}") { request, context -> Response in
             let repo = context.parameters.get("repo") ?? ""
             let reference = context.parameters.get("reference") ?? ""
@@ -182,50 +265,47 @@ struct AgentImageRegistry: Sendable {
             )
             return Response(status: .created)
         }
+    }
 
-        router.head("/v2/{repo}/manifests/{reference}") { _, context -> Response in
-            let repo = context.parameters.get("repo") ?? ""
-            let reference = context.parameters.get("reference") ?? ""
-            guard BlobStore.isValidRepository(repo), BlobStore.isValidReference(reference) else {
-                return Response(status: .notFound)
-            }
-            guard let url = store.manifestURL(repository: repo, reference: reference),
-                let data = try? Data(contentsOf: url)
-            else { return Response(status: .notFound) }
-            return Response(
-                status: .ok,
-                headers: [
-                    .contentType: Self.manifestMediaType(data),
-                    Self.dockerContentDigest: Self.contentDigest(of: data),
-                ]
-            )
+    /// Builds the Hummingbird application for this listener. Throws when the
+    /// TLS configuration is present but unusable (bad PEM) — callers must
+    /// treat that as "listener stays down", never fall back to plain HTTP.
+    ///
+    /// The "listening" log fires from `onServerRunning` so it reports the
+    /// actually-bound address (tests bind port 0).
+    func buildApplication(
+        onServerRunning: @escaping @Sendable (any Channel) async -> Void = { _ in }
+    ) throws -> Application<RouterResponder<BasicRequestContext>> {
+        let server: HTTPServerBuilder
+        if let tls = self.configuration.tls {
+            server = try .tls(.http1(), configuration: RegistryTLS.channelConfiguration(tls))
+        } else {
+            server = .http1()
         }
-
-        router.get("/v2/{repo}/manifests/{reference}") { _, context -> Response in
-            let repo = context.parameters.get("repo") ?? ""
-            let reference = context.parameters.get("reference") ?? ""
-            guard BlobStore.isValidRepository(repo), BlobStore.isValidReference(reference) else {
-                return Response(status: .notFound)
+        let logger = self.logger
+        let label = self.configuration.label
+        let scheme = self.configuration.tls == nil ? "http" : "https"
+        return Application(
+            router: self.buildRouter(),
+            server: server,
+            configuration: .init(
+                address: .hostname(self.configuration.host, port: self.configuration.port)
+            ),
+            onServerRunning: { channel in
+                logger.info(
+                    "Agent image registry listening",
+                    metadata: [
+                        "listener": "\(label)",
+                        "scheme": "\(scheme)",
+                        "address": "\(channel.localAddress.map(String.init(describing:)) ?? "unknown")",
+                    ]
+                )
+                await onServerRunning(channel)
             }
-            guard let url = store.manifestURL(repository: repo, reference: reference),
-                let data = try? Data(contentsOf: url)
-            else { return Response(status: .notFound) }
-            // Content-Type must echo the stored manifest's mediaType; default to OCI.
-            return Response(
-                status: .ok,
-                headers: [
-                    .contentType: Self.manifestMediaType(data),
-                    Self.dockerContentDigest: Self.contentDigest(of: data),
-                ],
-                body: .init(byteBuffer: ByteBuffer(bytes: data))
-            )
-        }
-
-        let app = Application(
-            router: router,
-            configuration: .init(address: .hostname("127.0.0.1", port: port))
         )
-        logger.info("Agent image registry listening", metadata: ["port": "\(port)"])
-        try await app.runService()
+    }
+
+    func run() async throws {
+        try await self.buildApplication().runService()
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/LocalRegistryRef.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/LocalRegistryRef.swift
@@ -1,0 +1,40 @@
+/// The agent's embedded registry listens on two ports (see `AgentImageRegistry`):
+///
+/// - **Push** (`pushPort`, all interfaces): where the CLI pushes images —
+///   plain HTTP while unprovisioned, HTTPS with client-certificate
+///   verification once provisioned. This is the port baked into the image
+///   references the CLI sends (`localhost:5555/<app>:latest`).
+/// - **Pull** (`pullPort`, loopback only, always plain HTTP): where the
+///   on-device Linux container backends (Apple `container`, Docker) pull
+///   from. Backends can't present client certificates, so they must never
+///   hit the push listener once it speaks TLS.
+///
+/// `rewriteForLocalPull` bridges the two: CLI-sent references keep the push
+/// port for a stable client-facing contract (and for apps installed before
+/// the split), and are rewritten to the pull listener at the moment the
+/// agent hands them to a backend.
+enum LocalRegistryRef {
+    static let pushPort = 5555
+    static let pullPort = 5556
+    static let pullHost = "127.0.0.1"
+
+    /// Authorities (the part of an image reference before the first `/`) that
+    /// designate this device's own push listener.
+    private static let localPushAuthorities: Set<String> = [
+        "localhost:\(pushPort)",
+        "127.0.0.1:\(pushPort)",
+        "[::1]:\(pushPort)",
+    ]
+
+    /// Rewrites a device-local push-port image reference
+    /// (`localhost:5555/<repo>...`) to the loopback pull listener
+    /// (`127.0.0.1:5556/<repo>...`). Any other reference — remote registries,
+    /// `sha256:` digests, legacy bare binary names — is returned unchanged.
+    /// Tags and `@sha256:` digest suffixes after the first `/` are preserved.
+    static func rewriteForLocalPull(_ ref: String) -> String {
+        guard let slash = ref.firstIndex(of: "/") else { return ref }
+        let authority = String(ref[..<slash])
+        guard localPushAuthorities.contains(authority) else { return ref }
+        return "\(pullHost):\(pullPort)\(ref[slash...])"
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
@@ -1,0 +1,102 @@
+import Foundation
+import HummingbirdTLS
+import Logging
+import NIOCore
+import NIOSSL
+
+/// Builds the TLS server configuration for the registry's push listener from
+/// the device's provisioned identity, mirroring the main gRPC server's mTLS
+/// setup (`WendyAgent.mTLSSecurity`): serve `[leaf, chain]`, demand a client
+/// certificate, and fully replace BoringSSL's chain validation with
+/// `ClientCertAuthorizer` (trust-root path verification + org-enforcement
+/// policy, failing closed).
+enum RegistryTLS {
+    /// Plain-`Sendable` inputs captured at configuration time; PEM parsing (and
+    /// its failure modes) happens later in `channelConfiguration`, inside the
+    /// listener's `run()`, where errors surface in the listener's error path.
+    struct Configuration: Sendable {
+        var certPEM: String
+        var chainPEM: String
+        var keyPEM: String
+        var deviceOrg: Int32?
+        var orgMode: ClientCertAuthorizer.OrgEnforcementMode
+    }
+
+    /// Derives the verification policy exactly like the gRPC server: the
+    /// device's org comes from its own leaf certificate (nil fails closed in
+    /// `ClientCertAuthorizer`), and the org-enforcement mode comes from
+    /// `WENDY_MTLS_ORG_ENFORCEMENT` (off|grace|strict, defaulting to grace).
+    static func makeConfiguration(
+        certs: ProvisioningService.ProvisioningCerts,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        logger: Logger
+    ) -> Configuration {
+        let deviceOrg = ClientCertAuthorizer.organizationID(fromLeafPEM: certs.certPEM)
+        if deviceOrg == nil {
+            logger.error(
+                "Could not determine device organization from its own certificate; the registry push listener will reject all clients (fail closed). Re-provision the device to recover."
+            )
+        }
+        let rawOrgEnforcement = environment["WENDY_MTLS_ORG_ENFORCEMENT"]
+        let (orgMode, recognized) = ClientCertAuthorizer.OrgEnforcementMode.parse(rawOrgEnforcement)
+        if !recognized {
+            logger.warning(
+                "Unrecognized WENDY_MTLS_ORG_ENFORCEMENT value; defaulting to grace",
+                metadata: ["value": "\(rawOrgEnforcement ?? "")"]
+            )
+        }
+        return Configuration(
+            certPEM: certs.certPEM,
+            chainPEM: certs.chainPEM,
+            keyPEM: certs.keyPEM,
+            deviceOrg: deviceOrg,
+            orgMode: orgMode
+        )
+    }
+
+    /// Builds the Hummingbird TLS channel configuration. Throws on unparseable
+    /// PEM — callers must treat that as "listener stays down", never as a
+    /// license to fall back to plain HTTP on a non-loopback interface.
+    ///
+    /// `certificateVerification = .noHostnameVerification` (rather than
+    /// `.noVerification`) is load-bearing: it requires the client to present a
+    /// certificate, and NIOSSL only invokes `customVerificationCallback` when
+    /// verification is not disabled. The callback fully REPLACES BoringSSL's
+    /// chain validation, so `ClientCertAuthorizer` performs the complete
+    /// verification itself and fails closed.
+    static func channelConfiguration(_ config: Configuration) throws -> TLSChannelConfiguration {
+        let leafCerts = try NIOSSLCertificate.fromPEMBytes(Array(config.certPEM.utf8))
+        let chainCerts = try NIOSSLCertificate.fromPEMBytes(Array(config.chainPEM.utf8))
+        guard let leaf = leafCerts.first else {
+            throw NIOSSLError.failedToLoadCertificate
+        }
+        let key = try NIOSSLPrivateKey(bytes: Array(config.keyPEM.utf8), format: .pem)
+
+        var tls = TLSConfiguration.makeServerConfiguration(
+            certificateChain: ([leaf] + leafCerts.dropFirst() + chainCerts).map { .certificate($0) },
+            privateKey: .privateKey(key)
+        )
+        tls.minimumTLSVersion = .tlsv12
+        tls.certificateVerification = .noHostnameVerification
+        tls.trustRoots = .certificates(chainCerts)
+
+        let trustRootsPEM = config.chainPEM
+        let deviceOrg = config.deviceOrg
+        let orgMode = config.orgMode
+        return TLSChannelConfiguration(
+            tlsConfiguration: tls,
+            customVerificationCallback: { peerCertificates, promise in
+                let ders = peerCertificates.compactMap { try? $0.toDERBytes() }
+                Task {
+                    let authorized = await ClientCertAuthorizer.isAuthorized(
+                        peerCertificatesDER: ders,
+                        trustRootsPEM: trustRootsPEM,
+                        deviceOrg: deviceOrg,
+                        mode: orgMode
+                    )
+                    promise.succeed(authorized ? .certificateVerified : .failed)
+                }
+            }
+        )
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -881,17 +881,32 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             let process: Foundation.Process
             let stdoutPipe: Pipe
             let stderrPipe: Pipe
+            // Stored image refs keep what the CLI sent (`localhost:5555/...`,
+            // the push listener); backends must pull from the loopback pull
+            // listener instead, so rewrite at use time. This also fixes apps
+            // installed before the push/pull port split with no migration.
+            let imageRef = LocalRegistryRef.rewriteForLocalPull(container.imageName)
+            if imageRef != container.imageName {
+                logger.info(
+                    "Rewriting local registry image ref for on-device pull",
+                    metadata: [
+                        "app_name": "\(appName)",
+                        "from": "\(container.imageName)",
+                        "to": "\(imageRef)",
+                    ]
+                )
+            }
             do {
                 // Pull first, then create+start. Both shell out to the Linux
                 // runtime CLI, which throws a plain `Error` (e.g. a nonzero exit
                 // with stderr) on failure. Wrap those in `RPCError` so the client
                 // sees the actionable message — an un-wrapped error surfaces as
                 // gRPC's opaque "Service method threw an unknown error." instead.
-                try await linuxBackend.pull(image: container.imageName)
+                try await linuxBackend.pull(image: imageRef)
                 self.prepareAppForLaunch(id: appName, launchToken: launchToken)
                 (process, stdoutPipe, stderrPipe) = try await linuxBackend.createAndStart(
                     appName: appName,
-                    imageName: container.imageName,
+                    imageName: imageRef,
                     appConfig: container.appConfig,
                     terminationHandler: self.makeTerminationHandler(
                         forAppID: appName,

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -56,25 +56,21 @@ public actor WendyAgent {
         do {
             let backend = await self.makeLinuxBackend()
 
-            if backend != nil, self.registryTask == nil {
-                let registry = AgentImageRegistry(
-                    store: BlobStore(root: WendyAgentPaths.stateDirectory)
-                )
-                self.registryTask = Task {
-                    do {
-                        try await registry.run()
-                    } catch {
-                        self.logger.error("Registry stopped", metadata: ["error": "\(error)"])
-                    }
-                }
-            }
-
             try await self.startMainServer(
                 linuxBackend: backend,
                 broadcaster: broadcaster
             )
             try await self.startOTelServer(broadcaster: broadcaster)
             try await self.startBonjour()
+
+            // Registry listeners come after startMainServer: the push listener
+            // reads the provisioned identity from provisioningService, which
+            // startMainServer creates. Best-effort — a failed registry bind
+            // must not brick native-app management on the device.
+            if backend != nil {
+                self.startPullRegistryIfNeeded()
+                await self.startPushRegistry()
+            }
 
             self.runIdentifier &+= 1
             self.handlingUnexpectedRuntimeExit = false
@@ -112,9 +108,7 @@ public actor WendyAgent {
         await self.stopOTelServer()
         await self.stopMainServer()
 
-        self.registryTask?.cancel()
-        await self.registryTask?.value
-        self.registryTask = nil
+        await self.stopRegistryListeners()
 
         self.clearRuntimeState()
         self.updateStatus(.stopped)
@@ -169,14 +163,20 @@ public actor WendyAgent {
     private var mainServer: PosixGRPCServer?
     private var mainServerTask: Task<Void, any Error>?
     private var containerService: ContainerService?
-    /// The embedded OCI registry serving `localhost:5555` for Linux container
-    /// image pushes/pulls. Started once, in `start()`, for the lifetime of the
-    /// process — it does not depend on the main gRPC server's plaintext/mTLS
-    /// mode, so it is deliberately NOT torn down/rebuilt by `switchMainServer()`
-    /// (which only stops/starts the main server). It is only cancelled (and
-    /// awaited, so the port is released) on a full agent stop or a failed
-    /// startup, via `rollbackStartup()`/`stop()`.
-    private var registryTask: Task<Void, Never>?
+    /// The embedded OCI registry's loopback pull listener
+    /// (`127.0.0.1:5556`, plain HTTP, read-only routes) that the on-device
+    /// Linux container backends pull from. Started once and kept for the
+    /// process lifetime — it never changes shape, so provisioning transitions
+    /// leave it alone. Cancelled (and awaited, so the port is released) only
+    /// on a full agent stop or a failed startup.
+    private var pullRegistryTask: Task<Void, Never>?
+    /// The registry's wildcard push listener (port 5555, all interfaces) that
+    /// the CLI pushes images to: plain HTTP while unprovisioned, TLS with
+    /// client-certificate verification once provisioned. Unlike the pull
+    /// listener it IS restarted on provisioning transitions (via
+    /// `switchMainServer()` → `startPushRegistry()`) so its scheme tracks the
+    /// device's provisioning state, mirroring the Linux agent's registry.
+    private var pushRegistryTask: Task<Void, Never>?
 
     /// The cloud tunnel-broker presence/relay loop, tied to the mTLS main
     /// server's lifetime: started in `startMainServer` when the server comes up
@@ -643,6 +643,16 @@ public actor WendyAgent {
             return
         }
 
+        // Restart the push listener so its scheme (plain HTTP vs mTLS) tracks
+        // the new provisioning state; the loopback pull listener never changes
+        // shape. Runs only from this detached-task context, never inside the
+        // provisioning RPC, so awaiting the old listener's shutdown here cannot
+        // deadlock the RPC that triggered the switch.
+        if backend != nil {
+            self.startPullRegistryIfNeeded()
+            await self.startPushRegistry()
+        }
+
         self.runIdentifier &+= 1
         self.handlingUnexpectedRuntimeExit = false
         self.startMonitorTask(runIdentifier: self.runIdentifier)
@@ -651,6 +661,98 @@ public actor WendyAgent {
             "Main server switched",
             metadata: ["mtls": "\(self.mainServerIsMTLS)"]
         )
+    }
+
+    /// Starts the loopback pull listener (`127.0.0.1:5556`, plain HTTP,
+    /// read-only routes) once per process. Best-effort: a bind failure is
+    /// logged with a port-in-use hint but never fails agent startup.
+    private func startPullRegistryIfNeeded() {
+        guard self.pullRegistryTask == nil else { return }
+        let registry = AgentImageRegistry(
+            store: BlobStore(root: WendyAgentPaths.stateDirectory),
+            configuration: .init(
+                host: LocalRegistryRef.pullHost,
+                port: LocalRegistryRef.pullPort,
+                tls: nil,
+                routes: .pullOnly,
+                label: "pull"
+            )
+        )
+        let logger = self.logger
+        self.pullRegistryTask = Task {
+            do {
+                try await registry.run()
+            } catch {
+                Self.logRegistryListenerStopped(
+                    logger, listener: "pull", port: LocalRegistryRef.pullPort, error: error)
+            }
+        }
+    }
+
+    /// (Re)starts the wildcard push listener (port 5555, all interfaces):
+    /// plain HTTP while unprovisioned, TLS with client-certificate
+    /// verification once provisioned. Always stop-then-start so a provisioning
+    /// transition swaps the scheme (mirroring the Linux agent's registry
+    /// restart). Fail closed: if the device is provisioned but its TLS
+    /// material is unusable, `run()` throws and the listener stays DOWN — it
+    /// never falls back to plain HTTP on a non-loopback interface. Best-effort
+    /// beyond that: a bind failure (e.g. a stale `wendy-registry` Docker
+    /// container squatting on 5555) must not brick native-app management or
+    /// provisioning, so it is logged, not fatal.
+    private func startPushRegistry() async {
+        self.pushRegistryTask?.cancel()
+        await self.pushRegistryTask?.value
+        self.pushRegistryTask = nil
+
+        var tls: RegistryTLS.Configuration?
+        if let certs = await self.provisioningService?.provisioningCerts() {
+            tls = RegistryTLS.makeConfiguration(certs: certs, logger: self.logger)
+        }
+        let registry = AgentImageRegistry(
+            store: BlobStore(root: WendyAgentPaths.stateDirectory),
+            configuration: .init(
+                host: "::",
+                port: LocalRegistryRef.pushPort,
+                tls: tls,
+                routes: .pushAndPull,
+                label: "push"
+            )
+        )
+        let logger = self.logger
+        self.pushRegistryTask = Task {
+            do {
+                try await registry.run()
+            } catch {
+                Self.logRegistryListenerStopped(
+                    logger, listener: "push", port: LocalRegistryRef.pushPort, error: error)
+            }
+        }
+    }
+
+    /// Cancels and awaits both registry listeners so their ports are released.
+    private func stopRegistryListeners() async {
+        self.pushRegistryTask?.cancel()
+        self.pullRegistryTask?.cancel()
+        await self.pushRegistryTask?.value
+        await self.pullRegistryTask?.value
+        self.pushRegistryTask = nil
+        self.pullRegistryTask = nil
+    }
+
+    private static func logRegistryListenerStopped(
+        _ logger: Logger, listener: String, port: Int, error: any Error
+    ) {
+        if error is CancellationError { return }
+        var metadata: Logger.Metadata = [
+            "listener": "\(listener)",
+            "port": "\(port)",
+            "error": "\(error)",
+        ]
+        if Self.isAddressAlreadyInUse(error) {
+            metadata["hint"] =
+                "port \(port) is already in use — check for a stale `wendy-registry` Docker container or another registry on this Mac"
+        }
+        logger.error("Agent image registry listener stopped", metadata: metadata)
     }
 
     private func startMonitorTask(runIdentifier: UInt64) {
@@ -681,9 +783,7 @@ public actor WendyAgent {
         await self.stopOTelServer()
         await self.stopMainServer()
 
-        self.registryTask?.cancel()
-        await self.registryTask?.value
-        self.registryTask = nil
+        await self.stopRegistryListeners()
     }
 
     private func clearRuntimeState() {

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentImageRegistryListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentImageRegistryListenerTests.swift
@@ -1,0 +1,136 @@
+import Crypto
+import Foundation
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("AgentImageRegistry listeners")
+struct AgentImageRegistryListenerTests {
+    private static func makeStore() -> BlobStore {
+        BlobStore(
+            root: FileManager.default.temporaryDirectory
+                .appendingPathComponent("registry-\(UUID().uuidString)")
+        )
+    }
+
+    private static func digest(of data: Data) -> String {
+        "sha256:" + SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func listener(
+        _ routes: AgentImageRegistry.ListenerConfiguration.Routes,
+        store: BlobStore
+    ) -> AgentImageRegistry {
+        AgentImageRegistry(
+            store: store,
+            configuration: .init(
+                host: "127.0.0.1",
+                port: 0,
+                tls: nil,
+                routes: routes,
+                label: "test"
+            )
+        )
+    }
+
+    @Test("pull-only listener serves reads but exposes no write routes")
+    func pullOnlyListenerIsReadOnly() async throws {
+        let store = Self.makeStore()
+        let blob = Data("layer-bytes".utf8)
+        let blobDigest = Self.digest(of: blob)
+        try store.writeBlob(blob, expectedDigest: blobDigest)
+        let manifest = Data(#"{"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#.utf8)
+        try store.writeManifest(manifest, repository: "app", reference: "latest")
+
+        let app = try Self.listener(.pullOnly, store: store).buildApplication()
+        try await app.test(.live) { client in
+            try await client.execute(uri: "/v2", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/v2/app/blobs/\(blobDigest)", method: .head) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/v2/app/blobs/\(blobDigest)", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.body == ByteBuffer(bytes: blob))
+            }
+            try await client.execute(uri: "/v2/app/manifests/latest", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.body == ByteBuffer(bytes: manifest))
+            }
+            // Write routes must not exist on the pull listener.
+            try await client.execute(uri: "/v2/app/blobs/uploads", method: .post) { response in
+                #expect(response.status == .notFound)
+            }
+            try await client.execute(
+                uri: "/v2/app/manifests/latest", method: .put,
+                body: .init(data: manifest)
+            ) { response in
+                #expect(response.status == .notFound)
+            }
+        }
+    }
+
+    @Test("push listener completes monolithic and chunked pushes")
+    func pushListenerAcceptsPushes() async throws {
+        let store = Self.makeStore()
+        let app = try Self.listener(.pushAndPull, store: store).buildApplication()
+        try await app.test(.live) { client in
+            // Monolithic: POST with ?digest= carries the whole blob.
+            let blob = Data("monolithic-layer".utf8)
+            let blobDigest = Self.digest(of: blob)
+            try await client.execute(
+                uri: "/v2/app/blobs/uploads?digest=\(blobDigest)", method: .post,
+                body: .init(data: blob)
+            ) { response in
+                #expect(response.status == .created)
+            }
+            #expect(store.hasBlob(digest: blobDigest))
+
+            // Chunked: POST starts a session, PATCH appends, PUT commits.
+            let chunked = Data("chunked-layer-contents".utf8)
+            let chunkedDigest = Self.digest(of: chunked)
+            let location = try await client.execute(
+                uri: "/v2/app/blobs/uploads", method: .post
+            ) { response -> String in
+                #expect(response.status == .accepted)
+                return try #require(response.headers[.location])
+            }
+            let half = chunked.count / 2
+            try await client.execute(
+                uri: location, method: .patch, body: .init(data: chunked.prefix(half))
+            ) { response in
+                #expect(response.status == .accepted)
+            }
+            try await client.execute(
+                uri: "\(location)?digest=\(chunkedDigest)", method: .put,
+                body: .init(data: chunked.suffix(from: half))
+            ) { response in
+                #expect(response.status == .created)
+            }
+            #expect(store.hasBlob(digest: chunkedDigest))
+
+            // Manifest PUT then read-back.
+            let manifest = Data(
+                #"{"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#.utf8)
+            try await client.execute(
+                uri: "/v2/app/manifests/latest", method: .put, body: .init(data: manifest)
+            ) { response in
+                #expect(response.status == .created)
+            }
+            try await client.execute(uri: "/v2/app/manifests/latest", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(response.body == ByteBuffer(bytes: manifest))
+            }
+        }
+    }
+}
+
+extension ByteBuffer {
+    fileprivate init(data: Data) {
+        self.init(bytes: data)
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceLinuxTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceLinuxTests.swift
@@ -9,6 +9,7 @@ import WendyAgentGRPC
 actor FakeLinuxBackend: LinuxContainerBackend {
     private(set) var pulled: [String] = []
     private(set) var started: [String] = []
+    private(set) var startedImages: [String] = []
     private(set) var stopped: [String] = []
     private(set) var removed: [String] = []
     /// Retains the process handed to `ContainerService` so `stop`/`remove` can
@@ -25,6 +26,7 @@ actor FakeLinuxBackend: LinuxContainerBackend {
         terminationHandler: (@Sendable (Foundation.Process) -> Void)?
     ) async throws -> (process: Foundation.Process, stdout: Pipe, stderr: Pipe) {
         started.append(appName)
+        startedImages.append(imageName)
         let p = Foundation.Process()
         // Long-lived: the app must be observably `.running` until the test stops
         // it. A short-lived process (e.g. `/bin/echo`) would exit immediately and
@@ -56,6 +58,7 @@ actor FakeLinuxBackend: LinuxContainerBackend {
 
     func pulledImages() -> [String] { pulled }
     func startedApps() -> [String] { started }
+    func startedImageNames() -> [String] { startedImages }
     func stoppedApps() -> [String] { stopped }
     func removedApps() -> [String] { removed }
 }
@@ -113,8 +116,12 @@ actor FakeLinuxBackend: LinuxContainerBackend {
         let runningInfo = try #require(await service.appInfo(forAppID: "svc"))
         #expect(runningInfo.status == .running)
 
-        #expect(await backend.pulledImages() == ["localhost:5555/svc:latest"])
+        // The stored ref keeps what the CLI sent (localhost:5555, the push
+        // listener); the backend must receive the loopback pull-listener
+        // rewrite, and pull/createAndStart must see the identical string.
+        #expect(await backend.pulledImages() == ["127.0.0.1:5556/svc:latest"])
         #expect(await backend.startedApps() == ["svc"])
+        #expect(await backend.startedImageNames() == ["127.0.0.1:5556/svc:latest"])
 
         // stopContainer routes to the backend's stop(appName:), which ends the
         // container's process and lets the streaming producer return.

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/LocalRegistryRefTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/LocalRegistryRefTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("LocalRegistryRef")
+struct LocalRegistryRefTests {
+    @Test("device-local push-port refs are rewritten to the pull listener")
+    func rewritesLocalPushRefs() {
+        #expect(
+            LocalRegistryRef.rewriteForLocalPull("localhost:5555/app:latest")
+                == "127.0.0.1:5556/app:latest")
+        #expect(
+            LocalRegistryRef.rewriteForLocalPull("127.0.0.1:5555/app:latest")
+                == "127.0.0.1:5556/app:latest")
+        #expect(
+            LocalRegistryRef.rewriteForLocalPull("[::1]:5555/app:latest")
+                == "127.0.0.1:5556/app:latest")
+    }
+
+    @Test("tags and digest suffixes after the authority are preserved")
+    func preservesSuffixes() {
+        #expect(
+            LocalRegistryRef.rewriteForLocalPull("localhost:5555/app@sha256:abc123")
+                == "127.0.0.1:5556/app@sha256:abc123")
+        #expect(
+            LocalRegistryRef.rewriteForLocalPull("localhost:5555/nested/repo:v1")
+                == "127.0.0.1:5556/nested/repo:v1")
+    }
+
+    @Test("non-local references pass through unchanged")
+    func passesThroughOtherRefs() {
+        for ref in [
+            "ghcr.io/wendylabsinc/app:latest",
+            "otherhost:5555/app:latest",
+            "localhost:5556/app:latest",
+            "localhost:5000/app:latest",
+            "docker.io/library/python:3.11-slim",
+            "sha256:0123456789abcdef",
+            "my-binary",
+            "",
+        ] {
+            #expect(LocalRegistryRef.rewriteForLocalPull(ref) == ref)
+        }
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import NIOPosix
+import NIOSSL
+import Testing
+
+@testable import WendyAgentCore
+
+/// Real-socket tests for the registry's TLS push listener: the server demands
+/// a client certificate, accepts only chains that verify against the device's
+/// CA (via `ClientCertAuthorizer`), and never answers plain HTTP.
+@Suite("Registry TLS listener")
+struct RegistryTLSListenerTests {
+    private struct ListenerNeverBound: Error {}
+    private struct ResponseTimeout: Error {}
+
+    private static func makeStore() -> BlobStore {
+        BlobStore(
+            root: FileManager.default.temporaryDirectory
+                .appendingPathComponent("registry-tls-\(UUID().uuidString)")
+        )
+    }
+
+    /// Starts a registry listener in a child task and waits for it to bind,
+    /// returning the bound port. Throws the listener's own error if it fails
+    /// to bind (e.g. port in use).
+    ///
+    /// Bind success and task failure both feed the same event stream: waiting
+    /// on the port alone would hang forever when the bind fails, because this
+    /// frame's reference to the application keeps the port continuation alive.
+    private static func startListener(
+        _ registry: AgentImageRegistry
+    ) async throws -> (port: Int, task: Task<Void, any Error>) {
+        let (events, continuation) = AsyncStream.makeStream(of: Result<Int, any Error>.self)
+        let app = try registry.buildApplication(onServerRunning: { channel in
+            continuation.yield(.success(channel.localAddress?.port ?? -1))
+        })
+        let task = Task {
+            do {
+                try await app.runService()
+                continuation.yield(.failure(ListenerNeverBound()))
+            } catch {
+                continuation.yield(.failure(error))
+                throw error
+            }
+        }
+        var iterator = events.makeAsyncIterator()
+        switch await iterator.next() {
+        case .success(let port):
+            return (port, task)
+        case .failure(let error):
+            task.cancel()
+            throw error
+        case nil:
+            task.cancel()
+            throw ListenerNeverBound()
+        }
+    }
+
+    private static func stop(_ task: Task<Void, any Error>) async {
+        task.cancel()
+        _ = try? await task.value
+    }
+
+    private static func tlsListener(port: Int, deviceOrg: Int32, ca: TestPKI.CA) throws
+        -> AgentImageRegistry
+    {
+        let device = try TestPKI.makeDeviceIdentity(org: deviceOrg, asset: 1, ca: ca)
+        return AgentImageRegistry(
+            store: Self.makeStore(),
+            configuration: .init(
+                host: "127.0.0.1",
+                port: port,
+                tls: RegistryTLS.Configuration(
+                    certPEM: device.certPEM,
+                    chainPEM: ca.pem,
+                    keyPEM: device.keyPEM,
+                    deviceOrg: deviceOrg,
+                    orgMode: .grace
+                ),
+                routes: .pushAndPull,
+                label: "test-push"
+            )
+        )
+    }
+
+    /// Collects whatever the server sends for one `GET /v2` request and
+    /// resolves when the connection closes (the request carries
+    /// `Connection: close`). A rejected handshake resolves to "".
+    private final class ResponseCollector: ChannelInboundHandler, @unchecked Sendable {
+        typealias InboundIn = ByteBuffer
+        typealias OutboundOut = ByteBuffer
+
+        private let promise: EventLoopPromise<String>
+        private var accumulated = ""
+        // All completion paths (close, error, timeout) funnel through
+        // complete(_:) exactly once — a second completion of an
+        // EventLoopPromise is a fatal error.
+        private var completed = false
+        private var timeout: Scheduled<Void>?
+
+        init(promise: EventLoopPromise<String>) {
+            self.promise = promise
+        }
+
+        private func complete(_ result: Result<String, any Error>) {
+            guard !self.completed else { return }
+            self.completed = true
+            self.timeout?.cancel()
+            self.promise.completeWith(result)
+        }
+
+        func handlerAdded(context: ChannelHandlerContext) {
+            // Backstop so a wedged handshake fails the test instead of hanging it.
+            self.timeout = context.eventLoop.scheduleTask(in: .seconds(10)) {
+                self.complete(.failure(ResponseTimeout()))
+                context.close(promise: nil)
+            }
+        }
+
+        func channelActive(context: ChannelHandlerContext) {
+            let request = "GET /v2 HTTP/1.1\r\nHost: registry\r\nConnection: close\r\n\r\n"
+            let buffer = context.channel.allocator.buffer(string: request)
+            context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
+            context.fireChannelActive()
+        }
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            var buffer = self.unwrapInboundIn(data)
+            self.accumulated += buffer.readString(length: buffer.readableBytes) ?? ""
+        }
+
+        func channelInactive(context: ChannelHandlerContext) {
+            self.complete(.success(self.accumulated))
+            context.fireChannelInactive()
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: any Error) {
+            // A refused handshake surfaces here; resolve with what we have ("").
+            self.complete(.success(self.accumulated))
+            context.close(promise: nil)
+        }
+    }
+
+    /// Sends `GET /v2` over TLS (optionally with a client identity) and
+    /// returns the raw response, or "" when the server rejected the handshake.
+    private static func tlsGET(port: Int, clientIdentity: TestPKI.Identity?) async throws -> String {
+        var tls = TLSConfiguration.makeClientConfiguration()
+        // The device cert carries no SAN for 127.0.0.1; server trust is not
+        // under test here (the CLI skips it too — buildkit `insecure = true`).
+        tls.certificateVerification = .none
+        if let clientIdentity {
+            let certs = try NIOSSLCertificate.fromPEMBytes(Array(clientIdentity.certPEM.utf8))
+            tls.certificateChain = certs.map { .certificate($0) }
+            tls.privateKey = .privateKey(
+                try NIOSSLPrivateKey(bytes: Array(clientIdentity.keyPEM.utf8), format: .pem))
+        }
+        let context = try NIOSSLContext(configuration: tls)
+        return try await Self.send(port: port) { channel in
+            try channel.pipeline.syncOperations.addHandler(
+                try NIOSSLClientHandler(context: context, serverHostname: nil))
+        }
+    }
+
+    /// Sends `GET /v2` as plain HTTP (no TLS handler).
+    private static func plainGET(port: Int) async throws -> String {
+        try await Self.send(port: port) { _ in }
+    }
+
+    private static func send(
+        port: Int,
+        configure: @escaping @Sendable (any Channel) throws -> Void
+    ) async throws -> String {
+        let group = MultiThreadedEventLoopGroup.singleton
+        let promise = group.next().makePromise(of: String.self)
+        let bootstrap = ClientBootstrap(group: group)
+            .channelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try configure(channel)
+                    try channel.pipeline.syncOperations.addHandler(
+                        ResponseCollector(promise: promise))
+                }
+            }
+        do {
+            _ = try await bootstrap.connect(host: "127.0.0.1", port: port).get()
+        } catch {
+            promise.fail(error)
+        }
+        return try await promise.futureResult.get()
+    }
+
+    @Test("a client certificate from the device CA is accepted")
+    func acceptsTrustedClientCert() async throws {
+        let ca = try TestPKI.makeCA()
+        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+
+        let client = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
+        let response = try await Self.tlsGET(port: port, clientIdentity: client)
+        #expect(response.contains("200 OK"))
+        await Self.stop(task)
+    }
+
+    @Test("a handshake without a client certificate is rejected")
+    func rejectsMissingClientCert() async throws {
+        let ca = try TestPKI.makeCA()
+        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+
+        let response = try await Self.tlsGET(port: port, clientIdentity: nil)
+        #expect(!response.contains("200 OK"))
+        await Self.stop(task)
+    }
+
+    @Test("a client certificate from a different CA is rejected")
+    func rejectsUntrustedClientCert() async throws {
+        let ca = try TestPKI.makeCA()
+        let otherCA = try TestPKI.makeCA(commonName: "Impostor CA")
+        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+
+        let impostor = try TestPKI.makeIdentity(commonName: "wendy/user/impostor", ca: otherCA)
+        let response = try await Self.tlsGET(port: port, clientIdentity: impostor)
+        #expect(!response.contains("200 OK"))
+        await Self.stop(task)
+    }
+
+    @Test("plain HTTP against the TLS listener fails fast")
+    func rejectsPlainHTTP() async throws {
+        let ca = try TestPKI.makeCA()
+        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+
+        let response = try await Self.plainGET(port: port)
+        #expect(!response.contains("200 OK"))
+        await Self.stop(task)
+    }
+
+    @Test("stop-then-start swaps a plain listener for a TLS one on the same port")
+    func restartSwapsScheme() async throws {
+        let plain = AgentImageRegistry(
+            store: Self.makeStore(),
+            configuration: .init(
+                host: "127.0.0.1", port: 0, tls: nil, routes: .pushAndPull, label: "test-push")
+        )
+        let (port, plainTask) = try await Self.startListener(plain)
+        #expect(try await Self.plainGET(port: port).contains("200 OK"))
+
+        // Provisioning transition: tear down, rebind the SAME port with TLS.
+        await Self.stop(plainTask)
+        let ca = try TestPKI.makeCA()
+        let (tlsPort, tlsTask) = try await Self.startListener(
+            try Self.tlsListener(port: port, deviceOrg: 1, ca: ca))
+        #expect(tlsPort == port)
+
+        let client = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
+        #expect(try await Self.tlsGET(port: port, clientIdentity: client).contains("200 OK"))
+        #expect(!(try await Self.plainGET(port: port).contains("200 OK")))
+        await Self.stop(tlsTask)
+    }
+
+    @Test("binding an occupied port surfaces an address-in-use error")
+    func occupiedPortThrows() async throws {
+        let first = AgentImageRegistry(
+            store: Self.makeStore(),
+            configuration: .init(
+                host: "127.0.0.1", port: 0, tls: nil, routes: .pullOnly, label: "first")
+        )
+        let (port, firstTask) = try await Self.startListener(first)
+
+        let second = AgentImageRegistry(
+            store: Self.makeStore(),
+            configuration: .init(
+                host: "127.0.0.1", port: port, tls: nil, routes: .pullOnly, label: "second")
+        )
+        await #expect(throws: (any Error).self) {
+            _ = try await Self.startListener(second)
+        }
+        await Self.stop(firstTask)
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSTests.swift
@@ -1,0 +1,65 @@
+import HummingbirdTLS
+import Logging
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("RegistryTLS")
+struct RegistryTLSTests {
+    private static let logger = Logger(label: "test.registry-tls")
+
+    @Test("configuration derives the device org from the leaf and org mode from the environment")
+    func configurationDerivation() throws {
+        let ca = try TestPKI.makeCA()
+        let device = try TestPKI.makeDeviceIdentity(org: 7, asset: 42, ca: ca)
+        let certs = ProvisioningService.ProvisioningCerts(
+            certPEM: device.certPEM,
+            chainPEM: ca.pem,
+            keyPEM: device.keyPEM
+        )
+
+        let config = RegistryTLS.makeConfiguration(
+            certs: certs,
+            environment: ["WENDY_MTLS_ORG_ENFORCEMENT": "strict"],
+            logger: Self.logger
+        )
+        #expect(config.deviceOrg == 7)
+        #expect(config.orgMode == .strict)
+
+        let defaulted = RegistryTLS.makeConfiguration(
+            certs: certs,
+            environment: [:],
+            logger: Self.logger
+        )
+        #expect(defaulted.orgMode == .grace)
+    }
+
+    @Test("channelConfiguration builds from a minted identity")
+    func channelConfigurationSucceeds() throws {
+        let ca = try TestPKI.makeCA()
+        let device = try TestPKI.makeDeviceIdentity(org: 1, asset: 2, ca: ca)
+        let config = RegistryTLS.Configuration(
+            certPEM: device.certPEM,
+            chainPEM: ca.pem,
+            keyPEM: device.keyPEM,
+            deviceOrg: 1,
+            orgMode: .grace
+        )
+        let channel = try RegistryTLS.channelConfiguration(config)
+        #expect(channel.customVerificationCallback != nil)
+    }
+
+    @Test("channelConfiguration throws on unusable PEM instead of degrading")
+    func channelConfigurationFailsClosed() throws {
+        let config = RegistryTLS.Configuration(
+            certPEM: "not a certificate",
+            chainPEM: "not a chain",
+            keyPEM: "not a key",
+            deviceOrg: 1,
+            orgMode: .grace
+        )
+        #expect(throws: (any Error).self) {
+            _ = try RegistryTLS.channelConfiguration(config)
+        }
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/TestPKI.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/TestPKI.swift
@@ -1,0 +1,91 @@
+import Crypto
+import Foundation
+import SwiftASN1
+import X509
+
+@testable import WendyAgentCore
+
+/// Shared PKI-minting helpers for TLS/mTLS tests: a self-signed CA plus
+/// CA-signed identities carrying their private keys (unlike the
+/// ClientCertAuthorizer suite's cert-only helpers, TLS handshakes need the
+/// keys too).
+enum TestPKI {
+    struct CA {
+        var certificate: Certificate
+        var privateKey: Certificate.PrivateKey
+        var pem: String
+    }
+
+    /// A leaf identity with its key material in the shapes the registry TLS
+    /// plumbing consumes.
+    struct Identity {
+        var certificate: Certificate
+        var certPEM: String
+        var keyPEM: String
+        var der: [UInt8]
+    }
+
+    static func makeCA(commonName: String = "Wendy Test CA") throws -> CA {
+        let key = P256.Signing.PrivateKey()
+        let name = try DistinguishedName { CommonName(commonName) }
+        let cert = try Certificate(
+            version: .v3,
+            serialNumber: Certificate.SerialNumber(),
+            publicKey: Certificate.PublicKey(key.publicKey),
+            notValidBefore: Date().addingTimeInterval(-3600),
+            notValidAfter: Date().addingTimeInterval(3600),
+            issuer: name,
+            subject: name,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: try Certificate.Extensions {
+                Critical(BasicConstraints.isCertificateAuthority(maxPathLength: nil))
+                Critical(KeyUsage(keyCertSign: true))
+            },
+            issuerPrivateKey: Certificate.PrivateKey(key)
+        )
+        return CA(
+            certificate: cert,
+            privateKey: Certificate.PrivateKey(key),
+            pem: try cert.serializeAsPEM().pemString
+        )
+    }
+
+    /// A CA-signed identity whose CommonName is the Wendy device identity for
+    /// (org, asset) — parseable by `ClientCertAuthorizer.organizationID` — with
+    /// the clientAuth+serverAuth EKUs real device certs carry.
+    static func makeDeviceIdentity(org: Int32, asset: Int32, ca: CA) throws -> Identity {
+        try makeIdentity(
+            commonName: DeviceIdentity.commonName(organizationID: org, assetID: asset),
+            ca: ca
+        )
+    }
+
+    static func makeIdentity(commonName: String, ca: CA) throws -> Identity {
+        let key = P256.Signing.PrivateKey()
+        let subject = try DistinguishedName { CommonName(commonName) }
+        let cert = try Certificate(
+            version: .v3,
+            serialNumber: Certificate.SerialNumber(),
+            publicKey: Certificate.PublicKey(key.publicKey),
+            notValidBefore: Date().addingTimeInterval(-3600),
+            notValidAfter: Date().addingTimeInterval(3600),
+            issuer: ca.certificate.subject,
+            subject: subject,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: try Certificate.Extensions {
+                Critical(BasicConstraints.notCertificateAuthority)
+                Critical(KeyUsage(digitalSignature: true))
+                try ExtendedKeyUsage([.clientAuth, .serverAuth])
+            },
+            issuerPrivateKey: ca.privateKey
+        )
+        var serializer = DER.Serializer()
+        try serializer.serialize(cert)
+        return Identity(
+            certificate: cert,
+            certPEM: try cert.serializeAsPEM().pemString,
+            keyPEM: key.pemRepresentation,
+            der: serializer.serializedBytes
+        )
+    }
+}


### PR DESCRIPTION
## Problem

LAN container deploys to a Mac agent could never work. The embedded OCI registry bound `127.0.0.1:5555` plain HTTP, while the CLI pushes to `<host>:5555` — plain HTTP for unprovisioned devices, HTTPS with a client certificate once provisioned. Every LAN push died as connection-refused buildx EOF spam (the cloud-tunnel path worked only because the device-side tunnel dials loopback). Live-diagnosed on a headless Mac mini: gRPC 50052 reachable, 5555 refused.

## Fix — split-listener registry, mirroring the Linux agent

- **Push listener (`0.0.0.0:5555`**, the port CLI image refs carry): plain HTTP while unprovisioned (Linux-agent parity); once provisioned, TLS with the device identity, demanding a client certificate verified by the same `ClientCertAuthorizer` policy as the gRPC server (trust-root path + `WENDY_MTLS_ORG_ENFORCEMENT`). Restarted on provisioning transitions via `switchMainServer` so its scheme tracks device state. Fail-closed: unusable TLS material keeps the listener down — never plain HTTP on a non-loopback interface while provisioned.
- **Pull listener (`127.0.0.1:5556`**, plain HTTP, read-only routes): where Apple `container`/Docker pull from — they cannot present client certificates. `ContainerService` rewrites `localhost:5555/...` refs to the pull listener at use time (`LocalRegistryRef.rewriteForLocalPull`), which also fixes apps installed before the split with no migration.
- Both listeners share one `BlobStore` (digest-addressed atomic writes); chunked-upload sessions stay on the push listener only.
- Registry bind failures now log the listener, port, and a port-in-use hint instead of a bare "Registry stopped".
- New dep: `HummingbirdTLS` product from the already-resolved hummingbird package (no new external package).

Agent-only change: already-shipped CLIs start working as soon as the agent updates, since they already push HTTP-unprovisioned / mTLS-provisioned to `<host>:5555`.

## Verification

- New suites: `LocalRegistryRefTests`, `RegistryTLSTests`, `AgentImageRegistryListenerTests` (route contracts incl. read-only pull listener), `RegistryTLSListenerTests` (real-socket TLS: trusted client cert accepted, missing cert rejected, wrong-CA rejected, plain HTTP rejected, stop-then-start scheme swap on the same port, occupied-port error). Full package suite green (233 tests / 43 suites).
- Live end-to-end on a real agent (`make agent-start`, unprovisioned): `wendy run` of Examples/HelloPython over the LAN push path deployed and ran; Apple `container` pulled the rewritten `127.0.0.1:5556/...` ref; push listener answers on the LAN IP while the pull listener refuses non-loopback.
- Remaining: on-device verify of the provisioned/mTLS path on the headless Mac mini once this ships in an agent build (the TLS handshake matrix is covered by the socket tests).

Companion CLI fix (fast, friendly error when the registry is genuinely absent): #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)