### PR TITLE
Remove MEM% column from wendy device top

### DIFF
--- a/go/internal/cli/commands/device_top.go
+++ b/go/internal/cli/commands/device_top.go
@@ -817,21 +817,21 @@ func topMeter(label string, ratio float64, value string, width int) string {
 // topNameWidth returns the flexible name width after reserving the resource and
 // state columns. The state column is deliberately wide enough for "crash-loop".
 func topNameWidth(width int) int {
-	// 1 (lead) + name + 1 + 6 (cpu) + 1 + 6 (memp) + 1 + 10 (mem) +
-	// 1 + 10 (state) = name + 37. Keep one spare cell for terminal quirks.
-	nameW := width - 38
+	// 1 (lead) + name + 1 + 6 (cpu) + 1 + 10 (mem) +
+	// 1 + 10 (state) = name + 30. Keep one spare cell for terminal quirks.
+	nameW := width - 31
 	if nameW < 10 {
 		nameW = 10
 	}
 	return nameW
 }
 
-func topFormatRow(name, cpu, memp, mem, state string, nameW int) string {
+func topFormatRow(name, cpu, mem, state string, nameW int) string {
 	r := []rune(name)
 	if len(r) > nameW {
 		name = string(r[:nameW])
 	}
-	return fmt.Sprintf(" %-*s %6s %6s %10s %-10s", nameW, name, cpu, memp, mem, state)
+	return fmt.Sprintf(" %-*s %6s %10s %-10s", nameW, name, cpu, mem, state)
 }
 
 func (m topModel) View() string {
@@ -972,7 +972,7 @@ func (m topModel) listLines(width int) []string {
 		memTitle = "MEM▾"
 	}
 	var lines []string
-	header := padOrCrop(topFormatRow("APP", cpuTitle, "MEM%", memTitle, "STATE", nameW), width)
+	header := padOrCrop(topFormatRow("APP", cpuTitle, memTitle, "STATE", nameW), width)
 	lines = append(lines, topHeaderBar.Render(header))
 
 	if len(m.rows) == 0 {
@@ -988,13 +988,11 @@ func (m topModel) listLines(width int) []string {
 		if r.hasCPU && m.havePrev {
 			cpu = fmt.Sprintf("%.1f", r.cpuPercent)
 		}
-		memp := "-"
 		mem := "—"
 		if r.state == agentpb.AppRunningState_RUNNING && memTotal > 0 {
-			memp = fmt.Sprintf("%.1f", float64(r.memBytes)/float64(memTotal)*100)
 			mem = formatBytes(r.memBytes)
 		}
-		row := padOrCrop(topFormatRow(topDisplayName(r), cpu, memp, mem, topStateLabel(r.state), nameW), width)
+		row := padOrCrop(topFormatRow(topDisplayName(r), cpu, mem, topStateLabel(r.state), nameW), width)
 		switch {
 		case i == m.cursor:
 			lines = append(lines, topSelRow.Render(row))


### PR DESCRIPTION
## Summary
- `wendy device top`'s app table showed both an absolute `MEM` figure and a `MEM%` figure computed as container memory / total host RAM. The percentage wasn't tied to any per-app limit, so it didn't add useful signal beyond the absolute value — drop it and keep the table to `APP CPU% MEM STATE`.

## Test plan
- [x] `gofmt -l` clean
- [x] `go test ./internal/cli/commands/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRVQjwsDPoNC3Fsn755YFB