### PR TITLE
Implement remote agent updates in the macOS agent

### DIFF
--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/AgentImageRegistry.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/AgentImageRegistry.swift
@@ -297,7 +297,8 @@ struct AgentImageRegistry: Sendable {
                     metadata: [
                         "listener": "\(label)",
                         "scheme": "\(scheme)",
-                        "address": "\(channel.localAddress.map(String.init(describing:)) ?? "unknown")",
+                        "address":
+                            "\(channel.localAddress.map(String.init(describing:)) ?? "unknown")",
                     ]
                 )
                 await onServerRunning(channel)

--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
@@ -73,7 +73,9 @@ enum RegistryTLS {
         let key = try NIOSSLPrivateKey(bytes: Array(config.keyPEM.utf8), format: .pem)
 
         var tls = TLSConfiguration.makeServerConfiguration(
-            certificateChain: ([leaf] + leafCerts.dropFirst() + chainCerts).map { .certificate($0) },
+            certificateChain: ([leaf] + leafCerts.dropFirst() + chainCerts).map {
+                .certificate($0)
+            },
             privateKey: .privateKey(key)
         )
         tls.minimumTLSVersion = .tlsv12

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -44,7 +44,17 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         // so `messages` can be captured directly in the @Sendable producer.
         let messages = request.messages
         let updateLock = self.updateLock
-        let dependencies = self.updateDependencies
+        // The commit hook is wired here rather than by whoever built the
+        // dependencies: this is the only place that holds both the lock and
+        // the session. Once the session commits, the lock must stop being
+        // stealable (see `AgentUpdateLock`) — the process is exiting, and a
+        // steal at that point could install a second bundle over the one just
+        // written.
+        let dependencies: AgentUpdateSession.Dependencies = {
+            var dependencies = self.updateDependencies
+            dependencies.onCommitted = { await updateLock.markCommitted() }
+            return dependencies
+        }()
         let logger = Self.updateLogger
 
         return StreamingServerResponse { writer in

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRPCCore
+import Logging
 import WendyAgentGRPC
 
 struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
@@ -7,6 +8,18 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     var hostname: any HostnameSetting = ScutilHostname()
     var wifi: any WiFiManaging = WiFiController()
     var bluetooth: any BluetoothManaging = BluetoothScanner()
+    /// Serializes agent self-updates. Held by `WendyAgent` (not created here)
+    /// so the same lock survives the service rebuilds that provisioning
+    /// transitions perform.
+    var updateLock: AgentUpdateLock = AgentUpdateLock()
+    var updateDependencies: AgentUpdateSession.Dependencies = .init(
+        relauncher: AgentRelauncher(terminate: nil)
+    )
+
+    // A `static` logger, not a stored property: a private stored property
+    // would make the synthesized memberwise initializer private, and callers
+    // (WendyAgent, tests) construct `AgentService` through it.
+    private static let updateLogger = Logger(label: "sh.wendy.agent.update")
 
     func runContainer(
         request: StreamingServerRequest<Wendy_Agent_Services_V1_RunContainerRequest>,
@@ -23,10 +36,34 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         request: StreamingServerRequest<Wendy_Agent_Services_V1_UpdateAgentRequest>,
         context: ServerContext
     ) async throws -> StreamingServerResponse<Wendy_Agent_Services_V1_UpdateAgentResponse> {
-        throw RPCError(
-            code: .unimplemented,
-            message: "Updating the agent is currently not supported by Wendy Agent for Mac."
-        )
+        guard await self.updateLock.tryAcquire() else {
+            throw RPCError(code: .failedPrecondition, message: "an update is already in progress")
+        }
+
+        // StreamingServerRequest and its RPCAsyncSequence are both Sendable,
+        // so `messages` can be captured directly in the @Sendable producer.
+        let messages = request.messages
+        let updateLock = self.updateLock
+        let dependencies = self.updateDependencies
+        let logger = Self.updateLogger
+
+        return StreamingServerResponse { writer in
+            do {
+                try await AgentUpdateSession.run(
+                    messages: messages,
+                    writeResponse: { try await writer.write($0) },
+                    deps: dependencies,
+                    logger: logger
+                )
+            } catch {
+                // Only released on failure: a committed update exits the
+                // process, and a retry against a committed-but-not-yet-dead
+                // agent must still see "an update is already in progress".
+                await updateLock.release()
+                throw error
+            }
+            return Metadata()
+        }
     }
 
     func getAgentVersion(

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateLock.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateLock.swift
@@ -1,20 +1,61 @@
 /// Serializes agent updates across main-server rebuilds. Deliberately NOT
 /// released after a successful commit — the process is about to exit, and a
 /// retry must see "an update is already in progress".
+///
+/// Self-healing by design: an acquisition that never committed and is older
+/// than `staleThreshold` may be stolen. grpc-swift's `ServerRPCExecutor`
+/// writes the response's initial metadata *before* running the response
+/// producer, so a client that aborts in that window leaves the lock held with
+/// nothing left to run its `release()`. Without the steal, that single lost
+/// release would fail every later update with `failedPrecondition` until
+/// somebody restarts the app by hand.
 actor AgentUpdateLock {
-    private var isHeld = false
+    /// How long an uncommitted acquisition stays authoritative. A genuine
+    /// update session cannot come close: the payload is capped at 256 MiB and
+    /// the verify/extract/swap steps are all bounded, so anything older is a
+    /// leaked acquisition rather than a live update.
+    static let defaultStaleThreshold: Duration = .seconds(30 * 60)
 
-    /// Attempts to acquire the lock. Returns `false` if it is already held.
+    private struct Holder {
+        let acquiredAt: ContinuousClock.Instant
+        var isCommitted: Bool
+    }
+
+    private let staleThreshold: Duration
+    private var holder: Holder?
+
+    /// - Parameter staleThreshold: overridable so tests can exercise the steal
+    ///   without waiting half an hour.
+    init(staleThreshold: Duration = AgentUpdateLock.defaultStaleThreshold) {
+        self.staleThreshold = staleThreshold
+    }
+
+    /// Attempts to acquire the lock. Returns `false` while it is held by a
+    /// live acquisition — one that has already committed (the process is on
+    /// its way out; stealing there could double-install over the bundle just
+    /// written) or one younger than `staleThreshold`.
     func tryAcquire() -> Bool {
-        guard !isHeld else { return false }
-        isHeld = true
+        let now = ContinuousClock.now
+        if let holder = self.holder {
+            guard !holder.isCommitted, now - holder.acquiredAt >= self.staleThreshold else {
+                return false
+            }
+        }
+        self.holder = Holder(acquiredAt: now, isCommitted: false)
         return true
+    }
+
+    /// Pins the in-flight update as committed: the new bundle is installed and
+    /// termination is about to be scheduled, so this lock must never be
+    /// stolen no matter how long the shutdown takes.
+    func markCommitted() {
+        self.holder?.isCommitted = true
     }
 
     /// Releases the lock. A successful update commit must NOT call this —
     /// the process exits shortly afterward, so the lock only needs to be
     /// released on abandoned/failed attempts. See the type-level doc comment.
     func release() {
-        isHeld = false
+        self.holder = nil
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateLock.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateLock.swift
@@ -1,0 +1,20 @@
+/// Serializes agent updates across main-server rebuilds. Deliberately NOT
+/// released after a successful commit — the process is about to exit, and a
+/// retry must see "an update is already in progress".
+actor AgentUpdateLock {
+    private var isHeld = false
+
+    /// Attempts to acquire the lock. Returns `false` if it is already held.
+    func tryAcquire() -> Bool {
+        guard !isHeld else { return false }
+        isHeld = true
+        return true
+    }
+
+    /// Releases the lock. A successful update commit must NOT call this —
+    /// the process exits shortly afterward, so the lock only needs to be
+    /// released on abandoned/failed attempts. See the type-level doc comment.
+    func release() {
+        isHeld = false
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
@@ -43,6 +43,11 @@ enum AgentUpdateSession {
         var signature: any UpdateSignatureChecking = DefaultUpdateSignatureChecker()
         var installer: any AgentBundleInstalling = DittoAgentBundleInstaller()
         var relauncher: any AgentRelaunchScheduling
+        /// Invoked at the point of no return — the new bundle is installed and
+        /// the relaunch/termination is about to be scheduled. `AgentService`
+        /// wires this to `AgentUpdateLock.markCommitted()` so the update lock
+        /// can no longer be stolen while the process shuts down.
+        var onCommitted: (@Sendable () async -> Void)?
     }
 
     /// Runs the session to completion. Returns normally only after a committed
@@ -180,7 +185,7 @@ enum AgentUpdateSession {
                     ]
                 )
 
-                Self.commitTail(deps: deps, logger: logger)
+                await Self.commitTail(deps: deps, logger: logger)
                 // Parity with the Go agent's `finishCommittedUpdate`: the
                 // restart is already scheduled, so a client that hangs up
                 // before the ack lands must not turn a committed install into
@@ -263,9 +268,15 @@ enum AgentUpdateSession {
         sessionDir: URL,
         deps: Dependencies
     ) async throws {
+        // Extract into a dedicated subdirectory instead of `sessionDir`: the
+        // payload sits at `sessionDir/payload.zip`, and an archive entry with
+        // that same name would otherwise overwrite the source mid-extract.
+        // `extractBundle` creates the directory itself.
+        let extractDir = sessionDir.appendingPathComponent("extract", isDirectory: true)
+
         let stagedApp: URL
         do {
-            stagedApp = try await deps.installer.extractBundle(zipAt: payloadURL, into: sessionDir)
+            stagedApp = try await deps.installer.extractBundle(zipAt: payloadURL, into: extractDir)
         } catch let error as AgentBundleInstallerError {
             throw Self.rpcError(for: error)
         } catch {
@@ -323,7 +334,12 @@ enum AgentUpdateSession {
     /// Schedules the relaunch and this process's termination. Runs *before*
     /// the ack is written so a failed ack cannot strand the agent in the
     /// "installed but never restarted" state.
-    private static func commitTail(deps: Dependencies, logger: Logger) {
+    private static func commitTail(deps: Dependencies, logger: Logger) async {
+        // Announce the commit before anything is scheduled: from here on the
+        // update lock must not be stealable, because the process is on its way
+        // out and a second update starting now could install over the bundle
+        // that was just swapped in.
+        await deps.onCommitted?()
         do {
             try deps.relauncher.scheduleRelaunch(of: deps.currentBundleURL)
         } catch {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
@@ -1,0 +1,401 @@
+import CryptoKit
+import Foundation
+import GRPCCore
+import Logging
+import WendyAgentGRPC
+
+/// Seam hiding the `@available(macOS 26)` ML-DSA verifier so the update
+/// session stays testable (and buildable/runnable below macOS 26).
+protocol UpdateSignatureChecking: Sendable {
+    /// Verifies the detached signature over the 32-byte SHA-256 digest of the
+    /// update payload. Throws `SignatureVerifierError` when the payload is
+    /// rejected; returns normally when it is accepted (or when verification is
+    /// disabled).
+    func verify(digest: Data, signature: Data) throws
+}
+
+/// Production checker: defers to the build-embedded `SignatureVerifier`.
+///
+/// ML-DSA65 requires macOS 26, so below that there is nothing to verify with
+/// and the check is skipped — the same fail-safe skip the Go agent performs
+/// while no pinned key is embedded (`SignatureVerifier.default.isEnabled` is
+/// `false` today, so even on macOS 26 this is currently a no-op).
+struct DefaultUpdateSignatureChecker: UpdateSignatureChecking {
+    func verify(digest: Data, signature: Data) throws {
+        if #available(macOS 26.0, *) {
+            try SignatureVerifier.default.verify(message: digest, signature: signature)
+        }
+    }
+}
+
+/// Drives one `UpdateAgent` bidi stream: receives the zipped `.app` payload,
+/// verifies its digest and signature, extracts and code-signature-gates the
+/// incoming bundle, swaps it into place, and schedules the relaunch.
+enum AgentUpdateSession {
+    /// Parity with the Go agent's `maxAgentBinarySize`.
+    static let maxPayloadBytes: Int64 = 256 * 1024 * 1024
+
+    struct Dependencies: Sendable {
+        var stagingRoot: URL = WendyAgentPaths.agentUpdateStagingDirectory
+        var maxPayloadBytes: Int64 = AgentUpdateSession.maxPayloadBytes
+        var currentBundleURL: URL = Bundle.main.bundleURL
+        var codesign: any CodesignVerifying = SecStaticCodeVerifier()
+        var signature: any UpdateSignatureChecking = DefaultUpdateSignatureChecker()
+        var installer: any AgentBundleInstalling = DittoAgentBundleInstaller()
+        var relauncher: any AgentRelaunchScheduling
+    }
+
+    /// Runs the session to completion. Returns normally only after a committed
+    /// install (the process is expected to exit shortly afterwards); every
+    /// other outcome throws an `RPCError`.
+    ///
+    /// The staging directory for this session is always removed before
+    /// returning or rethrowing, so a failed update never leaks a
+    /// several-hundred-MiB payload into Application Support.
+    static func run<Messages: AsyncSequence & Sendable>(
+        messages: Messages,
+        writeResponse: (Wendy_Agent_Services_V1_UpdateAgentResponse) async throws -> Void,
+        deps: Dependencies,
+        logger: Logger
+    ) async throws where Messages.Element == Wendy_Agent_Services_V1_UpdateAgentRequest {
+        Self.removeStaleSessions(in: deps.stagingRoot, logger: logger)
+
+        let sessionDir = deps.stagingRoot.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        do {
+            try FileManager.default.createDirectory(
+                at: sessionDir,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw RPCError(
+                code: .internalError,
+                message: "failed to create update staging directory: \(error)"
+            )
+        }
+
+        do {
+            try await Self.runStaged(
+                messages: messages,
+                writeResponse: writeResponse,
+                sessionDir: sessionDir,
+                deps: deps,
+                logger: logger
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: sessionDir)
+            throw error
+        }
+        try? FileManager.default.removeItem(at: sessionDir)
+    }
+
+    // MARK: - Session body
+
+    private static func runStaged<Messages: AsyncSequence & Sendable>(
+        messages: Messages,
+        writeResponse: (Wendy_Agent_Services_V1_UpdateAgentResponse) async throws -> Void,
+        sessionDir: URL,
+        deps: Dependencies,
+        logger: Logger
+    ) async throws where Messages.Element == Wendy_Agent_Services_V1_UpdateAgentRequest {
+        let payloadURL = sessionDir.appendingPathComponent("payload.zip")
+        guard FileManager.default.createFile(atPath: payloadURL.path, contents: nil),
+            let payloadHandle = FileHandle(forWritingAtPath: payloadURL.path)
+        else {
+            throw RPCError(
+                code: .internalError,
+                message: "failed to open update staging file at \(payloadURL.path)"
+            )
+        }
+        // Cleared once the handle is closed explicitly, so the defer does not
+        // close an already-closed handle.
+        var openHandle: FileHandle? = payloadHandle
+        defer { try? openHandle?.close() }
+
+        var hasher = SHA256()
+        var received: Int64 = 0
+        var messageIterator = messages.makeAsyncIterator()
+
+        while let message = try await messageIterator.next() {
+            switch message.requestType {
+            case .chunk(let chunk):
+                let data = chunk.data
+                guard received + Int64(data.count) <= deps.maxPayloadBytes else {
+                    throw RPCError(
+                        code: .resourceExhausted,
+                        message:
+                            "update stream exceeds maximum agent bundle size (\(deps.maxPayloadBytes >> 20) MiB)"
+                    )
+                }
+                do {
+                    try payloadHandle.write(contentsOf: data)
+                } catch {
+                    throw RPCError(
+                        code: .internalError,
+                        message: "failed to write update chunk: \(error)"
+                    )
+                }
+                hasher.update(data: data)
+                received += Int64(data.count)
+
+            case .control(let control):
+                guard case .update(let update) = control.command else {
+                    throw RPCError(
+                        code: .invalidArgument,
+                        message: "unsupported update control command"
+                    )
+                }
+
+                let digest = Data(hasher.finalize())
+                try Self.verifyDigest(digest, against: update.sha256)
+                try Self.verifySignature(
+                    digest: digest,
+                    signature: update.signature,
+                    checker: deps.signature
+                )
+
+                // The payload must be fully flushed before `ditto` reads it.
+                do {
+                    try payloadHandle.close()
+                    openHandle = nil
+                } catch {
+                    throw RPCError(
+                        code: .internalError,
+                        message: "failed to finalize update payload: \(error)"
+                    )
+                }
+
+                logger.info(
+                    "Installing agent update",
+                    metadata: ["bytes": "\(received)", "sha256": "\(Self.hexString(digest))"]
+                )
+                try await Self.install(payloadURL: payloadURL, sessionDir: sessionDir, deps: deps)
+                logger.info(
+                    "Agent bundle replaced",
+                    metadata: [
+                        "bundle": "\(deps.currentBundleURL.path)",
+                        "version": "\(Self.bundleVersion(at: deps.currentBundleURL) ?? "unknown")",
+                    ]
+                )
+
+                Self.commitTail(deps: deps, logger: logger)
+                // Parity with the Go agent's `finishCommittedUpdate`: the
+                // restart is already scheduled, so a client that hangs up
+                // before the ack lands must not turn a committed install into
+                // a failed RPC.
+                do {
+                    var response = Wendy_Agent_Services_V1_UpdateAgentResponse()
+                    response.responseType = .updated(
+                        Wendy_Agent_Services_V1_UpdateAgentResponse.Updated()
+                    )
+                    try await writeResponse(response)
+                } catch {
+                    logger.warning(
+                        "agent update committed but ack not delivered; restarting anyway",
+                        metadata: ["error": "\(error)"]
+                    )
+                }
+                return
+
+            case nil:
+                throw RPCError(
+                    code: .invalidArgument,
+                    message: "unexpected empty message in update stream"
+                )
+            }
+        }
+
+        throw RPCError(
+            code: .invalidArgument,
+            message: "update stream ended without update control command"
+        )
+    }
+
+    // MARK: - Steps
+
+    private static func verifyDigest(_ digest: Data, against expected: String) throws {
+        guard expected.count == 64, expected.allSatisfy({ $0.isASCII && $0.isHexDigit }) else {
+            throw RPCError(
+                code: .invalidArgument,
+                message: "update control command is missing a valid SHA256"
+            )
+        }
+        let computed = Self.hexString(digest)
+        guard expected.caseInsensitiveCompare(computed) == .orderedSame else {
+            throw RPCError(
+                code: .dataLoss,
+                message: "SHA256 mismatch: expected \(expected), got \(computed)"
+            )
+        }
+    }
+
+    private static func verifySignature(
+        digest: Data,
+        signature: Data,
+        checker: any UpdateSignatureChecking
+    ) throws {
+        do {
+            try checker.verify(digest: digest, signature: signature)
+        } catch SignatureVerifierError.unsigned {
+            throw RPCError(
+                code: .failedPrecondition,
+                message: "agent update is unsigned; refusing install"
+            )
+        } catch SignatureVerifierError.badSignature {
+            throw RPCError(
+                code: .dataLoss,
+                message: "agent update signature verification failed; refusing install"
+            )
+        } catch {
+            throw RPCError(
+                code: .internalError,
+                message: "agent update signature verification error: \(error)"
+            )
+        }
+    }
+
+    /// Extracts the payload, applies the code-signature policy, and swaps the
+    /// incoming bundle into place.
+    private static func install(
+        payloadURL: URL,
+        sessionDir: URL,
+        deps: Dependencies
+    ) async throws {
+        let stagedApp: URL
+        do {
+            stagedApp = try await deps.installer.extractBundle(zipAt: payloadURL, into: sessionDir)
+        } catch let error as AgentBundleInstallerError {
+            throw Self.rpcError(for: error)
+        }
+
+        let incoming: CodesignInfo
+        do {
+            incoming = try await deps.codesign.inspect(bundleAt: stagedApp)
+        } catch CodesignVerificationError.invalidSignature(let detail) {
+            throw RPCError(
+                code: .failedPrecondition,
+                message: "incoming agent bundle failed code signature verification: \(detail)"
+            )
+        } catch {
+            throw RPCError(
+                code: .internalError,
+                message: "could not inspect the incoming agent bundle: \(Self.detail(of: error))"
+            )
+        }
+
+        let running: CodesignInfo
+        do {
+            running = try await deps.codesign.inspect(bundleAt: deps.currentBundleURL)
+        } catch {
+            // A running bundle that cannot be inspected is an agent-side
+            // problem — never report it as if the client sent something bad.
+            throw RPCError(
+                code: .internalError,
+                message: "could not inspect the running agent bundle: \(Self.detail(of: error))"
+            )
+        }
+
+        if let policyError = AgentUpdateCodesignPolicy.check(incoming: incoming, running: running) {
+            throw policyError
+        }
+
+        do {
+            try await deps.installer.replaceBundle(at: deps.currentBundleURL, with: stagedApp)
+        } catch let error as AgentBundleInstallerError {
+            throw Self.rpcError(for: error)
+        }
+    }
+
+    /// Schedules the relaunch and this process's termination. Runs *before*
+    /// the ack is written so a failed ack cannot strand the agent in the
+    /// "installed but never restarted" state.
+    private static func commitTail(deps: Dependencies, logger: Logger) {
+        do {
+            try deps.relauncher.scheduleRelaunch(of: deps.currentBundleURL)
+        } catch {
+            logger.error(
+                "Failed to schedule agent relaunch; the agent will exit without reopening",
+                metadata: ["error": "\(error)"]
+            )
+        }
+        deps.relauncher.scheduleTermination()
+    }
+
+    // MARK: - Helpers
+
+    private static func rpcError(for error: AgentBundleInstallerError) -> RPCError {
+        switch error {
+        case .notAnAppArchive(let detail):
+            RPCError(
+                code: .invalidArgument,
+                message: "update payload is not a valid app archive: \(detail)"
+            )
+        case .invalidBundle(let detail):
+            RPCError(
+                code: .invalidArgument,
+                message: "update payload is not a valid agent app bundle: \(detail)"
+            )
+        case .parentNotWritable(let detail):
+            RPCError(code: .permissionDenied, message: detail)
+        case .swapFailed(let detail):
+            // `.swapFailed` details already state whether the destination was
+            // touched or rolled back — pass them through verbatim.
+            RPCError(
+                code: .internalError,
+                message: "failed to install updated app bundle: \(detail)"
+            )
+        }
+    }
+
+    private static func detail(of error: any Error) -> String {
+        guard let codesignError = error as? CodesignVerificationError else { return "\(error)" }
+        switch codesignError {
+        case .invalidSignature(let detail), .inspectionFailed(let detail):
+            return detail
+        }
+    }
+
+    /// Best-effort removal of staging directories left behind by earlier
+    /// interrupted attempts (e.g. a crash mid-upload).
+    private static func removeStaleSessions(in stagingRoot: URL, logger: Logger) {
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: stagingRoot,
+                includingPropertiesForKeys: nil
+            )
+        else {
+            return
+        }
+        for entry in entries {
+            do {
+                try FileManager.default.removeItem(at: entry)
+            } catch {
+                logger.debug(
+                    "Could not remove stale agent update staging entry",
+                    metadata: ["path": "\(entry.path)", "error": "\(error)"]
+                )
+            }
+        }
+    }
+
+    private static func bundleVersion(at bundleURL: URL) -> String? {
+        let infoPlistURL = bundleURL.appendingPathComponent("Contents/Info.plist")
+        guard let data = FileManager.default.contents(atPath: infoPlistURL.path),
+            let parsed = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ),
+            let plist = parsed as? [String: Any]
+        else {
+            return nil
+        }
+        return plist["WLWendyAgentVersion"] as? String
+    }
+
+    private static func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentUpdateSession.swift
@@ -268,6 +268,13 @@ enum AgentUpdateSession {
             stagedApp = try await deps.installer.extractBundle(zipAt: payloadURL, into: sessionDir)
         } catch let error as AgentBundleInstallerError {
             throw Self.rpcError(for: error)
+        } catch {
+            // e.g. the staging directory or `ditto` itself could not be
+            // spawned — an agent-side failure, not a bad payload.
+            throw RPCError(
+                code: .internalError,
+                message: "failed to extract the update payload: \(error)"
+            )
         }
 
         let incoming: CodesignInfo
@@ -305,6 +312,11 @@ enum AgentUpdateSession {
             try await deps.installer.replaceBundle(at: deps.currentBundleURL, with: stagedApp)
         } catch let error as AgentBundleInstallerError {
             throw Self.rpcError(for: error)
+        } catch {
+            throw RPCError(
+                code: .internalError,
+                message: "failed to install updated app bundle: \(error)"
+            )
         }
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+enum AgentBundleInstallerError: Error {
+    /// `ditto -x -k` failed, or the file simply isn't a zip.
+    case notAnAppArchive(String)
+    /// Wrong shape: not exactly one top-level `.app`, or its Info.plist is
+    /// missing/missing required keys.
+    case invalidBundle(String)
+    /// The destination's parent directory cannot be written to, so the
+    /// bundle cannot be replaced.
+    case parentNotWritable(String)
+    /// The rename dance failed; the message notes whether rollback to the
+    /// previous version succeeded.
+    case swapFailed(String)
+}
+
+protocol AgentBundleInstalling: Sendable {
+    /// Extracts the zip with `ditto -x -k` and returns the URL of the single
+    /// top-level `.app` bundle inside `stagingDir`.
+    func extractBundle(zipAt zip: URL, into stagingDir: URL) async throws -> URL
+    /// Replaces `destination` with `staged` via same-directory renames.
+    func replaceBundle(at destination: URL, with staged: URL) async throws
+}
+
+/// Performs a single `FileManager.moveItem` rename. Exists as a seam so
+/// tests can inject a version that fails one specific step of
+/// `replaceBundle`'s rename dance (to exercise the rollback path) without
+/// needing to contrive real filesystem obstacles.
+protocol FileMoving: Sendable {
+    func moveItem(at source: URL, to destination: URL) throws
+}
+
+struct RealFileMover: FileMoving {
+    func moveItem(at source: URL, to destination: URL) throws {
+        try FileManager.default.moveItem(at: source, to: destination)
+    }
+}
+
+/// Installs a downloaded agent bundle: extracts the `ditto`-created zip
+/// (`extractBundle`) and swaps the extracted `.app` into place via
+/// same-directory renames (`replaceBundle`).
+struct DittoAgentBundleInstaller: AgentBundleInstalling {
+    var fileMover: any FileMoving = RealFileMover()
+
+    func extractBundle(zipAt zip: URL, into stagingDir: URL) async throws -> URL {
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+        let result = try await Subprocess.run(
+            "/usr/bin/ditto",
+            ["-x", "-k", zip.path, stagingDir.path],
+            timeout: .seconds(120)
+        )
+        guard result.status == 0 else {
+            throw AgentBundleInstallerError.notAnAppArchive(
+                "ditto -x -k failed (status \(result.status)): "
+                    + result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+
+        let entries = try FileManager.default.contentsOfDirectory(
+            at: stagingDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let appBundles = try entries.filter { url in
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+            return (values.isDirectory ?? false) && url.pathExtension == "app"
+        }
+        guard let appBundle = appBundles.first, appBundles.count == 1 else {
+            throw AgentBundleInstallerError.invalidBundle(
+                "expected exactly one top-level .app bundle in \(stagingDir.path), found \(appBundles.count)"
+            )
+        }
+
+        try Self.validateInfoPlist(of: appBundle)
+        return appBundle
+    }
+
+    /// Reads `Info.plist` with `PropertyListSerialization` rather than
+    /// `Bundle(url:)` — `Bundle` caches by path, and a later successful
+    /// update reusing the same staging path could return stale, already-cached
+    /// metadata instead of re-reading the newly-extracted plist.
+    private static func validateInfoPlist(of appBundle: URL) throws {
+        let infoPlistURL = appBundle.appendingPathComponent("Contents/Info.plist")
+        guard let data = FileManager.default.contents(atPath: infoPlistURL.path) else {
+            throw AgentBundleInstallerError.invalidBundle(
+                "missing Info.plist at \(infoPlistURL.path)"
+            )
+        }
+
+        let plist: [String: Any]
+        do {
+            guard
+                let parsed = try PropertyListSerialization.propertyList(
+                    from: data,
+                    options: [],
+                    format: nil
+                )
+                    as? [String: Any]
+            else {
+                throw AgentBundleInstallerError.invalidBundle(
+                    "Info.plist at \(infoPlistURL.path) is not a dictionary"
+                )
+            }
+            plist = parsed
+        } catch let error as AgentBundleInstallerError {
+            throw error
+        } catch {
+            throw AgentBundleInstallerError.invalidBundle(
+                "failed to parse Info.plist at \(infoPlistURL.path): \(error)"
+            )
+        }
+
+        guard let bundleIdentifier = plist["CFBundleIdentifier"] as? String,
+            !bundleIdentifier.isEmpty
+        else {
+            throw AgentBundleInstallerError.invalidBundle(
+                "Info.plist at \(infoPlistURL.path) is missing CFBundleIdentifier"
+            )
+        }
+        // An app missing WLWendyAgentVersion fatalErrors at launch (see
+        // WendyAgent.version) — installing it would brick a supervisor-less
+        // agent, so reject it here before it's ever swapped into place.
+        guard let agentVersion = plist["WLWendyAgentVersion"] as? String, !agentVersion.isEmpty
+        else {
+            throw AgentBundleInstallerError.invalidBundle(
+                "Info.plist at \(infoPlistURL.path) is missing WLWendyAgentVersion"
+            )
+        }
+    }
+
+    func replaceBundle(at destination: URL, with staged: URL) async throws {
+        let fileManager = FileManager.default
+        let parent = destination.deletingLastPathComponent()
+        guard fileManager.isWritableFile(atPath: parent.path) else {
+            throw AgentBundleInstallerError.parentNotWritable(
+                "cannot replace app bundle at \(destination.path): directory is not writable by the agent"
+            )
+        }
+
+        let name = destination.lastPathComponent
+        Self.removeStaleSiblings(named: name, in: parent, fileManager: fileManager)
+
+        let uuid = UUID().uuidString
+        let incomingURL = parent.appendingPathComponent(".\(name).incoming-\(uuid)")
+        let oldURL = parent.appendingPathComponent(".\(name).old-\(uuid)")
+
+        try self.fileMover.moveItem(at: staged, to: incomingURL)
+
+        let destinationExisted = fileManager.fileExists(atPath: destination.path)
+        if destinationExisted {
+            do {
+                try self.fileMover.moveItem(at: destination, to: oldURL)
+            } catch {
+                try? fileManager.removeItem(at: incomingURL)
+                throw AgentBundleInstallerError.swapFailed(
+                    "failed to move aside existing bundle at \(destination.path): \(error)"
+                )
+            }
+        }
+
+        // The two renames above/below (destination -> old, incoming ->
+        // destination) leave a brief window where `destination` doesn't
+        // exist. `renamex_np(RENAME_SWAP)` would close that window with a
+        // single atomic syscall, but it requires an unsafe C call; not worth
+        // it here because the agent process exits immediately after a
+        // successful swap and the CLI re-verifies the running version on
+        // reconnect.
+        do {
+            try self.fileMover.moveItem(at: incomingURL, to: destination)
+        } catch let installError {
+            guard destinationExisted else {
+                throw AgentBundleInstallerError.swapFailed(
+                    "failed to install new bundle at \(destination.path): \(installError)"
+                )
+            }
+            do {
+                try self.fileMover.moveItem(at: oldURL, to: destination)
+            } catch let rollbackError {
+                throw AgentBundleInstallerError.swapFailed(
+                    "failed to install new bundle at \(destination.path): \(installError);"
+                        + " rollback also failed: \(rollbackError)"
+                )
+            }
+            throw AgentBundleInstallerError.swapFailed(
+                "failed to install new bundle at \(destination.path): \(installError);"
+                    + " previous version restored"
+            )
+        }
+
+        if destinationExisted {
+            try? fileManager.removeItem(at: oldURL)
+        }
+    }
+
+    /// Best-effort cleanup of siblings left behind by a prior interrupted
+    /// update attempt. Failures are ignored — a stray leftover from a
+    /// previous run is not worth failing the current one over.
+    private static func removeStaleSiblings(
+        named name: String,
+        in parent: URL,
+        fileManager: FileManager
+    ) {
+        guard
+            let entries = try? fileManager.contentsOfDirectory(
+                at: parent,
+                includingPropertiesForKeys: nil
+            )
+        else {
+            return
+        }
+        let oldPrefix = ".\(name).old-"
+        let incomingPrefix = ".\(name).incoming-"
+        for entry in entries {
+            let filename = entry.lastPathComponent
+            if filename.hasPrefix(oldPrefix) || filename.hasPrefix(incomingPrefix) {
+                try? fileManager.removeItem(at: entry)
+            }
+        }
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
@@ -145,7 +145,14 @@ struct DittoAgentBundleInstaller: AgentBundleInstalling {
         let incomingURL = parent.appendingPathComponent(".\(name).incoming-\(uuid)")
         let oldURL = parent.appendingPathComponent(".\(name).old-\(uuid)")
 
-        try self.fileMover.moveItem(at: staged, to: incomingURL)
+        do {
+            try self.fileMover.moveItem(at: staged, to: incomingURL)
+        } catch {
+            throw AgentBundleInstallerError.swapFailed(
+                "failed to stage incoming bundle at \(incomingURL.path): \(error); "
+                    + "destination \(destination.path) was not touched"
+            )
+        }
 
         let destinationExisted = fileManager.fileExists(atPath: destination.path)
         if destinationExisted {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentBundleInstaller.swift
@@ -195,14 +195,20 @@ struct DittoAgentBundleInstaller: AgentBundleInstalling {
             )
         }
 
-        if destinationExisted {
-            try? fileManager.removeItem(at: oldURL)
-        }
+        // `oldURL` is deliberately left in place. A bundle that extracts,
+        // verifies, and swaps cleanly can still crash on launch (the realistic
+        // dev-push failure), and on a headless device that would leave no
+        // agent and no way back. Keeping `.<name>.old-<uuid>` next to the
+        // bundle is the manual-recovery escape (`mv` it back over SSH); the
+        // next update's `removeStaleSiblings` reclaims the space.
     }
 
-    /// Best-effort cleanup of siblings left behind by a prior interrupted
-    /// update attempt. Failures are ignored — a stray leftover from a
-    /// previous run is not worth failing the current one over.
+    /// Best-effort cleanup of siblings left behind by earlier updates: the
+    /// rollback copy the previous successful swap retained, plus anything a
+    /// prior interrupted attempt abandoned. This is the *only* thing that
+    /// reclaims those, so it runs before every swap. Failures are ignored — a
+    /// stray leftover from a previous run is not worth failing the current one
+    /// over.
     private static func removeStaleSiblings(
         named name: String,
         in parent: URL,

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
@@ -1,0 +1,69 @@
+import Darwin
+import Foundation
+
+protocol AgentRelaunchScheduling: Sendable {
+    /// Spawns the detached watcher that reopens the bundle after this process exits.
+    func scheduleRelaunch(of bundleURL: URL) throws
+    /// Kicks off process termination after a short ack-flush delay.
+    func scheduleTermination()
+}
+
+/// Spawns a detached watcher process that waits for this agent process to
+/// exit, then reopens the (freshly swapped-in) app bundle — the mechanism
+/// that turns "install a new bundle" into "the new version is running."
+struct AgentRelauncher: AgentRelaunchScheduling {
+    /// Injected by the app target (clean quit path); nil ⇒ exit(0).
+    let terminate: (@Sendable () async -> Void)?
+
+    func scheduleRelaunch(of bundleURL: URL) throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = Self.makeArguments(pid: pid, bundlePath: bundleURL.path)
+        // Null all three stdio handles so the child does not hold our pipes
+        // open — it must be able to outlive us cleanly.
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        // Deliberately not waiting: once this process exits, the child is
+        // reparented and survives — it IS the mechanism that relaunches the
+        // app after we're gone.
+    }
+
+    /// Builds the `/bin/sh -c <script> wendy-agent-relaunch <pid> <bundlePath>`
+    /// arguments. `pid`/`bundlePath` are passed as positional args (`$1`/`$2`)
+    /// rather than interpolated into the script text, avoiding shell quoting
+    /// bugs for paths with spaces or other special characters.
+    static func makeArguments(pid: Int32, bundlePath: String) -> [String] {
+        let script = """
+            i=0
+            while /bin/kill -0 "$1" 2>/dev/null; do
+              /bin/sleep 0.5
+              i=$((i+1)); [ "$i" -ge 600 ] && exit 1
+            done
+            exec /usr/bin/open "$2"
+            """
+        return ["-c", script, "wendy-agent-relaunch", String(pid), bundlePath]
+    }
+
+    func scheduleTermination() {
+        // Hard watchdog: if a hung graceful stop never calls `terminate`,
+        // force the process down anyway so the update can't wedge forever.
+        Task.detached {
+            try? await Task.sleep(for: .seconds(15))
+            exit(0)
+        }
+        // Give the gRPC ack a brief moment to flush to the client before we
+        // tear the connection down.
+        Task.detached {
+            try? await Task.sleep(for: .milliseconds(500))
+            if let terminate = self.terminate {
+                await terminate()
+            } else {
+                exit(0)
+            }
+        }
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
@@ -15,6 +15,23 @@ struct AgentRelauncher: AgentRelaunchScheduling {
     /// Injected by the app target (clean quit path); nil ⇒ exit(0).
     let terminate: (@Sendable () async -> Void)?
 
+    /// How long the graceful quit gets before the process is forced down.
+    /// Two bounds pin this value:
+    ///  - It must outlast a real teardown: `WendyAgent.stop()` stops running
+    ///    apps *sequentially*, and a containerized app can cost ~10 s (the
+    ///    `docker stop` timeout) plus a ~5 s attached wait, so two running
+    ///    apps already need ~30-35 s. The old 15 s hard-killed every update on
+    ///    a device that was actually running something.
+    ///  - It must stay comfortably inside the CLI's darwin agent-restart wait
+    ///    (`darwinAgentRestartTimeout`, 60 s, polled from the update ack):
+    ///    exiting at 45 s still leaves the relaunched app time to come back up
+    ///    before the CLI gives up on it.
+    static let hardExitDelay: Duration = .seconds(45)
+
+    /// How long the gRPC ack gets to flush to the client before the graceful
+    /// quit tears the connection down.
+    static let ackFlushDelay: Duration = .milliseconds(500)
+
     func scheduleRelaunch(of bundleURL: URL) throws {
         let pid = ProcessInfo.processInfo.processIdentifier
         let process = Process()
@@ -52,13 +69,13 @@ struct AgentRelauncher: AgentRelaunchScheduling {
         // Hard watchdog: if a hung graceful stop never calls `terminate`,
         // force the process down anyway so the update can't wedge forever.
         Task.detached {
-            try? await Task.sleep(for: .seconds(15))
+            try? await Task.sleep(for: Self.hardExitDelay)
             exit(0)
         }
         // Give the gRPC ack a brief moment to flush to the client before we
         // tear the connection down.
         Task.detached {
-            try? await Task.sleep(for: .milliseconds(500))
+            try? await Task.sleep(for: Self.ackFlushDelay)
             if let terminate = self.terminate {
                 await terminate()
             } else {

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/CodesignVerifier.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/CodesignVerifier.swift
@@ -63,7 +63,7 @@ struct SecStaticCodeVerifier: CodesignVerifying {
         )
         guard validityStatus == errSecSuccess else {
             let detail =
-                cfError.map { String(describing: $0.takeRetainedValue() as Error) }
+                cfError.map { String(describing: $0.takeRetainedValue() as (any Error)) }
                 ?? "status \(validityStatus)"
             throw CodesignVerificationError.invalidSignature(detail)
         }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/CodesignVerifier.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/CodesignVerifier.swift
@@ -1,0 +1,154 @@
+import Foundation
+import GRPCCore
+import Security
+
+/// Team ID, Developer ID status, and code identifier for a code-signed app
+/// bundle, as inspected via the SecStaticCode API.
+struct CodesignInfo: Sendable, Equatable {
+    /// `kSecCodeInfoTeamIdentifier`; `nil` for ad-hoc/unsigned bundles.
+    var teamID: String?
+    /// Whether the bundle satisfies the Developer ID requirement (Apple root
+    /// anchor plus the Developer ID intermediate/leaf certificate policy OIDs).
+    var isDeveloperID: Bool
+    /// `kSecCodeInfoIdentifier` — the bundle's code identifier, typically its
+    /// `CFBundleIdentifier`.
+    var bundleIdentifier: String?
+}
+
+enum CodesignVerificationError: Error {
+    /// Deep/strict validation failed — the bundle is unsigned, tampered, or
+    /// otherwise does not pass `SecStaticCodeCheckValidityWithErrors`.
+    case invalidSignature(String)
+    /// The bundle could not even be inspected (e.g. `SecStaticCodeCreateWithPath`
+    /// or `SecCodeCopySigningInformation` failed).
+    case inspectionFailed(String)
+}
+
+protocol CodesignVerifying: Sendable {
+    /// Deep+strict-verifies the bundle at `url`; throws `CodesignVerificationError`.
+    func inspect(bundleAt url: URL) async throws -> CodesignInfo
+}
+
+/// `CodesignVerifying` backed by the SecStaticCode API — NOT `codesign`
+/// output parsing. `SecStaticCodeCheckValidityWithErrors` with
+/// `kSecCSCheckNestedCode | kSecCSStrictValidate | kSecCSCheckAllArchitectures`
+/// is the same validation engine as `codesign --verify --deep --strict`.
+struct SecStaticCodeVerifier: CodesignVerifying {
+    func inspect(bundleAt url: URL) async throws -> CodesignInfo {
+        // Deep/strict validation walks every nested bundle and architecture
+        // slice, so it is I/O heavy — run it off the cooperative pool.
+        try await BlockingExecutor.run {
+            try Self.inspectBlocking(bundleAt: url)
+        }
+    }
+
+    private static func inspectBlocking(bundleAt url: URL) throws -> CodesignInfo {
+        var code: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(url as CFURL, [], &code)
+        guard createStatus == errSecSuccess, let code else {
+            throw CodesignVerificationError.inspectionFailed(
+                "SecStaticCodeCreateWithPath failed (status \(createStatus)) for \(url.path)"
+            )
+        }
+
+        let validityFlags = SecCSFlags(
+            rawValue: kSecCSCheckNestedCode | kSecCSStrictValidate | kSecCSCheckAllArchitectures
+        )
+        var cfError: Unmanaged<CFError>?
+        let validityStatus = SecStaticCodeCheckValidityWithErrors(
+            code,
+            validityFlags,
+            nil,
+            &cfError
+        )
+        guard validityStatus == errSecSuccess else {
+            let detail =
+                cfError.map { String(describing: $0.takeRetainedValue() as Error) }
+                ?? "status \(validityStatus)"
+            throw CodesignVerificationError.invalidSignature(detail)
+        }
+
+        var infoDict: CFDictionary?
+        let infoStatus = SecCodeCopySigningInformation(
+            code,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &infoDict
+        )
+        guard infoStatus == errSecSuccess, let infoDict = infoDict as? [String: Any] else {
+            throw CodesignVerificationError.inspectionFailed(
+                "SecCodeCopySigningInformation failed (status \(infoStatus)) for \(url.path)"
+            )
+        }
+
+        return CodesignInfo(
+            teamID: infoDict[kSecCodeInfoTeamIdentifier as String] as? String,
+            isDeveloperID: Self.satisfiesDeveloperIDRequirement(code: code),
+            bundleIdentifier: infoDict[kSecCodeInfoIdentifier as String] as? String
+        )
+    }
+
+    /// Apple root anchor + Developer ID intermediate/leaf certificate policy
+    /// OIDs — the same requirement Gatekeeper checks for Developer ID signed
+    /// software.
+    private static let developerIDRequirementString =
+        "anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6]"
+        + " and certificate leaf[field.1.2.840.113635.100.6.1.13]"
+
+    private static func satisfiesDeveloperIDRequirement(code: SecStaticCode) -> Bool {
+        var requirement: SecRequirement?
+        let requirementStatus = SecRequirementCreateWithString(
+            developerIDRequirementString as CFString,
+            [],
+            &requirement
+        )
+        guard requirementStatus == errSecSuccess, let requirement else {
+            return false
+        }
+        return SecStaticCodeCheckValidity(code, [], requirement) == errSecSuccess
+    }
+}
+
+/// Policy gate applied before an incoming agent bundle is installed.
+enum AgentUpdateCodesignPolicy {
+    /// `running` describes the currently-installed (already-executing)
+    /// bundle; `incoming` describes the bundle about to be installed.
+    /// Returns `nil` when the incoming bundle may be installed.
+    static func check(incoming: CodesignInfo, running: CodesignInfo) -> RPCError? {
+        // Never swap in a different app, regardless of signing posture.
+        if let incomingID = incoming.bundleIdentifier,
+            let runningID = running.bundleIdentifier,
+            incomingID != runningID
+        {
+            return RPCError(
+                code: .failedPrecondition,
+                message: "incoming bundle identifier \(incomingID) does not match \(runningID)"
+            )
+        }
+
+        guard running.isDeveloperID else {
+            // Dev escape hatch: a dev/ad-hoc-signed running build accepts any
+            // validly signed bundle, so dev-on-dev pushes to the headless
+            // test mini keep working.
+            return nil
+        }
+
+        guard incoming.isDeveloperID else {
+            return RPCError(
+                code: .failedPrecondition,
+                message: "incoming agent bundle is not Developer ID signed; refusing install"
+            )
+        }
+
+        guard let incomingTeamID = incoming.teamID, let runningTeamID = running.teamID,
+            incomingTeamID == runningTeamID
+        else {
+            return RPCError(
+                code: .permissionDenied,
+                message:
+                    "incoming agent bundle Team ID (\(incoming.teamID ?? "none")) does not match the running agent (\(running.teamID ?? "none"))"
+            )
+        }
+
+        return nil
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -140,6 +140,13 @@ public actor WendyAgent {
         }
     }
 
+    /// Registers the app's clean-quit path, used to terminate the process once
+    /// a self-update has been installed. Call before `start()`: the handler is
+    /// captured when the main server's services are built.
+    public func setAgentTerminationHandler(_ handler: @escaping @Sendable () async -> Void) {
+        self.agentTerminationHandler = handler
+    }
+
     public func stopApp(id: String) async {
         await self.containerService?.stopApp(id: id)
     }
@@ -159,6 +166,14 @@ public actor WendyAgent {
     }()
 
     private let logger = Logger(label: "sh.wendy.agent")
+
+    /// Held here, not on `AgentService`, so a single in-flight update stays
+    /// serialized across the service rebuilds that provisioning transitions
+    /// perform (`switchMainServer()`).
+    private let agentUpdateLock = AgentUpdateLock()
+    /// The app's clean-quit path, invoked after an agent update is committed.
+    /// `nil` (e.g. in tests) falls back to `exit(0)` inside `AgentRelauncher`.
+    private var agentTerminationHandler: (@Sendable () async -> Void)?
 
     private var mainServer: PosixGRPCServer?
     private var mainServerTask: Task<Void, any Error>?
@@ -304,7 +319,12 @@ public actor WendyAgent {
         let info = await provisioningService.provisioningInfo()
 
         let services: [any RegistrableRPCService] = [
-            AgentService(),
+            AgentService(
+                updateLock: self.agentUpdateLock,
+                updateDependencies: .init(
+                    relauncher: AgentRelauncher(terminate: self.agentTerminationHandler)
+                )
+            ),
             containerService,
             AudioService(),
             provisioningService,

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -704,7 +704,11 @@ public actor WendyAgent {
                 try await registry.run()
             } catch {
                 Self.logRegistryListenerStopped(
-                    logger, listener: "pull", port: LocalRegistryRef.pullPort, error: error)
+                    logger,
+                    listener: "pull",
+                    port: LocalRegistryRef.pullPort,
+                    error: error
+                )
             }
         }
     }
@@ -744,7 +748,11 @@ public actor WendyAgent {
                 try await registry.run()
             } catch {
                 Self.logRegistryListenerStopped(
-                    logger, listener: "push", port: LocalRegistryRef.pushPort, error: error)
+                    logger,
+                    listener: "push",
+                    port: LocalRegistryRef.pushPort,
+                    error: error
+                )
             }
         }
     }
@@ -760,7 +768,10 @@ public actor WendyAgent {
     }
 
     private static func logRegistryListenerStopped(
-        _ logger: Logger, listener: String, port: Int, error: any Error
+        _ logger: Logger,
+        listener: String,
+        port: Int,
+        error: any Error
     ) {
         if error is CancellationError { return }
         var metadata: Logger.Metadata = [

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgentPaths.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgentPaths.swift
@@ -8,6 +8,12 @@ enum WendyAgentPaths {
         )
     }
 
+    /// Scratch space for downloading and staging an incoming agent bundle
+    /// during a remote self-update, before it is swapped into place.
+    static var agentUpdateStagingDirectory: URL {
+        self.stateDirectory.appendingPathComponent("agent-update", isDirectory: true)
+    }
+
     private static var applicationSupportDirectory: URL {
         FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.homeDirectoryForCurrentUser

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import Testing
+
+@testable import WendyAgentCore
+
+private func makeTempDirectory() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "AgentBundleInstallerTests-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+private func writeInfoPlist(
+    bundleIdentifier: String,
+    agentVersion: String?,
+    into appBundle: URL
+) throws {
+    let contentsDir = appBundle.appendingPathComponent("Contents", isDirectory: true)
+    try FileManager.default.createDirectory(at: contentsDir, withIntermediateDirectories: true)
+    var plist: [String: Any] = ["CFBundleIdentifier": bundleIdentifier]
+    if let agentVersion {
+        plist["WLWendyAgentVersion"] = agentVersion
+    }
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    try data.write(to: contentsDir.appendingPathComponent("Info.plist"))
+}
+
+private func makeFakeApp(at url: URL, marker: String) throws {
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try Data(marker.utf8).write(to: url.appendingPathComponent("marker.txt"))
+}
+
+private func readMarker(of appURL: URL) throws -> String {
+    let data = try Data(contentsOf: appURL.appendingPathComponent("marker.txt"))
+    return String(decoding: data, as: UTF8.self)
+}
+
+/// Zips `source` (an absolute path) with `ditto -c -k`. When `keepParent` is
+/// true, `source`'s own directory name is preserved as a top-level wrapper in
+/// the archive; otherwise `source`'s *contents* become the archive's top
+/// level (verified empirically against the system `ditto`).
+private func zip(_ source: URL, to zipURL: URL, keepParent: Bool) async throws {
+    var arguments = ["-c", "-k"]
+    if keepParent {
+        arguments.append("--keepParent")
+    }
+    arguments.append(contentsOf: [source.path, zipURL.path])
+    let result = try await Subprocess.run("/usr/bin/ditto", arguments)
+    try #require(result.status == 0, "ditto -c -k setup failed: \(result.stderr)")
+}
+
+@Suite("DittoAgentBundleInstaller.extractBundle")
+struct DittoAgentBundleInstallerExtractTests {
+    private func expectInvalidBundle(
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ operation: () async throws -> Void
+    ) async {
+        do {
+            try await operation()
+            Issue.record("expected .invalidBundle", sourceLocation: sourceLocation)
+        } catch AgentBundleInstallerError.invalidBundle {
+            // expected
+        } catch {
+            Issue.record("expected .invalidBundle, got \(error)", sourceLocation: sourceLocation)
+        }
+    }
+
+    @Test("garbage bytes are not a valid app archive")
+    func garbageBytesThrowsNotAnAppArchive() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let zipURL = root.appendingPathComponent("garbage.zip")
+        try Data("not a zip file, just garbage bytes".utf8).write(to: zipURL)
+
+        let stagingDir = root.appendingPathComponent("staging", isDirectory: true)
+        let installer = DittoAgentBundleInstaller()
+
+        do {
+            _ = try await installer.extractBundle(zipAt: zipURL, into: stagingDir)
+            Issue.record("expected .notAnAppArchive")
+        } catch AgentBundleInstallerError.notAnAppArchive {
+            // expected
+        } catch {
+            Issue.record("expected .notAnAppArchive, got \(error)")
+        }
+    }
+
+    @Test("a zip with no top-level .app bundle is invalid")
+    func noAppBundleThrowsInvalidBundle() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appBundle = root.appendingPathComponent("source/Foo.app", isDirectory: true)
+        try writeInfoPlist(
+            bundleIdentifier: "sh.wendy.agent",
+            agentVersion: "1.2.3",
+            into: appBundle
+        )
+
+        let zipURL = root.appendingPathComponent("nofolder.zip")
+        // No --keepParent: Foo.app's *contents* (Contents/Info.plist) become
+        // the archive's top level, so there is no top-level .app after extraction.
+        try await zip(appBundle, to: zipURL, keepParent: false)
+
+        let stagingDir = root.appendingPathComponent("staging", isDirectory: true)
+        let installer = DittoAgentBundleInstaller()
+        await self.expectInvalidBundle {
+            _ = try await installer.extractBundle(zipAt: zipURL, into: stagingDir)
+        }
+    }
+
+    @Test("a zip with two top-level .app bundles is invalid")
+    func twoAppBundlesThrowsInvalidBundle() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sourceDir = root.appendingPathComponent("source", isDirectory: true)
+        try writeInfoPlist(
+            bundleIdentifier: "sh.wendy.agent",
+            agentVersion: "1.2.3",
+            into: sourceDir.appendingPathComponent("Foo.app", isDirectory: true)
+        )
+        try writeInfoPlist(
+            bundleIdentifier: "sh.wendy.agent",
+            agentVersion: "1.2.3",
+            into: sourceDir.appendingPathComponent("Bar.app", isDirectory: true)
+        )
+
+        let zipURL = root.appendingPathComponent("twoapps.zip")
+        try await zip(sourceDir, to: zipURL, keepParent: false)
+
+        let stagingDir = root.appendingPathComponent("staging", isDirectory: true)
+        let installer = DittoAgentBundleInstaller()
+        await self.expectInvalidBundle {
+            _ = try await installer.extractBundle(zipAt: zipURL, into: stagingDir)
+        }
+    }
+
+    @Test("an .app missing WLWendyAgentVersion is invalid")
+    func missingAgentVersionThrowsInvalidBundle() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appBundle = root.appendingPathComponent("source/Foo.app", isDirectory: true)
+        try writeInfoPlist(bundleIdentifier: "sh.wendy.agent", agentVersion: nil, into: appBundle)
+
+        let zipURL = root.appendingPathComponent("noversion.zip")
+        try await zip(appBundle, to: zipURL, keepParent: true)
+
+        let stagingDir = root.appendingPathComponent("staging", isDirectory: true)
+        let installer = DittoAgentBundleInstaller()
+        await self.expectInvalidBundle {
+            _ = try await installer.extractBundle(zipAt: zipURL, into: stagingDir)
+        }
+    }
+
+    @Test("a valid app bundle is extracted and its URL returned")
+    func validBundleReturnsAppURL() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appBundle = root.appendingPathComponent("source/Foo.app", isDirectory: true)
+        try writeInfoPlist(
+            bundleIdentifier: "sh.wendy.agent",
+            agentVersion: "1.2.3",
+            into: appBundle
+        )
+
+        let zipURL = root.appendingPathComponent("valid.zip")
+        try await zip(appBundle, to: zipURL, keepParent: true)
+
+        let stagingDir = root.appendingPathComponent("staging", isDirectory: true)
+        let installer = DittoAgentBundleInstaller()
+        let extracted = try await installer.extractBundle(zipAt: zipURL, into: stagingDir)
+
+        let expected = stagingDir.appendingPathComponent("Foo.app", isDirectory: true)
+        #expect(extracted.standardizedFileURL.path == expected.standardizedFileURL.path)
+
+        let infoPlistData = try Data(
+            contentsOf: extracted.appendingPathComponent("Contents/Info.plist")
+        )
+        let plist =
+            try PropertyListSerialization.propertyList(
+                from: infoPlistData,
+                options: [],
+                format: nil
+            )
+            as? [String: Any]
+        #expect(plist?["CFBundleIdentifier"] as? String == "sh.wendy.agent")
+        #expect(plist?["WLWendyAgentVersion"] as? String == "1.2.3")
+    }
+}
+
+@Suite("DittoAgentBundleInstaller.replaceBundle")
+struct DittoAgentBundleInstallerReplaceTests {
+    /// Stray `.Foo.app.old-*` / `.Foo.app.incoming-*` siblings left directly
+    /// inside `parent`.
+    private func staleSiblings(in parent: URL, name: String) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: parent.path)
+            .filter { $0.hasPrefix(".\(name).") }
+    }
+
+    @Test("swaps destination contents and leaves no stray siblings behind")
+    func happySwapReplacesContents() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = root.appendingPathComponent("Foo.app", isDirectory: true)
+        try makeFakeApp(at: destination, marker: "old")
+
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        let installer = DittoAgentBundleInstaller()
+        try await installer.replaceBundle(at: destination, with: staged)
+
+        #expect(try readMarker(of: destination) == "new")
+        #expect(!FileManager.default.fileExists(atPath: staged.path))
+        #expect(try self.staleSiblings(in: root, name: "Foo.app").isEmpty)
+    }
+
+    @Test("installs fresh when destination does not exist yet")
+    func freshInstallWhenDestinationMissing() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = root.appendingPathComponent("Foo.app", isDirectory: true)
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        let installer = DittoAgentBundleInstaller()
+        try await installer.replaceBundle(at: destination, with: staged)
+
+        #expect(try readMarker(of: destination) == "new")
+        #expect(!FileManager.default.fileExists(atPath: staged.path))
+        #expect(try self.staleSiblings(in: root, name: "Foo.app").isEmpty)
+    }
+
+    @Test("a non-writable parent directory is rejected before touching the bundle")
+    func nonWritableParentThrowsParentNotWritable() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parent = root.appendingPathComponent("locked", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let destination = parent.appendingPathComponent("Foo.app", isDirectory: true)
+        try makeFakeApp(at: destination, marker: "old")
+
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: parent.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: parent.path
+            )
+        }
+
+        let installer = DittoAgentBundleInstaller()
+        do {
+            try await installer.replaceBundle(at: destination, with: staged)
+            Issue.record("expected .parentNotWritable")
+        } catch AgentBundleInstallerError.parentNotWritable {
+            // expected
+        } catch {
+            Issue.record("expected .parentNotWritable, got \(error)")
+        }
+    }
+
+    /// `FileMoving` double that fails the *first* time it is asked to move
+    /// something onto `target`, then behaves normally afterward. This lets a
+    /// test sabotage exactly the final `incoming -> destination` rename in
+    /// `replaceBundle` (whose `to` is `destination`/`target`) and observe the
+    /// rollback, while the rollback's own `old -> destination` move (the
+    /// second time `to == target`) is allowed to succeed for real.
+    private final class FailOnceMover: FileMoving, @unchecked Sendable {
+        private let target: URL
+        private var hasFailed = false
+
+        init(target: URL) {
+            self.target = target
+        }
+
+        func moveItem(at source: URL, to destination: URL) throws {
+            if destination.standardizedFileURL == self.target.standardizedFileURL, !self.hasFailed {
+                self.hasFailed = true
+                throw SabotageError.simulatedFailure
+            }
+            try FileManager.default.moveItem(at: source, to: destination)
+        }
+    }
+
+    private enum SabotageError: Error {
+        case simulatedFailure
+    }
+
+    @Test("a failure on the final rename rolls back to the previous version")
+    func finalRenameFailureRollsBack() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = root.appendingPathComponent("Foo.app", isDirectory: true)
+        try makeFakeApp(at: destination, marker: "old")
+
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        var installer = DittoAgentBundleInstaller()
+        installer.fileMover = FailOnceMover(target: destination)
+
+        do {
+            try await installer.replaceBundle(at: destination, with: staged)
+            Issue.record("expected .swapFailed")
+        } catch AgentBundleInstallerError.swapFailed(let message) {
+            #expect(message.contains("previous version restored"))
+        } catch {
+            Issue.record("expected .swapFailed, got \(error)")
+        }
+
+        // Rollback must have restored the original bundle at `destination`.
+        #expect(try readMarker(of: destination) == "old")
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
@@ -294,8 +294,60 @@ struct DittoAgentBundleInstallerReplaceTests {
         }
     }
 
+    /// `FileMoving` double that always fails when asked to move something
+    /// *from* `source`. `replaceBundle`'s first rename (`staged ->
+    /// incomingURL`) is the only step whose origin is known ahead of time
+    /// (the intermediate `incomingURL`/`oldURL` paths are UUID-suffixed), so
+    /// matching on `source` is what lets a test sabotage exactly that step.
+    private final class FailMovingFrom: FileMoving, @unchecked Sendable {
+        private let source: URL
+
+        init(source: URL) {
+            self.source = source
+        }
+
+        func moveItem(at source: URL, to destination: URL) throws {
+            if source.standardizedFileURL == self.source.standardizedFileURL {
+                throw SabotageError.simulatedFailure
+            }
+            try FileManager.default.moveItem(at: source, to: destination)
+        }
+    }
+
     private enum SabotageError: Error {
         case simulatedFailure
+    }
+
+    @Test(
+        "a failure staging the incoming bundle is reported as .swapFailed and leaves destination untouched"
+    )
+    func stagingFailureLeavesDestinationUntouched() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = root.appendingPathComponent("Foo.app", isDirectory: true)
+        try makeFakeApp(at: destination, marker: "old")
+
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        var installer = DittoAgentBundleInstaller()
+        installer.fileMover = FailMovingFrom(source: staged)
+
+        do {
+            try await installer.replaceBundle(at: destination, with: staged)
+            Issue.record("expected .swapFailed")
+        } catch AgentBundleInstallerError.swapFailed(let message) {
+            #expect(message.contains("was not touched"))
+        } catch {
+            Issue.record("expected .swapFailed, got \(error)")
+        }
+
+        // Nothing was moved: the original bundle is still at `destination`
+        // and `staged` is untouched, with no leftover rename-dance siblings.
+        #expect(try readMarker(of: destination) == "old")
+        #expect(try readMarker(of: staged) == "new")
+        #expect(try self.staleSiblings(in: root, name: "Foo.app").isEmpty)
     }
 
     @Test("a failure on the final rename rolls back to the previous version")

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentBundleInstallerTests.swift
@@ -203,7 +203,7 @@ struct DittoAgentBundleInstallerReplaceTests {
             .filter { $0.hasPrefix(".\(name).") }
     }
 
-    @Test("swaps destination contents and leaves no stray siblings behind")
+    @Test("swaps destination contents and keeps the replaced bundle as a rollback copy")
     func happySwapReplacesContents() async throws {
         let root = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -219,7 +219,50 @@ struct DittoAgentBundleInstallerReplaceTests {
 
         #expect(try readMarker(of: destination) == "new")
         #expect(!FileManager.default.fileExists(atPath: staged.path))
-        #expect(try self.staleSiblings(in: root, name: "Foo.app").isEmpty)
+
+        // The previous bundle is deliberately retained: a new bundle that
+        // installs cleanly can still crash on launch, and this copy is the
+        // only local way back on a headless device. The next replaceBundle
+        // reclaims it.
+        let siblings = try self.staleSiblings(in: root, name: "Foo.app")
+        #expect(siblings.count == 1)
+        let rollback = try #require(siblings.first)
+        #expect(rollback.hasPrefix(".Foo.app.old-"))
+        #expect(try readMarker(of: root.appendingPathComponent(rollback)) == "old")
+    }
+
+    @Test("stale siblings are reclaimed, leaving only the bundle this swap replaced")
+    func staleSiblingsAreReclaimedByTheNextSwap() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = root.appendingPathComponent("Foo.app", isDirectory: true)
+        try makeFakeApp(at: destination, marker: "old")
+
+        // Left behind by earlier updates: a retained rollback copy and an
+        // interrupted attempt's staging directory. This cleanup is the only
+        // thing that reclaims them, so it is load-bearing.
+        let strayOld = root.appendingPathComponent(".Foo.app.old-\(UUID().uuidString)")
+        let strayIncoming = root.appendingPathComponent(".Foo.app.incoming-\(UUID().uuidString)")
+        try makeFakeApp(at: strayOld, marker: "ancient")
+        try makeFakeApp(at: strayIncoming, marker: "interrupted")
+
+        let staged = root.appendingPathComponent("staged/Foo.app", isDirectory: true)
+        try makeFakeApp(at: staged, marker: "new")
+
+        let installer = DittoAgentBundleInstaller()
+        try await installer.replaceBundle(at: destination, with: staged)
+
+        #expect(try readMarker(of: destination) == "new")
+        #expect(!FileManager.default.fileExists(atPath: strayOld.path))
+        #expect(!FileManager.default.fileExists(atPath: strayIncoming.path))
+
+        // Exactly one sibling survives: the bundle this swap just replaced.
+        let siblings = try self.staleSiblings(in: root, name: "Foo.app")
+        #expect(siblings.count == 1)
+        let rollback = try #require(siblings.first)
+        #expect(rollback.hasPrefix(".Foo.app.old-"))
+        #expect(try readMarker(of: root.appendingPathComponent(rollback)) == "old")
     }
 
     @Test("installs fresh when destination does not exist yet")

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentImageRegistryListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentImageRegistryListenerTests.swift
@@ -50,7 +50,8 @@ struct AgentImageRegistryListenerTests {
             try await client.execute(uri: "/v2", method: .get) { response in
                 #expect(response.status == .ok)
             }
-            try await client.execute(uri: "/v2/app/blobs/\(blobDigest)", method: .head) { response in
+            try await client.execute(uri: "/v2/app/blobs/\(blobDigest)", method: .head) {
+                response in
                 #expect(response.status == .ok)
             }
             try await client.execute(uri: "/v2/app/blobs/\(blobDigest)", method: .get) { response in
@@ -66,7 +67,8 @@ struct AgentImageRegistryListenerTests {
                 #expect(response.status == .notFound)
             }
             try await client.execute(
-                uri: "/v2/app/manifests/latest", method: .put,
+                uri: "/v2/app/manifests/latest",
+                method: .put,
                 body: .init(data: manifest)
             ) { response in
                 #expect(response.status == .notFound)
@@ -83,7 +85,8 @@ struct AgentImageRegistryListenerTests {
             let blob = Data("monolithic-layer".utf8)
             let blobDigest = Self.digest(of: blob)
             try await client.execute(
-                uri: "/v2/app/blobs/uploads?digest=\(blobDigest)", method: .post,
+                uri: "/v2/app/blobs/uploads?digest=\(blobDigest)",
+                method: .post,
                 body: .init(data: blob)
             ) { response in
                 #expect(response.status == .created)
@@ -94,19 +97,23 @@ struct AgentImageRegistryListenerTests {
             let chunked = Data("chunked-layer-contents".utf8)
             let chunkedDigest = Self.digest(of: chunked)
             let location = try await client.execute(
-                uri: "/v2/app/blobs/uploads", method: .post
+                uri: "/v2/app/blobs/uploads",
+                method: .post
             ) { response -> String in
                 #expect(response.status == .accepted)
                 return try #require(response.headers[.location])
             }
             let half = chunked.count / 2
             try await client.execute(
-                uri: location, method: .patch, body: .init(data: chunked.prefix(half))
+                uri: location,
+                method: .patch,
+                body: .init(data: chunked.prefix(half))
             ) { response in
                 #expect(response.status == .accepted)
             }
             try await client.execute(
-                uri: "\(location)?digest=\(chunkedDigest)", method: .put,
+                uri: "\(location)?digest=\(chunkedDigest)",
+                method: .put,
                 body: .init(data: chunked.suffix(from: half))
             ) { response in
                 #expect(response.status == .created)
@@ -115,9 +122,12 @@ struct AgentImageRegistryListenerTests {
 
             // Manifest PUT then read-back.
             let manifest = Data(
-                #"{"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#.utf8)
+                #"{"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#.utf8
+            )
             try await client.execute(
-                uri: "/v2/app/manifests/latest", method: .put, body: .init(data: manifest)
+                uri: "/v2/app/manifests/latest",
+                method: .put,
+                body: .init(data: manifest)
             ) { response in
                 #expect(response.status == .created)
             }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import GRPCCore
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("AgentUpdateCodesignPolicy")
+struct AgentUpdateCodesignPolicyTests {
+    private func info(
+        teamID: String?,
+        isDeveloperID: Bool,
+        bundleIdentifier: String?
+    ) -> CodesignInfo {
+        CodesignInfo(
+            teamID: teamID,
+            isDeveloperID: isDeveloperID,
+            bundleIdentifier: bundleIdentifier
+        )
+    }
+
+    @Test("Developer ID incoming and running with the same team ID is allowed")
+    func sameTeamDeveloperIDAllowed() {
+        let running = self.info(
+            teamID: "TEAM1",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let incoming = self.info(
+            teamID: "TEAM1",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        #expect(AgentUpdateCodesignPolicy.check(incoming: incoming, running: running) == nil)
+    }
+
+    @Test("Developer ID incoming and running with different team IDs is denied")
+    func differentTeamDeveloperIDDenied() {
+        let running = self.info(
+            teamID: "TEAM1",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let incoming = self.info(
+            teamID: "TEAM2",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let error = AgentUpdateCodesignPolicy.check(incoming: incoming, running: running)
+        #expect(error?.code == .permissionDenied)
+        #expect(error?.message.contains("TEAM2") == true)
+        #expect(error?.message.contains("TEAM1") == true)
+    }
+
+    @Test("Developer ID running rejects a non-Developer-ID incoming bundle")
+    func developerIDRunningRejectsNonDeveloperIDIncoming() {
+        let running = self.info(
+            teamID: "TEAM1",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let incoming = self.info(
+            teamID: nil,
+            isDeveloperID: false,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let error = AgentUpdateCodesignPolicy.check(incoming: incoming, running: running)
+        #expect(error?.code == .failedPrecondition)
+        #expect(error?.message.contains("not Developer ID signed") == true)
+    }
+
+    @Test("non-Developer-ID running accepts an ad-hoc-signed incoming bundle (dev escape hatch)")
+    func nonDeveloperIDRunningAllowsAdHocIncoming() {
+        let running = self.info(
+            teamID: nil,
+            isDeveloperID: false,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let incoming = self.info(
+            teamID: nil,
+            isDeveloperID: false,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        #expect(AgentUpdateCodesignPolicy.check(incoming: incoming, running: running) == nil)
+    }
+
+    @Test("bundle identifier mismatch is denied even for a dev running build")
+    func bundleIdentifierMismatchDeniedForDevRunning() {
+        let running = self.info(
+            teamID: nil,
+            isDeveloperID: false,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        let incoming = self.info(
+            teamID: nil,
+            isDeveloperID: false,
+            bundleIdentifier: "sh.wendy.evil"
+        )
+        let error = AgentUpdateCodesignPolicy.check(incoming: incoming, running: running)
+        #expect(error?.code == .failedPrecondition)
+        #expect(error?.message.contains("sh.wendy.evil") == true)
+        #expect(error?.message.contains("sh.wendy.agent") == true)
+    }
+
+    @Test("nil vs. set bundle identifier is allowed (not treated as a mismatch)")
+    func nilVersusSetBundleIdentifierAllowed() {
+        let running = self.info(teamID: "TEAM1", isDeveloperID: true, bundleIdentifier: nil)
+        let incoming = self.info(
+            teamID: "TEAM1",
+            isDeveloperID: true,
+            bundleIdentifier: "sh.wendy.agent"
+        )
+        #expect(AgentUpdateCodesignPolicy.check(incoming: incoming, running: running) == nil)
+    }
+}
+
+@Suite("AgentUpdateLock")
+struct AgentUpdateLockTests {
+    @Test("tryAcquire succeeds once, fails while held, then succeeds again after release")
+    func tryAcquireThenRelease() async {
+        let lock = AgentUpdateLock()
+        #expect(await lock.tryAcquire() == true)
+        #expect(await lock.tryAcquire() == false)
+        await lock.release()
+        #expect(await lock.tryAcquire() == true)
+    }
+}
+
+@Suite("AgentRelauncher.makeArguments")
+struct AgentRelauncherMakeArgumentsTests {
+    @Test("pid and bundle path land in $1/$2 positions; script polls kill -0 then execs open")
+    func argumentsShapeAndScriptContent() {
+        let arguments = AgentRelauncher.makeArguments(
+            pid: 4242,
+            bundlePath: "/Applications/Wendy Agent.app"
+        )
+
+        #expect(arguments[0] == "-c")
+
+        let script = arguments[1]
+        #expect(script.contains(#"while /bin/kill -0 "$1" 2>/dev/null; do"#))
+        #expect(script.contains("/bin/sleep 0.5"))
+        #expect(script.contains(#"[ "$i" -ge 600 ] && exit 1"#))
+        #expect(script.contains(#"exec /usr/bin/open "$2""#))
+
+        // $0 is a placeholder positional arg (script name); $1/$2 are pid/path.
+        #expect(arguments[2] == "wendy-agent-relaunch")
+        #expect(arguments[3] == "4242")
+        #expect(arguments[4] == "/Applications/Wendy Agent.app")
+        #expect(arguments.count == 5)
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
@@ -123,6 +123,59 @@ struct AgentUpdateLockTests {
         await lock.release()
         #expect(await lock.tryAcquire() == true)
     }
+
+    @Test("a fresh uncommitted lock is not stolen")
+    func freshLockIsNotStolen() async {
+        let lock = AgentUpdateLock(staleThreshold: .seconds(30 * 60))
+        #expect(await lock.tryAcquire() == true)
+        #expect(await lock.tryAcquire() == false)
+    }
+
+    @Test("an uncommitted lock older than the stale threshold is stolen")
+    func staleUncommittedLockIsStolen() async throws {
+        let lock = AgentUpdateLock(staleThreshold: .milliseconds(50))
+        #expect(await lock.tryAcquire() == true)
+        #expect(await lock.tryAcquire() == false)
+
+        // Models the leak: whoever acquired the lock never got to release it
+        // (grpc-swift can fail the initial-metadata write before the response
+        // producer, and its `release`, ever runs).
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(await lock.tryAcquire() == true)
+    }
+
+    @Test("a committed lock is never stolen, however old")
+    func committedLockIsNeverStolen() async throws {
+        let lock = AgentUpdateLock(staleThreshold: .milliseconds(50))
+        #expect(await lock.tryAcquire() == true)
+        await lock.markCommitted()
+
+        try await Task.sleep(for: .milliseconds(200))
+        // Post-commit the process is exiting; a steal here could double-install.
+        #expect(await lock.tryAcquire() == false)
+    }
+
+    @Test("the production stale threshold is half an hour")
+    func defaultStaleThreshold() {
+        #expect(AgentUpdateLock.defaultStaleThreshold == .seconds(30 * 60))
+    }
+}
+
+@Suite("AgentRelauncher.scheduleTermination timings")
+struct AgentRelauncherTerminationTimingTests {
+    @Test("the hard-exit watchdog outlasts a multi-app teardown but stays inside the CLI's wait")
+    func hardExitDelayBounds() {
+        #expect(AgentRelauncher.hardExitDelay == .seconds(45))
+        // Two containerized apps stop sequentially at ~10 s + ~5 s each.
+        #expect(AgentRelauncher.hardExitDelay > .seconds(35))
+        // The CLI polls a darwin agent for 60 s after the update ack.
+        #expect(AgentRelauncher.hardExitDelay < .seconds(60))
+    }
+
+    @Test("the ack-flush delay stays short")
+    func ackFlushDelayUnchanged() {
+        #expect(AgentRelauncher.ackFlushDelay == .milliseconds(500))
+    }
 }
 
 @Suite("AgentRelauncher.makeArguments")

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
@@ -1,0 +1,817 @@
+import CryptoKit
+import Foundation
+import GRPCCore
+import Logging
+import Testing
+import WendyAgentGRPC
+
+@testable import WendyAgentCore
+
+@Suite("AgentUpdateSession")
+struct AgentUpdateSessionTests {
+
+    // MARK: - Happy path
+
+    @Test("commits the update, schedules the relaunch before acking, and cleans up staging")
+    func happyPath() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [
+                chunkRequest(payload.prefix(6)),
+                chunkRequest(payload.dropFirst(6)),
+                updateRequest(sha256: payloadSHA256),
+            ],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        // The relaunch must be scheduled before the ack: a client that hangs
+        // up must not leave the agent installed-but-never-restarted.
+        #expect(harness.log.events() == ["extract", "replace", "relaunch", "terminate", "ack"])
+        let responses = harness.log.responses()
+        #expect(responses.count == 1)
+        #expect(
+            responses.first?.responseType
+                == .updated(Wendy_Agent_Services_V1_UpdateAgentResponse.Updated())
+        )
+        // Chunks were streamed to disk verbatim.
+        #expect(harness.log.payloadSeen() == payload)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("the default signature checker accepts an unsigned payload (verification disabled)")
+    func defaultSignatureCheckerPasses() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, signature: DefaultUpdateSignatureChecker()),
+            log: harness.log
+        )
+
+        #expect(harness.log.events().contains("replace"))
+        #expect(harness.log.responses().count == 1)
+    }
+
+    @Test("a failed ack still commits: the session returns and the relaunch is scheduled")
+    func ackFailureStillCommits() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness),
+            log: harness.log,
+            ackThrows: true
+        )
+
+        #expect(harness.log.events() == ["extract", "replace", "relaunch", "terminate", "ack"])
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("a relaunch that cannot be scheduled still terminates and acks")
+    func relaunchFailureStillCommits() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, relaunchThrows: true),
+            log: harness.log
+        )
+
+        #expect(harness.log.events() == ["extract", "replace", "relaunch", "terminate", "ack"])
+    }
+
+    // MARK: - Digest validation
+
+    @Test("a SHA256 mismatch fails with dataLoss and never touches the installed bundle")
+    func shaMismatch() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: String(repeating: "a", count: 64))],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(error?.code == .dataLoss)
+        #expect(error?.message.contains("SHA256 mismatch") == true)
+        #expect(error?.message.contains(payloadSHA256) == true)
+        #expect(harness.log.events().isEmpty)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test(
+        "a malformed SHA256 fails with invalidArgument",
+        arguments: [
+            "",
+            String(repeating: "a", count: 63),
+            String(repeating: "a", count: 65),
+            String(repeating: "z", count: 64),
+            "not-a-digest",
+        ]
+    )
+    func malformedSHA(_ sha: String) async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: sha)],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(error?.code == .invalidArgument)
+        #expect(error?.message == "update control command is missing a valid SHA256")
+        #expect(harness.log.events().isEmpty)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("an uppercase SHA256 is accepted")
+    func uppercaseSHAAccepted() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256.uppercased())],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(harness.log.responses().count == 1)
+    }
+
+    // MARK: - Stream framing
+
+    @Test("a payload larger than the cap fails with resourceExhausted")
+    func oversizePayload() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let error = await runSessionExpectingFailure(
+            [
+                chunkRequest(Data(repeating: 0x41, count: 3)),
+                chunkRequest(Data(repeating: 0x41, count: 3)),
+                updateRequest(sha256: payloadSHA256),
+            ],
+            deps: makeDependencies(harness, maxPayloadBytes: 4),
+            log: harness.log
+        )
+
+        #expect(error?.code == .resourceExhausted)
+        #expect(error?.message.contains("exceeds maximum agent bundle size") == true)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("a stream that ends without a control command fails with invalidArgument")
+    func missingControlCommand() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload)],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(error?.code == .invalidArgument)
+        #expect(error?.message == "update stream ended without update control command")
+        #expect(harness.log.events().isEmpty)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("an empty control command fails with invalidArgument")
+    func emptyControlCommand() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        var request = Wendy_Agent_Services_V1_UpdateAgentRequest()
+        request.requestType = .control(Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand())
+
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), request],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(error?.code == .invalidArgument)
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    // MARK: - Installer error mapping
+
+    @Test("extractBundle errors map to RPC codes")
+    func extractErrorMapping() async throws {
+        let cases: [(AgentBundleInstallerError, RPCError.Code, String)] = [
+            (.notAnAppArchive("ditto failed"), .invalidArgument, "not a valid app archive"),
+            (
+                .invalidBundle("missing WLWendyAgentVersion"), .invalidArgument,
+                "WLWendyAgentVersion"
+            ),
+        ]
+
+        for (installerError, expectedCode, expectedFragment) in cases {
+            let harness = try Harness()
+            defer { harness.cleanup() }
+
+            let installer = StubInstaller(
+                log: harness.log,
+                stagedApp: harness.stagedApp,
+                extractError: installerError
+            )
+            let error = await runSessionExpectingFailure(
+                [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+                deps: makeDependencies(harness, installer: installer),
+                log: harness.log
+            )
+
+            #expect(error?.code == expectedCode)
+            #expect(error?.message.contains(expectedFragment) == true)
+            #expect(harness.log.events() == ["extract"])
+            #expect(harness.stagingEntries().isEmpty)
+        }
+    }
+
+    @Test("replaceBundle errors map to RPC codes and pass their detail through")
+    func replaceErrorMapping() async throws {
+        let cases: [(AgentBundleInstallerError, RPCError.Code, String)] = [
+            (.parentNotWritable("directory is not writable"), .permissionDenied, "not writable"),
+            (
+                .swapFailed("failed to install new bundle at /x: boom; previous version restored"),
+                .internalError, "previous version restored"
+            ),
+        ]
+
+        for (installerError, expectedCode, expectedFragment) in cases {
+            let harness = try Harness()
+            defer { harness.cleanup() }
+
+            let installer = StubInstaller(
+                log: harness.log,
+                stagedApp: harness.stagedApp,
+                replaceError: installerError
+            )
+            let error = await runSessionExpectingFailure(
+                [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+                deps: makeDependencies(harness, installer: installer),
+                log: harness.log
+            )
+
+            #expect(error?.code == expectedCode)
+            #expect(error?.message.contains(expectedFragment) == true)
+            #expect(harness.log.events() == ["extract", "replace"])
+            #expect(harness.stagingEntries().isEmpty)
+        }
+    }
+
+    // MARK: - Code signature gating
+
+    @Test("an incoming bundle with an invalid signature fails with failedPrecondition")
+    func incomingInvalidSignature() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let codesign = StubCodesignVerifier(
+            results: [
+                harness.stagedApp.path: .failure(.invalidSignature("code object is not signed"))
+            ]
+        )
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, codesign: codesign),
+            log: harness.log
+        )
+
+        #expect(error?.code == .failedPrecondition)
+        #expect(
+            error?.message.contains("incoming agent bundle failed code signature verification")
+                == true
+        )
+        #expect(error?.message.contains("code object is not signed") == true)
+        #expect(harness.log.events() == ["extract"])
+    }
+
+    @Test("an incoming bundle that cannot be inspected fails with internalError")
+    func incomingInspectionFailure() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let codesign = StubCodesignVerifier(
+            results: [harness.stagedApp.path: .failure(.inspectionFailed("SecStaticCode failed"))]
+        )
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, codesign: codesign),
+            log: harness.log
+        )
+
+        #expect(error?.code == .internalError)
+        #expect(error?.message.contains("could not inspect the incoming agent bundle") == true)
+    }
+
+    @Test("a running bundle that fails verification is an internalError, not a client error")
+    func runningBundleInspectionFailure() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        // `.invalidSignature` on the RUNNING bundle must not masquerade as the
+        // client having sent an unsigned payload.
+        let codesign = StubCodesignVerifier(
+            results: [harness.currentBundle.path: .failure(.invalidSignature("running is ad-hoc"))]
+        )
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, codesign: codesign),
+            log: harness.log
+        )
+
+        #expect(error?.code == .internalError)
+        #expect(error?.message.contains("could not inspect the running agent bundle") == true)
+        #expect(error?.message.contains("running is ad-hoc") == true)
+        #expect(harness.log.events() == ["extract"])
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    @Test("a code signature policy rejection propagates its RPCError")
+    func policyRejectionPropagates() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let codesign = StubCodesignVerifier(
+            results: [
+                harness.stagedApp.path: .success(
+                    CodesignInfo(
+                        teamID: "TEAM2",
+                        isDeveloperID: true,
+                        bundleIdentifier: "sh.wendy.someone-else"
+                    )
+                ),
+                harness.currentBundle.path: .success(
+                    CodesignInfo(
+                        teamID: "TEAM1",
+                        isDeveloperID: true,
+                        bundleIdentifier: "sh.wendy.agent"
+                    )
+                ),
+            ]
+        )
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness, codesign: codesign),
+            log: harness.log
+        )
+
+        #expect(error?.code == .failedPrecondition)
+        #expect(error?.message.contains("does not match") == true)
+        #expect(harness.log.events() == ["extract"])
+        #expect(harness.stagingEntries().isEmpty)
+    }
+
+    // MARK: - Signature seam
+
+    @Test("signature verification failures map to RPC codes")
+    func signatureErrorMapping() async throws {
+        let cases: [(any Error, RPCError.Code, String)] = [
+            (
+                SignatureVerifierError.unsigned, .failedPrecondition,
+                "agent update is unsigned; refusing install"
+            ),
+            (
+                SignatureVerifierError.badSignature, .dataLoss,
+                "agent update signature verification failed; refusing install"
+            ),
+            (
+                StubError.signatureBroken, .internalError,
+                "agent update signature verification error"
+            ),
+        ]
+
+        for (thrownError, expectedCode, expectedFragment) in cases {
+            let harness = try Harness()
+            defer { harness.cleanup() }
+
+            let checker = StubSignatureChecker { _, _ in throw thrownError }
+            let error = await runSessionExpectingFailure(
+                [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+                deps: makeDependencies(harness, signature: checker),
+                log: harness.log
+            )
+
+            #expect(error?.code == expectedCode)
+            #expect(error?.message.contains(expectedFragment) == true)
+            #expect(harness.log.events().isEmpty)
+            #expect(harness.stagingEntries().isEmpty)
+        }
+    }
+
+    @Test("the digest and signature reach the verifier")
+    func signatureInputs() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let expectedDigest = Data(SHA256.hash(data: payload))
+        let signature = Data([0x01, 0x02, 0x03])
+        let checker = StubSignatureChecker { digest, receivedSignature in
+            #expect(digest == expectedDigest)
+            #expect(receivedSignature == signature)
+        }
+
+        try await runSession(
+            [
+                chunkRequest(payload),
+                updateRequest(sha256: payloadSHA256, signature: signature),
+            ],
+            deps: makeDependencies(harness, signature: checker),
+            log: harness.log
+        )
+    }
+
+    // MARK: - Staging hygiene
+
+    @Test("stale staging directories from earlier attempts are wiped")
+    func staleSessionsWiped() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let stale = harness.stagingRoot.appendingPathComponent("stale-session")
+        try FileManager.default.createDirectory(at: stale, withIntermediateDirectories: true)
+        try Data("leftover".utf8).write(to: stale.appendingPathComponent("payload.zip"))
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        #expect(harness.stagingEntries().isEmpty)
+    }
+}
+
+// MARK: - Lock behavior
+
+// Lock semantics in isolation live in `AgentUpdateLockTests`
+// (AgentUpdatePlatformTests.swift); these cover how the handler uses it.
+@Suite("AgentService.updateAgent locking")
+struct AgentServiceUpdateLockingTests {
+    @Test("a second concurrent updateAgent call is rejected with failedPrecondition")
+    func concurrentUpdatesRejected() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let lock = AgentUpdateLock()
+        let service = AgentService(
+            updateLock: lock,
+            updateDependencies: makeDependencies(harness)
+        )
+
+        // The first call acquires the lock and returns its (not yet driven)
+        // streaming response, so the update is still in flight.
+        _ = try await service.updateAgent(
+            request: makeStreamingRequest([chunkRequest(payload)]),
+            context: makeUpdateContext()
+        )
+
+        do {
+            _ = try await service.updateAgent(
+                request: makeStreamingRequest([chunkRequest(payload)]),
+                context: makeUpdateContext()
+            )
+            Issue.record("Expected the second updateAgent call to be rejected")
+        } catch let error as RPCError {
+            #expect(error.code == .failedPrecondition)
+            #expect(error.message == "an update is already in progress")
+        }
+    }
+
+    @Test("a failed update releases the lock so the client can retry")
+    func failedUpdateReleasesLock() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let lock = AgentUpdateLock()
+        let service = AgentService(
+            updateLock: lock,
+            updateDependencies: makeDependencies(harness)
+        )
+
+        // No control command: the session fails.
+        let response = try await service.updateAgent(
+            request: makeStreamingRequest([chunkRequest(payload)]),
+            context: makeUpdateContext()
+        )
+        let writer = CollectingWriter<Wendy_Agent_Services_V1_UpdateAgentResponse>()
+        await #expect(throws: RPCError.self) {
+            _ = try await response.accepted.get().producer(RPCWriter(wrapping: writer))
+        }
+
+        #expect(await lock.tryAcquire())
+    }
+
+    @Test("a committed update keeps the lock held so retries see an update in progress")
+    func committedUpdateKeepsLock() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let lock = AgentUpdateLock()
+        let service = AgentService(
+            updateLock: lock,
+            updateDependencies: makeDependencies(harness)
+        )
+
+        let response = try await service.updateAgent(
+            request: makeStreamingRequest([
+                chunkRequest(payload),
+                updateRequest(sha256: payloadSHA256),
+            ]),
+            context: makeUpdateContext()
+        )
+        let writer = CollectingWriter<Wendy_Agent_Services_V1_UpdateAgentResponse>()
+        _ = try await response.accepted.get().producer(RPCWriter(wrapping: writer))
+
+        #expect(writer.snapshot().count == 1)
+        #expect(harness.log.events().contains("relaunch"))
+        #expect(await lock.tryAcquire() == false)
+    }
+}
+
+// MARK: - Fixtures
+
+private let payload = Data("fake-agent-bundle-zip".utf8)
+private let payloadSHA256 = Data(SHA256.hash(data: payload)).map { String(format: "%02x", $0) }
+    .joined()
+
+private enum StubError: Error {
+    case ackFailed
+    case relaunchFailed
+    case signatureBroken
+}
+
+/// Ordered record of the side effects a session performs, plus the responses
+/// it writes. A lock-guarded class (not an actor) because
+/// `AgentRelaunchScheduling` is synchronous.
+private final class SessionLog: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "wendy.tests.agent-update-log")
+    private var recordedEvents: [String] = []
+    private var recordedResponses: [Wendy_Agent_Services_V1_UpdateAgentResponse] = []
+    private var recordedPayload: Data?
+
+    func record(_ event: String) {
+        self.queue.sync { self.recordedEvents.append(event) }
+    }
+    func append(_ response: Wendy_Agent_Services_V1_UpdateAgentResponse) {
+        self.queue.sync { self.recordedResponses.append(response) }
+    }
+    func recordPayload(_ data: Data?) {
+        self.queue.sync { self.recordedPayload = data }
+    }
+    func events() -> [String] { self.queue.sync { self.recordedEvents } }
+    func responses() -> [Wendy_Agent_Services_V1_UpdateAgentResponse] {
+        self.queue.sync { self.recordedResponses }
+    }
+    func payloadSeen() -> Data? { self.queue.sync { self.recordedPayload } }
+}
+
+private struct Harness {
+    let root: URL
+    let stagingRoot: URL
+    let currentBundle: URL
+    let stagedApp: URL
+    let log = SessionLog()
+
+    init() throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wendy-agent-update-test-\(UUID().uuidString)")
+        self.stagingRoot = self.root.appendingPathComponent("staging")
+        self.currentBundle = self.root.appendingPathComponent("Applications/WendyAgentMac.app")
+        self.stagedApp = self.root.appendingPathComponent("staged/WendyAgentMac.app")
+
+        try FileManager.default.createDirectory(
+            at: self.stagingRoot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: self.stagedApp,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: self.currentBundle.appendingPathComponent("Contents"),
+            withIntermediateDirectories: true
+        )
+        let plist: [String: Any] = [
+            "CFBundleIdentifier": "sh.wendy.agent",
+            "WLWendyAgentVersion": "1.2.3",
+        ]
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: self.currentBundle.appendingPathComponent("Contents/Info.plist"))
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: self.root)
+    }
+
+    func stagingEntries() -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: self.stagingRoot,
+            includingPropertiesForKeys: nil
+        )) ?? []
+    }
+}
+
+private struct StubSignatureChecker: UpdateSignatureChecking {
+    let onVerify: @Sendable (Data, Data) throws -> Void
+
+    init(_ onVerify: @escaping @Sendable (Data, Data) throws -> Void) {
+        self.onVerify = onVerify
+    }
+
+    func verify(digest: Data, signature: Data) throws {
+        try self.onVerify(digest, signature)
+    }
+}
+
+private struct StubCodesignVerifier: CodesignVerifying {
+    /// Keyed by bundle path; anything not listed gets `fallback`.
+    var results: [String: Result<CodesignInfo, CodesignVerificationError>] = [:]
+    var fallback: Result<CodesignInfo, CodesignVerificationError> = .success(
+        CodesignInfo(teamID: "TEAM1", isDeveloperID: true, bundleIdentifier: "sh.wendy.agent")
+    )
+
+    func inspect(bundleAt url: URL) async throws -> CodesignInfo {
+        try (self.results[url.path] ?? self.fallback).get()
+    }
+}
+
+private struct StubInstaller: AgentBundleInstalling {
+    let log: SessionLog
+    let stagedApp: URL
+    var extractError: AgentBundleInstallerError?
+    var replaceError: AgentBundleInstallerError?
+
+    func extractBundle(zipAt zip: URL, into stagingDir: URL) async throws -> URL {
+        self.log.recordPayload(FileManager.default.contents(atPath: zip.path))
+        self.log.record("extract")
+        if let extractError = self.extractError { throw extractError }
+        return self.stagedApp
+    }
+
+    func replaceBundle(at destination: URL, with staged: URL) async throws {
+        self.log.record("replace")
+        if let replaceError = self.replaceError { throw replaceError }
+    }
+}
+
+private struct SpyRelauncher: AgentRelaunchScheduling {
+    let log: SessionLog
+    var throwOnRelaunch = false
+
+    func scheduleRelaunch(of bundleURL: URL) throws {
+        self.log.record("relaunch")
+        if self.throwOnRelaunch { throw StubError.relaunchFailed }
+    }
+
+    func scheduleTermination() {
+        self.log.record("terminate")
+    }
+}
+
+private final class CollectingWriter<Element: Sendable>: RPCWriterProtocol, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "wendy.tests.agent-update-writer")
+    private var elements: [Element] = []
+
+    func write(_ element: Element) async throws {
+        self.queue.sync { self.elements.append(element) }
+    }
+    func write(contentsOf elements: some Sequence<Element>) async throws {
+        self.queue.sync { self.elements.append(contentsOf: elements) }
+    }
+    func snapshot() -> [Element] {
+        self.queue.sync { self.elements }
+    }
+}
+
+// MARK: - Helpers
+
+private func makeDependencies(
+    _ harness: Harness,
+    installer: StubInstaller? = nil,
+    codesign: StubCodesignVerifier = StubCodesignVerifier(),
+    signature: any UpdateSignatureChecking = StubSignatureChecker { _, _ in },
+    maxPayloadBytes: Int64 = AgentUpdateSession.maxPayloadBytes,
+    relaunchThrows: Bool = false
+) -> AgentUpdateSession.Dependencies {
+    AgentUpdateSession.Dependencies(
+        stagingRoot: harness.stagingRoot,
+        maxPayloadBytes: maxPayloadBytes,
+        currentBundleURL: harness.currentBundle,
+        codesign: codesign,
+        signature: signature,
+        installer: installer ?? StubInstaller(log: harness.log, stagedApp: harness.stagedApp),
+        relauncher: SpyRelauncher(log: harness.log, throwOnRelaunch: relaunchThrows)
+    )
+}
+
+private func runSession(
+    _ messages: [Wendy_Agent_Services_V1_UpdateAgentRequest],
+    deps: AgentUpdateSession.Dependencies,
+    log: SessionLog,
+    ackThrows: Bool = false
+) async throws {
+    try await AgentUpdateSession.run(
+        messages: makeStream(messages),
+        writeResponse: { response in
+            log.record("ack")
+            log.append(response)
+            if ackThrows { throw StubError.ackFailed }
+        },
+        deps: deps,
+        logger: Logger(label: "test")
+    )
+}
+
+private func runSessionExpectingFailure(
+    _ messages: [Wendy_Agent_Services_V1_UpdateAgentRequest],
+    deps: AgentUpdateSession.Dependencies,
+    log: SessionLog
+) async -> RPCError? {
+    do {
+        try await runSession(messages, deps: deps, log: log)
+        Issue.record("Expected AgentUpdateSession.run to throw")
+        return nil
+    } catch let error as RPCError {
+        return error
+    } catch {
+        Issue.record("Expected an RPCError, got \(error)")
+        return nil
+    }
+}
+
+private func chunkRequest(_ data: some DataProtocol) -> Wendy_Agent_Services_V1_UpdateAgentRequest {
+    var chunk = Wendy_Agent_Services_V1_UpdateAgentRequest.Chunk()
+    chunk.data = Data(data)
+
+    var request = Wendy_Agent_Services_V1_UpdateAgentRequest()
+    request.requestType = .chunk(chunk)
+    return request
+}
+
+private func updateRequest(
+    sha256: String,
+    signature: Data = Data()
+) -> Wendy_Agent_Services_V1_UpdateAgentRequest {
+    var update = Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand.Update()
+    update.sha256 = sha256
+    update.signature = signature
+
+    var control = Wendy_Agent_Services_V1_UpdateAgentRequest.ControlCommand()
+    control.command = .update(update)
+
+    var request = Wendy_Agent_Services_V1_UpdateAgentRequest()
+    request.requestType = .control(control)
+    return request
+}
+
+private func makeStream(
+    _ messages: [Wendy_Agent_Services_V1_UpdateAgentRequest]
+) -> AsyncStream<Wendy_Agent_Services_V1_UpdateAgentRequest> {
+    AsyncStream { continuation in
+        for message in messages { continuation.yield(message) }
+        continuation.finish()
+    }
+}
+
+private func makeStreamingRequest(
+    _ messages: [Wendy_Agent_Services_V1_UpdateAgentRequest]
+) -> StreamingServerRequest<Wendy_Agent_Services_V1_UpdateAgentRequest> {
+    StreamingServerRequest(
+        metadata: [:],
+        messages: RPCAsyncSequence(
+            wrapping: AsyncThrowingStream<
+                Wendy_Agent_Services_V1_UpdateAgentRequest, any Error
+            > { continuation in
+                for message in messages { continuation.yield(message) }
+                continuation.finish()
+            }
+        )
+    )
+}
+
+private func makeUpdateContext() -> ServerContext {
+    ServerContext(
+        descriptor: MethodDescriptor(
+            fullyQualifiedService: "wendy.agent.services.v1.WendyAgentService",
+            method: "UpdateAgent"
+        ),
+        remotePeer: "in-process:test",
+        localPeer: "in-process:test",
+        cancellation: .init()
+    )
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
@@ -72,6 +72,70 @@ struct AgentUpdateSessionTests {
         #expect(harness.stagingEntries().isEmpty)
     }
 
+    @Test("the commit hook fires before the relaunch and termination are scheduled")
+    func commitHookRunsBeforeTermination() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        var deps = makeDependencies(harness)
+        let log = harness.log
+        deps.onCommitted = { log.record("commit") }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: deps,
+            log: harness.log
+        )
+
+        // The lock must be pinned as committed before anything can tear the
+        // process down, so a stale-lock steal can never race the shutdown.
+        let expected = ["extract", "replace", "commit", "relaunch", "terminate", "ack"]
+        #expect(harness.log.events() == expected)
+    }
+
+    @Test("the commit hook does not fire when the update fails")
+    func commitHookSkippedOnFailure() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        var deps = makeDependencies(harness)
+        let log = harness.log
+        deps.onCommitted = { log.record("commit") }
+
+        let error = await runSessionExpectingFailure(
+            [chunkRequest(payload), updateRequest(sha256: String(repeating: "a", count: 64))],
+            deps: deps,
+            log: harness.log
+        )
+
+        #expect(error?.code == .dataLoss)
+        #expect(!harness.log.events().contains("commit"))
+    }
+
+    @Test("the payload is extracted into a subdirectory, never over the payload itself")
+    func extractionUsesDedicatedSubdirectory() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        try await runSession(
+            [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+            deps: makeDependencies(harness),
+            log: harness.log
+        )
+
+        let extract = try #require(harness.log.extractSeen())
+        #expect(extract.into.lastPathComponent == "extract")
+        #expect(extract.zip.lastPathComponent == "payload.zip")
+        // Both live directly under the session directory, so an archive entry
+        // named `payload.zip` cannot clobber the source mid-extract.
+        #expect(
+            extract.zip.deletingLastPathComponent().standardizedFileURL
+                == extract.into.deletingLastPathComponent().standardizedFileURL
+        )
+        let extractRoot = extract.into.standardizedFileURL.path
+        #expect(!extract.zip.standardizedFileURL.path.hasPrefix(extractRoot))
+    }
+
     @Test("a relaunch that cannot be scheduled still terminates and acks")
     func relaunchFailureStillCommits() async throws {
         let harness = try Harness()
@@ -559,6 +623,60 @@ struct AgentServiceUpdateLockingTests {
         #expect(harness.log.events().contains("relaunch"))
         #expect(await lock.tryAcquire() == false)
     }
+
+    @Test("a lock leaked before the response producer runs is stolen once it goes stale")
+    func leakedLockIsStolenWhenStale() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let lock = AgentUpdateLock(staleThreshold: .milliseconds(50))
+        let service = AgentService(
+            updateLock: lock,
+            updateDependencies: makeDependencies(harness)
+        )
+
+        // grpc-swift writes the response's initial metadata *before* running
+        // the producer; if the client aborts in that window the producer — and
+        // the `release` in its catch — never runs. Dropping the response here
+        // models exactly that leak.
+        _ = try await service.updateAgent(
+            request: makeStreamingRequest([chunkRequest(payload)]),
+            context: makeUpdateContext()
+        )
+        #expect(await lock.tryAcquire() == false)
+
+        try await Task.sleep(for: .milliseconds(200))
+        // Without the steal, every later update would fail with
+        // failedPrecondition until someone restarted the app by hand.
+        #expect(await lock.tryAcquire() == true)
+    }
+
+    @Test("a committed update pins the lock so it is never stolen")
+    func committedUpdateIsNeverStolen() async throws {
+        let harness = try Harness()
+        defer { harness.cleanup() }
+
+        let lock = AgentUpdateLock(staleThreshold: .milliseconds(50))
+        let service = AgentService(
+            updateLock: lock,
+            updateDependencies: makeDependencies(harness)
+        )
+
+        let response = try await service.updateAgent(
+            request: makeStreamingRequest([
+                chunkRequest(payload),
+                updateRequest(sha256: payloadSHA256),
+            ]),
+            context: makeUpdateContext()
+        )
+        let writer = CollectingWriter<Wendy_Agent_Services_V1_UpdateAgentResponse>()
+        _ = try await response.accepted.get().producer(RPCWriter(wrapping: writer))
+
+        try await Task.sleep(for: .milliseconds(200))
+        // The handler wires the session's commit hook to markCommitted(), so
+        // the shutdown window can never be raced by a second install.
+        #expect(await lock.tryAcquire() == false)
+    }
 }
 
 // MARK: - Fixtures
@@ -582,10 +700,15 @@ private final class SessionLog: @unchecked Sendable {
     private var recordedEvents: [String] = []
     private var recordedResponses: [Wendy_Agent_Services_V1_UpdateAgentResponse] = []
     private var recordedPayload: Data?
+    private var recordedExtract: (zip: URL, into: URL)?
 
     func record(_ event: String) {
         self.queue.sync { self.recordedEvents.append(event) }
     }
+    func recordExtract(zip: URL, into directory: URL) {
+        self.queue.sync { self.recordedExtract = (zip: zip, into: directory) }
+    }
+    func extractSeen() -> (zip: URL, into: URL)? { self.queue.sync { self.recordedExtract } }
     func append(_ response: Wendy_Agent_Services_V1_UpdateAgentResponse) {
         self.queue.sync { self.recordedResponses.append(response) }
     }
@@ -688,6 +811,7 @@ private struct StubInstaller: AgentBundleInstalling {
 
     func extractBundle(zipAt zip: URL, into stagingDir: URL) async throws -> URL {
         self.log.recordPayload(FileManager.default.contents(atPath: zip.path))
+        self.log.recordExtract(zip: zip, into: stagingDir)
         self.log.record("extract")
         if let extractError = self.extractError { throw extractError }
         if self.unexpectedFailure == .extract { throw StubError.installerBroken }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdateSessionTests.swift
@@ -269,6 +269,28 @@ struct AgentUpdateSessionTests {
         }
     }
 
+    @Test("a non-installer failure inside the installer surfaces as internalError")
+    func unexpectedInstallerFailure() async throws {
+        for stage in [StubInstaller.Stage.extract, .replace] {
+            let harness = try Harness()
+            defer { harness.cleanup() }
+
+            let installer = StubInstaller(
+                log: harness.log,
+                stagedApp: harness.stagedApp,
+                unexpectedFailure: stage
+            )
+            let error = await runSessionExpectingFailure(
+                [chunkRequest(payload), updateRequest(sha256: payloadSHA256)],
+                deps: makeDependencies(harness, installer: installer),
+                log: harness.log
+            )
+
+            #expect(error?.code == .internalError)
+            #expect(harness.stagingEntries().isEmpty)
+        }
+    }
+
     // MARK: - Code signature gating
 
     @Test("an incoming bundle with an invalid signature fails with failedPrecondition")
@@ -549,6 +571,7 @@ private enum StubError: Error {
     case ackFailed
     case relaunchFailed
     case signatureBroken
+    case installerBroken
 }
 
 /// Ordered record of the side effects a session performs, plus the responses
@@ -651,21 +674,30 @@ private struct StubCodesignVerifier: CodesignVerifying {
 }
 
 private struct StubInstaller: AgentBundleInstalling {
+    /// Which call throws a non-`AgentBundleInstallerError` error.
+    enum Stage: Sendable {
+        case extract
+        case replace
+    }
+
     let log: SessionLog
     let stagedApp: URL
     var extractError: AgentBundleInstallerError?
     var replaceError: AgentBundleInstallerError?
+    var unexpectedFailure: Stage?
 
     func extractBundle(zipAt zip: URL, into stagingDir: URL) async throws -> URL {
         self.log.recordPayload(FileManager.default.contents(atPath: zip.path))
         self.log.record("extract")
         if let extractError = self.extractError { throw extractError }
+        if self.unexpectedFailure == .extract { throw StubError.installerBroken }
         return self.stagedApp
     }
 
     func replaceBundle(at destination: URL, with staged: URL) async throws {
         self.log.record("replace")
         if let replaceError = self.replaceError { throw replaceError }
+        if self.unexpectedFailure == .replace { throw StubError.installerBroken }
     }
 }
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/LocalRegistryRefTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/LocalRegistryRefTests.swift
@@ -8,23 +8,28 @@ struct LocalRegistryRefTests {
     func rewritesLocalPushRefs() {
         #expect(
             LocalRegistryRef.rewriteForLocalPull("localhost:5555/app:latest")
-                == "127.0.0.1:5556/app:latest")
+                == "127.0.0.1:5556/app:latest"
+        )
         #expect(
             LocalRegistryRef.rewriteForLocalPull("127.0.0.1:5555/app:latest")
-                == "127.0.0.1:5556/app:latest")
+                == "127.0.0.1:5556/app:latest"
+        )
         #expect(
             LocalRegistryRef.rewriteForLocalPull("[::1]:5555/app:latest")
-                == "127.0.0.1:5556/app:latest")
+                == "127.0.0.1:5556/app:latest"
+        )
     }
 
     @Test("tags and digest suffixes after the authority are preserved")
     func preservesSuffixes() {
         #expect(
             LocalRegistryRef.rewriteForLocalPull("localhost:5555/app@sha256:abc123")
-                == "127.0.0.1:5556/app@sha256:abc123")
+                == "127.0.0.1:5556/app@sha256:abc123"
+        )
         #expect(
             LocalRegistryRef.rewriteForLocalPull("localhost:5555/nested/repo:v1")
-                == "127.0.0.1:5556/nested/repo:v1")
+                == "127.0.0.1:5556/nested/repo:v1"
+        )
     }
 
     @Test("non-local references pass through unchanged")

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
@@ -63,7 +63,11 @@ struct RegistryTLSListenerTests {
         _ = try? await task.value
     }
 
-    private static func tlsListener(port: Int, deviceOrg: Int32, ca: TestPKI.CA) throws
+    private static func tlsListener(
+        port: Int,
+        deviceOrg: Int32,
+        ca: TestPKI.CA
+    ) throws
         -> AgentImageRegistry
     {
         let device = try TestPKI.makeDeviceIdentity(org: deviceOrg, asset: 1, ca: ca)
@@ -145,7 +149,8 @@ struct RegistryTLSListenerTests {
 
     /// Sends `GET /v2` over TLS (optionally with a client identity) and
     /// returns the raw response, or "" when the server rejected the handshake.
-    private static func tlsGET(port: Int, clientIdentity: TestPKI.Identity?) async throws -> String {
+    private static func tlsGET(port: Int, clientIdentity: TestPKI.Identity?) async throws -> String
+    {
         var tls = TLSConfiguration.makeClientConfiguration()
         // The device cert carries no SAN for 127.0.0.1; server trust is not
         // under test here (the CLI skips it too — buildkit `insecure = true`).
@@ -154,12 +159,14 @@ struct RegistryTLSListenerTests {
             let certs = try NIOSSLCertificate.fromPEMBytes(Array(clientIdentity.certPEM.utf8))
             tls.certificateChain = certs.map { .certificate($0) }
             tls.privateKey = .privateKey(
-                try NIOSSLPrivateKey(bytes: Array(clientIdentity.keyPEM.utf8), format: .pem))
+                try NIOSSLPrivateKey(bytes: Array(clientIdentity.keyPEM.utf8), format: .pem)
+            )
         }
         let context = try NIOSSLContext(configuration: tls)
         return try await Self.send(port: port) { channel in
             try channel.pipeline.syncOperations.addHandler(
-                try NIOSSLClientHandler(context: context, serverHostname: nil))
+                try NIOSSLClientHandler(context: context, serverHostname: nil)
+            )
         }
     }
 
@@ -179,7 +186,8 @@ struct RegistryTLSListenerTests {
                 channel.eventLoop.makeCompletedFuture {
                     try configure(channel)
                     try channel.pipeline.syncOperations.addHandler(
-                        ResponseCollector(promise: promise))
+                        ResponseCollector(promise: promise)
+                    )
                 }
             }
         do {
@@ -193,7 +201,9 @@ struct RegistryTLSListenerTests {
     @Test("a client certificate from the device CA is accepted")
     func acceptsTrustedClientCert() async throws {
         let ca = try TestPKI.makeCA()
-        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+        let (port, task) = try await Self.startListener(
+            try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca)
+        )
 
         let client = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
         let response = try await Self.tlsGET(port: port, clientIdentity: client)
@@ -204,7 +214,9 @@ struct RegistryTLSListenerTests {
     @Test("a handshake without a client certificate is rejected")
     func rejectsMissingClientCert() async throws {
         let ca = try TestPKI.makeCA()
-        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+        let (port, task) = try await Self.startListener(
+            try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca)
+        )
 
         let response = try await Self.tlsGET(port: port, clientIdentity: nil)
         #expect(!response.contains("200 OK"))
@@ -215,7 +227,9 @@ struct RegistryTLSListenerTests {
     func rejectsUntrustedClientCert() async throws {
         let ca = try TestPKI.makeCA()
         let otherCA = try TestPKI.makeCA(commonName: "Impostor CA")
-        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+        let (port, task) = try await Self.startListener(
+            try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca)
+        )
 
         let impostor = try TestPKI.makeIdentity(commonName: "wendy/user/impostor", ca: otherCA)
         let response = try await Self.tlsGET(port: port, clientIdentity: impostor)
@@ -226,7 +240,9 @@ struct RegistryTLSListenerTests {
     @Test("plain HTTP against the TLS listener fails fast")
     func rejectsPlainHTTP() async throws {
         let ca = try TestPKI.makeCA()
-        let (port, task) = try await Self.startListener(try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca))
+        let (port, task) = try await Self.startListener(
+            try Self.tlsListener(port: 0, deviceOrg: 1, ca: ca)
+        )
 
         let response = try await Self.plainGET(port: port)
         #expect(!response.contains("200 OK"))
@@ -238,7 +254,12 @@ struct RegistryTLSListenerTests {
         let plain = AgentImageRegistry(
             store: Self.makeStore(),
             configuration: .init(
-                host: "127.0.0.1", port: 0, tls: nil, routes: .pushAndPull, label: "test-push")
+                host: "127.0.0.1",
+                port: 0,
+                tls: nil,
+                routes: .pushAndPull,
+                label: "test-push"
+            )
         )
         let (port, plainTask) = try await Self.startListener(plain)
         #expect(try await Self.plainGET(port: port).contains("200 OK"))
@@ -247,7 +268,8 @@ struct RegistryTLSListenerTests {
         await Self.stop(plainTask)
         let ca = try TestPKI.makeCA()
         let (tlsPort, tlsTask) = try await Self.startListener(
-            try Self.tlsListener(port: port, deviceOrg: 1, ca: ca))
+            try Self.tlsListener(port: port, deviceOrg: 1, ca: ca)
+        )
         #expect(tlsPort == port)
 
         let client = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
@@ -261,14 +283,24 @@ struct RegistryTLSListenerTests {
         let first = AgentImageRegistry(
             store: Self.makeStore(),
             configuration: .init(
-                host: "127.0.0.1", port: 0, tls: nil, routes: .pullOnly, label: "first")
+                host: "127.0.0.1",
+                port: 0,
+                tls: nil,
+                routes: .pullOnly,
+                label: "first"
+            )
         )
         let (port, firstTask) = try await Self.startListener(first)
 
         let second = AgentImageRegistry(
             store: Self.makeStore(),
             configuration: .init(
-                host: "127.0.0.1", port: port, tls: nil, routes: .pullOnly, label: "second")
+                host: "127.0.0.1",
+                port: port,
+                tls: nil,
+                routes: .pullOnly,
+                label: "second"
+            )
         )
         await #expect(throws: (any Error).self) {
             _ = try await Self.startListener(second)

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/UnsupportedRPCTests.swift
@@ -27,21 +27,6 @@ struct UnsupportedRPCTests {
                 }
             ),
             (
-                "UpdateAgent",
-                "Updating the agent is currently not supported by Wendy Agent for Mac.",
-                {
-                    _ = try await service.updateAgent(
-                        request: makeStreamingRequest(
-                            Wendy_Agent_Services_V1_UpdateAgentRequest()
-                        ),
-                        context: makeServerContext(
-                            service: "wendy.agent.services.v1.WendyAgentService",
-                            method: "UpdateAgent"
-                        )
-                    )
-                }
-            ),
-            (
                 "UpdateOS",
                 "This setup cannot be updated with wendy os update. Use this machine’s normal OS update tools instead. To use WendyOS OTA updates, install WendyOS on supported hardware with wendy os install.",
                 {

--- a/swift/WendyAgentMac/Sources/AppDelegate.swift
+++ b/swift/WendyAgentMac/Sources/AppDelegate.swift
@@ -32,6 +32,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
                 delegate: self
             )
 
+            // Registered before start() so the services the agent builds at
+            // startup capture it. Invoked from a detached task after the
+            // update RPC has returned, so stop()'s drain cannot deadlock on
+            // the still-open update stream.
+            await self.wendyAgent.setAgentTerminationHandler { [weak self] in
+                await self?.performQuit()
+            }
+
             do {
                 try await self.wendyAgent.start()
             } catch {
@@ -58,6 +66,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
     }
 
     func statusMenuControllerDidSelectQuit(_ controller: StatusMenuController) {
+        self.performQuit()
+    }
+
+    /// Shuts the agent down and terminates the app. Shared by the Quit menu
+    /// item and the agent's post-update termination handler; re-entrant calls
+    /// are ignored.
+    private func performQuit() {
         guard !self.isQuitting else { return }
         self.isQuitting = true
 


### PR DESCRIPTION
## Summary

- implement the v1 `UpdateAgent` RPC in the macOS agent so `wendy device update` can replace `WendyAgentMac.app` remotely, replacing the `.unimplemented` stub
- verify every pushed bundle: SHA-256 over the stream, the ML-DSA signature seam, `codesign` deep+strict validation, bundle identifier, and a Team ID that matches the running app
- swap the bundle at `Bundle.main.bundleURL` with same-directory renames, keep the previous copy as a rollback escape, then relaunch through a detached watcher that reopens the app once this process exits
- self-heal the update lock so an aborted stream can never wedge updates for the process lifetime

## Why

Updating a Mac agent meant a hands-on side-load: copy a zip to the machine, quit the app, swap `/Applications/WendyAgentMac.app`, reopen it. On a headless mini that is Screen Sharing or SSH every time. The Linux agent has had `UpdateAgent` since the beginning; this closes the gap without a proto change — the CLI streams the same signed, notarized `wendy-agent-macos-<arch>-<version>.zip` we already publish.

## How it works

`AgentUpdateSession` consumes the chunk stream into a per-session staging directory while hashing it, then on the `Update` control command verifies the digest, checks the signature seam, extracts with `ditto -x -k` into a dedicated subdirectory, requires exactly one `.app` carrying a usable `WLWendyAgentVersion`, runs the codesign policy, swaps the bundle, and only then schedules the relaunch and terminates. The ack is best-effort — the restart never depends on it, matching the Go agent's `finishCommittedUpdate`.

The codesign policy keeps dev pushes working: a bundle identifier mismatch is always refused, and when the running app is Developer ID signed the incoming bundle must be too, with a matching Team ID. When the running app is a dev build the Team ID check is relaxed, so pushing a locally-built agent to a test machine still works.

Two failure modes get explicit handling. The previous bundle is retained as `.WendyAgentMac.app.old-<uuid>` and reclaimed on the next update, so a bundle that verifies but crashes on launch still has a local escape on a machine with no supervisor. And the update lock records when it was taken: an uncommitted lock older than 30 minutes can be stolen, because grpc-swift writes response metadata before running the producer and a client abort in that window would otherwise leave the lock held until someone restarts the app.

## Impact

`wendy device update`, `wendy device update --binary`, and the "agent is behind the CLI" prompt all work against Macs once the CLI side lands (PR for `ed/mac-agent-remote-update-cli`). `wendy os update` remains intentionally unsupported on macOS. No proto changes; the agent's plaintext listener now accepts a code-install RPC that the codesign policy gates — the same listener that already accepts app deploys before enrollment.

## Validation

- `swift test` — 286 tests, 51 suites, passing; `xcodebuild -scheme WendyAgentMac` builds
- live on a Mac agent (dev-signed, run from an isolated path): pushed 000001 → 000002, the bundle swapped in place, the app relaunched on a new PID, and `GetAgentVersion` reported the new version; a second push reclaimed the previous rollback copy leaving exactly one, and the staging directory was empty afterwards
- a truncated (still PK-magic) zip was rejected with `update payload is not a valid app archive: ditto -x -k failed …` and the running agent kept serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)
