### PR TITLE
Support native gamepad input entitlements

### DIFF
--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -531,6 +531,8 @@ func TestParseEntitlementsFromAnnotations_RoundTrip(t *testing.T) {
 		{Type: appconfig.EntitlementNetwork, Mode: "host"},
 		{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"},
 		{Type: appconfig.EntitlementPersist, Name: "logs", Path: "/logs"},
+		{Type: appconfig.EntitlementSerial, Device: "ttyUSB0"},
+		{Type: appconfig.EntitlementSerial, Device: "ttyUSB1"},
 		{Type: appconfig.EntitlementGPU},
 	}
 
@@ -559,6 +561,10 @@ func TestParseEntitlementsFromAnnotations_RoundTrip(t *testing.T) {
 	}
 	if len(byType[appconfig.EntitlementGPU]) != 1 {
 		t.Errorf("gpu entitlement round-trip failed: %+v", byType[appconfig.EntitlementGPU])
+	}
+	serial := byType[appconfig.EntitlementSerial]
+	if len(serial) != 2 || serial[0].Device != "ttyUSB0" || serial[1].Device != "ttyUSB1" {
+		t.Errorf("serial entitlement round-trip failed: %+v", serial)
 	}
 }
 

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -24,8 +24,10 @@ const (
 	audioGroupGID uint32 = 29
 	// videoGroupGID is the standard video group GID.
 	videoGroupGID uint32 = 44
-	// inputGroupGID is the standard input group GID (for /dev/input devices).
-	inputGroupGID uint32 = 105
+	// inputGroupFallbackGID is used when the host input group cannot be resolved.
+	// Debian/Ubuntu commonly use 105; WendyOS deliberately uses 19, so normal
+	// operation must resolve the host group instead of assuming this value.
+	inputGroupFallbackGID uint32 = 105
 	// dialoutGroupGID is the standard dialout group GID (owns serial tty nodes
 	// like /dev/ttyACM* and /dev/ttyUSB* on Debian/Ubuntu hosts).
 	dialoutGroupGID uint32 = 20
@@ -692,6 +694,21 @@ var lookupRenderGID = func() (uint32, bool) {
 	return uint32(gid), true
 }
 
+// lookupInputGID resolves the host group that owns /dev/input. It is behind a
+// var so tests can cover WendyOS's GID 19 and the legacy fallback without
+// depending on the developer machine's group database.
+var lookupInputGID = func() (uint32, bool) {
+	g, err := user.LookupGroup("input")
+	if err != nil {
+		return 0, false
+	}
+	gid, err := strconv.ParseUint(g.Gid, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(gid), true
+}
+
 // AdminAgentSocketHostPath is the host wendy-agent local control socket exposed
 // to containers granted the admin entitlement. It is the single source of truth
 // for the host socket location — the agent's local listener (main.go) uses it
@@ -1224,10 +1241,18 @@ func applySPI(spec *Spec) {
 	})
 }
 
-// applyInput adds HID input device access (barcode scanners, keyboards, etc.).
+// applyInput adds Linux input access (game controllers, scanners, keyboards,
+// etc.).
 func applyInput(spec *Spec) {
-	// Add input group for /dev/input device permissions.
-	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, inputGroupGID)
+	// Add the host's input group for /dev/input permissions. Group IDs are an
+	// image policy detail rather than a portable ABI: WendyOS uses 19 while
+	// Debian/Ubuntu commonly use 105. The supplemental group is what lets a
+	// non-root OCI process open the recursively mounted event nodes.
+	inputGID := inputGroupFallbackGID
+	if gid, ok := lookupInputGID(); ok {
+		inputGID = gid
+	}
+	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, inputGID)
 
 	// Mount /dev/input for HID event devices.
 	spec.Mounts = append(spec.Mounts, Mount{

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -834,60 +834,83 @@ func TestApplyEntitlements_Multiple(t *testing.T) {
 }
 
 func TestApplyEntitlements_Input(t *testing.T) {
-	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
-	cfg := &appconfig.AppConfig{
-		AppID: "test-app",
-		Entitlements: []appconfig.Entitlement{
-			{Type: appconfig.EntitlementInput},
-		},
+	originalLookup := lookupInputGID
+	t.Cleanup(func() { lookupInputGID = originalLookup })
+
+	tests := []struct {
+		name        string
+		resolvedGID uint32
+		resolved    bool
+		wantGID     uint32
+	}{
+		{name: "WendyOS host group", resolvedGID: 19, resolved: true, wantGID: 19},
+		{name: "lookup fallback", resolved: false, wantGID: 105},
 	}
 
-	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
-		t.Fatalf("ApplyEntitlements() error = %v", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookupInputGID = func() (uint32, bool) { return tc.resolvedGID, tc.resolved }
+			spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+			// Input access must work for the normal non-root container user and
+			// must not rewrite its primary identity.
+			spec.Process.User.UID = 1000
+			spec.Process.User.GID = 1000
+			cfg := &appconfig.AppConfig{
+				AppID: "test-app",
+				Entitlements: []appconfig.Entitlement{
+					{Type: appconfig.EntitlementInput},
+				},
+			}
 
-	// Should add input group GID 105.
-	if !hasGID(spec, 105) {
-		t.Error("input entitlement did not add GID 105")
-	}
+			if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+				t.Fatalf("ApplyEntitlements() error = %v", err)
+			}
+			if !hasGID(spec, tc.wantGID) {
+				t.Errorf("input entitlement GIDs = %v, want supplemental GID %d", spec.Process.User.AdditionalGids, tc.wantGID)
+			}
+			if spec.Process.User.UID != 1000 || spec.Process.User.GID != 1000 {
+				t.Errorf("input entitlement changed non-root identity to uid=%d gid=%d", spec.Process.User.UID, spec.Process.User.GID)
+			}
 
-	// Should mount /dev/input.
-	if !hasMountDest(spec, "/dev/input") {
-		t.Error("input entitlement did not add /dev/input mount")
-	}
+			// Should mount /dev/input.
+			if !hasMountDest(spec, "/dev/input") {
+				t.Error("input entitlement did not add /dev/input mount")
+			}
 
-	// Verify mount options.
-	for _, m := range spec.Mounts {
-		if m.Destination == "/dev/input" {
-			if m.Source != "/dev/input" {
-				t.Errorf("input mount source = %q, want %q", m.Source, "/dev/input")
+			// Verify mount options.
+			for _, m := range spec.Mounts {
+				if m.Destination == "/dev/input" {
+					if m.Source != "/dev/input" {
+						t.Errorf("input mount source = %q, want %q", m.Source, "/dev/input")
+					}
+					if m.Type != "bind" {
+						t.Errorf("input mount type = %q, want %q", m.Type, "bind")
+					}
+					if !slices.Contains(m.Options, "rbind") {
+						t.Error("input mount missing rbind option")
+					}
+					if !slices.Contains(m.Options, "nosuid") {
+						t.Error("input mount missing nosuid option")
+					}
+					if !slices.Contains(m.Options, "noexec") {
+						t.Error("input mount missing noexec option")
+					}
+					break
+				}
 			}
-			if m.Type != "bind" {
-				t.Errorf("input mount type = %q, want %q", m.Type, "bind")
-			}
-			if !slices.Contains(m.Options, "rbind") {
-				t.Error("input mount missing rbind option")
-			}
-			if !slices.Contains(m.Options, "nosuid") {
-				t.Error("input mount missing nosuid option")
-			}
-			if !slices.Contains(m.Options, "noexec") {
-				t.Error("input mount missing noexec option")
-			}
-			break
-		}
-	}
 
-	// Should add a cgroup rule for input devices (major 13).
-	foundInputRule := false
-	for _, d := range spec.Linux.Resources.Devices {
-		if d.Major != nil && *d.Major == 13 && d.Allow {
-			foundInputRule = true
-			break
-		}
-	}
-	if !foundInputRule {
-		t.Error("input entitlement did not add cgroup device rule (major 13)")
+			// Should add a cgroup rule for hot-plugged input devices (major 13).
+			foundInputRule := false
+			for _, d := range spec.Linux.Resources.Devices {
+				if d.Major != nil && *d.Major == 13 && d.Allow && d.Access == "rw" {
+					foundInputRule = true
+					break
+				}
+			}
+			if !foundInputRule {
+				t.Error("input entitlement did not add rw cgroup device rule (major 13)")
+			}
+		})
 	}
 }
 

--- a/go/internal/cli/assets/docs/device/entitlements.md
+++ b/go/internal/cli/assets/docs/device/entitlements.md
@@ -69,7 +69,7 @@ A "network" type entitlement can have the following values:
 
 ## Input
 
-The input entitlement allows the container to access HID input devices such as barcode scanners, keyboards, and other devices that appear under `/dev/input/`. This is separate from the USB entitlement — USB covers `/dev/bus/usb` (raw USB access), while input covers the higher-level Linux input subsystem.
+The input entitlement allows the container to access Linux input devices such as game controllers, barcode scanners, keyboards, and other devices that appear under `/dev/input/`. This is separate from the USB entitlement — USB covers `/dev/bus/usb` (raw USB access), while input covers the higher-level Linux input subsystem.
 
 ```json
 {
@@ -79,22 +79,37 @@ The input entitlement allows the container to access HID input devices such as b
 
 The container receives:
 - A bind mount of `/dev/input/` (including `by-id/` symlinks for stable device identification)
-- Membership in the `input` group (GID 105) for device permissions
+- Membership in the host's `input` group for device permissions
 - A cgroup device rule allowing access to input devices (major 13)
 
 ### Device discovery
 
-Event device numbers (`/dev/input/event0`, `event1`, etc.) are assigned dynamically and can change across reboots. Use the stable symlinks under `/dev/input/by-id/` to identify devices reliably:
+Event device numbers (`/dev/input/event0`, `event1`, etc.) are assigned dynamically and can change across reboots. Use a stable symlink basename under `/dev/input/by-id/` where one exists, or the evdev device's `uniq` identity, to identify devices reliably:
 
 ```
 /dev/input/by-id/usb-USBKey_Chip_USBKey_Module_202730041341-event-kbd
 ```
 
+### Bluetooth game controllers
+
+BlueZ on WendyOS owns pairing, trust, and reconnect. Pair and trust the pad on
+the device first (both behaviors are enabled by default):
+
+```sh
+wendy device bluetooth connect <address>
+```
+
+Then declare `{ "type": "input" }` on the service that reads the controller
+and select it by `/dev/input/by-id` basename or evdev `uniq`. No controller API,
+mapping service, or raw `usb` entitlement is required for standard Linux
+gamepad event codes. The same input entitlement also covers a controller used
+over wired USB.
+
 ### When to use input vs USB
 
 | Entitlement | Access | Use case |
 |-------------|--------|----------|
-| `input` | `/dev/input/` (Linux input subsystem) | Reading HID events — barcode scanners, keyboards, game controllers |
+| `input` | `/dev/input/` (Linux input subsystem) | Reading input events — game controllers, barcode scanners, keyboards |
 | `usb` | `/dev/bus/usb` (raw USB) | Low-level USB communication — custom protocols, firmware updates, libusb |
 
 Most USB HID devices (scanners, keyboards) should use `input`. You only need `usb` if your app talks raw USB protocols.

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -551,16 +551,21 @@ func buildComposeServiceConfigs(projectName string, cfg *composeConfig, companio
 }
 
 // deduplicateEntitlements returns a copy of ents with duplicates removed.
-// Two entitlements are considered duplicates when their type, name, and mode
-// are equal; the first occurrence is kept. This covers the common cases:
+// Two entitlements are considered duplicates when their type and complete
+// canonical annotation value are equal; the first occurrence is kept. This
+// covers the common cases without collapsing parameterized same-type grants:
 //   - GPU declared in both shared and per-service sections
 //   - Network mode declared in both compose (network_mode:host) and companion
-//   - Persist volumes declared multiple times with the same name
+//   - Persist volumes declared multiple times with the same name and path
+//
+// Device, GPIO, allowlist, port, and every other entitlement parameter is part
+// of EntitlementAnnotationValue, so (for example) ttyUSB0 and ttyUSB1 remain
+// two serial entitlements.
 func deduplicateEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
 	seen := make(map[string]bool, len(ents))
 	out := make([]appconfig.Entitlement, 0, len(ents))
 	for _, e := range ents {
-		key := string(e.Type) + "\x00" + e.Name + "\x00" + e.Mode
+		key := e.Type + "\x00" + appconfig.EntitlementAnnotationValue(e)
 		if !seen[key] {
 			seen[key] = true
 			out = append(out, e)

--- a/go/internal/cli/commands/compose_test.go
+++ b/go/internal/cli/commands/compose_test.go
@@ -599,6 +599,8 @@ func TestDeduplicateEntitlements(t *testing.T) {
 	net := appconfig.Entitlement{Type: appconfig.EntitlementNetwork, Mode: "host"}
 	persist1 := appconfig.Entitlement{Type: appconfig.EntitlementPersist, Name: "data"}
 	persist2 := appconfig.Entitlement{Type: appconfig.EntitlementPersist, Name: "logs"}
+	serial0 := appconfig.Entitlement{Type: appconfig.EntitlementSerial, Device: "ttyUSB0"}
+	serial1 := appconfig.Entitlement{Type: appconfig.EntitlementSerial, Device: "ttyUSB1"}
 
 	t.Run("removes exact duplicates", func(t *testing.T) {
 		got := deduplicateEntitlements([]appconfig.Entitlement{gpu, cam, gpu})
@@ -618,6 +620,27 @@ func TestDeduplicateEntitlements(t *testing.T) {
 		got := deduplicateEntitlements([]appconfig.Entitlement{persist1, persist2, persist1})
 		if len(got) != 2 {
 			t.Fatalf("want 2, got %d: %+v", len(got), got)
+		}
+	})
+
+	t.Run("distinct serial devices are kept", func(t *testing.T) {
+		got := deduplicateEntitlements([]appconfig.Entitlement{serial0, serial1, serial0})
+		if len(got) != 2 || got[0].Device != "ttyUSB0" || got[1].Device != "ttyUSB1" {
+			t.Fatalf("want ttyUSB0 and ttyUSB1 once each, got %+v", got)
+		}
+	})
+
+	t.Run("all parameter fields participate in identity", func(t *testing.T) {
+		ents := []appconfig.Entitlement{
+			{Type: appconfig.EntitlementGPIO, Pins: []int{17}},
+			{Type: appconfig.EntitlementGPIO, Pins: []int{18}},
+			{Type: appconfig.EntitlementCamera, Allowlist: []string{"/dev/video0"}},
+			{Type: appconfig.EntitlementCamera, Allowlist: []string{"/dev/video1"}},
+			{Type: appconfig.EntitlementNetwork, Ports: []appconfig.PortMapping{{Host: 8080, Container: 80}}},
+			{Type: appconfig.EntitlementNetwork, Ports: []appconfig.PortMapping{{Host: 9090, Container: 90}}},
+		}
+		if got := deduplicateEntitlements(ents); len(got) != len(ents) {
+			t.Fatalf("parameterized entitlements collapsed: got %+v", got)
 		}
 	})
 

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -108,7 +108,7 @@ var wendyOSEntitlementQuestions = []entitlementQuestion{
 	{"Does your app need I2C bus access?", appconfig.EntitlementI2C, "I2C bus devices"},
 	{"Does your app need audio input/output?", appconfig.EntitlementAudio, "Microphone and speaker access"},
 	{"Does your app need camera access?", appconfig.EntitlementCamera, "Camera device access"},
-	{"Does your app need HID input device access (barcode scanners, keyboards)?", appconfig.EntitlementInput, "HID input devices"},
+	{"Does your app need Linux input device access (game controllers, barcode scanners, keyboards)?", appconfig.EntitlementInput, "Linux input devices"},
 	{"Does your app need persistent storage?", appconfig.EntitlementPersist, "Data persisted across restarts"},
 }
 

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -108,7 +108,7 @@ var wendyOSEntitlementQuestions = []entitlementQuestion{
 	{"Does your app need I2C bus access?", appconfig.EntitlementI2C, "I2C bus devices"},
 	{"Does your app need audio input/output?", appconfig.EntitlementAudio, "Microphone and speaker access"},
 	{"Does your app need camera access?", appconfig.EntitlementCamera, "Camera device access"},
-	{"Does your app need Linux input device access (game controllers, barcode scanners, keyboards)?", appconfig.EntitlementInput, "Linux input devices"},
+	{"Does your app need Linux input device access (barcode scanners, keyboards, controllers)?", appconfig.EntitlementInput, "Linux input devices"},
 	{"Does your app need persistent storage?", appconfig.EntitlementPersist, "Data persisted across restarts"},
 }
 

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -28,7 +28,7 @@ var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementI2C:       "Access I2C bus devices",
 	appconfig.EntitlementGPIO:      "Access GPIO pins",
 	appconfig.EntitlementSPI:       "Access SPI bus devices (displays, sensors, flash - may require GPIO access)",
-	appconfig.EntitlementInput:     "Access HID input devices (barcode scanners, keyboards)",
+	appconfig.EntitlementInput:     "Access Linux input devices (game controllers, barcode scanners, keyboards)",
 }
 
 func newProjectCmd() *cobra.Command {

--- a/go/internal/shared/appconfig/annotation_test.go
+++ b/go/internal/shared/appconfig/annotation_test.go
@@ -2,6 +2,7 @@ package appconfig
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -163,6 +164,7 @@ func TestEntitlementAnnotationRoundTrip(t *testing.T) {
 		{Type: EntitlementGPIO, Pins: []int{17, 18, 27}},
 		{Type: EntitlementMCP, Port: 8080},
 		{Type: EntitlementI2C, Device: "i2c-1"},
+		{Type: EntitlementSerial, Device: "ttyUSB0"},
 		{Type: EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"},
 	}
 
@@ -171,6 +173,27 @@ func TestEntitlementAnnotationRoundTrip(t *testing.T) {
 		got := ParseEntitlementAnnotation(want.Type, value)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("round-trip %+v: encoded %q, decoded %+v", want, value, got)
+		}
+	}
+}
+
+func TestBuildEntitlementAnnotationsIndexesDistinctSerialDevices(t *testing.T) {
+	want := []Entitlement{
+		{Type: EntitlementSerial, Device: "ttyUSB0"},
+		{Type: EntitlementSerial, Device: "ttyUSB1"},
+	}
+	annotations := BuildEntitlementAnnotations(want)
+	if len(annotations) != 2 {
+		t.Fatalf("got %d annotations, want 2: %v", len(annotations), annotations)
+	}
+	for i, entitlement := range want {
+		key := EntitlementAnnotationKeyPrefix + EntitlementSerial + "." + strconv.Itoa(i)
+		value, ok := annotations[key]
+		if !ok {
+			t.Fatalf("missing indexed annotation %q in %v", key, annotations)
+		}
+		if got := ParseEntitlementAnnotation(EntitlementSerial, value); !reflect.DeepEqual(got, entitlement) {
+			t.Errorf("%s round-trip = %+v, want %+v", key, got, entitlement)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- resolve the host `input` group when granting `/dev/input` access, with the existing GID 105 fallback
- deduplicate entitlements by type plus their complete encoded value so distinct serial devices, GPIO sets, allowlists, and ports survive
- document the native gamepad workflow through BlueZ, the existing `input` entitlement, and stable evdev identity
- cover WendyOS GID 19, non-root OCI access, multi-serial preservation, and indexed annotation round-trips

## Why

WendyOS owns `/dev/input` with GID 19, while the Agent previously granted GID 105 unconditionally. In parallel, CLI compose deduplication treated same-type parameterized entitlements as duplicates, which could omit a second serial device such as the LiDAR adapter.

These fixes make the existing Linux input entitlement the native controller contract and preserve all distinct hardware grants through OCI/containerd metadata.

## Impact

Non-root services can open hot-plugged evdev gamepads on WendyOS, and multi-device manifests retain every distinct serial and hardware entitlement. No controller-specific System API is added.

This is the first PR in the rollout order; the WendyOS kernel guarantee and Rosmaster sample changes follow separately.

## Validation

- `go test ./...`
- `git diff --check`