### PR TITLE
fix(docs): bump nanoid to patch high-severity npm audit finding

### DIFF
--- a/go/internal/cli/assets/docs/package-lock.json
+++ b/go/internal/cli/assets/docs/package-lock.json
@@ -5180,9 +5180,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- The Fumadocs CI workflow's `npm audit --audit-level=high` gate started failing repo-wide after a new high-severity nanoid advisory (GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8) was published for nanoid <=3.3.16.
- `go/internal/cli/assets/docs/package-lock.json` had nanoid pinned at 3.3.12 (a transitive dep of postcss, which allows `^3.3.12`). Ran `npm audit fix` to bump it to 3.3.18 — no stated dependency ranges changed.
- Confirmed `npm audit --audit-level=high` now exits 0, and `next build` still succeeds for the docs site.
- One pre-existing moderate-severity postcss advisory remains (below the `--audit-level=high` threshold, requires `--force` and an out-of-range next bump to fully resolve) — left untouched as out of scope.

## Test plan
- [x] `npm audit --audit-level=high` exits 0 in `go/internal/cli/assets/docs`
- [x] `npm run build` (next build) succeeds
- [ ] CI Fumadocs workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCw3BUJmZRvMWyqf27Ugmr