### PR TITLE
docs: design Stagefile as a semantic build graph

### DIFF
--- a/specs/2026-08-07-stagefile-ir-cachekey-plan.md
+++ b/specs/2026-08-07-stagefile-ir-cachekey-plan.md
@@ -1,0 +1,1239 @@
+# Stagefile IR + cache keys (stage 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a typed intermediate representation (`ir`) and a stable,
+versioned cache-key function (`cachekey`) for Stagefile, and retarget `codegen`
+to consume the IR — with byte-identical Dockerfile output as the acceptance test.
+
+**Architecture:** `spec` (YAML) → `ir.Lower` (typed DAG, no rendered shell) →
+`codegen.Generate` (Dockerfile text). `cachekey.Key` hashes an IR node over its
+semantic dependency closure. This stage adds no BuildKit LLB, no CAS, and no
+behavior change; it exists so stage 2 has a graph to emit from and stage 3 has a
+key to look up.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3`, stdlib `crypto/sha256`. No new
+dependencies.
+
+## Global Constraints
+
+- **Branch base: `jo/stagefile-parallel-compile` (PR #1607), NOT `jo/try-stagefile`.**
+  #1607 already modified `codegen.go` (the `cacheRun` helper), `lock/resolve.go`,
+  and `stagefile.go`. Basing on #1585 guarantees a three-way conflict in exactly
+  the files this stage rewrites.
+- **Zero behavior change.** Every existing test in
+  `go/internal/stagefile/...` and `go/internal/cli/commands/...` must pass
+  unmodified. If a test needs changing to go green, that is a defect in this
+  work, not in the test.
+- **No rendered shell strings in `ir`.** The IR carries typed recipe parameters;
+  `codegen` owns all quoting and rendering. Putting a rendered string in the IR
+  would reintroduce, at the key layer, exactly the opacity this design removes.
+- **`ir` must not reuse `spec` types in node payloads.** `spec` will grow fields
+  as DSL coverage gaps close (`specs/stagefile-dsl-gaps.md`). If `ir` aliased
+  those types, adding a spec field would silently change cache keys fleet-wide.
+  Decoupling forces every new field through `Lower`, where the version bump is a
+  visible decision.
+- **Recipe versions are frozen constants.** All start at `1`. Changing one is a
+  reviewed act, never a refactoring side effect.
+- Test command throughout: `go test ./go/internal/stagefile/...`
+- Go module path prefix: `github.com/wendylabsinc/wendy/go/internal/stagefile`
+- Commit style matches the repo: `feat:`, `refactor:`, `test:` prefixes.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `go/internal/stagefile/ir/ir.go` **create** | Node/Graph types, recipe identities. Types only, no logic. |
+| `go/internal/stagefile/ir/lower.go` **create** | `Lower(*spec.File) (*Graph, error)`. The sole place mapping spec → nodes. |
+| `go/internal/stagefile/ir/lower_test.go` **create** | Lowering tests, one per spec construct. |
+| `go/internal/stagefile/cachekey/canonical.go` **create** | Deterministic byte encoding. Length-prefixed, no maps, no `%v`. |
+| `go/internal/stagefile/cachekey/cachekey.go` **create** | `Key(...)` over the encoding. |
+| `go/internal/stagefile/cachekey/cachekey_test.go` **create** | Key semantics: closure sensitivity, sibling insensitivity. |
+| `go/internal/stagefile/cachekey/golden_keys_test.go` **create** | Frozen key corpus. Guards fleet-wide invalidation. |
+| `go/internal/stagefile/codegen/codegen.go` **modify** | `Generate` takes `*ir.Graph`; `GenerateSpec` shim retained. |
+| `go/internal/stagefile/codegen/golden_test.go` **modify** | Routes through `ir.Lower`; expected output unchanged. |
+
+---
+
+### Task 1: The `ir` types and `Lower`
+
+**Files:**
+- Create: `go/internal/stagefile/ir/ir.go`
+- Create: `go/internal/stagefile/ir/lower.go`
+- Test: `go/internal/stagefile/ir/lower_test.go`
+
+**Interfaces:**
+- Consumes: `spec.File`, `spec.Stage`, `spec.NpmLockfile` (from `spec/spec.go`).
+- Produces: `ir.Graph`, `ir.Node`, `ir.OpKind`, `ir.Recipe`, and
+  `ir.Lower(f *spec.File) (*Graph, error)`. Task 2 hashes `ir.Node`; Task 3
+  renders `ir.Graph`.
+
+**Design note for the implementer.** A `Graph` holds a flat, topologically
+ordered `[]Node`. Edges are integer indices into that slice, never pointers —
+indices serialize deterministically and pointers do not, which matters in Task 2.
+`Stages` records the file's stage names and the index of each stage's final node,
+so `codegen` can rebuild `FROM ... AS <name>` blocks in original order.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/stagefile/ir/lower_test.go`:
+
+```go
+package ir
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func TestLowerSingleStageImageOnly(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages:  []spec.Stage{{Name: "app", From: "debian:12"}},
+	}
+	g, err := Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if len(g.Nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1", len(g.Nodes))
+	}
+	if g.Nodes[0].Kind != OpImage {
+		t.Fatalf("got kind %q, want %q", g.Nodes[0].Kind, OpImage)
+	}
+	if g.Nodes[0].Image.Ref != "debian:12" {
+		t.Fatalf("got ref %q, want debian:12", g.Nodes[0].Image.Ref)
+	}
+	if len(g.Stages) != 1 || g.Stages[0].Name != "app" || g.Stages[0].Final != 0 {
+		t.Fatalf("got stages %+v, want one stage app→0", g.Stages)
+	}
+}
+
+func TestLowerAptThenPipChainsInputs(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "deps",
+			From: "python:3.12-slim",
+			Install: &spec.Install{
+				Apt: &spec.AptInstall{Packages: []string{"build-essential"}},
+				Pip: &spec.PipInstall{Requirements: "requirements.txt"},
+			},
+		}},
+	}
+	g, err := Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if len(g.Nodes) != 3 {
+		t.Fatalf("got %d nodes, want 3 (image, apt, pip)", len(g.Nodes))
+	}
+	if g.Nodes[1].Exec.Recipe != RecipeApt {
+		t.Fatalf("node 1 recipe = %+v, want apt", g.Nodes[1].Exec.Recipe)
+	}
+	if g.Nodes[2].Exec.Recipe != RecipePip {
+		t.Fatalf("node 2 recipe = %+v, want pip", g.Nodes[2].Exec.Recipe)
+	}
+	// The chain must be explicit: pip runs on apt's result.
+	if len(g.Nodes[2].Inputs) != 1 || g.Nodes[2].Inputs[0] != 1 {
+		t.Fatalf("pip inputs = %v, want [1]", g.Nodes[2].Inputs)
+	}
+	if g.Nodes[2].Exec.Pip.Requirements != "requirements.txt" {
+		t.Fatalf("pip requirements = %q", g.Nodes[2].Exec.Pip.Requirements)
+	}
+	if g.Stages[0].Final != 2 {
+		t.Fatalf("stage final = %d, want 2", g.Stages[0].Final)
+	}
+}
+
+func TestLowerCopyFromPriorStageReferencesItsFinalNode(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{
+			{Name: "deps", From: "python:3.12-slim",
+				Install: &spec.Install{Apt: &spec.AptInstall{Packages: []string{"gcc"}}}},
+			{Name: "app", From: "python:3.12-slim",
+				Copy: []spec.CopyEntry{{From: "deps", Paths: []string{"/usr/lib"}}}},
+		},
+	}
+	g, err := Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	depsFinal := g.Stages[0].Final
+	var copyNode *Node
+	for i := range g.Nodes {
+		if g.Nodes[i].Kind == OpCopy {
+			copyNode = &g.Nodes[i]
+		}
+	}
+	if copyNode == nil {
+		t.Fatal("no copy node lowered")
+	}
+	// Inputs[0] is the stage this copy lands on; Inputs[1] is the source stage.
+	if len(copyNode.Inputs) != 2 || copyNode.Inputs[1] != depsFinal {
+		t.Fatalf("copy inputs = %v, want [_, %d]", copyNode.Inputs, depsFinal)
+	}
+	if copyNode.Copy.FromLocal {
+		t.Fatal("copy from a named stage must not be marked FromLocal")
+	}
+}
+
+func TestLowerCopyFromLocalHasNoStageInput(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "app", From: "debian:12",
+			Copy: []spec.CopyEntry{{From: "local", Paths: []string{"app.py"}}},
+		}},
+	}
+	g, err := Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	copyNode := g.Nodes[g.Stages[0].Final]
+	if copyNode.Kind != OpCopy || !copyNode.Copy.FromLocal {
+		t.Fatalf("final node = %+v, want a local copy", copyNode)
+	}
+	if len(copyNode.Inputs) != 1 {
+		t.Fatalf("local copy inputs = %v, want exactly the base", copyNode.Inputs)
+	}
+}
+
+func TestLowerRejectsUnknownBuildLang(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "app", From: "debian:12",
+			Build: &spec.Build{Lang: "cobol"},
+		}},
+	}
+	if _, err := Lower(f); err == nil {
+		t.Fatal("Lower accepted an unsupported build.lang")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./go/internal/stagefile/ir/...`
+Expected: FAIL — the package does not exist (`no required module provides package .../ir`).
+
+- [ ] **Step 3: Write the IR types**
+
+Create `go/internal/stagefile/ir/ir.go`:
+
+```go
+// Package ir is the typed intermediate representation between a parsed
+// Stagefile and any backend that renders it. A Graph is a flat,
+// topologically ordered list of Nodes whose edges are indices into that
+// list — never pointers, because Node must serialize deterministically for
+// cache-key computation (see package cachekey).
+//
+// Two rules hold everywhere in this package:
+//
+//  1. No node carries a rendered shell string. Nodes carry typed recipe
+//     parameters; rendering and quoting belong to a backend.
+//  2. No node payload aliases a spec type. spec grows fields as DSL coverage
+//     gaps close; if ir aliased those types, a new spec field would silently
+//     change cache keys fleet-wide. Every field crosses the boundary through
+//     Lower, by hand, on purpose.
+package ir
+
+// OpKind is the closed set of node operations. Adding a kind is a
+// deliberate extension of the model, not a convenience.
+type OpKind string
+
+const (
+	OpImage OpKind = "image"
+	OpExec  OpKind = "exec"
+	OpCopy  OpKind = "copy"
+)
+
+// Recipe identifies a typed exec operation and the version of its
+// compilation rules. Version participates in the cache key: bumping it
+// invalidates every node using that recipe, everywhere. Treat a bump as a
+// migration, not a refactor.
+type Recipe struct {
+	Name    string
+	Version int
+}
+
+var (
+	RecipeApt   = Recipe{Name: "apt", Version: 1}
+	RecipeApk   = Recipe{Name: "apk", Version: 1}
+	RecipePip   = Recipe{Name: "pip", Version: 1}
+	RecipeNpm   = Recipe{Name: "npm", Version: 1}
+	RecipeBuild = Recipe{Name: "build", Version: 1}
+)
+
+// Graph is a lowered Stagefile.
+type Graph struct {
+	Nodes  []Node
+	Stages []Stage
+}
+
+// Stage names a build stage and points at the node holding its final state.
+type Stage struct {
+	Name  string
+	Final int
+	// Entrypoint and User are stage-level image config rather than
+	// filesystem operations, so they hang off the stage, not off a node.
+	// They never enter a cache key: changing an entrypoint does not
+	// invalidate a built filesystem.
+	Entrypoint []string
+	User       string
+}
+
+// Node is one operation. Exactly one of Image/Exec/Copy is non-nil,
+// matching Kind.
+type Node struct {
+	Kind   OpKind
+	Inputs []int
+	Image  *ImageOp
+	Exec   *ExecOp
+	Copy   *CopyOp
+}
+
+// ImageOp is a base image by its original reference. The resolved digest is
+// supplied separately at key time and at render time, so the graph itself
+// stays independent of any particular lockfile state.
+type ImageOp struct {
+	Ref string
+}
+
+// ExecOp is a typed operation. Exactly one params pointer is non-nil, and
+// it must correspond to Recipe.
+type ExecOp struct {
+	Recipe Recipe
+	Apt    *AptParams
+	Apk    *AptParams
+	Pip    *PipParams
+	Npm    *NpmParams
+	Build  *BuildParams
+}
+
+// AptParams covers both apt and apk; the declared shape is identical and
+// only the rendered command differs.
+type AptParams struct {
+	Packages   []string
+	Recommends bool
+}
+
+// PipParams installs from a requirements file, an explicit list, or both.
+type PipParams struct {
+	Requirements string
+	Packages     []string
+}
+
+// NpmParams records the resolved manager and its lockfile, both resolved at
+// lower time so no backend re-derives them and drifts.
+type NpmParams struct {
+	Manager  string
+	Lockfile string
+}
+
+// BuildParams is a language compile step with its profile resolved.
+type BuildParams struct {
+	Lang    string
+	Profile string
+}
+
+// CopyOp promotes paths into the stage this node belongs to. When FromLocal
+// is set the source is the build context and Inputs holds only the base;
+// otherwise Inputs is [base, sourceStageFinalNode].
+type CopyOp struct {
+	FromLocal bool
+	Paths     []string
+	Dest      string
+}
+```
+
+- [ ] **Step 4: Write `Lower`**
+
+Create `go/internal/stagefile/ir/lower.go`:
+
+```go
+package ir
+
+import (
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// supportedLangs mirrors the languages codegen can render. Lower rejects
+// anything else here so an unsupported language fails at lowering rather
+// than surfacing from a backend deep in the pipeline.
+var supportedLangs = map[string]bool{"rust": true, "go": true, "swift": true}
+
+// Lower converts a validated spec.File into a Graph. Node order within a
+// stage matches the order codegen must emit: install, then copy, then
+// build. That ordering is load-bearing — a copy that lands source files
+// must happen after the installs the build depends on, and reversing it was
+// a real defect once already (see codegen/golden_test.go).
+func Lower(f *spec.File) (*Graph, error) {
+	g := &Graph{}
+	stageFinal := map[string]int{}
+
+	for _, s := range f.Stages {
+		cur := g.add(Node{Kind: OpImage, Image: &ImageOp{Ref: s.From}})
+
+		if s.Install != nil {
+			if s.Install.Apt != nil {
+				cur = g.add(execNode(cur, &ExecOp{
+					Recipe: RecipeApt,
+					Apt:    &AptParams{Packages: s.Install.Apt.Packages, Recommends: s.Install.Apt.Recommends},
+				}))
+			}
+			if s.Install.Apk != nil {
+				cur = g.add(execNode(cur, &ExecOp{
+					Recipe: RecipeApk,
+					Apk:    &AptParams{Packages: s.Install.Apk.Packages, Recommends: s.Install.Apk.Recommends},
+				}))
+			}
+			if s.Install.Pip != nil {
+				cur = g.add(execNode(cur, &ExecOp{
+					Recipe: RecipePip,
+					Pip:    &PipParams{Requirements: s.Install.Pip.Requirements, Packages: s.Install.Pip.Packages},
+				}))
+			}
+			if s.Install.Npm != nil {
+				manager := s.Install.Npm.Manager
+				if manager == "" {
+					manager = "npm"
+				}
+				cur = g.add(execNode(cur, &ExecOp{
+					Recipe: RecipeNpm,
+					Npm:    &NpmParams{Manager: manager, Lockfile: spec.NpmLockfile(s.Install.Npm.Manager)},
+				}))
+			}
+		}
+
+		for _, c := range s.Copy {
+			n := Node{Kind: OpCopy, Inputs: []int{cur}, Copy: &CopyOp{
+				Paths: c.Paths,
+				Dest:  c.Dest,
+			}}
+			if c.From == "local" {
+				n.Copy.FromLocal = true
+			} else {
+				src, ok := stageFinal[c.From]
+				if !ok {
+					return nil, fmt.Errorf("stage %q: copy from unknown stage %q", s.Name, c.From)
+				}
+				n.Inputs = append(n.Inputs, src)
+			}
+			cur = g.add(n)
+		}
+
+		if s.Build != nil {
+			if !supportedLangs[s.Build.Lang] {
+				return nil, fmt.Errorf("stage %q: unsupported build.lang %q (supported: go, rust, swift)", s.Name, s.Build.Lang)
+			}
+			profile := s.Build.Profile
+			if profile == "" {
+				profile = "release"
+			}
+			cur = g.add(execNode(cur, &ExecOp{
+				Recipe: RecipeBuild,
+				Build:  &BuildParams{Lang: s.Build.Lang, Profile: profile},
+			}))
+		}
+
+		st := Stage{Name: s.Name, Final: cur, User: s.User}
+		if s.Entrypoint != nil {
+			st.Entrypoint = s.Entrypoint.Exec
+		}
+		g.Stages = append(g.Stages, st)
+		stageFinal[s.Name] = cur
+	}
+	return g, nil
+}
+
+func execNode(base int, e *ExecOp) Node {
+	return Node{Kind: OpExec, Inputs: []int{base}, Exec: e}
+}
+
+func (g *Graph) add(n Node) int {
+	g.Nodes = append(g.Nodes, n)
+	return len(g.Nodes) - 1
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/stagefile/ir/... -v`
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/stagefile/ir/
+git commit -m "feat(stagefile): add typed IR and spec lowering"
+```
+
+---
+
+### Task 2: `cachekey` — deterministic encoding and `Key`
+
+**Files:**
+- Create: `go/internal/stagefile/cachekey/canonical.go`
+- Create: `go/internal/stagefile/cachekey/cachekey.go`
+- Test: `go/internal/stagefile/cachekey/cachekey_test.go`
+
+**Interfaces:**
+- Consumes: `ir.Graph`, `ir.Node`, `ir.Recipe` from Task 1.
+- Produces: `cachekey.Inputs` and
+  `cachekey.Key(g *ir.Graph, idx int, in Inputs) (string, error)`, returning
+  `"sha256:<hex>"`. Stage 3's CAS calls this.
+
+**Design note for the implementer.** Determinism is the whole product here. Never
+hash a Go map directly, never use `fmt.Sprintf("%v", ...)`, and never hash a
+struct via `encoding/gob` or `encoding/json` — all three are either
+order-unstable or silently sensitive to field reordering during a refactor. The
+encoder below writes explicit tags and length prefixes, so a field added without
+a version bump changes the bytes loudly rather than quietly.
+
+Keys are computed recursively over a node's inputs. That is deliberate: a node
+that runs on another node's result genuinely depends on it. What the key omits is
+everything Docker's layer ID carries beyond that — file position, instruction
+text, and unrelated sibling stages.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/stagefile/cachekey/cachekey_test.go`:
+
+```go
+package cachekey
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func mustLower(t *testing.T, f *spec.File) *ir.Graph {
+	t.Helper()
+	g, err := ir.Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	return g
+}
+
+func pipStage(name, from, reqs string, aptPkgs []string) spec.Stage {
+	s := spec.Stage{Name: name, From: from, Install: &spec.Install{
+		Pip: &spec.PipInstall{Requirements: reqs},
+	}}
+	if aptPkgs != nil {
+		s.Install.Apt = &spec.AptInstall{Packages: aptPkgs}
+	}
+	return s
+}
+
+func testInputs() Inputs {
+	return Inputs{
+		Images: map[string]string{"python:3.12-slim": "sha256:aaa", "debian:12": "sha256:bbb"},
+		Files:  map[string]string{"requirements.txt": "sha256:reqs1"},
+	}
+}
+
+// The core property: the same pip install on the same base yields the same
+// key across two unrelated Stagefiles.
+func TestKeyIsStableAcrossUnrelatedFiles(t *testing.T) {
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "unrelated", From: "debian:12"},
+		pipStage("otherName", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	ka, err := Key(a, a.Stages[0].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key(a): %v", err)
+	}
+	kb, err := Key(b, b.Stages[1].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key(b): %v", err)
+	}
+	if ka != kb {
+		t.Fatalf("keys differ across unrelated files:\n a=%s\n b=%s", ka, kb)
+	}
+	if !strings.HasPrefix(ka, "sha256:") {
+		t.Fatalf("key %q lacks sha256: prefix", ka)
+	}
+}
+
+// The soundness property: a different dependency closure must key
+// differently, even with identical pip params.
+func TestKeyDiffersWhenClosureDiffers(t *testing.T) {
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", []string{"foo"}),
+	}})
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", []string{"bar"}),
+	}})
+
+	ka, _ := Key(a, a.Stages[0].Final, testInputs())
+	kb, _ := Key(b, b.Stages[0].Final, testInputs())
+	if ka == kb {
+		t.Fatal("pip keyed identically over different apt closures — cache is unsound")
+	}
+}
+
+func TestKeyDiffersWhenInputFileChanges(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	in1 := testInputs()
+	k1, _ := Key(g, g.Stages[0].Final, in1)
+
+	in2 := testInputs()
+	in2.Files["requirements.txt"] = "sha256:reqs2"
+	k2, _ := Key(g, g.Stages[0].Final, in2)
+
+	if k1 == k2 {
+		t.Fatal("key ignored requirements.txt content")
+	}
+}
+
+func TestKeyDiffersWhenBaseDigestChanges(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	k1, _ := Key(g, g.Stages[0].Final, testInputs())
+	in2 := testInputs()
+	in2.Images["python:3.12-slim"] = "sha256:ccc"
+	k2, _ := Key(g, g.Stages[0].Final, in2)
+
+	if k1 == k2 {
+		t.Fatal("key ignored the base image digest")
+	}
+}
+
+func TestKeyErrorsOnMissingImageDigest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "alpine:3.20"},
+	}})
+	if _, err := Key(g, 0, testInputs()); err == nil {
+		t.Fatal("Key succeeded with no resolved digest for alpine:3.20")
+	}
+}
+
+func TestKeyErrorsOnMissingFileDigest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "absent.txt", nil),
+	}})
+	if _, err := Key(g, g.Stages[0].Final, testInputs()); err == nil {
+		t.Fatal("Key succeeded with no digest for absent.txt")
+	}
+}
+
+// Entrypoint and user are image config, not filesystem content; changing
+// them must not invalidate a built node.
+func TestKeyIgnoresEntrypointAndUser(t *testing.T) {
+	base := pipStage("deps", "python:3.12-slim", "requirements.txt", nil)
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{base}})
+
+	withCfg := base
+	withCfg.Entrypoint = &spec.Entrypoint{Exec: []string{"python3", "x.py"}}
+	withCfg.User = "1000"
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{withCfg}})
+
+	ka, _ := Key(a, a.Stages[0].Final, testInputs())
+	kb, _ := Key(b, b.Stages[0].Final, testInputs())
+	if ka != kb {
+		t.Fatal("entrypoint/user changed the filesystem key")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./go/internal/stagefile/cachekey/...`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write the canonical encoder**
+
+Create `go/internal/stagefile/cachekey/canonical.go`:
+
+```go
+package cachekey
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// enc writes a self-delimiting, order-explicit byte stream into a hash.
+//
+// Everything is length-prefixed and every field is preceded by a literal
+// tag. This is deliberately more verbose than gob or JSON: both of those
+// can change their output when a struct's fields are reordered or a field
+// is added, which would silently invalidate every cached node in the fleet
+// during an ordinary refactor. Here, any change to the encoding is a
+// visible edit to this file.
+type enc struct{ h hash.Hash }
+
+func (e enc) tag(name string) {
+	e.str(name)
+}
+
+func (e enc) str(s string) {
+	var n [8]byte
+	binary.BigEndian.PutUint64(n[:], uint64(len(s)))
+	e.h.Write(n[:])
+	e.h.Write([]byte(s))
+}
+
+func (e enc) int(i int) {
+	var n [8]byte
+	binary.BigEndian.PutUint64(n[:], uint64(i))
+	e.h.Write(n[:])
+}
+
+func (e enc) bool(b bool) {
+	if b {
+		e.int(1)
+		return
+	}
+	e.int(0)
+}
+
+// strs encodes a slice in its given order. Order is significant for package
+// lists: apt resolves differently depending on order in rare cases, and
+// pretending otherwise would key two genuinely different rootfs alike.
+func (e enc) strs(ss []string) {
+	e.int(len(ss))
+	for _, s := range ss {
+		e.str(s)
+	}
+}
+```
+
+- [ ] **Step 4: Write `Key`**
+
+Create `go/internal/stagefile/cachekey/cachekey.go`:
+
+```go
+// Package cachekey computes stable content-addressed keys for ir nodes.
+//
+// A key covers a node's semantic dependency closure: its recipe and
+// version, its declared parameters, the digests of any input files it
+// reads, and — recursively — the keys of the nodes it runs on. It does not
+// cover the node's position in the source file, the text of any rendered
+// command, or any unrelated sibling stage. That is the difference between
+// this and a Docker layer ID, and it is why two projects that reach the
+// same rootfs by different routes converge on the same key.
+package cachekey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+// keyFormatVersion prefixes every key. Bumping it invalidates every cached
+// node everywhere; it exists for changes to the keying scheme itself, as
+// distinct from ir.Recipe.Version which scopes an invalidation to one
+// recipe.
+const keyFormatVersion = 1
+
+// Inputs supplies the externally-resolved facts a key depends on: base
+// image digests (from the lockfile) and build-context path digests.
+//
+// Files maps a context-relative path to a digest of its content. For a
+// directory that must be a digest over the whole tree — names, modes, and
+// contents — because a copy of a directory depends on all of it. Computing
+// these belongs to the caller; stage 3 supplies them from the build
+// context, and stage 1 only ever receives them from tests. Key treats a
+// missing entry as an error rather than hashing an empty string, so a
+// caller that forgets a path cannot silently produce a key that collides
+// across different content.
+type Inputs struct {
+	Images map[string]string
+	Files  map[string]string
+}
+
+// Key returns the "sha256:<hex>" key of node idx in g.
+func Key(g *ir.Graph, idx int, in Inputs) (string, error) {
+	h := sha256.New()
+	e := enc{h: h}
+	e.tag("stagefile-key")
+	e.int(keyFormatVersion)
+	if err := write(e, g, idx, in); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func write(e enc, g *ir.Graph, idx int, in Inputs) error {
+	if idx < 0 || idx >= len(g.Nodes) {
+		return fmt.Errorf("cachekey: node index %d out of range", idx)
+	}
+	n := g.Nodes[idx]
+
+	// Inputs are folded in by key, not by index — an index is a position in
+	// this particular file and must never reach the hash.
+	e.tag("inputs")
+	e.int(len(n.Inputs))
+	for _, dep := range n.Inputs {
+		sub, err := Key(g, dep, in)
+		if err != nil {
+			return err
+		}
+		e.str(sub)
+	}
+
+	e.tag(string(n.Kind))
+	switch n.Kind {
+	case ir.OpImage:
+		digest, ok := in.Images[n.Image.Ref]
+		if !ok {
+			return fmt.Errorf("cachekey: no resolved digest for image %q", n.Image.Ref)
+		}
+		// The ref itself is excluded on purpose: two tags pointing at the
+		// same digest are the same rootfs and must share a key.
+		e.str(digest)
+	case ir.OpCopy:
+		e.bool(n.Copy.FromLocal)
+		e.strs(n.Copy.Paths)
+		e.str(n.Copy.Dest)
+		if n.Copy.FromLocal {
+			for _, p := range n.Copy.Paths {
+				d, ok := in.Files[p]
+				if !ok {
+					return fmt.Errorf("cachekey: no digest for context path %q", p)
+				}
+				e.str(d)
+			}
+		}
+	case ir.OpExec:
+		if err := writeExec(e, n.Exec, in); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("cachekey: unhandled node kind %q", n.Kind)
+	}
+	return nil
+}
+
+func writeExec(e enc, x *ir.ExecOp, in Inputs) error {
+	e.str(x.Recipe.Name)
+	e.int(x.Recipe.Version)
+	switch {
+	case x.Apt != nil:
+		e.strs(x.Apt.Packages)
+		e.bool(x.Apt.Recommends)
+	case x.Apk != nil:
+		e.strs(x.Apk.Packages)
+		e.bool(x.Apk.Recommends)
+	case x.Pip != nil:
+		e.str(x.Pip.Requirements)
+		e.strs(x.Pip.Packages)
+		if x.Pip.Requirements != "" {
+			d, ok := in.Files[x.Pip.Requirements]
+			if !ok {
+				return fmt.Errorf("cachekey: no digest for %q", x.Pip.Requirements)
+			}
+			e.str(d)
+		}
+	case x.Npm != nil:
+		e.str(x.Npm.Manager)
+		e.str(x.Npm.Lockfile)
+		d, ok := in.Files[x.Npm.Lockfile]
+		if !ok {
+			return fmt.Errorf("cachekey: no digest for %q", x.Npm.Lockfile)
+		}
+		e.str(d)
+	case x.Build != nil:
+		e.str(x.Build.Lang)
+		e.str(x.Build.Profile)
+	default:
+		return fmt.Errorf("cachekey: exec node has no params")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./go/internal/stagefile/cachekey/... -v`
+Expected: all eight tests PASS.
+
+Note: `TestKeyErrorsOnMissingFileDigest` and the npm path both require a file
+digest. If `TestKeyIsStableAcrossUnrelatedFiles` fails, the likely cause is that
+`ir.Lower` recorded something file-position-dependent in a node — check that no
+node carries a stage name or index.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/stagefile/cachekey/
+git commit -m "feat(stagefile): add deterministic content-addressed cache keys"
+```
+
+---
+
+### Task 3: Retarget `codegen` to the IR
+
+**Files:**
+- Modify: `go/internal/stagefile/codegen/codegen.go` (`Generate`, lines 26–80)
+- Modify: `go/internal/stagefile/codegen/golden_test.go`
+- Test: existing `go/internal/stagefile/codegen/codegen_test.go` (unchanged)
+
+**Interfaces:**
+- Consumes: `ir.Graph` from Task 1.
+- Produces: `codegen.Generate(g *ir.Graph, images map[string]string, platform string) (string, error)`
+  and the compatibility shim
+  `codegen.GenerateSpec(f *spec.File, images map[string]string, platform string) (string, error)`,
+  which lowers then generates. `stagefile.compileFile` keeps calling `GenerateSpec`,
+  so no caller outside this package changes in stage 1.
+
+**Design note for the implementer.** This is the risky task, and its acceptance
+test is severe on purpose: **the generated Dockerfile must be byte-identical.**
+The existing `codegen_test.go` and `golden_test.go` are the specification. Do not
+edit expected strings. If output differs, the lowering or the rendering is wrong.
+
+Watch the ordering trap called out in `golden_test.go`'s comment: install must
+render before copy within a stage. `ir.Lower` already fixes that order, and
+rendering nodes in graph order preserves it — but only if you iterate nodes, not
+re-read the spec.
+
+- [ ] **Step 1: Run the existing tests to capture the baseline**
+
+Run: `go test ./go/internal/stagefile/... -v 2>&1 | tail -40`
+Expected: all PASS. Note the count; it must not drop.
+
+- [ ] **Step 2: Rewrite `Generate` over the IR**
+
+In `go/internal/stagefile/codegen/codegen.go`, replace the existing `Generate`
+(currently `spec`-typed) with the pair below. Leave `shellQuote`, `cacheRun`,
+`aptInstallLines`, `apkInstallLines`, `pipInstallLines`, `npmInstallLines`,
+`copyLines`, `buildLines`, and `entrypointLine` in place — only their parameter
+types change from `spec.*` to `ir.*`, since the two now carry identical fields.
+
+```go
+// Generate compiles a lowered graph into Dockerfile text. images maps every
+// base-image ref in g to its resolved "sha256:..." digest. platform, if
+// non-empty, is applied to every FROM via --platform.
+func Generate(g *ir.Graph, images map[string]string, platform string) (string, error) {
+	var blocks []string
+	lastIdx := len(g.Stages) - 1
+
+	// Nodes belong to the stage whose range they fall in; walking stages and
+	// slicing the node list preserves both stage order and within-stage
+	// operation order without consulting the spec again.
+	start := 0
+	for si, st := range g.Stages {
+		var lines []string
+		for i := start; i <= st.Final; i++ {
+			n := g.Nodes[i]
+			switch n.Kind {
+			case ir.OpImage:
+				digest, ok := images[n.Image.Ref]
+				if !ok {
+					return "", fmt.Errorf("stage %q: no resolved digest for %q; run `stagefile lock`", st.Name, n.Image.Ref)
+				}
+				lines = append(lines, fromLine(n.Image.Ref, digest, st.Name, platform))
+			case ir.OpExec:
+				el, err := execLines(n.Exec)
+				if err != nil {
+					return "", fmt.Errorf("stage %q: %w", st.Name, err)
+				}
+				lines = append(lines, el...)
+			case ir.OpCopy:
+				lines = append(lines, copyLine(g, n))
+			default:
+				return "", fmt.Errorf("stage %q: unhandled node kind %q", st.Name, n.Kind)
+			}
+		}
+		if si == lastIdx {
+			if len(st.Entrypoint) > 0 {
+				lines = append(lines, entrypointLine(st.Entrypoint))
+			}
+			user := st.User
+			if user == "" {
+				user = defaultUser
+			}
+			lines = append(lines, "USER "+user)
+		}
+		blocks = append(blocks, strings.Join(lines, "\n"))
+		start = st.Final + 1
+	}
+	return strings.Join(blocks, "\n\n") + "\n", nil
+}
+
+// GenerateSpec lowers f and generates from the result. It exists so callers
+// outside this package are untouched while the IR lands; stage 2 removes it
+// once every caller holds a graph of its own.
+func GenerateSpec(f *spec.File, images map[string]string, platform string) (string, error) {
+	g, err := ir.Lower(f)
+	if err != nil {
+		return "", err
+	}
+	return Generate(g, images, platform)
+}
+
+func execLines(x *ir.ExecOp) ([]string, error) {
+	switch {
+	case x.Apt != nil:
+		return aptInstallLines(x.Apt), nil
+	case x.Apk != nil:
+		return apkInstallLines(x.Apk), nil
+	case x.Pip != nil:
+		return pipInstallLines(x.Pip), nil
+	case x.Npm != nil:
+		return npmInstallLines(x.Npm), nil
+	case x.Build != nil:
+		return buildLines(x.Build)
+	default:
+		return nil, fmt.Errorf("exec node has no params")
+	}
+}
+
+// copyLine renders one copy node. The source stage's name comes from the
+// graph rather than the node, so a copy node itself stays free of any
+// file-local naming.
+func copyLine(g *ir.Graph, n ir.Node) string {
+	dest := n.Copy.Dest
+	if dest == "" {
+		dest = n.Copy.Paths[0]
+	}
+	// BuildKit requires a multi-source COPY's destination to end with "/";
+	// a dest without one validates here but hard-fails at docker build.
+	if len(n.Copy.Paths) > 1 && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
+	from := ""
+	if !n.Copy.FromLocal {
+		for _, st := range g.Stages {
+			if st.Final == n.Inputs[1] {
+				from = "--from=" + st.Name + " "
+				break
+			}
+		}
+	}
+	return fmt.Sprintf("COPY %s%s %s", from, strings.Join(n.Copy.Paths, " "), dest)
+}
+
+func entrypointLine(exec []string) string {
+	quoted := make([]string, len(exec))
+	for i, s := range exec {
+		quoted[i] = strconv.Quote(s)
+	}
+	return "ENTRYPOINT [" + strings.Join(quoted, ", ") + "]"
+}
+```
+
+Then change the remaining helper signatures from `*spec.AptInstall` →
+`*ir.AptParams`, `*spec.PipInstall` → `*ir.PipParams`, `*spec.NpmInstall` →
+`*ir.NpmParams`, `*spec.Build` → `*ir.BuildParams`. In `npmInstallLines`, replace
+the `spec.NpmLockfile(n.Manager)` call and the `manager == ""` defaulting with
+`n.Lockfile` and `n.Manager` — `ir.Lower` already resolved both.
+
+In `buildLines`, drop the `profile == ""` defaulting for the same reason, and
+keep the `default:` error arm even though `ir.Lower` now rejects unknown
+languages first; a backend that trusts its input silently is how a future caller
+constructing a graph directly gets a wrong Dockerfile instead of an error.
+
+- [ ] **Step 3: Point `stagefile.go` at the shim**
+
+In `go/internal/stagefile/stagefile.go`, change the single call in
+`compileFile` from `codegen.Generate(f, updated.Images, platform)` to
+`codegen.GenerateSpec(f, updated.Images, platform)`. Nothing else in that file
+changes.
+
+- [ ] **Step 4: Update the golden test to route through the IR**
+
+In `go/internal/stagefile/codegen/golden_test.go`, replace the `Generate` call
+with a lowering plus generate. **Leave the `want` string exactly as it is.**
+
+```go
+	g, err := ir.Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	out, err := Generate(g, images, "")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+```
+
+Add `"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"` to that file's
+imports. Apply the same two-line change to every `Generate(` call site in
+`codegen_test.go`, again without touching any expected output.
+
+- [ ] **Step 5: Run the full package suite**
+
+Run: `go test ./go/internal/stagefile/... -v 2>&1 | tail -40`
+Expected: every test PASS, including `TestGenerateGoldenExampleFixture` with its
+`want` string untouched. A diff there means the lowering reordered operations.
+
+- [ ] **Step 6: Run the CLI suite for regressions**
+
+Run: `go test ./go/internal/cli/commands/... ./go/internal/cli/optimize/...`
+Expected: PASS. These exercise `stagefile.CompileFile` end to end via
+`TestResolveDockerfile_CompilesStagefile`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go/internal/stagefile/
+git commit -m "refactor(stagefile): generate Dockerfiles from the IR"
+```
+
+---
+
+### Task 4: Freeze the key corpus
+
+**Files:**
+- Create: `go/internal/stagefile/cachekey/golden_keys_test.go`
+
+**Interfaces:**
+- Consumes: `cachekey.Key`, `ir.Lower`, and the shipped fixture
+  `go/internal/stagefile/testdata/example.stagefile.yaml`.
+- Produces: nothing consumed by later code. This is a tripwire.
+
+**Design note for the implementer.** A silent key change invalidates every cached
+node in the fleet — at stage 7 that is a global cache flush triggered by an
+innocuous refactor. This test makes that impossible to do by accident: the
+literal key strings are checked in, so any change to lowering, encoding, or
+recipe versions fails CI with a diff naming the node.
+
+- [ ] **Step 1: Write the test with deliberately wrong expected values**
+
+Create `go/internal/stagefile/cachekey/golden_keys_test.go`:
+
+```go
+package cachekey
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// TestGoldenKeys pins the key of every node in the shipped example
+// Stagefile. These strings are a wire format, not an implementation detail:
+// changing one invalidates that node for every cache tier, in every org,
+// permanently. A diff here is only ever correct alongside a bump to
+// ir.Recipe.Version (scoped) or keyFormatVersion (global), and both belong
+// in their own reviewed commit.
+func TestGoldenKeys(t *testing.T) {
+	data, err := os.ReadFile("../testdata/example.stagefile.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := spec.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	g, err := ir.Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	in := Inputs{
+		Images: map[string]string{"python:3.12-slim": "sha256:abc123"},
+		Files: map[string]string{
+			"requirements.txt": "sha256:fixedreqs",
+			"app.py":           "sha256:fixedapp",
+		},
+	}
+
+	want := []string{
+		"REPLACE_ME_NODE_0",
+		"REPLACE_ME_NODE_1",
+		"REPLACE_ME_NODE_2",
+		"REPLACE_ME_NODE_3",
+		"REPLACE_ME_NODE_4",
+		"REPLACE_ME_NODE_5",
+	}
+	if len(g.Nodes) != len(want) {
+		t.Fatalf("fixture lowered to %d nodes, corpus pins %d — update both together", len(g.Nodes), len(want))
+	}
+	for i := range g.Nodes {
+		got, err := Key(g, i, in)
+		if err != nil {
+			t.Fatalf("Key(node %d): %v", i, err)
+		}
+		if got != want[i] {
+			t.Errorf("node %d (%s) key drift:\n got  %s\n want %s", i, g.Nodes[i].Kind, got, want[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run it to harvest the real keys**
+
+Run: `go test ./go/internal/stagefile/cachekey/ -run TestGoldenKeys -v`
+Expected: FAIL, printing a `got` value for each node (and possibly a node-count
+mismatch first — if so, resize `want` to the reported count and rerun).
+
+- [ ] **Step 3: Paste the harvested keys into `want`**
+
+Replace each `REPLACE_ME_NODE_n` with the corresponding `got` value from the
+failure output, in order. Do not hand-edit or reformat them.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./go/internal/stagefile/cachekey/ -run TestGoldenKeys -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the tripwire actually trips**
+
+Temporarily change `RecipePip` in `go/internal/stagefile/ir/ir.go` to
+`Version: 2`, then run:
+
+Run: `go test ./go/internal/stagefile/cachekey/ -run TestGoldenKeys`
+Expected: FAIL, naming the pip node and every node downstream of it.
+
+Revert the version back to `1` and rerun to confirm PASS. A test that cannot fail
+is not protecting anything, and this one is the whole safeguard against an
+accidental fleet-wide flush.
+
+- [ ] **Step 6: Run everything**
+
+Run: `go test ./go/internal/stagefile/... ./go/internal/cli/commands/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go/internal/stagefile/cachekey/golden_keys_test.go
+git commit -m "test(stagefile): freeze the cache-key corpus against silent drift"
+```
+
+---
+
+## Done when
+
+- `ir`, `cachekey` exist; `codegen` renders from `ir`.
+- `TestGenerateGoldenExampleFixture` passes with its `want` string never edited.
+- The key corpus is frozen and demonstrably fails on a recipe-version bump.
+- `go test ./go/internal/stagefile/... ./go/internal/cli/commands/... ./go/internal/cli/optimize/...` is green.
+- No caller outside `go/internal/stagefile/` changed.
+
+## Explicitly out of scope
+
+- BuildKit LLB emission (stage 2).
+- Any CAS, any tier, any network call (stage 3+).
+- apt/apk dependency pinning (stage 4) — until it lands, apt nodes are keyed
+  over their declared package list, which is *not* sufficient for promotion
+  beyond a local tier. The design doc's default-deny promotion rule is what
+  keeps that honest; nothing in this stage may be read as making apt nodes
+  shareable.
+- Closing any DSL gap in `specs/stagefile-dsl-gaps.md`.

--- a/specs/2026-08-07-stagefile-ir-cachekey-plan.md
+++ b/specs/2026-08-07-stagefile-ir-cachekey-plan.md
@@ -870,7 +870,7 @@ func writeExec(e enc, x *ir.ExecOp, in Inputs) error {
 - [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `go test ./go/internal/stagefile/cachekey/... -v`
-Expected: all eight tests PASS.
+Expected: all seven tests PASS.
 
 Note: `TestKeyErrorsOnMissingFileDigest` and the npm path both require a file
 digest. If `TestKeyIsStableAcrossUnrelatedFiles` fails, the likely cause is that

--- a/specs/2026-08-07-stagefile-llb-backend-plan.md
+++ b/specs/2026-08-07-stagefile-llb-backend-plan.md
@@ -606,12 +606,34 @@ behind `//go:build buildkit_integration` and skip when no address resolves. Stat
 in the file's doc comment how to run it, because a gated test nobody knows how to
 run is a test that does not exist.
 
-For each `Examples/*/build.stagefile.yaml` plus both `testdata` fixtures: build
-via the Dockerfile backend to an OCI layout, build via the LLB backend to an OCI
-layout, then compare the layer diff-IDs and the image config (entrypoint, user).
-Compare unpacked content, not layer digests — timestamps and layer boundaries
-legitimately differ between the two paths, and asserting on them would produce a
-test that fails for reasons nobody can act on.
+Drive this from real `Examples/*/build.stagefile.yaml` builds, whose lockfiles
+carry real digests. Do **not** reuse the unit-test fixtures: `llbgen` validates
+image refs and rejects their synthetic `sha256:abc123`, which `codegen` accepts.
+
+**What to compare, decided during task 3 rather than left to the implementer:**
+
+- **Compare:** `rootfs.diff_ids`; the `config` object field by field (`Env`,
+  `Entrypoint`, `Cmd`, `User`, `WorkingDir`, `Labels`, `ExposedPorts`,
+  `Volumes`, `Healthcheck`, `StopSignal`); and top-level `os`/`architecture`/
+  `variant`.
+- **Exclude:** `history`, `created`, and the image/config digests.
+
+`created` is excluded because the exporter backfills build time, so the two runs
+legitimately differ. The digests are excluded because they are functions of the
+fields already compared — asserting on them adds no coverage and converts any
+excluded-field difference into an opaque "image ID differs".
+
+`history` is excluded on a considered judgment, not for convenience. The
+op→instruction mapping exists only during Dockerfile lowering and cannot be
+recovered from a marshalled `llb.Definition`. `llbgen` could synthesize a history
+slice — it walks the graph and knows each recipe's command — but exact
+`created_by` parity means reproducing BuildKit's own instruction-text formatting
+(the `# buildkit` suffix, `|N ARG=` prefixes, the
+`Comment: "buildkit.dockerfile.v0"`) and re-verifying it on every BuildKit bump,
+for a field nothing reads at build time. Partial parity would be worse than
+none: it would look authoritative while differing in ways no one audits. The
+consequence to accept knowingly is that `docker history` output differs between
+the two backends.
 
 - [ ] **Step 1: Write the test**
 - [ ] **Step 2: Run it with the tag against a live daemon; record the result**

--- a/specs/2026-08-07-stagefile-llb-backend-plan.md
+++ b/specs/2026-08-07-stagefile-llb-backend-plan.md
@@ -289,8 +289,16 @@ git commit -m "refactor(stagefile): give recipes one definition shared by both b
 **Interfaces:**
 - Consumes: `ir.Graph`, `recipe.For`, `recipe.RunSpec`.
 - Produces: `llbgen.ImageConfig{Entrypoint []string; User string}` and
-  `llbgen.Emit(g *ir.Graph, images map[string]string, platform string) (*llb.Definition, *ImageConfig, error)`.
-  Task 3 solves the definition and applies the config.
+  `llbgen.Emit(g *ir.Graph, images map[string]string, configs map[string][]byte, platform string) (*llb.Definition, *ImageConfig, error)`.
+  Task 3 solves the definition and stamps the returned output config onto the
+  result.
+
+  `configs` holds each base image's raw OCI image-config JSON, keyed by the same
+  ref as `images`. It is a parameter rather than something a later stage applies
+  because `WithImageConfig` acts on an `llb.State` and `Emit` marshals before
+  returning — after that the states no longer exist. It is also a genuine build
+  input: `PATH` and `WorkingDir` change the resulting filesystem, so it belongs
+  in the function whose output a cache key will eventually describe.
 
 **Design note.** Build one `llb.State` per node, indexed like `ir.Graph.Nodes`, so
 the graph maps across one-to-one. Ops:
@@ -456,8 +464,28 @@ git commit -m "feat(stagefile): compile the IR to BuildKit LLB"
 
 Only `Address` needs unit tests; `Run` needs a daemon and is covered in task 5.
 
-The gateway callback is the whole reason for this design — it is where image
-config gets attached, which raw LLB cannot express:
+**Correction to this plan, found during task 2.** "Image config" is two
+different things, and the original text conflated them:
+
+- **Output image config** — the `Entrypoint` and `User` stamped onto the image
+  this build produces. That belongs here, in the gateway callback, exactly as
+  written below.
+- **Base image config** — the `Env` (notably `PATH`) and `WorkingDir` that a
+  Dockerfile `RUN` inherits from its base image. That canNOT be applied here.
+  `WithImageConfig` operates on an `llb.State` and must be applied before any
+  dependent op is built, but `llbgen.Emit` marshals before returning, so by the
+  time this task holds a `*llb.Definition` the states are gone.
+
+Base config therefore became a parameter of `Emit`
+(`configs map[string][]byte`, keyed like `images`). **This task's remaining job
+for it is to resolve those configs** — fetch each base image's OCI config JSON
+via the registry client already used by `lock` — and hand them to `Emit`. Do not
+default a missing config to empty: an exec with no inherited `PATH` fails to
+find `go` or `cargo`, and a missing `WorkingDir` silently relocates every
+relative copy to `/`, producing a build that succeeds and yields a different
+image than the Dockerfile backend.
+
+The gateway callback below is for the output config only:
 
 ```go
 res, err := c.Solve(ctx, gateway.SolveRequest{Definition: def.ToPB()})

--- a/specs/2026-08-07-stagefile-llb-backend-plan.md
+++ b/specs/2026-08-07-stagefile-llb-backend-plan.md
@@ -1,0 +1,626 @@
+# Stagefile LLB backend (stage 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compile the Stagefile IR to BuildKit LLB and solve it through BuildKit's
+Go client, behind a flag, producing images equivalent to the Dockerfile backend.
+
+**Architecture:** `ir.Graph` → `recipe` (shared structured render) → either
+`codegen` (Dockerfile text, default) or `llbgen` (LLB definition + image config,
+opt-in) → `solve` (`client.Build` with a gateway callback that attaches image
+config). No CAS in this stage — that is stage 3. The point of doing LLB first is
+that stage 3's cache lookup then happens host-side, where it can consult a local
+store without network egress or credentials inside the build sandbox.
+
+**Tech Stack:** Go 1.26, `github.com/moby/buildkit v0.32.2` (already added and
+verified in commit `a7a435d94`), existing `buildprogress.go` renderer.
+
+## Global Constraints
+
+- **Branch base: `jo/stagefile-ir-cachekey` (stage 1).** This branch is
+  `jo/stagefile-llb-backend`, worktree `.worktrees/stagefile-llb`.
+- **The Dockerfile backend stays the default and stays byte-identical.**
+  `codegen/golden_test.go`'s `want` strings must never be edited. Any task that
+  cannot keep them is wrong.
+- **The frozen cache-key corpus must not move.** `cachekey/golden_keys_test.go`
+  values stay as committed and `keyFormatVersion` stays 2. Nothing in this stage
+  should touch key computation at all; if a key moves, you changed the IR.
+- **Recipes get exactly one definition.** After task 1, the shell command and
+  cache-mount directory for apt/apk/pip/npm/build live in `recipe` and nowhere
+  else. A backend that re-derives a command is a defect — that duplication is
+  precisely how two backends come to build different images.
+- **`apple-container` is out of scope.** It has no BuildKit underneath, so
+  `--builder apple-container` keeps Dockerfile emission permanently. Document it;
+  do not attempt it.
+- **No network in unit tests.** Anything needing a live buildkitd goes behind the
+  build tag in task 5.
+- Test command: `go test ./go/internal/stagefile/... ./go/internal/cli/commands/...`
+- Module prefix: `github.com/wendylabsinc/wendy/go/internal/stagefile`
+- Import naming: the BuildKit package is `github.com/moby/buildkit/client/llb`.
+  Our package is `llbgen` to avoid the collision. Never name a local package `llb`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `go/internal/stagefile/recipe/recipe.go` **create** | `RunSpec` type + one function per recipe returning it. The single definition of what each recipe *does*. |
+| `go/internal/stagefile/recipe/recipe_test.go` **create** | Per-recipe spec assertions. |
+| `go/internal/stagefile/codegen/codegen.go` **modify** | Renders `RunSpec` to Dockerfile text. Stops owning command strings. |
+| `go/internal/stagefile/llbgen/llbgen.go` **create** | `Emit(g, images, platform) (*llb.Definition, *ImageConfig, error)`. |
+| `go/internal/stagefile/llbgen/llbgen_test.go` **create** | Structural assertions over the emitted definition. |
+| `go/internal/stagefile/solve/addr.go` **create** | buildkitd address resolution. |
+| `go/internal/stagefile/solve/solve.go` **create** | `client.Build` driver + gateway callback attaching image config. |
+| `go/internal/cli/commands/stagefilebackend.go` **create** | Flag/env plumbing selecting the backend. |
+| `go/internal/stagefile/llbgen/differential_test.go` **create** | Build-tagged differential test against a live buildkitd. |
+
+---
+
+### Task 1: Extract recipe rendering into a shared package
+
+**Files:**
+- Create: `go/internal/stagefile/recipe/recipe.go`
+- Create: `go/internal/stagefile/recipe/recipe_test.go`
+- Modify: `go/internal/stagefile/codegen/codegen.go`
+
+**Interfaces:**
+- Consumes: `ir.AptParams`, `ir.PipParams`, `ir.NpmParams`, `ir.BuildParams`.
+- Produces: `recipe.RunSpec`, `recipe.CacheMount`, and
+  `recipe.For(x *ir.ExecOp) (RunSpec, error)`. Task 2 consumes `RunSpec`.
+
+**Design note.** `RunSpec` describes a step without committing to a rendering.
+`Command` is the `/bin/sh -c` argument — a shell string, because apt genuinely
+needs `&&` and that is not expressible as argv. That is safe here for the same
+reason it is safe today: every interpolated value passes through `shellQuote`,
+and there is no user-supplied raw-shell field in the spec. `PreCopies` carries
+the file(s) a recipe needs staged before it runs (pip's requirements file, npm's
+manifest and lockfile) — today those are `COPY` lines emitted inline by
+`pipInstallLines`/`npmInstallLines`, and both backends need them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/stagefile/recipe/recipe_test.go`:
+
+```go
+package recipe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+func TestForAptQuotesPackagesAndCleansLists(t *testing.T) {
+	got, err := For(&ir.ExecOp{Recipe: ir.RecipeApt, Apt: &ir.AptParams{Packages: []string{"build-essential", "flask>=2.0"}}})
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	if !strings.Contains(got.Command, "'flask>=2.0'") {
+		t.Fatalf("package not shell-quoted: %q", got.Command)
+	}
+	if !strings.Contains(got.Command, "--no-install-recommends") {
+		t.Fatalf("missing --no-install-recommends: %q", got.Command)
+	}
+	if !strings.Contains(got.Command, "rm -rf /var/lib/apt/lists/*") {
+		t.Fatalf("missing list cleanup: %q", got.Command)
+	}
+	if len(got.CacheMounts) != 0 {
+		t.Fatalf("apt should declare no cache mount, got %+v", got.CacheMounts)
+	}
+}
+
+func TestForPipStagesRequirementsAndMountsCache(t *testing.T) {
+	got, err := For(&ir.ExecOp{Recipe: ir.RecipePip, Pip: &ir.PipParams{Requirements: "requirements.txt"}})
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	if len(got.PreCopies) != 1 || got.PreCopies[0] != "requirements.txt" {
+		t.Fatalf("PreCopies = %v, want [requirements.txt]", got.PreCopies)
+	}
+	if len(got.CacheMounts) != 1 || got.CacheMounts[0].Dir != "/root/.cache/pip" {
+		t.Fatalf("CacheMounts = %+v, want one at /root/.cache/pip", got.CacheMounts)
+	}
+	if !got.CacheMounts[0].Locked {
+		t.Fatal("cache mount must be locked; concurrent service builds share it")
+	}
+	if !strings.Contains(got.Command, "-r 'requirements.txt'") {
+		t.Fatalf("requirements not passed: %q", got.Command)
+	}
+}
+
+func TestForNpmStagesManifestAndLockfile(t *testing.T) {
+	got, err := For(&ir.ExecOp{Recipe: ir.RecipeNpm, Npm: &ir.NpmParams{Manager: "pnpm", Manifest: "package.json", Lockfile: "pnpm-lock.yaml"}})
+	if err != nil {
+		t.Fatalf("For: %v", err)
+	}
+	if len(got.PreCopies) != 2 || got.PreCopies[0] != "package.json" || got.PreCopies[1] != "pnpm-lock.yaml" {
+		t.Fatalf("PreCopies = %v", got.PreCopies)
+	}
+	if !strings.Contains(got.Command, "pnpm install --frozen-lockfile") {
+		t.Fatalf("wrong command: %q", got.Command)
+	}
+}
+
+func TestForBuildRejectsUnsupportedLang(t *testing.T) {
+	if _, err := For(&ir.ExecOp{Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "cobol", Profile: "release"}}); err == nil {
+		t.Fatal("expected an error for an unsupported build.lang")
+	}
+}
+
+func TestForRejectsNilPayload(t *testing.T) {
+	if _, err := For(&ir.ExecOp{Recipe: ir.RecipeApt}); err == nil {
+		t.Fatal("expected an error for an exec op with no params")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./go/internal/stagefile/recipe/...`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write the recipe package**
+
+Create `go/internal/stagefile/recipe/recipe.go`. Move the bodies of
+`aptInstallLines`, `apkInstallLines`, `pipInstallLines`, `npmInstallLines`, and
+`buildLines` out of `codegen/codegen.go`, reshaped to return a `RunSpec` instead
+of Dockerfile lines. Move `shellQuote` here too — it is the safety property both
+backends depend on, and it must not exist twice.
+
+```go
+// Package recipe is the single definition of what each Stagefile install and
+// build step actually does: the command to run, the files it needs staged
+// first, and the cache directories it mounts.
+//
+// It exists because there is now more than one backend. codegen renders a
+// RunSpec to Dockerfile text; llbgen renders the same RunSpec to BuildKit LLB.
+// If either derived its own command, the two backends would build subtly
+// different images and only an end-to-end differential test would notice.
+package recipe
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+// CacheMount is a persistent build cache directory.
+type CacheMount struct {
+	Dir string
+	// Locked serializes concurrent access. Wendy builds up to four services
+	// at once on top of BuildKit's own parallelism; an unlocked mount lets
+	// them collide inside the package manager where the waiting is invisible.
+	Locked bool
+}
+
+// RunSpec is one execution step, backend-agnostic.
+type RunSpec struct {
+	// Command is the argument to /bin/sh -c. It is a shell string rather
+	// than argv because apt genuinely needs "&&". Every interpolated value
+	// is shell-quoted by this package, and the spec has no raw-shell field,
+	// so nothing user-supplied reaches the shell unquoted.
+	Command string
+	// PreCopies are build-context paths that must be staged into the image
+	// before Command runs, in order.
+	PreCopies   []string
+	CacheMounts []CacheMount
+}
+
+// For returns the RunSpec for one exec op.
+func For(x *ir.ExecOp) (RunSpec, error) {
+	switch {
+	case x.Apt != nil:
+		return aptSpec(x.Apt, false), nil
+	case x.Apk != nil:
+		return aptSpec(x.Apk, true), nil
+	case x.Pip != nil:
+		return pipSpec(x.Pip), nil
+	case x.Npm != nil:
+		return npmSpec(x.Npm), nil
+	case x.Build != nil:
+		return buildSpec(x.Build)
+	default:
+		return RunSpec{}, fmt.Errorf("recipe: exec op %q has no params", x.Recipe.Name)
+	}
+}
+
+// ShellQuote wraps s in single quotes so shell metacharacters in it — including
+// the ">" in an ordinary version specifier like "flask>=2.0" — are never given
+// special meaning. Strictly more complete than a denylist: it needs no
+// enumeration of "dangerous" characters, several of which are also legal and
+// necessary in real package specifiers.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+```
+
+Write `aptSpec`, `pipSpec`, `npmSpec`, and `buildSpec` by transcribing the
+existing command construction from `codegen.go` exactly — same flags, same order,
+same quoting, same cache directories. The apt spec's `Command` must reproduce the
+current two-line `RUN` as a single shell string joined with ` && `; codegen will
+re-split it for rendering (see step 4).
+
+- [ ] **Step 4: Rewire codegen onto RunSpec**
+
+In `codegen.go`, replace the five `*InstallLines`/`buildLines` helpers with one
+function that renders a `RunSpec` to Dockerfile lines: emit a `COPY <p> <p>` for
+each `PreCopies` entry, then a single `RUN` carrying
+`--mount=type=cache,sharing=locked,target=<dir>` for each cache mount, then the
+command.
+
+**The apt line is the byte-identity trap.** Today apt renders as two physical
+lines with a `\` continuation and four-space indent:
+
+```
+RUN apt-get update && apt-get install -y --no-install-recommends 'x' \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Reproduce that exactly. The simplest faithful approach is for `aptSpec` to keep
+the ` && rm -rf /var/lib/apt/lists/*` as the final clause and for the renderer to
+split the command on that final ` && ` when emitting Dockerfile text. Whatever
+approach you choose, the golden test is the arbiter — do not edit it.
+
+Delete `shellQuote` from `codegen.go` and use `recipe.ShellQuote`.
+
+- [ ] **Step 5: Verify byte-identity**
+
+Run: `go test ./go/internal/stagefile/... ./go/internal/cli/commands/... ./go/internal/cli/optimize/...`
+Expected: all PASS, `codegen/golden_test.go` untouched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/internal/stagefile/recipe/ go/internal/stagefile/codegen/
+git commit -m "refactor(stagefile): give recipes one definition shared by both backends"
+```
+
+---
+
+### Task 2: `llbgen.Emit`
+
+**Files:**
+- Create: `go/internal/stagefile/llbgen/llbgen.go`
+- Test: `go/internal/stagefile/llbgen/llbgen_test.go`
+
+**Interfaces:**
+- Consumes: `ir.Graph`, `recipe.For`, `recipe.RunSpec`.
+- Produces: `llbgen.ImageConfig{Entrypoint []string; User string}` and
+  `llbgen.Emit(g *ir.Graph, images map[string]string, platform string) (*llb.Definition, *ImageConfig, error)`.
+  Task 3 solves the definition and applies the config.
+
+**Design note.** Build one `llb.State` per node, indexed like `ir.Graph.Nodes`, so
+the graph maps across one-to-one. Ops:
+
+- `ir.OpImage` → `llb.Image(ref+"@"+digest, llb.Platform(p))`
+- `ir.OpExec` → `state.Run(llb.Args([]string{"/bin/sh","-c", spec.Command}), mounts...).Root()`,
+  with each `CacheMount` as `llb.AddMount(dir, llb.Scratch(), llb.AsPersistentCacheDir(dir, llb.CacheMountLocked))`,
+  and each `PreCopies` entry copied from the local context first
+- `ir.OpCopy` → `llb.Copy(src, path, dest)` where `src` is `llb.Local("context")`
+  for `FromLocal`, else the state of `Inputs[1]`
+
+`ImageConfig` comes from the final stage — the same place `codegen` reads it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/stagefile/llbgen/llbgen_test.go`. Assert on structure rather
+than on marshalled bytes — the protobuf encoding is a BuildKit implementation
+detail and pinning it would make a dependency bump look like a regression.
+
+```go
+package llbgen
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func lower(t *testing.T, y string) *ir.Graph {
+	t.Helper()
+	f, err := spec.Parse([]byte(y))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	g, err := ir.Lower(f)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	return g
+}
+
+const twoStage = `
+version: 1
+stages:
+  - name: deps
+    from: python:3.12-slim
+    install:
+      pip:
+        requirements: requirements.txt
+  - name: app
+    from: python:3.12-slim
+    copy:
+      - from: deps
+        paths: ["/usr/local/lib"]
+      - from: local
+        paths: ["app.py"]
+    entrypoint:
+      exec: [python3, app.py]
+`
+
+func TestEmitProducesADefinitionAndConfig(t *testing.T) {
+	g := lower(t, twoStage)
+	images := map[string]string{"python:3.12-slim": "sha256:abc123"}
+
+	def, cfg, err := Emit(g, images, "linux/arm64")
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if def == nil || len(def.Def) == 0 {
+		t.Fatal("empty definition")
+	}
+	if cfg == nil {
+		t.Fatal("nil image config")
+	}
+	if len(cfg.Entrypoint) != 2 || cfg.Entrypoint[0] != "python3" {
+		t.Fatalf("Entrypoint = %v", cfg.Entrypoint)
+	}
+	if cfg.User != "65532" {
+		t.Fatalf("User = %q, want the distroless-style default 65532", cfg.User)
+	}
+}
+
+func TestEmitErrorsOnMissingDigest(t *testing.T) {
+	g := lower(t, twoStage)
+	if _, _, err := Emit(g, map[string]string{}, ""); err == nil {
+		t.Fatal("Emit succeeded with no resolved digest")
+	}
+}
+
+func TestEmitIsDeterministic(t *testing.T) {
+	g := lower(t, twoStage)
+	images := map[string]string{"python:3.12-slim": "sha256:abc123"}
+
+	a, _, err := Emit(g, images, "linux/arm64")
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	b, _, err := Emit(g, images, "linux/arm64")
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(a.Def) != len(b.Def) {
+		t.Fatalf("definition length differs across runs: %d vs %d", len(a.Def), len(b.Def))
+	}
+	for i := range a.Def {
+		if string(a.Def[i]) != string(b.Def[i]) {
+			t.Fatalf("definition op %d differs across runs", i)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./go/internal/stagefile/llbgen/...`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Implement `Emit`**
+
+Create `go/internal/stagefile/llbgen/llbgen.go`. Walk `g.Nodes` in order building
+a `states []llb.State` parallel to it, exactly as `codegen.Generate` walks stages
+by slicing on `Stage.Final`. Marshal with
+`st.Marshal(context.TODO(), llb.LinuxArm64)` or the parsed platform; return
+`ErrUnsupported`-style errors for a nil payload or a missing digest, mirroring
+`codegen`'s guards — do not trust the graph silently.
+
+For the default user, reuse `codegen`'s `defaultUser` value `"65532"`. Export it
+from `codegen` or lift it into `ir`; do not type the literal twice.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./go/internal/stagefile/llbgen/... -v`
+Expected: all three PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/stagefile/llbgen/
+git commit -m "feat(stagefile): compile the IR to BuildKit LLB"
+```
+
+---
+
+### Task 3: buildkitd address resolution and the solver
+
+**Files:**
+- Create: `go/internal/stagefile/solve/addr.go`
+- Create: `go/internal/stagefile/solve/solve.go`
+- Test: `go/internal/stagefile/solve/addr_test.go`
+
+**Interfaces:**
+- Produces: `solve.Address(ctx) (string, error)` and
+  `solve.Run(ctx, addr string, def *llb.Definition, cfg *llbgen.ImageConfig, out Output) error`.
+
+**Design note.** Address resolution order, most explicit first:
+1. `BUILDKIT_HOST` if set — the standard BuildKit env var; respect it.
+2. On-device: the buildkitd socket, when `WENDY_AGENT_SOCKET` is set (the same
+   condition `shouldUseBuildkitOnDevice` already uses in `docker.go`).
+3. buildx's own daemon: `docker-container://buildx_buildkit_<builder>0`, via
+   `github.com/moby/buildkit/client/connhelper/dockercontainer`. This is the
+   macOS path, where buildkitd lives inside a container rather than on the host.
+
+Only `Address` needs unit tests; `Run` needs a daemon and is covered in task 5.
+
+The gateway callback is the whole reason for this design — it is where image
+config gets attached, which raw LLB cannot express:
+
+```go
+res, err := c.Solve(ctx, gateway.SolveRequest{Definition: def.ToPB()})
+if err != nil {
+    return nil, err
+}
+ref, err := res.SingleRef()
+if err != nil {
+    return nil, err
+}
+img := specs.Image{ /* platform, rootfs from the solve */ }
+img.Config.Entrypoint = cfg.Entrypoint
+img.Config.User = cfg.User
+cfgJSON, err := json.Marshal(img)
+if err != nil {
+    return nil, err
+}
+out := gateway.NewResult()
+out.SetRef(ref)
+out.AddMeta(exptypes.ExporterImageConfigKey, cfgJSON)
+return out, nil
+```
+
+- [ ] **Step 1: Write the failing test for address resolution**
+
+Create `go/internal/stagefile/solve/addr_test.go` with table-driven cases
+covering: `BUILDKIT_HOST` set wins over everything; `WENDY_AGENT_SOCKET` set and
+no `BUILDKIT_HOST` selects the device socket; neither set falls back to the
+buildx container address. Inject the environment through package-level function
+variables (`lookupEnv`, `lookPath`) the way `docker.go` already does with
+`imageBuilderLookPath` — do not call `os.Setenv` in tests.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./go/internal/stagefile/solve/...`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Implement `addr.go`, then `solve.go`**
+
+Wire progress through the existing renderer in
+`go/internal/cli/commands/buildprogress.go` — read it first and match how the
+buildx path feeds it, so LLB builds look identical to users. Do not invent a
+second progress UI.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./go/internal/stagefile/solve/... -v`
+Expected: PASS. `Run` is not unit-tested here by design; task 5 covers it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/stagefile/solve/
+git commit -m "feat(stagefile): solve LLB through BuildKit's Go client"
+```
+
+---
+
+### Task 4: CLI wiring behind a flag
+
+**Files:**
+- Create: `go/internal/cli/commands/stagefilebackend.go`
+- Modify: `go/internal/stagefile/stagefile.go`
+- Test: `go/internal/cli/commands/stagefilebackend_test.go`
+
+**Interfaces:**
+- Produces: `stagefileBackendLLB() bool` and a `CompileToLLB` entry point on the
+  `stagefile` package mirroring `CompileFile`.
+
+**Design note.** Opt-in only. Selection order: an explicit
+`--stagefile-backend=llb|dockerfile` flag wins; else `WENDY_STAGEFILE_BACKEND`;
+else `dockerfile`. When `--builder apple-container` is active, LLB is
+unavailable — if the user asked for LLB explicitly, fail with a message naming
+the incompatibility rather than silently falling back, because a silent fallback
+here means the user believes they tested the new backend when they did not.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover: flag beats env; env used when no flag; default is `dockerfile`; an invalid
+value is a clear error; `llb` combined with `apple-container` errors rather than
+falling back. Follow the table-driven style already in `docker_test.go`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./go/internal/cli/commands/ -run Stagefile`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add `CompileToLLB(dir, platform string) (*llb.Definition, *llbgen.ImageConfig, error)`
+to `stagefile.go`, sharing `compileFile`'s parse/lock/resolve path so the
+lockfile behaviour is identical between backends — resolve once, then branch on
+backend. Do not duplicate the lock logic.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./go/internal/stagefile/... ./go/internal/cli/commands/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/ go/internal/stagefile/stagefile.go
+git commit -m "feat(stagefile): select the LLB backend behind an opt-in flag"
+```
+
+---
+
+### Task 5: Differential test against a live buildkitd
+
+**Files:**
+- Create: `go/internal/stagefile/llbgen/differential_test.go`
+
+**Design note.** This is the test that earns trust in the new backend, and the
+one thing no unit test can substitute for: **the same Stagefile through both
+backends must produce the same image filesystem.** It needs a daemon, so gate it
+behind `//go:build buildkit_integration` and skip when no address resolves. State
+in the file's doc comment how to run it, because a gated test nobody knows how to
+run is a test that does not exist.
+
+For each `Examples/*/build.stagefile.yaml` plus both `testdata` fixtures: build
+via the Dockerfile backend to an OCI layout, build via the LLB backend to an OCI
+layout, then compare the layer diff-IDs and the image config (entrypoint, user).
+Compare unpacked content, not layer digests — timestamps and layer boundaries
+legitimately differ between the two paths, and asserting on them would produce a
+test that fails for reasons nobody can act on.
+
+- [ ] **Step 1: Write the test**
+- [ ] **Step 2: Run it with the tag against a live daemon; record the result**
+
+Run: `go test -tags buildkit_integration ./go/internal/stagefile/llbgen/ -run Differential -v`
+Expected: PASS, or a precise report of which fixture diverges and how.
+
+- [ ] **Step 3: Run the untagged suite to confirm it stays skipped**
+
+Run: `go test ./go/internal/stagefile/...`
+Expected: PASS, differential test not compiled.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/internal/stagefile/llbgen/differential_test.go
+git commit -m "test(stagefile): differential-test the LLB backend against Dockerfile output"
+```
+
+---
+
+## Done when
+
+- `recipe` is the only definition of each recipe's command and cache mounts.
+- `codegen` output byte-identical; its golden `want` strings never edited.
+- The cache-key corpus unmoved; `keyFormatVersion` still 2.
+- `llbgen.Emit` is pure and deterministic.
+- `--stagefile-backend=llb` builds a runnable image with correct entrypoint and user.
+- The differential test passes, or its divergences are documented and understood.
+- `go test ./go/...` green.
+
+## Explicitly out of scope
+
+- **Any CAS, any tier, any cache lookup.** Stage 3. This stage only makes the
+  graph executable; it does not yet skip work. Do not add a cache here — the
+  tiering and trust rules in the design doc are what make it safe, and none of
+  them exist yet.
+- `apple-container` support.
+- Removing the Dockerfile backend. It stays the default and remains the fallback
+  for builders BuildKit does not serve.

--- a/specs/2026-08-07-stagefile-semantic-build-graph-design.md
+++ b/specs/2026-08-07-stagefile-semantic-build-graph-design.md
@@ -176,7 +176,7 @@ improves 10–100×. 2000× is the tail, not the median.**
 
 ---
 
-## The three things that can sink this
+## The four things that can sink this
 
 ### 1. apt and apk are not deterministic
 
@@ -215,6 +215,25 @@ rebuild-verify a sample rather than trusting on signature alone. The cross-org
 tier should ship last, behind the org tier, precisely because it is the only one
 that introduces a new trust root.
 
+### 4. A device cache tier with no eviction policy is a leak, not a cache
+
+"The robot is the bottom of the tier stack" is the design's most elegant
+consequence, and it is also the one with an unowned failure mode. A device
+accumulates nodes; a Jetson or a Pi has a finite disk. Nothing above specifies an
+eviction policy, a disk budget, or what happens when the node store fills
+partway through a deploy.
+
+On a workstation a full cache is an annoyance. On a robot in the field it is a
+device that stops accepting deployments, or worse, one that fills the partition
+its runtime shares. That is a bricking-shaped risk, not a performance nit, and it
+belongs to stage 8 rather than to whoever discovers it.
+
+**Resolution:** stage 8 does not ship without an explicit per-device node budget,
+an eviction policy (LRU over node last-use, with pinning for nodes belonging to
+the currently-running image), and a deploy path that fails cleanly and reversibly
+when the budget cannot be met — never a partial assembly. The device tier should
+also be the only tier permitted to refuse a promotion outright.
+
 ### Also worth naming: cache-key stability
 
 Bumping `pip/v1` → `pip/v2` invalidates that node for everyone. Op versions live
@@ -238,7 +257,8 @@ worth shipping.
 5. **`cas.Org`** on the per-org registry work.
 6. **`cas.Mesh`** on the existing mesh mTLS data plane.
 7. **`cas.Global`** + signing + transparency log + promotion policy.
-8. **Device as a tier**; node-delta deploy.
+8. **Device as a tier**; node-delta deploy. Gated on the per-device node budget
+   and eviction policy from risk 4 — this stage does not ship without them.
 
 Native-arch build farms are orthogonal to all eight and can proceed in parallel;
 they are the single largest multiplier and the least architecturally risky.

--- a/specs/2026-08-07-stagefile-semantic-build-graph-design.md
+++ b/specs/2026-08-07-stagefile-semantic-build-graph-design.md
@@ -36,8 +36,9 @@ Dockerfile-based tool at any level of engineering effort.
 
 ## Goals
 
-- Node-level content addressing where a node's cache key is **independent of its
-  parent chain**.
+- Node-level content addressing where a node's cache key is a function of its
+  **semantic dependency closure** rather than of textual layer history, so two
+  projects that reach the same rootfs by different routes share cache.
 - A tiered cache — local → LAN → org → global — so an expensive node is built
   once by anyone rather than once per project.
 - Devices participate as cache tiers, so deploying ships only missing nodes.
@@ -94,16 +95,40 @@ only component with I/O, and it sits behind one interface.
 
 ### The load-bearing property
 
-`cachekey.Key` includes `(op_version, base_digest, op_inputs)` and **never the
-parent chain**.
+`cachekey.Key` is taken over a node's **semantic dependency closure** —
+`(recipe_version, resolved_input_keys, declared_params, input_file_digests)` —
+and not over textual or positional layer history.
 
-This is the whole design in one line. A Dockerfile layer's cache key
-transitively includes every layer before it, so `pip install -r
-requirements.txt` on top of my stage-3 is a different cache entry from the
-identical install on top of yours, even with a byte-identical lock. Under
-content addressing they are the same node. That is what makes cross-project and
-cross-org reuse possible at all, and it is why this cannot be retrofitted onto
-Dockerfile emission — it is a property of the key, not of the cache.
+Stated carefully, because the imprecise version of this claim is tempting and
+wrong. A node that runs on the result of another node genuinely *does* depend on
+it: `pip install` on a rootfs where `apt install foo` ran is not the same node as
+the identical install where `apt install bar` ran, and keying them alike would
+make the cache unsound. The dependency is real and the key must carry it.
+
+What the key drops is everything Docker's key carries *beyond* that dependency:
+the literal instruction text, the position in the file, the identity of unrelated
+sibling stages, and the accumulated history of layers this op does not actually
+read. Under Docker, two projects that reach a byte-identical rootfs by different
+routes have different layer IDs and therefore can never share cache. Under
+content addressing, they converge — the key is a function of what the node
+depends on, not of how the file got there.
+
+So reuse happens exactly when dependency closures coincide. That is a narrower
+claim than "identical ops always share," and it is still where the money is: the
+expensive nodes in practice are common dependencies on stock bases (torch/cu126
+on `python:3.12-slim`), which is precisely the case where closures do coincide
+across projects and orgs.
+
+This is why it cannot be retrofitted onto Dockerfile emission: it is a property
+of how the key is computed, not of where the cache lives.
+
+**Tradeoff worth naming:** the rejected "pure derivations" option (a node
+produces a free-standing tree, composed at COPY time) *would* give true
+base-independence, and a strictly higher reuse ceiling — the same site-packages
+node reusable across *different* base images. It was rejected because ecosystems
+that run postinstall scripts, `ldconfig`, or absolute paths assume a real rootfs.
+If the closure-coincidence rate measured in stage 3 turns out disappointing, that
+is the decision to revisit.
 
 ### The inner loop, concretely
 

--- a/specs/2026-08-07-stagefile-semantic-build-graph-design.md
+++ b/specs/2026-08-07-stagefile-semantic-build-graph-design.md
@@ -1,0 +1,244 @@
+# Stagefile as a semantic build graph
+
+**Status:** design, not an implementation plan. No code in this PR.
+
+**Depends on:** the Stagefile compiler introduced in PR #1585 (`jo/try-stagefile`).
+This branch is stacked on it and references the packages it adds
+(`go/internal/stagefile/{spec,codegen,lock,dockerignore}`).
+
+**Companion:** `specs/stagefile-dsl-gaps.md` covers DSL *coverage*. This document
+covers *performance and identity*, and deliberately does not close those gaps.
+
+---
+
+## Problem
+
+Stagefile today is a safer notation for the same build.
+
+Its safety properties are real and unusual — no raw-shell escape hatch, everything
+shell-quoted by construction, base images digest-pinned in a lockfile. But its
+performance contribution is approximately zero. Every cache mount `codegen`
+emits (`/root/.cache/pip`, `/root/.cargo`, `/root/.swiftpm`) is one you would
+write by hand in a Dockerfile. BuildKit does all the actual work. The compiler
+produces a Dockerfile and shells out.
+
+Meanwhile the build is the slowest thing in the WendyOS inner loop. The worst
+realistic case — edit one line of Python in a CUDA app, get it running on a
+Jetson over LTE — is 45–60 minutes, dominated by qemu-emulated arm64 wheel
+builds and a multi-gigabyte image push.
+
+**The asset nobody is spending:** Stagefile *knows what each step means*. A
+Dockerfile does not. To BuildKit, `RUN pip install -r requirements.txt` is an
+opaque string whose cache key is "this exact text, on this exact parent
+chain." To Stagefile it is a typed op with declared inputs. That difference is
+worth one to two orders of magnitude, and it is not available to any
+Dockerfile-based tool at any level of engineering effort.
+
+## Goals
+
+- Node-level content addressing where a node's cache key is **independent of its
+  parent chain**.
+- A tiered cache — local → LAN → org → global — so an expensive node is built
+  once by anyone rather than once per project.
+- Devices participate as cache tiers, so deploying ships only missing nodes.
+- The Dockerfile backend is retained, for audit artifacts and for environments
+  without BuildKit.
+
+## Non-goals
+
+- Closing the DSL coverage gaps in `specs/stagefile-dsl-gaps.md`. Separate track.
+- Replacing BuildKit's executor, snapshotter, or mount handling.
+- Adding a `run:` escape hatch. It would destroy node determinism as thoroughly
+  as it would destroy the security property — an opaque shell string has no
+  computable cache key beyond its own text.
+
+---
+
+## Architecture
+
+The current pipeline is a straight line with one hinge:
+
+```
+spec.Parse → spec.Validate → lock.Resolve(crane) → codegen.Generate → Dockerfile → buildx
+```
+
+The new one inserts a graph where the string-formatting used to be:
+
+```
+build.stagefile.yaml
+  │
+  ├─ spec.Parse / Validate            unchanged
+  ├─ ir.Lower                         NEW  typed graph, not text
+  ├─ lock.Resolve                     EXTENDED  pins every dep, not just from:
+  ├─ cachekey.Key(node)               NEW  pure, versioned per-op
+  ├─ cas.Tiered.Has(keys...)          NEW  local → LAN → org → global
+  ├─ llb.Emit(graph, satisfied)       NEW  unsatisfied subgraph only
+  └─ BuildKit executes → results promoted back up the tiers
+        │
+        └─ codegen.Generate retained as the Dockerfile backend
+```
+
+### Components
+
+| Package | Responsibility | Depends on |
+|---|---|---|
+| `spec` *(exists)* | parse + validate YAML | — |
+| `ir` **new** | lower spec → `Graph` of `Node{Op, Inputs, Attrs}`. Closed op set: `Image`, `Exec`, `CopyTree`, `Merge`. The only place that knows how an `install.pip` becomes nodes. | `spec` |
+| `cachekey` **new** | `Key(node, resolvedInputs) → digest`. Pure. Versioned per op (`pip/v1`). | `ir` |
+| `cas` **new** | `Has/Get/Put`. Impls: `Local`, `Mesh`, `Org`, `Global`; `Tiered` composes them. Read: first hit wins, promote upward on hit. Write: policy-gated per tier. | — |
+| `llb` **new** | `Emit(graph, satisfied) → *llb.Definition`. Satisfied nodes become sources, not exec ops. | `ir`, `cas` |
+| `codegen` *(exists)* | Dockerfile backend | retargeted from `spec` to `ir` |
+
+`ir.Lower`, `cachekey.Key`, and `llb.Emit` are all pure functions. `cas` is the
+only component with I/O, and it sits behind one interface.
+
+### The load-bearing property
+
+`cachekey.Key` includes `(op_version, base_digest, op_inputs)` and **never the
+parent chain**.
+
+This is the whole design in one line. A Dockerfile layer's cache key
+transitively includes every layer before it, so `pip install -r
+requirements.txt` on top of my stage-3 is a different cache entry from the
+identical install on top of yours, even with a byte-identical lock. Under
+content addressing they are the same node. That is what makes cross-project and
+cross-org reuse possible at all, and it is why this cannot be retrofitted onto
+Dockerfile emission — it is a property of the key, not of the cache.
+
+### The inner loop, concretely
+
+You edit `app.py`. Only the `CopyTree(local, [app.py])` node's key changes.
+Every upstream node is CAS-satisfied, so `llb.Emit` produces a DAG with **zero
+exec ops** — BuildKit assembles an image without running a container. Your pip
+install, your `swift build`, your CUDA layer: never touched, not even
+cache-validated against a shell command.
+
+### Devices are cache tiers
+
+When `wendy run` targets a Jetson, the device reports which node digests it
+already holds and receives only the missing ones. Delta OTA stops being a
+feature to build and becomes a consequence of the cache being content-addressed.
+The robot is not a deploy target; it is the bottom of the tier stack.
+
+This is where the performance axis and the identity axis turn out to be the same
+lever seen from two ends: a node is safely shareable exactly when its inputs are
+fully declared and pinned, which is also exactly when the image has a truthful
+SBOM.
+
+---
+
+## Where the multiplier actually comes from
+
+| Lever | Multiplier | Applies to |
+|---|---|---|
+| Native arm64 instead of qemu | 10–50× | every arm64 build on x86 CI |
+| CAS hit on an expensive node (torch/cu126 Jetson: ~42 min → ~50 s pull) | ~50× | first-time-in-org builds of common deps |
+| Fine-grained invalidation | rebuild one node vs. rebuild the tail | inner loop |
+| Node-delta ship | 2 GB → single-digit MB | every device deploy |
+
+**Compounded worst-case inner loop** (one-line Python edit in a CUDA app, onto a
+Jetson over LTE): ~45–60 min → ~20–40 s. That is roughly **100×**, and it is the
+number to plan against.
+
+**The 2000× case is real but narrow:** a cold CI job on a machine that has never
+seen the project, where every node is a global-tier hit. 45 minutes of building
+becomes sub-second graph resolution plus parallel pulls. It exists *only* because
+of the cross-org tier, and only for dependency-heavy projects whose deps someone
+else has already built.
+
+Stated plainly so nobody quotes the wrong number later: **the median build
+improves 10–100×. 2000× is the tail, not the median.**
+
+---
+
+## The three things that can sink this
+
+### 1. apt and apk are not deterministic
+
+`apt-get install foo` today does not produce the same bytes as `apt-get install
+foo` tomorrow. Under content addressing that is no longer a reproducibility
+nicety — it is a correctness hazard, because the same key would map to different
+content across the fleet.
+
+**Resolution:** apt/apk installs must resolve to a pinned package set, either via
+a snapshot archive (`snapshot.debian.org`) or by resolving-then-pinning into the
+lockfile the way pip and npm locks already work. `lock.Resolve` today pins only
+`from:` values (`stagefile.go:67`, `imageRefs`); it must come to pin every
+declared dependency.
+
+Until an ecosystem is pinnable, **its nodes are local-tier-only and are never
+promoted** to org or global. Promotion is default-deny.
+
+### 2. Existence probing leaks private dependency sets
+
+A node key is a hash, but `Has(key)` on a shared tier answers a yes/no question
+about your private `requirements.txt`. An attacker who can guess a dependency
+set can confirm it, and can do so at scale.
+
+**Resolution:** the global tier serves only nodes whose inputs are
+publicly derivable — public registries, public package indexes. Anything
+touching `from: local`, a private index, or private source is salted per-org and
+can never be promoted past the org tier. Again: default-deny on promotion.
+
+### 3. Trust in shared nodes
+
+A poisoned global node is a supply-chain event with a blast radius of every org.
+
+**Resolution:** nodes are signed at the tier that produced them; a transparency
+log records promotions to the global tier; orgs can set policy to
+rebuild-verify a sample rather than trusting on signature alone. The cross-org
+tier should ship last, behind the org tier, precisely because it is the only one
+that introduces a new trust root.
+
+### Also worth naming: cache-key stability
+
+Bumping `pip/v1` → `pip/v2` invalidates that node for everyone. Op versions live
+in a registry file with a changelog, and bumping one is a deliberate, reviewed
+act rather than a side effect of refactoring codegen.
+
+---
+
+## Staging
+
+Each stage delivers value on its own; no stage depends on a later one to be
+worth shipping.
+
+1. **`ir` + `cachekey`, retarget `codegen` to `ir`.** No behavior change.
+   Dockerfile output byte-identical — the existing golden tests
+   (`codegen/golden_test.go`) prove it.
+2. **`llb` backend behind a flag.** Same images, real DAG.
+3. **`cas.Local` + `cas.Tiered` with a single tier.** The inner-loop
+   invalidation win lands here — this is the first stage a user *feels*.
+4. **Dependency pinning for apt/apk.** Unblocks promotion beyond local.
+5. **`cas.Org`** on the per-org registry work.
+6. **`cas.Mesh`** on the existing mesh mTLS data plane.
+7. **`cas.Global`** + signing + transparency log + promotion policy.
+8. **Device as a tier**; node-delta deploy.
+
+Native-arch build farms are orthogonal to all eight and can proceed in parallel;
+they are the single largest multiplier and the least architecturally risky.
+
+---
+
+## Testing
+
+- `ir.Lower`, `cachekey.Key`, `llb.Emit` are pure → golden tests throughout.
+- **Key-stability corpus:** a golden set of `(node → key)` pairs. Any diff must
+  be accompanied by an op-version bump, enforced in CI.
+- `cas` tiers sit behind one interface → fakes, no live registry in unit tests
+  (matching how `compileFile` already injects `lock.Resolver`).
+- **Differential test, the strong one:** for every `Examples/*` Stagefile, the
+  LLB backend and the Dockerfile backend must produce identical image
+  filesystems. This is how the new backend earns trust, and it is why stage 1
+  keeps Dockerfile output byte-identical.
+
+---
+
+## Open questions
+
+- Does `cas.Mesh` reuse the datagram/tunnelframe transport, or warrant its own
+  RPC?
+- Is the global tier opt-in or opt-out for a new org? (Recommend opt-in until
+  the transparency log exists.)
+- Does `codegen`'s Dockerfile backend stay a first-class supported path
+  long-term, or become audit-only once LLB is default?


### PR DESCRIPTION
Design doc only — no code. Stacked on #1585, so **the base is `jo/try-stagefile`, not `main`**; retarget to `main` once #1585 lands.

## Why

Stagefile today is a safer notation for the same build. The safety properties are real (no shell escape hatch, digest-pinned bases), but the performance contribution is ~zero — every cache mount `codegen` emits is one you'd hand-write, and BuildKit does all the work.

The idle asset: **Stagefile knows what each step means and a Dockerfile does not.** To BuildKit, `RUN pip install -r requirements.txt` is an opaque string keyed on its own text plus the entire parent chain. To Stagefile it's a typed op with declared inputs.

## What the design proposes

Compile to **BuildKit LLB** instead of Dockerfile text, so a node's cache key is `(op_version, base_digest, op_inputs)` and **never the parent chain**. That one property is what lets your `pip install` and mine be the same node — and it's why this can't be retrofitted onto Dockerfile emission, since it's a property of the key rather than of the cache.

On top of that, a **tiered CAS**: local → LAN → org → global, with devices as the bottom tier. Node-delta deploy then falls out of content addressing instead of being a feature to build.

Six components, three of them pure functions (`ir.Lower`, `cachekey.Key`, `llb.Emit`); `cas` is the only one with I/O. `codegen` is retained as the Dockerfile backend for audit and BuildKit-less environments.

## The honest number

Median build improves **10–100×**. The compounded worst-case inner loop (one-line Python edit in a CUDA app → running on a Jetson over LTE) goes ~45–60 min → ~20–40 s.

**2000× is the tail, not the median** — a cold CI job where every node is a global-tier hit. Written down explicitly so the wrong number doesn't get quoted later.

## The three things that can sink it

Each gets a default-deny resolution in the doc:

1. **apt/apk aren't deterministic** — same key, different bytes. Unpinnable ecosystems stay local-tier-only.
2. **Existence probing leaks private dependency sets** — `Has(key)` answers a yes/no question about your private `requirements.txt`. Only publicly-derivable nodes reach the global tier; everything else is salted per-org.
3. **A poisoned global node is a cross-org supply-chain event** — signing, transparency log, rebuild-verify policy. This tier ships last, because it's the only one introducing a new trust root.

## Review focus

Sections 2–4 (arithmetic, risks, staging) haven't been reviewed conversationally — the architecture section had sign-off, the rest landed straight in the doc. The staging list and the open questions at the end are the parts most worth arguing with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tZuoVDZRvf2RqYeprnmuA