### PR TITLE
perf: export chunk-diff builds to a persistent OCI layout dir

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -142,7 +142,10 @@ func saveDeployFingerprint(appID, deviceKey string, fp deployFingerprint) {
 // rebuild, never a missed change.
 func computeBuildInputHash(cwd, dockerfile, platform string, buildArgs map[string]string, deployEnv []string) (string, error) {
 	h := sha256.New()
-	io.WriteString(h, "wendy-deploy-fingerprint-v1\n")
+	// v2: invalidates fingerprints recorded while the stale-manifest bug
+	// (fixed 2026-08-08 in this PR) could pair a fresh input hash with a
+	// stale deploy — forces one honest rebuild per app after upgrade.
+	io.WriteString(h, "wendy-deploy-fingerprint-v2\n")
 	io.WriteString(h, "platform="+platform+"\n")
 
 	// deployEnv arrives sorted from resolveServiceEnv; --env order is the

--- a/go/internal/cli/commands/deployfastpath_test.go
+++ b/go/internal/cli/commands/deployfastpath_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -158,5 +159,32 @@ func TestComputeBuildInputHash_EnvChangesHash(t *testing.T) {
 	}
 	if withEnv == changed {
 		t.Error("changing an env value did not change the hash")
+	}
+}
+
+func TestBuildInputHashSaltIsV2(t *testing.T) {
+	// The v1→v2 bump deliberately invalidates fingerprints recorded while
+	// the stale-manifest bug (2026-08-08) could pair a current input hash
+	// with a stale deploy. Do not revert to v1; bump again only with a
+	// matching migration rationale.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h, err := computeBuildInputHash(dir, "Dockerfile", "linux/arm64", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Recompute what v1 would have produced by checking the source constant
+	// is gone: the simplest stable assertion is on the salt itself.
+	data, err := os.ReadFile("deployfastpath.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"wendy-deploy-fingerprint-v2\n"`) {
+		t.Fatalf("deploy fingerprint salt must be v2 (see comment); hash was %s", h)
+	}
+	if strings.Contains(string(data), `"wendy-deploy-fingerprint-v1\n"`) {
+		t.Fatal("v1 salt string still present in deployfastpath.go")
 	}
 }

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -238,6 +238,58 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 		return io.ReadAll(io.NewSectionReader(f, loc.off, loc.size))
 	}
 
+	img, err := ociImageFromIndex(indexJSON, getBlob, platform)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	layers := make([]localLayer, 0, len(img.Layers))
+	for i, desc := range img.Layers {
+		layerHex, err := digestToHex(desc.Digest)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: invalid digest %q: %w", i, desc.Digest, err)
+		}
+		loc, ok := blobOffsets[layerHex]
+		if !ok {
+			return nil, nil, fmt.Errorf("layer %d blob %s not found in OCI tar", i, desc.Digest)
+		}
+		// Reference the compressed blob by its range in the on-disk tar; it is
+		// streamed (never fully buffered) during the push, and decompression is
+		// deferred so cache-resolved layers are never read at all.
+		layers = append(layers, localLayer{
+			Digest:    desc.Digest,
+			DiffID:    desc.DiffID,
+			MediaType: desc.MediaType,
+			TarPath:   ociTarPath,
+			Offset:    loc.off,
+			Size:      loc.size,
+		})
+	}
+	return layers, img.ImageConfig, nil
+}
+
+// ociResolvedImage is the platform-resolved content of an OCI layout: the raw
+// image config plus the manifest's layer descriptors, labelled with diff IDs
+// when the config's rootfs.diff_ids align 1:1 with the layer list.
+type ociResolvedImage struct {
+	ImageConfig []byte
+	Layers      []ociResolvedLayer
+}
+
+// ociResolvedLayer is one manifest layer descriptor, independent of where its
+// compressed bytes live (tar byte range or layout-dir blob file).
+type ociResolvedLayer struct {
+	Digest    string // "sha256:<hex>" compressed blob digest
+	DiffID    string // "" when the config's diff_ids don't align with the layer list
+	MediaType string
+	Size      int64 // from the manifest descriptor; 0 when absent
+}
+
+// ociImageFromIndex resolves an OCI layout's index.json to the image manifest
+// for the target platform and returns its layer descriptors plus the raw image
+// config blob. getBlob fetches small blobs (manifests, indexes, the config) by
+// hex digest; layer blobs are never fetched here.
+func ociImageFromIndex(indexJSON []byte, getBlob func(hex string) ([]byte, error), platform string) (*ociResolvedImage, error) {
 	// Parse index.json and resolve to a concrete image manifest. buildx emits
 	// index.json → image-manifest directly, while Apple Container's `image save`
 	// wraps the image in one (or two) nested image-indexes; both are handled by
@@ -246,16 +298,16 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 		Manifests []ociDescriptor `json:"manifests"`
 	}
 	if err := json.Unmarshal(indexJSON, &index); err != nil {
-		return nil, nil, fmt.Errorf("parsing index.json: %w", err)
+		return nil, fmt.Errorf("parsing index.json: %w", err)
 	}
 	if len(index.Manifests) == 0 {
-		return nil, nil, fmt.Errorf("index.json has no manifests")
+		return nil, fmt.Errorf("index.json has no manifests")
 	}
 
 	wantOS, wantArch := parseOCIPlatform(platform)
 	manifestData, err := resolveOCIImageManifest(index.Manifests, getBlob, wantOS, wantArch, 0)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Parse the manifest to get the config descriptor and layer descriptors.
@@ -266,10 +318,11 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 		Layers []struct {
 			MediaType string `json:"mediaType"`
 			Digest    string `json:"digest"`
+			Size      int64  `json:"size"`
 		} `json:"layers"`
 	}
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, nil, fmt.Errorf("parsing manifest: %w", err)
+		return nil, fmt.Errorf("parsing manifest: %w", err)
 	}
 
 	// Fetch the image config blob so the runtime config (Cmd/Entrypoint/Env/
@@ -282,11 +335,11 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 	if manifest.Config.Digest != "" {
 		configHex, err := digestToHex(manifest.Config.Digest)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid config digest %q: %w", manifest.Config.Digest, err)
+			return nil, fmt.Errorf("invalid config digest %q: %w", manifest.Config.Digest, err)
 		}
 		imageConfig, err = getBlob(configHex)
 		if err != nil {
-			return nil, nil, fmt.Errorf("config blob %s: %w", manifest.Config.Digest, err)
+			return nil, fmt.Errorf("config blob %s: %w", manifest.Config.Digest, err)
 		}
 		var cfg struct {
 			RootFS struct {
@@ -306,33 +359,20 @@ func readOCILayoutLayers(ociTarPath, platform string) ([]localLayer, []byte, err
 	// it the slow way rather than risk mislabelling a layer.
 	diffIDsAligned := len(diffIDs) == len(manifest.Layers)
 
-	layers := make([]localLayer, 0, len(manifest.Layers))
+	img := &ociResolvedImage{ImageConfig: imageConfig}
 	for i, desc := range manifest.Layers {
-		layerHex, err := digestToHex(desc.Digest)
-		if err != nil {
-			return nil, nil, fmt.Errorf("layer %d: invalid digest %q: %w", i, desc.Digest, err)
-		}
-		loc, ok := blobOffsets[layerHex]
-		if !ok {
-			return nil, nil, fmt.Errorf("layer %d blob %s not found in OCI tar", i, desc.Digest)
-		}
 		var diffID string
 		if diffIDsAligned {
 			diffID = diffIDs[i]
 		}
-		// Reference the compressed blob by its range in the on-disk tar; it is
-		// streamed (never fully buffered) during the push, and decompression is
-		// deferred so cache-resolved layers are never read at all.
-		layers = append(layers, localLayer{
+		img.Layers = append(img.Layers, ociResolvedLayer{
 			Digest:    desc.Digest,
 			DiffID:    diffID,
 			MediaType: desc.MediaType,
-			TarPath:   ociTarPath,
-			Offset:    loc.off,
-			Size:      loc.size,
+			Size:      desc.Size,
 		})
 	}
-	return layers, imageConfig, nil
+	return img, nil
 }
 
 // blobLoc is a blob's byte range within an OCI-layout tar.

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -171,6 +171,10 @@ func pickOCIDescriptor(descs []ociDescriptor, wantOS, wantArch string) *ociDescr
 	}
 	for i := len(descs) - 1; i >= 0; i-- {
 		d := &descs[i]
+		if d.Platform != nil && d.Platform.OS == "unknown" && d.Platform.Architecture == "unknown" {
+			// buildx attestation manifest — never a deployable image.
+			continue
+		}
 		if isOCIImageManifestMediaType(d.MediaType) || isOCIImageIndexMediaType(d.MediaType) {
 			return d
 		}
@@ -919,9 +923,15 @@ func buildImageToOCILayoutDirWithDocker(ctx context.Context, cwd, dockerfile, pl
 		return err
 	}
 	// The export appended this build's manifest; drop every older entry so
-	// readers and GC see exactly one current image.
+	// readers and GC see exactly one current image. Prune is hygiene, not
+	// correctness: pickOCIDescriptor (newest-last) and gcOCILayoutDir (keeps
+	// everything index-reachable) are both correct even without pruning, and
+	// prune is strictly LESS tolerant than either (exact top-level platform
+	// match only, no nested indexes). A buildx environment whose index shapes
+	// prune refuses must not lose the ability to build, so a prune failure is
+	// only a warning here.
 	if err := pruneOCILayoutDirIndex(destDir, platform); err != nil {
-		return fmt.Errorf("pruning OCI layout index: %w", err)
+		fmt.Fprintf(stderr, "warning: could not prune OCI layout index (continuing; superseded entries accumulate until a successful prune): %v\n", err)
 	}
 	return nil
 }

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -653,6 +653,69 @@ func buildImageToOCILayout(ctx context.Context, cwd, dockerfile, platform string
 		return buildImageToOCILayoutWithBuildkit(ctx, cwd, dockerfile, platform, buildArgs, dest, stdout, stderr)
 	}
 
+	return buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, dest, false, stdout, stderr)
+}
+
+// buildImageToOCILayoutDirWithDocker builds with the shared buildx builder and
+// exports into an OCI layout DIRECTORY (`--output type=oci,tar=false`). Unlike
+// the tar export, BuildKit skips blobs already present at dest, so a warm
+// persistent directory turns the per-build export cost from O(image size)
+// into O(changed bytes). Callers own dest's lifecycle (locking and GC).
+func buildImageToOCILayoutDirWithDocker(ctx context.Context, cwd, dockerfile, platform string, buildArgs map[string]string, destDir string, stdout, stderr io.Writer) error {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("creating OCI layout directory: %w", err)
+	}
+	return buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, destDir, true, stdout, stderr)
+}
+
+// chunkLayoutDir is the persistent per-app OCI layout directory used by the
+// chunk-diff deploy path's tar=false export. Keyed by app AND platform so a
+// device-architecture switch never GC-thrashes the other platform's blobs.
+func chunkLayoutDir(userCacheDir, appID, platform string) string {
+	return filepath.Join(userCacheDir, "wendy", "ocilayout",
+		sanitizeCacheKey(appID)+"-"+sanitizeCacheKey(platform))
+}
+
+// buildxOCIExportArgs assembles the `docker buildx build` argument vector for
+// an OCI export (tar or layout-dir). Pure function for testability; build-arg
+// keys are sorted for a reproducible command line.
+func buildxOCIExportArgs(builder, platform, dockerfile, cacheDir, dest string, tarFalse bool, buildArgs map[string]string, haveCacheIndex bool) []string {
+	// buildkitd inside the Linux VM appends "/index.json" to the cache src/dest,
+	// so pass forward-slash paths to avoid mixed-separator warnings on Windows.
+	cacheDirSlash := filepath.ToSlash(cacheDir)
+	args := []string{
+		"buildx", "build",
+		"--builder", builder,
+		"--platform", platform,
+		"--progress", "plain",
+	}
+	if dockerfile != "" {
+		args = append(args, "-f", dockerfile)
+	}
+	if haveCacheIndex {
+		args = append(args, "--cache-from", "type=local,src="+cacheDirSlash)
+	}
+	args = append(args, "--cache-to", "type=local,dest="+cacheDirSlash)
+	keys := make([]string, 0, len(buildArgs))
+	for k := range buildArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "--build-arg", k+"="+buildArgs[k])
+	}
+	output := "type=oci,dest=" + dest
+	if tarFalse {
+		output += ",tar=false"
+	}
+	args = append(args, "--output", output, ".")
+	return args
+}
+
+// buildImageWithBuildxOCIExport is the shared docker-buildx body behind both
+// OCI export shapes: dest is a tar path (tarFalse=false, legacy) or a layout
+// directory (tarFalse=true).
+func buildImageWithBuildxOCIExport(ctx context.Context, cwd, dockerfile, platform string, buildArgs map[string]string, dest string, tarFalse bool, stdout, stderr io.Writer) error {
 	// Sub-phase timing (gated on WENDY_TIMING) to split the "build (oci export)"
 	// phase into lock acquisition, builder verification (the buildx inspect
 	// calls), and the actual buildx solve.
@@ -695,42 +758,15 @@ func buildImageToOCILayout(ctx context.Context, cwd, dockerfile, platform string
 		return err
 	}
 
-	// buildkitd inside the Linux VM appends "/index.json" to the cache src/dest,
-	// so pass forward-slash paths to avoid mixed-separator warnings on Windows.
-	cacheDirSlash := filepath.ToSlash(cacheDir)
-	args := []string{
-		"buildx", "build",
-		"--builder", buildxBuilder,
-		"--platform", platform,
-		"--progress", "plain",
-	}
+	resolvedDockerfile := ""
 	if dockerfile != "" {
-		resolvedDockerfile, err := confinedDockerfilePath(cwd, dockerfile)
+		resolvedDockerfile, err = confinedDockerfilePath(cwd, dockerfile)
 		if err != nil {
 			return err
 		}
-		args = append(args, "-f", resolvedDockerfile)
 	}
-	if _, err := os.Stat(filepath.Join(cacheDir, "index.json")); err == nil {
-		args = append(args, "--cache-from", "type=local,src="+cacheDirSlash)
-	}
-	args = append(args, "--cache-to", "type=local,dest="+cacheDirSlash)
-
-	// Sort build-arg keys for reproducible argument order.
-	keys := make([]string, 0, len(buildArgs))
-	for k := range buildArgs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		args = append(args, "--build-arg", k+"="+buildArgs[k])
-	}
-
-	// OCI-layout export instead of registry push.
-	args = append(args,
-		"--output", "type=oci,dest="+dest,
-		".",
-	)
+	_, cacheIndexErr := os.Stat(filepath.Join(cacheDir, "index.json"))
+	args := buildxOCIExportArgs(buildxBuilder, platform, resolvedDockerfile, cacheDir, dest, tarFalse, buildArgs, cacheIndexErr == nil)
 
 	submark("  build: setup (cache/env)")
 

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -375,6 +375,55 @@ func ociImageFromIndex(indexJSON []byte, getBlob func(hex string) ([]byte, error
 	return img, nil
 }
 
+// readOCILayoutDirLayers is readOCILayoutLayers' sibling for an OCI layout
+// DIRECTORY (buildx `--output type=oci,tar=false`): dir holds index.json plus
+// blobs/sha256/<hex> files. Layers come back file-backed against the blob
+// files themselves (offset 0, whole file). Each layer blob's on-disk size is
+// validated against the manifest descriptor so a partially-written blob (e.g.
+// a killed export) fails loudly instead of pushing garbage — callers respond
+// by wiping the directory and rebuilding.
+func readOCILayoutDirLayers(dir, platform string) ([]localLayer, []byte, error) {
+	indexJSON, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read OCI layout index: %w", err)
+	}
+	blobPath := func(hex string) string {
+		return filepath.Join(dir, "blobs", "sha256", hex)
+	}
+	getBlob := func(hex string) ([]byte, error) {
+		return os.ReadFile(blobPath(hex))
+	}
+
+	img, err := ociImageFromIndex(indexJSON, getBlob, platform)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	layers := make([]localLayer, 0, len(img.Layers))
+	for i, desc := range img.Layers {
+		layerHex, err := digestToHex(desc.Digest)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: invalid digest %q: %w", i, desc.Digest, err)
+		}
+		fi, err := os.Stat(blobPath(layerHex))
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d blob %s not found in OCI layout dir: %w", i, desc.Digest, err)
+		}
+		if desc.Size > 0 && fi.Size() != desc.Size {
+			return nil, nil, fmt.Errorf("layer blob sha256:%s is %d bytes on disk but the manifest says %d (partial write?)", layerHex, fi.Size(), desc.Size)
+		}
+		layers = append(layers, localLayer{
+			Digest:    desc.Digest,
+			DiffID:    desc.DiffID,
+			MediaType: desc.MediaType,
+			TarPath:   blobPath(layerHex),
+			Offset:    0,
+			Size:      fi.Size(),
+		})
+	}
+	return layers, img.ImageConfig, nil
+}
+
 // blobLoc is a blob's byte range within an OCI-layout tar.
 type blobLoc struct {
 	off  int64

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -409,7 +409,16 @@ func readOCILayoutDirLayers(dir, platform string) ([]localLayer, []byte, error) 
 		if err != nil {
 			return nil, nil, fmt.Errorf("layer %d blob %s not found in OCI layout dir: %w", i, desc.Digest, err)
 		}
-		if desc.Size > 0 && fi.Size() != desc.Size {
+		// Descriptor sizes are REQUIRED by the OCI spec; refusing a size-less
+		// descriptor keeps the partial-write check from being silently skipped.
+		// SECURITY: content is intentionally NOT re-hashed here — the cache dir
+		// is 0700 (same-user trust boundary), and re-hashing every layer per
+		// iteration would reintroduce the O(image size) per-build cost this
+		// layout-dir path exists to remove.
+		if desc.Size <= 0 {
+			return nil, nil, fmt.Errorf("layer blob sha256:%s has no size in its manifest descriptor", layerHex)
+		}
+		if fi.Size() != desc.Size {
 			return nil, nil, fmt.Errorf("layer blob sha256:%s is %d bytes on disk but the manifest says %d (partial write?)", layerHex, fi.Size(), desc.Size)
 		}
 		layers = append(layers, localLayer{
@@ -544,10 +553,10 @@ func gcOCILayoutDir(dir string) error {
 // directory (dir+".lock") so a self-heal RemoveAll(dir) never deletes a held
 // lock. Returns a release func that must be called exactly once.
 func lockOCILayoutDir(ctx context.Context, dir string) (func(), error) {
-	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o700); err != nil {
 		return nil, fmt.Errorf("creating OCI layout parent: %w", err)
 	}
-	f, err := os.OpenFile(dir+".lock", os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := os.OpenFile(dir+".lock", os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("opening OCI layout lock: %w", err)
 	}
@@ -806,7 +815,11 @@ func buildImageToOCILayout(ctx context.Context, cwd, dockerfile, platform string
 // persistent directory turns the per-build export cost from O(image size)
 // into O(changed bytes). Callers own dest's lifecycle (locking and GC).
 func buildImageToOCILayoutDirWithDocker(ctx context.Context, cwd, dockerfile, platform string, buildArgs map[string]string, destDir string, stdout, stderr io.Writer) error {
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
+	// 0700: image layers/config can embed build-time material, and the legacy
+	// temp-tar this replaces lived in a MkdirTemp (0700) dir. Restricting the
+	// top-level dir gates traversal regardless of the modes BuildKit gives the
+	// blob files it writes beneath it.
+	if err := os.MkdirAll(destDir, 0o700); err != nil {
 		return fmt.Errorf("creating OCI layout directory: %w", err)
 	}
 	return buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, destDir, true, stdout, stderr)

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -424,6 +424,126 @@ func readOCILayoutDirLayers(dir, platform string) ([]localLayer, []byte, error) 
 	return layers, img.ImageConfig, nil
 }
 
+// gcOCILayoutDir deletes blobs in dir that are no longer reachable from
+// index.json. buildx's tar=false export only ever ADDS blobs, so superseded
+// manifests/configs/layers accumulate until pruned. Reachability keeps every
+// index entry (nested indexes and attestation manifests included), each
+// manifest's config, and each manifest's layers. A missing dir or index is a
+// no-op; unreadable blobs during the walk are kept (best-effort, never breaks
+// a deployable layout).
+func gcOCILayoutDir(dir string) error {
+	indexJSON, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read OCI layout index for GC: %w", err)
+	}
+	var index struct {
+		Manifests []ociDescriptor `json:"manifests"`
+	}
+	if err := json.Unmarshal(indexJSON, &index); err != nil {
+		return fmt.Errorf("parsing index.json for GC: %w", err)
+	}
+
+	referenced := map[string]bool{}
+	var walk func(descs []ociDescriptor, depth int)
+	walk = func(descs []ociDescriptor, depth int) {
+		if depth > 6 {
+			return
+		}
+		for _, d := range descs {
+			hexDigest, err := digestToHex(d.Digest)
+			if err != nil {
+				continue
+			}
+			referenced[hexDigest] = true
+			blob, err := os.ReadFile(filepath.Join(dir, "blobs", "sha256", hexDigest))
+			if err != nil {
+				continue
+			}
+			if isOCIImageIndexMediaType(d.MediaType) {
+				var nested struct {
+					Manifests []ociDescriptor `json:"manifests"`
+				}
+				if err := json.Unmarshal(blob, &nested); err == nil {
+					walk(nested.Manifests, depth+1)
+				}
+				continue
+			}
+			// Image manifests (attestation manifests share the media type): keep
+			// the config and every layer blob.
+			var manifest struct {
+				Config struct {
+					Digest string `json:"digest"`
+				} `json:"config"`
+				Layers []struct {
+					Digest string `json:"digest"`
+				} `json:"layers"`
+			}
+			if err := json.Unmarshal(blob, &manifest); err != nil {
+				continue
+			}
+			if hexDigest, err := digestToHex(manifest.Config.Digest); err == nil {
+				referenced[hexDigest] = true
+			}
+			for _, l := range manifest.Layers {
+				if hexDigest, err := digestToHex(l.Digest); err == nil {
+					referenced[hexDigest] = true
+				}
+			}
+		}
+	}
+	walk(index.Manifests, 0)
+
+	blobsDir := filepath.Join(dir, "blobs", "sha256")
+	dirEntries, err := os.ReadDir(blobsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("listing blobs for GC: %w", err)
+	}
+	for _, e := range dirEntries {
+		if e.IsDir() || referenced[e.Name()] {
+			continue
+		}
+		if err := os.Remove(filepath.Join(blobsDir, e.Name())); err != nil {
+			return fmt.Errorf("pruning blob %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+// lockOCILayoutDir serializes use of a persistent layout directory across
+// wendy processes (build → read → push → GC). The lock file sits NEXT TO the
+// directory (dir+".lock") so a self-heal RemoveAll(dir) never deletes a held
+// lock. Returns a release func that must be called exactly once.
+func lockOCILayoutDir(ctx context.Context, dir string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return nil, fmt.Errorf("creating OCI layout parent: %w", err)
+	}
+	f, err := os.OpenFile(dir+".lock", os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening OCI layout lock: %w", err)
+	}
+	locked, err := tryLockFile(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("acquiring OCI layout lock: %w", err)
+	}
+	if !locked {
+		if err := blockLockFile(ctx, f); err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("acquiring OCI layout lock: %w", err)
+		}
+	}
+	return func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	}, nil
+}
+
 // blobLoc is a blob's byte range within an OCI-layout tar.
 type blobLoc struct {
 	off  int64

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -554,6 +554,93 @@ func gcOCILayoutDir(dir string) error {
 	return nil
 }
 
+// pruneOCILayoutDirIndex rewrites dir's index.json to reference only the
+// newest image manifest matching platform. buildx's tar=false export
+// appends manifests, so without pruning the index accumulates one entry
+// per build; older entries (and attestation manifests) keep superseded
+// blobs GC-reachable and — before pickOCIDescriptor preferred the newest
+// — pinned every reader to the first build. Runs under the caller's
+// layout-dir flock. A single already-pruned index is left byte-identical.
+func pruneOCILayoutDirIndex(dir, platform string) error {
+	indexPath := filepath.Join(dir, "index.json")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("reading index.json for prune: %w", err)
+	}
+	var typed struct {
+		Manifests []ociDescriptor `json:"manifests"`
+	}
+	var raw struct {
+		Manifests []json.RawMessage `json:"manifests"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return fmt.Errorf("parsing index.json for prune: %w", err)
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing index.json for prune: %w", err)
+	}
+	if len(typed.Manifests) != len(raw.Manifests) {
+		return fmt.Errorf("index.json manifest parse mismatch (%d vs %d)", len(typed.Manifests), len(raw.Manifests))
+	}
+
+	wantOS, wantArch := parseOCIPlatform(platform)
+	chosen := pickOCIDescriptor(typed.Manifests, wantOS, wantArch)
+	// pickOCIDescriptor falls back to the newest manifest/index of ANY
+	// platform when no exact match exists (the right call for best-effort
+	// resolution). Pruning must not inherit that permissiveness: keeping a
+	// wrong-platform entry because it merely LOOKED like a manifest would
+	// silently discard the layout's only real candidate for wantOS/wantArch.
+	if chosen == nil || chosen.Platform == nil || chosen.Platform.OS != wantOS || chosen.Platform.Architecture != wantArch {
+		return fmt.Errorf("no manifest for %s in index.json; refusing to prune", platform)
+	}
+	chosenIdx := -1
+	for i := range typed.Manifests {
+		if &typed.Manifests[i] == chosen {
+			chosenIdx = i
+			break
+		}
+	}
+	if chosenIdx < 0 {
+		return fmt.Errorf("internal: chosen descriptor not found in index")
+	}
+	if len(typed.Manifests) == 1 && chosenIdx == 0 {
+		return nil
+	}
+
+	out := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.index.v1+json",
+		"manifests":     []json.RawMessage{raw.Manifests[chosenIdx]},
+	}
+	pruned, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshaling pruned index.json: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".index-*.json")
+	if err != nil {
+		return fmt.Errorf("staging pruned index.json: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(pruned); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("writing pruned index.json: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("closing pruned index.json: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod pruned index.json: %w", err)
+	}
+	if err := os.Rename(tmpName, indexPath); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("replacing index.json: %w", err)
+	}
+	return nil
+}
+
 // lockOCILayoutDir serializes use of a persistent layout directory across
 // wendy processes (build → read → push → GC). The lock file sits NEXT TO the
 // directory (dir+".lock") so a self-heal RemoveAll(dir) never deletes a held
@@ -828,7 +915,15 @@ func buildImageToOCILayoutDirWithDocker(ctx context.Context, cwd, dockerfile, pl
 	if err := os.MkdirAll(destDir, 0o700); err != nil {
 		return fmt.Errorf("creating OCI layout directory: %w", err)
 	}
-	return buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, destDir, true, stdout, stderr)
+	if err := buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, destDir, true, stdout, stderr); err != nil {
+		return err
+	}
+	// The export appended this build's manifest; drop every older entry so
+	// readers and GC see exactly one current image.
+	if err := pruneOCILayoutDirIndex(destDir, platform); err != nil {
+		return fmt.Errorf("pruning OCI layout index: %w", err)
+	}
+	return nil
 }
 
 // chunkLayoutDir is the persistent per-app OCI layout directory used by the

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -154,16 +154,22 @@ func resolveOCIImageManifest(descs []ociDescriptor, getBlob func(hex string) ([]
 }
 
 // pickOCIDescriptor chooses the best descriptor for the target platform:
-// an exact os/arch match if present, otherwise the first image manifest or
-// image index (skipping attestation/unknown entries).
+// the NEWEST exact os/arch match if present, otherwise the newest image
+// manifest or image index (skipping attestation/unknown entries).
+//
+// Newest means LAST in slice order: buildx's tar=false dir export APPENDS
+// each build's manifest to index.json, so several entries can match the
+// platform and the current build is always the final one. Resolving the
+// first match shipped the layout dir's first-ever build forever (stale
+// deps bug, on-device pass 2026-08-08).
 func pickOCIDescriptor(descs []ociDescriptor, wantOS, wantArch string) *ociDescriptor {
-	for i := range descs {
+	for i := len(descs) - 1; i >= 0; i-- {
 		d := &descs[i]
 		if d.Platform != nil && d.Platform.OS == wantOS && d.Platform.Architecture == wantArch {
 			return d
 		}
 	}
-	for i := range descs {
+	for i := len(descs) - 1; i >= 0; i-- {
 		d := &descs[i]
 		if isOCIImageManifestMediaType(d.MediaType) || isOCIImageIndexMediaType(d.MediaType) {
 			return d

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -424,6 +424,30 @@ func readOCILayoutDirLayers(dir, platform string) ([]localLayer, []byte, error) 
 	return layers, img.ImageConfig, nil
 }
 
+// chunkExportModeEnv forces the chunk-diff deploy's legacy temp-tar export
+// ("tar") instead of the persistent layout directory. Escape hatch only.
+const chunkExportModeEnv = "WENDY_CHUNK_EXPORT"
+
+// chunkExportPlan decides how the chunk-diff deploy exports the built image:
+// "dir" — persistent OCI layout directory (buildx tar=false, blob-deduped) —
+// for the docker backend, "tar" for backends that can only emit a tar
+// (apple-container, on-device buildctl), for the WENDY_CHUNK_EXPORT=tar
+// escape hatch, and for unknown builders (whose normalize error then surfaces
+// on the tar path exactly as before).
+func chunkExportPlan(builder string) string {
+	if os.Getenv(chunkExportModeEnv) == "tar" {
+		return "tar"
+	}
+	if !imageBuilderWasExplicit(builder) && shouldUseBuildkitOnDevice() {
+		return "tar"
+	}
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil || normalized != imageBuilderDocker {
+		return "tar"
+	}
+	return "dir"
+}
+
 // gcOCILayoutDir deletes blobs in dir that are no longer reachable from
 // index.json. buildx's tar=false export only ever ADDS blobs, so superseded
 // manifests/configs/layers accumulate until pruned. Reachability keeps every

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestIsImageBuildFailure verifies the classification used by the chunk-diff
@@ -267,6 +269,76 @@ func TestReadOCILayoutDirLayersMissingIndex(t *testing.T) {
 	_, _, err := readOCILayoutDirLayers(t.TempDir(), "linux/arm64")
 	if err == nil {
 		t.Fatal("want error for missing index.json, got nil")
+	}
+}
+
+// GC must keep every blob reachable from index.json (all index entries, nested
+// indexes and attestation manifests included) and delete only orphans left
+// behind by superseded builds.
+func TestGCOCILayoutDir(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("gc-test-layer-tar")
+	entries := minimalOCILayoutEntries(t, raw, "application/vnd.oci.image.layer.v1.tar", raw)
+	orphan := []byte("orphaned-blob-from-a-previous-build")
+	entries["blobs/sha256/"+sha256Hex(orphan)] = orphan
+	writeOCILayoutDir(t, dir, entries)
+
+	if err := gcOCILayoutDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "blobs", "sha256", sha256Hex(orphan))); !os.IsNotExist(err) {
+		t.Fatal("orphan blob should have been deleted")
+	}
+	for name := range minimalOCILayoutEntries(t, raw, "application/vnd.oci.image.layer.v1.tar", raw) {
+		if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(name))); err != nil {
+			t.Fatalf("referenced entry %q should survive GC: %v", name, err)
+		}
+	}
+}
+
+func TestGCOCILayoutDirMissingDirIsNoop(t *testing.T) {
+	if err := gcOCILayoutDir(filepath.Join(t.TempDir(), "nope")); err != nil {
+		t.Fatalf("missing dir should be a no-op, got %v", err)
+	}
+}
+
+// The per-app layout lock must exclude a second acquirer until released. The
+// lock file lives NEXT TO the directory so self-heal's RemoveAll(dir) can
+// never delete a held lock.
+func TestLockOCILayoutDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "app-layout")
+	release, err := lockOCILayoutDir(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir + ".lock"); err != nil {
+		t.Fatalf("lock file should sit next to the dir: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		r2, err := lockOCILayoutDir(context.Background(), dir)
+		if err != nil {
+			t.Error(err)
+			close(acquired)
+			return
+		}
+		close(acquired)
+		r2()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second acquire should block while the lock is held")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-acquired:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second acquire never succeeded after release")
 	}
 }
 

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -352,6 +352,75 @@ func TestGCOCILayoutDirMissingDirIsNoop(t *testing.T) {
 	}
 }
 
+// writeLayoutIndex writes an index.json with the given raw manifest entries.
+func writeLayoutIndex(t *testing.T, dir string, entries ...string) {
+	t.Helper()
+	idx := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[` +
+		strings.Join(entries, ",") + `]}`
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(idx), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPruneOCILayoutDirIndexKeepsOnlyNewestPlatformManifest(t *testing.T) {
+	dir := t.TempDir()
+	old := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	att := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:cccc","size":1,"platform":{"architecture":"unknown","os":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest"}}`
+	niu := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbb","size":1,"platform":{"architecture":"arm64","os":"linux"},"annotations":{"org.opencontainers.image.created":"x"}}`
+	writeLayoutIndex(t, dir, old, niu, att)
+
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx struct {
+		Manifests []json.RawMessage `json:"manifests"`
+	}
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("want exactly 1 manifest entry after prune, got %d: %s", len(idx.Manifests), data)
+	}
+	// The kept entry must be the newest platform match, raw bytes preserved
+	// (annotations intact).
+	if !strings.Contains(string(idx.Manifests[0]), "sha256:bbbb") ||
+		!strings.Contains(string(idx.Manifests[0]), "org.opencontainers.image.created") {
+		t.Fatalf("kept entry lost identity or annotations: %s", idx.Manifests[0])
+	}
+}
+
+func TestPruneOCILayoutDirIndexSingleEntryNoop(t *testing.T) {
+	dir := t.TempDir()
+	only := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	writeLayoutIndex(t, dir, only)
+	before, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if !bytes.Equal(before, after) {
+		t.Fatalf("single-entry index must be untouched\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
+func TestPruneOCILayoutDirIndexNoMatchErrorsAndPreservesIndex(t *testing.T) {
+	dir := t.TempDir()
+	amd := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"amd64","os":"linux"}}`
+	writeLayoutIndex(t, dir, amd)
+	before, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err == nil {
+		t.Fatal("want error when no manifest matches the platform")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if !bytes.Equal(before, after) {
+		t.Fatal("index must be untouched on error")
+	}
+}
+
 // The per-app layout lock must exclude a second acquirer until released. The
 // lock file lives NEXT TO the directory so self-heal's RemoveAll(dir) can
 // never delete a held lock.

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -766,3 +766,31 @@ func TestReadOCILayoutLayersPlatformSelection(t *testing.T) {
 		t.Fatalf("selected wrong platform layer: got %q want %q", got, armLayer)
 	}
 }
+
+func TestPickOCIDescriptorPrefersNewestPlatformMatch(t *testing.T) {
+	arm := &struct {
+		Architecture string `json:"architecture"`
+		OS           string `json:"os"`
+	}{Architecture: "arm64", OS: "linux"}
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:aaaa", Platform: arm},
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:bbbb", Platform: arm},
+	}
+	got := pickOCIDescriptor(descs, "linux", "arm64")
+	if got == nil || got.Digest != "sha256:bbbb" {
+		t.Fatalf("want newest (last) match sha256:bbbb, got %+v", got)
+	}
+}
+
+func TestPickOCIDescriptorFallbackPrefersNewest(t *testing.T) {
+	// No platform info at all: the fallback loop must also prefer the last
+	// image-manifest entry (buildx appends newest last).
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:aaaa"},
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:bbbb"},
+	}
+	got := pickOCIDescriptor(descs, "linux", "arm64")
+	if got == nil || got.Digest != "sha256:bbbb" {
+		t.Fatalf("want newest (last) fallback sha256:bbbb, got %+v", got)
+	}
+}

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -269,6 +270,54 @@ func TestReadOCILayoutDirLayersMissingIndex(t *testing.T) {
 	_, _, err := readOCILayoutDirLayers(t.TempDir(), "linux/arm64")
 	if err == nil {
 		t.Fatal("want error for missing index.json, got nil")
+	}
+}
+
+// Descriptor sizes are required by the OCI spec; without one the partial-write
+// check would be silently skipped, so the reader must refuse.
+func TestReadOCILayoutDirLayersRequiresDescriptorSize(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte("sizeless-layer-tar")
+	layerDigest := "sha256:" + sha256Hex(raw)
+	config := []byte(`{"architecture":"arm64","os":"linux","rootfs":{"type":"layers","diff_ids":["` + layerDigest + `"]}}`)
+	configDigest := "sha256:" + sha256Hex(config)
+	manifest := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",` +
+		`"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"` + configDigest + `","size":` + fmt.Sprint(len(config)) + `},` +
+		`"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"` + layerDigest + `"}]}`)
+	manifestDigest := sha256Hex(manifest)
+	index := []byte(`{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:` + manifestDigest + `","size":` + fmt.Sprint(len(manifest)) + `}]}`)
+	writeOCILayoutDir(t, dir, map[string][]byte{
+		"oci-layout":                        []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		"index.json":                        index,
+		"blobs/sha256/" + manifestDigest:    manifest,
+		"blobs/sha256/" + sha256Hex(config): config,
+		"blobs/sha256/" + sha256Hex(raw):    raw,
+	})
+
+	_, _, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err == nil || !strings.Contains(err.Error(), "no size") {
+		t.Fatalf("want a no-size error, got %v", err)
+	}
+}
+
+// The persistent cache must not be world-readable: the layout parent dir is
+// created 0700 and the lock file 0600.
+func TestLockOCILayoutDirPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	parent := filepath.Join(t.TempDir(), "ocilayout")
+	dir := filepath.Join(parent, "app-linux_arm64")
+	release, err := lockOCILayoutDir(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if fi, err := os.Stat(parent); err != nil || fi.Mode().Perm() != 0o700 {
+		t.Fatalf("layout parent perm = %v (err %v), want 0700", fi.Mode().Perm(), err)
+	}
+	if fi, err := os.Stat(dir + ".lock"); err != nil || fi.Mode().Perm() != 0o600 {
+		t.Fatalf("lock file perm = %v (err %v), want 0600", fi.Mode().Perm(), err)
 	}
 }
 

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -864,6 +864,44 @@ func TestPickOCIDescriptorFallbackPrefersNewest(t *testing.T) {
 	}
 }
 
+// TestPickOCIDescriptorFallbackSkipsAttestationManifest ensures that with
+// newest-last iteration, a trailing buildx attestation manifest
+// (platform os=unknown/arch=unknown) does NOT win the fallback over a real
+// image manifest when no exact platform match exists.
+func TestPickOCIDescriptorFallbackSkipsAttestationManifest(t *testing.T) {
+	arm := &struct {
+		Architecture string `json:"architecture"`
+		OS           string `json:"os"`
+	}{Architecture: "arm64", OS: "linux"}
+	unknown := &struct {
+		Architecture string `json:"architecture"`
+		OS           string `json:"os"`
+	}{Architecture: "unknown", OS: "unknown"}
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:image", Platform: arm},
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:attestation", Platform: unknown},
+	}
+	// No exact match for linux/amd64: the fallback must skip the trailing
+	// attestation manifest and return the real image manifest instead.
+	got := pickOCIDescriptor(descs, "linux", "amd64")
+	if got == nil || got.Digest != "sha256:image" {
+		t.Fatalf("want fallback to skip attestation manifest and return sha256:image, got %+v", got)
+	}
+}
+
+// TestPickOCIDescriptorFallbackNilPlatformStillWins ensures the fallback still
+// picks a platform-NIL descriptor when it is the only candidate (nil platform
+// must not be mistaken for the unknown/unknown attestation shape).
+func TestPickOCIDescriptorFallbackNilPlatformStillWins(t *testing.T) {
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:onlycandidate"},
+	}
+	got := pickOCIDescriptor(descs, "linux", "amd64")
+	if got == nil || got.Digest != "sha256:onlycandidate" {
+		t.Fatalf("want the only nil-platform candidate to win the fallback, got %+v", got)
+	}
+}
+
 // writeBlob writes content under blobs/sha256/<sha256(content)> and returns
 // the digest string.
 func writeBlob(t *testing.T, dir string, content []byte) string {

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -342,6 +342,32 @@ func TestLockOCILayoutDir(t *testing.T) {
 	}
 }
 
+// The export-mode dispatcher: docker buildx gets the persistent layout dir;
+// backends that can only emit tars (apple-container, on-device buildctl) and
+// the escape-hatch env keep the legacy temp tar.
+func TestChunkExportPlan(t *testing.T) {
+	t.Setenv("WENDY_CHUNK_EXPORT", "")
+	if got := chunkExportPlan(""); got != "dir" {
+		t.Fatalf("default builder: got %q, want dir", got)
+	}
+	if got := chunkExportPlan("docker"); got != "dir" {
+		t.Fatalf("docker builder: got %q, want dir", got)
+	}
+	if got := chunkExportPlan("apple-container"); got != "tar" {
+		t.Fatalf("apple-container builder: got %q, want tar", got)
+	}
+	if got := chunkExportPlan("buildkit"); got != "tar" {
+		t.Fatalf("buildkit builder: got %q, want tar", got)
+	}
+	if got := chunkExportPlan("no-such-builder"); got != "tar" {
+		t.Fatalf("invalid builder: got %q, want tar (error surfaces on the tar path)", got)
+	}
+	t.Setenv("WENDY_CHUNK_EXPORT", "tar")
+	if got := chunkExportPlan("docker"); got != "tar" {
+		t.Fatalf("env override: got %q, want tar", got)
+	}
+}
+
 func TestChunkLayoutDir(t *testing.T) {
 	got := chunkLayoutDir("/cache", "Com.Wendylabs.Examples.App", "linux/arm64")
 	want := filepath.Join("/cache", "wendy", "ocilayout", "com.wendylabs.examples.app-linux_arm64")

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -108,6 +109,13 @@ func writeOCITar(t *testing.T, path string, entries map[string][]byte) {
 // compute the DiffID in the config (for uncompressed layers it equals blobData).
 func writeMinimalOCILayout(t *testing.T, path string, blobData []byte, mediaType string, diffIDBytes []byte) {
 	t.Helper()
+	writeOCITar(t, path, minimalOCILayoutEntries(t, blobData, mediaType, diffIDBytes))
+}
+
+// minimalOCILayoutEntries builds the entry map (name → data) for a minimal
+// single-layer OCI layout, shared by the tar and directory fixture writers.
+func minimalOCILayoutEntries(t *testing.T, blobData []byte, mediaType string, diffIDBytes []byte) map[string][]byte {
+	t.Helper()
 
 	diffID := "sha256:" + sha256Hex(diffIDBytes)
 	layerDigest := "sha256:" + sha256Hex(blobData)
@@ -153,14 +161,113 @@ func writeMinimalOCILayout(t *testing.T, path string, blobData []byte, mediaType
 		t.Fatal(err)
 	}
 
-	entries := map[string][]byte{
+	return map[string][]byte{
 		"oci-layout": []byte(`{"imageLayoutVersion":"1.0.0"}`),
 		"index.json": indexBytes,
 		"blobs/sha256/" + sha256Hex(manifestBytes): manifestBytes,
 		"blobs/sha256/" + sha256Hex(configBytes):   configBytes,
 		"blobs/sha256/" + sha256Hex(blobData):      blobData,
 	}
-	writeOCITar(t, path, entries)
+}
+
+// writeOCILayoutDir materializes entries (same shape writeOCITar takes) as an
+// OCI layout directory: "index.json" and "blobs/sha256/<hex>" become files.
+func writeOCILayoutDir(t *testing.T, dir string, entries map[string][]byte) {
+	t.Helper()
+	for name, data := range entries {
+		p := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// The layout-dir reader must return file-backed layers pointing at the blob
+// files themselves (offset 0, whole file), with DiffID and config populated
+// exactly like the tar reader.
+func TestReadOCILayoutDirLayers(t *testing.T) {
+	dir := t.TempDir()
+
+	raw := bytes.Repeat([]byte("wendy-layout-dir-payload-"), 4000)
+	var gz bytes.Buffer
+	gw := gzip.NewWriter(&gz)
+	if _, err := gw.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed := gz.Bytes()
+
+	writeOCILayoutDir(t, dir, minimalOCILayoutEntries(t, compressed, "application/vnd.oci.image.layer.v1.tar+gzip", raw))
+
+	layers, imageConfig, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layers) != 1 {
+		t.Fatalf("want 1 layer, got %d", len(layers))
+	}
+	l := layers[0]
+
+	wantPath := filepath.Join(dir, "blobs", "sha256", sha256Hex(compressed))
+	if l.TarPath != wantPath {
+		t.Fatalf("layer path = %q, want %q", l.TarPath, wantPath)
+	}
+	if l.Offset != 0 {
+		t.Fatalf("layer offset = %d, want 0", l.Offset)
+	}
+	if l.Size != int64(len(compressed)) {
+		t.Fatalf("layer size = %d, want %d", l.Size, len(compressed))
+	}
+	if want := "sha256:" + sha256Hex(raw); l.DiffID != want {
+		t.Fatalf("diffID = %q, want %q", l.DiffID, want)
+	}
+
+	got, err := l.decompress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Fatal("decompressed bytes do not match original raw tar")
+	}
+	if !bytes.Contains(imageConfig, []byte(`"WorkingDir":"/app"`)) {
+		t.Fatal("image config not round-tripped")
+	}
+}
+
+// A blob file whose size disagrees with the manifest descriptor is a partial
+// write (e.g. a killed export); the reader must fail loudly so the caller can
+// self-heal by wiping the directory.
+func TestReadOCILayoutDirLayersSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	raw := []byte("layer-tar-bytes-for-truncation")
+	entries := minimalOCILayoutEntries(t, raw, "application/vnd.oci.image.layer.v1.tar", raw)
+	writeOCILayoutDir(t, dir, entries)
+
+	blobPath := filepath.Join(dir, "blobs", "sha256", sha256Hex(raw))
+	if err := os.Truncate(blobPath, int64(len(raw)-5)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err == nil {
+		t.Fatal("want error for truncated layer blob, got nil")
+	}
+	if !strings.Contains(err.Error(), sha256Hex(raw)) {
+		t.Fatalf("error should name the bad blob digest, got: %v", err)
+	}
+}
+
+func TestReadOCILayoutDirLayersMissingIndex(t *testing.T) {
+	_, _, err := readOCILayoutDirLayers(t.TempDir(), "linux/arm64")
+	if err == nil {
+		t.Fatal("want error for missing index.json, got nil")
+	}
 }
 
 // readOCILayoutLayers must reference layer blobs by their byte range in the

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -863,3 +863,62 @@ func TestPickOCIDescriptorFallbackPrefersNewest(t *testing.T) {
 		t.Fatalf("want newest (last) fallback sha256:bbbb, got %+v", got)
 	}
 }
+
+// writeBlob writes content under blobs/sha256/<sha256(content)> and returns
+// the digest string.
+func writeBlob(t *testing.T, dir string, content []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(content)
+	hexd := hex.EncodeToString(sum[:])
+	p := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(p, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(p, hexd), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return "sha256:" + hexd
+}
+
+func TestPruneThenGCDropsSupersededBuild(t *testing.T) {
+	dir := t.TempDir()
+	// Old build: config + one layer + manifest referencing them.
+	oldCfg := writeBlob(t, dir, []byte(`{"old":"config"}`))
+	oldLayer := writeBlob(t, dir, []byte("old-layer"))
+	oldManifest := writeBlob(t, dir, []byte(`{"config":{"digest":"`+oldCfg+`"},"layers":[{"digest":"`+oldLayer+`"}]}`))
+	// New build: shares nothing with the old one.
+	newCfg := writeBlob(t, dir, []byte(`{"new":"config"}`))
+	newLayer := writeBlob(t, dir, []byte("new-layer"))
+	newManifest := writeBlob(t, dir, []byte(`{"config":{"digest":"`+newCfg+`"},"layers":[{"digest":"`+newLayer+`"}]}`))
+
+	entry := func(digest string) string {
+		return `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + digest + `","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	}
+	writeLayoutIndex(t, dir, entry(oldManifest), entry(newManifest))
+
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	if err := gcOCILayoutDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	mustExist := func(digest string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(dir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:"))); err != nil {
+			t.Fatalf("blob %s should survive GC: %v", digest, err)
+		}
+	}
+	mustBeGone := func(digest string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(dir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:"))); !os.IsNotExist(err) {
+			t.Fatalf("blob %s should be GC'd, stat err=%v", digest, err)
+		}
+	}
+	mustExist(newManifest)
+	mustExist(newCfg)
+	mustExist(newLayer)
+	mustBeGone(oldManifest)
+	mustBeGone(oldCfg)
+	mustBeGone(oldLayer)
+}

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -270,6 +270,52 @@ func TestReadOCILayoutDirLayersMissingIndex(t *testing.T) {
 	}
 }
 
+func TestChunkLayoutDir(t *testing.T) {
+	got := chunkLayoutDir("/cache", "Com.Wendylabs.Examples.App", "linux/arm64")
+	want := filepath.Join("/cache", "wendy", "ocilayout", "com.wendylabs.examples.app-linux_arm64")
+	if got != want {
+		t.Fatalf("chunkLayoutDir = %q, want %q", got, want)
+	}
+}
+
+func TestBuildxOCIExportArgs(t *testing.T) {
+	t.Run("dir mode, no cache index, sorted build args", func(t *testing.T) {
+		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "/proj/Dockerfile", "/c/buildx", "/dest/layout", true,
+			map[string]string{"ZED": "2", "ALPHA": "1"}, false)
+		want := []string{
+			"buildx", "build",
+			"--builder", "wendy-oci",
+			"--platform", "linux/arm64",
+			"--progress", "plain",
+			"-f", "/proj/Dockerfile",
+			"--cache-to", "type=local,dest=/c/buildx",
+			"--build-arg", "ALPHA=1",
+			"--build-arg", "ZED=2",
+			"--output", "type=oci,dest=/dest/layout,tar=false",
+			".",
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("args mismatch:\n got  %q\n want %q", got, want)
+		}
+	})
+	t.Run("tar mode with cache index, no dockerfile", func(t *testing.T) {
+		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "", "/c/buildx", "/tmp/image.tar", false, nil, true)
+		want := []string{
+			"buildx", "build",
+			"--builder", "wendy-oci",
+			"--platform", "linux/arm64",
+			"--progress", "plain",
+			"--cache-from", "type=local,src=/c/buildx",
+			"--cache-to", "type=local,dest=/c/buildx",
+			"--output", "type=oci,dest=/tmp/image.tar",
+			".",
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("args mismatch:\n got  %q\n want %q", got, want)
+		}
+	})
+}
+
 // readOCILayoutLayers must reference layer blobs by their byte range in the
 // on-disk tar (never buffering them in RAM), and that range must be exact —
 // the compressed bytes read back have to hash to the layer digest.

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -2192,35 +2192,91 @@ const imageSignaturePathEnv = "WENDY_IMAGE_SIGNATURE_PATH"
 // skipping a rebuild (WDY-1824).
 func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, platform, dockerfile string, buildArgs map[string]string, deployEnv []string, opts runOptions) ([]string, error) {
 	mark := phaseTimer()
-	tmp, err := os.MkdirTemp("", "wendy-oci-*")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(tmp)
-	ociTar := filepath.Join(tmp, "image.tar")
 
 	buildTitle := fmt.Sprintf("Building image (OCI layout) for %s...", tui.Value(platform))
-	if opts.quietBuild {
-		// wendy watch: keep the legacy quiet behavior (buffer, surface only on
-		// genuine failure) rather than rendering a live UI under the watcher.
-		var buildLog bytes.Buffer
-		if err := buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, &buildLog, &buildLog); err != nil {
-			if ctx.Err() == nil {
-				_, _ = os.Stderr.Write(buildLog.Bytes())
+	runBuild := func(build func(stream, logw io.Writer) error) error {
+		if opts.quietBuild {
+			// wendy watch: keep the legacy quiet behavior (buffer, surface only on
+			// genuine failure) rather than rendering a live UI under the watcher.
+			var buildLog bytes.Buffer
+			if err := build(&buildLog, &buildLog); err != nil {
+				if ctx.Err() == nil {
+					_, _ = os.Stderr.Write(buildLog.Bytes())
+				}
+				return err
 			}
+			return nil
+		}
+		return runBuildWithProgress(ctx, buildTitle, shouldDumpChunkDiffBuildLog(opts.chunking), build)
+	}
+
+	// The docker backend exports into a persistent per-app OCI layout DIRECTORY:
+	// BuildKit skips blobs already present there, so a warm rebuild writes only
+	// the changed layers instead of re-serializing the whole image (which costs
+	// seconds per GB of image on every iteration). Tar-only backends and the
+	// WENDY_CHUNK_EXPORT=tar escape hatch keep the legacy temp tar.
+	exportMode := chunkExportPlan(opts.builder)
+	var layoutDir string
+	if exportMode == "dir" {
+		if userCache, cacheErr := os.UserCacheDir(); cacheErr == nil {
+			layoutDir = chunkLayoutDir(userCache, appCfg.AppID, platform)
+		} else {
+			exportMode = "tar"
+		}
+	}
+
+	var layers []localLayer
+	var imageConfig []byte
+	if exportMode == "dir" {
+		releaseLayout, err := lockOCILayoutDir(ctx, layoutDir)
+		if err != nil {
 			return nil, err
 		}
+		defer releaseLayout()
+		build := func(stream, logw io.Writer) error {
+			return buildImageToOCILayoutDirWithDocker(ctx, cwd, dockerfile, platform, buildArgs, layoutDir, stream, logw)
+		}
+		if err := runBuild(build); err != nil {
+			return nil, err
+		}
+		mark("build (oci export)")
+		layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform)
+		if err != nil {
+			// Self-heal exactly once: a corrupt or partially-written layout dir is
+			// wiped and rebuilt from scratch, which is precisely the legacy cold
+			// behavior. A second failure is a real bug and surfaces.
+			cliLogln("OCI layout cache unreadable (%v); rebuilding it from scratch", err)
+			if rmErr := os.RemoveAll(layoutDir); rmErr != nil {
+				return nil, fmt.Errorf("resetting OCI layout cache %s: %w", layoutDir, rmErr)
+			}
+			if err := runBuild(build); err != nil {
+				return nil, err
+			}
+			if layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform); err != nil {
+				return nil, err
+			}
+		}
+		// Prune blobs superseded by this build once the deploy is done with them.
+		// Best-effort: reachable blobs are never touched, so a failed GC only
+		// leaves garbage for the next run to collect.
+		defer func() { _ = gcOCILayoutDir(layoutDir) }()
 	} else {
-		if err := runBuildWithProgress(ctx, buildTitle, shouldDumpChunkDiffBuildLog(opts.chunking), func(stream, logw io.Writer) error {
+		tmp, err := os.MkdirTemp("", "wendy-oci-*")
+		if err != nil {
+			return nil, err
+		}
+		defer os.RemoveAll(tmp)
+		ociTar := filepath.Join(tmp, "image.tar")
+		if err := runBuild(func(stream, logw io.Writer) error {
 			return buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, stream, logw)
 		}); err != nil {
 			return nil, err
 		}
-	}
-	mark("build (oci export)")
-	layers, imageConfig, err := readOCILayoutLayers(ociTar, platform)
-	if err != nil {
-		return nil, err
+		mark("build (oci export)")
+		layers, imageConfig, err = readOCILayoutLayers(ociTar, platform)
+		if err != nil {
+			return nil, err
+		}
 	}
 	mark("read+decompress layers")
 

--- a/specs/2026-08-08-oci-layout-stale-manifest-fix-plan.md
+++ b/specs/2026-08-08-oci-layout-stale-manifest-fix-plan.md
@@ -1,0 +1,769 @@
+# OCI Layout Stale-Manifest Fix + Debug/Crash-Loop Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the critical stale-manifest bug in PR #1608's persistent OCI layout dir (deps changes silently never deploy), and scope the three adjacent findings from the 2026-08-08 on-device pass into a follow-up PR.
+
+**Architecture:** Part 1 (this PR, branch `ed/oci-layout-dir-export`) makes the layout-dir pipeline correct under BuildKit's append-only `tar=false` export: the platform resolver prefers the *newest* manifest, the export step prunes superseded index entries, and a deploy-fingerprint salt bump forces one clean rebuild for anyone bitten. Part 2 (follow-up PR off `main`, suggested branch `ed/debug-crashloop-followups`) fixes `--debug` crash-looping Stagefile apps, the container replace/stop races against the restart monitor, and missing live crash-loop logs in `device logs --tail`.
+
+**Tech Stack:** Go (CLI in `go/internal/cli/commands`, agent in `go/internal/agent`), standard `go test`, BuildKit/buildx `--output type=oci,tar=false`.
+
+## Global Constraints
+
+- Branch naming: everything Claude pushes is prefixed `ed/`.
+- Run `gofmt -l .` from `go/` before every push; `gofmt -w` anything listed.
+- Build/test from `go/`: `go build ./...`, `go test ./internal/cli/commands/ -run <Name> -v`.
+- Linux-only agent tests can be pre-verified via `docker run golang:1.26 go test ./go/internal/agent/...`.
+- The full bug evidence chain and reproduction transcript live in `specs/2026-08-08-on-device-test-plan.md` (main checkout, untracked) — RESULTS section.
+
+## Background: the bug (all links verified live on hardware 2026-08-08)
+
+1. BuildKit's `tar=false` dir export **appends** each build's manifest to `index.json`; the previous entries stay, oldest first (verified: index went 1 → 2 entries, old entry first).
+2. `pickOCIDescriptor` (`go/internal/cli/commands/ocilayers.go:159`) returns the **first** platform match — the *oldest* manifest. Every reader (`readOCILayoutDirLayers`, and #1610's `adoptNativeLayers` downstream) therefore resolves the first build the layout dir ever produced.
+3. `gcOCILayoutDir` keeps only index-reachable blobs — once anything rewrites the index to the old manifest (as #1610's splice does), **the correct new build's blobs are deleted**.
+4. `saveDeployFingerprint` records the *current* input hash against the stale deploy, so subsequent identical runs skip the build entirely and the staleness locks in.
+
+Net effect: after the first build lands in a layout dir, requirements/deps changes never reach the device again, with success reported every time. App-only (final COPY layer) changes masked the bug in earlier verification. Recovery for bitten users: wipe the app's layout dir (`~/Library/Caches/wendy/ocilayout/<app>-<platform>/` on macOS) — verified to heal.
+
+---
+
+# Part 1 — PR #1608 fixes (this branch)
+
+### Task 1: Resolver prefers the newest manifest
+
+**Files:**
+- Modify: `go/internal/cli/commands/ocilayers.go:156-173` (`pickOCIDescriptor`)
+- Test: `go/internal/cli/commands/ocilayers_test.go`
+
+**Interfaces:**
+- Consumes: `ociDescriptor` struct (`ocilayers.go:86`: `MediaType`, `Digest`, `Platform{Architecture, OS}`).
+- Produces: `pickOCIDescriptor(descs []ociDescriptor, wantOS, wantArch string) *ociDescriptor` — same signature, now returns the LAST match in slice order. Tasks 2–3 rely on this.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ocilayers_test.go` (reuse the file's existing synthetic-layout helpers if present; otherwise this is self-contained):
+
+```go
+func TestPickOCIDescriptorPrefersNewestPlatformMatch(t *testing.T) {
+	arm := &struct {
+		Architecture string `json:"architecture"`
+		OS           string `json:"os"`
+	}{Architecture: "arm64", OS: "linux"}
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:aaaa", Platform: arm},
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:bbbb", Platform: arm},
+	}
+	got := pickOCIDescriptor(descs, "linux", "arm64")
+	if got == nil || got.Digest != "sha256:bbbb" {
+		t.Fatalf("want newest (last) match sha256:bbbb, got %+v", got)
+	}
+}
+
+func TestPickOCIDescriptorFallbackPrefersNewest(t *testing.T) {
+	// No platform info at all: the fallback loop must also prefer the last
+	// image-manifest entry (buildx appends newest last).
+	descs := []ociDescriptor{
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:aaaa"},
+		{MediaType: "application/vnd.oci.image.manifest.v1+json", Digest: "sha256:bbbb"},
+	}
+	got := pickOCIDescriptor(descs, "linux", "arm64")
+	if got == nil || got.Digest != "sha256:bbbb" {
+		t.Fatalf("want newest (last) fallback sha256:bbbb, got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestPickOCIDescriptor -v`
+Expected: both FAIL with `got ...sha256:aaaa` (current code returns the first match).
+
+- [ ] **Step 3: Reverse both selection loops**
+
+Replace the body of `pickOCIDescriptor`:
+
+```go
+// pickOCIDescriptor chooses the best descriptor for the target platform:
+// the NEWEST exact os/arch match if present, otherwise the newest image
+// manifest or image index (skipping attestation/unknown entries).
+//
+// Newest means LAST in slice order: buildx's tar=false dir export APPENDS
+// each build's manifest to index.json, so several entries can match the
+// platform and the current build is always the final one. Resolving the
+// first match shipped the layout dir's first-ever build forever (stale
+// deps bug, on-device pass 2026-08-08).
+func pickOCIDescriptor(descs []ociDescriptor, wantOS, wantArch string) *ociDescriptor {
+	for i := len(descs) - 1; i >= 0; i-- {
+		d := &descs[i]
+		if d.Platform != nil && d.Platform.OS == wantOS && d.Platform.Architecture == wantArch {
+			return d
+		}
+	}
+	for i := len(descs) - 1; i >= 0; i-- {
+		d := &descs[i]
+		if isOCIImageManifestMediaType(d.MediaType) || isOCIImageIndexMediaType(d.MediaType) {
+			return d
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the new tests plus the whole package**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestPickOCIDescriptor -v && go test ./internal/cli/commands/`
+Expected: new tests PASS; full package green (existing single-manifest fixtures are order-insensitive, but if any test pinned first-entry semantics, update it to pin newest-entry semantics instead — that is the new contract).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/ocilayers.go go/internal/cli/commands/ocilayers_test.go
+git commit -m "fix(cli): resolve the newest OCI index manifest, not the oldest
+
+buildx's tar=false dir export appends manifests to index.json; picking
+the first platform match pinned every read to the layout dir's first
+build, so deps changes never deployed (found in on-device verification)."
+```
+
+### Task 2: Prune superseded index entries after every dir export
+
+**Files:**
+- Modify: `go/internal/cli/commands/ocilayers.go` (add `pruneOCILayoutDirIndex`; call it from `buildImageToOCILayoutDirWithDocker:817-826`)
+- Test: `go/internal/cli/commands/ocilayers_test.go`
+
+**Interfaces:**
+- Consumes: `pickOCIDescriptor` (Task 1 semantics: newest), `parseOCIPlatform(platform string) (os, arch string)` (already in `ocilayers.go`).
+- Produces: `pruneOCILayoutDirIndex(dir, platform string) error` — rewrites `dir/index.json` to reference only the newest matching image manifest. Task 3's GC test depends on this running before `gcOCILayoutDir`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// writeLayoutIndex writes an index.json with the given raw manifest entries.
+func writeLayoutIndex(t *testing.T, dir string, entries ...string) {
+	t.Helper()
+	idx := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[` +
+		strings.Join(entries, ",") + `]}`
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(idx), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPruneOCILayoutDirIndexKeepsOnlyNewestPlatformManifest(t *testing.T) {
+	dir := t.TempDir()
+	old := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	att := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:cccc","size":1,"platform":{"architecture":"unknown","os":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest"}}`
+	niu := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbb","size":1,"platform":{"architecture":"arm64","os":"linux"},"annotations":{"org.opencontainers.image.created":"x"}}`
+	writeLayoutIndex(t, dir, old, niu, att)
+
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx struct {
+		Manifests []json.RawMessage `json:"manifests"`
+	}
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("want exactly 1 manifest entry after prune, got %d: %s", len(idx.Manifests), data)
+	}
+	// The kept entry must be the newest platform match, raw bytes preserved
+	// (annotations intact).
+	if !strings.Contains(string(idx.Manifests[0]), "sha256:bbbb") ||
+		!strings.Contains(string(idx.Manifests[0]), "org.opencontainers.image.created") {
+		t.Fatalf("kept entry lost identity or annotations: %s", idx.Manifests[0])
+	}
+}
+
+func TestPruneOCILayoutDirIndexSingleEntryNoop(t *testing.T) {
+	dir := t.TempDir()
+	only := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	writeLayoutIndex(t, dir, only)
+	before, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if !bytes.Equal(before, after) {
+		t.Fatalf("single-entry index must be untouched\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
+func TestPruneOCILayoutDirIndexNoMatchErrorsAndPreservesIndex(t *testing.T) {
+	dir := t.TempDir()
+	amd := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa","size":1,"platform":{"architecture":"amd64","os":"linux"}}`
+	writeLayoutIndex(t, dir, amd)
+	before, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err == nil {
+		t.Fatal("want error when no manifest matches the platform")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if !bytes.Equal(before, after) {
+		t.Fatal("index must be untouched on error")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestPruneOCILayoutDirIndex -v`
+Expected: FAIL — `pruneOCILayoutDirIndex` undefined.
+
+- [ ] **Step 3: Implement the prune**
+
+Add to `ocilayers.go` (near `gcOCILayoutDir`). Raw-message parallel parsing preserves descriptor fields we don't model (annotations, artifactType):
+
+```go
+// pruneOCILayoutDirIndex rewrites dir's index.json to reference only the
+// newest image manifest matching platform. buildx's tar=false export
+// appends manifests, so without pruning the index accumulates one entry
+// per build; older entries (and attestation manifests) keep superseded
+// blobs GC-reachable and — before pickOCIDescriptor preferred the newest
+// — pinned every reader to the first build. Runs under the caller's
+// layout-dir flock. A single already-pruned index is left byte-identical.
+func pruneOCILayoutDirIndex(dir, platform string) error {
+	indexPath := filepath.Join(dir, "index.json")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("reading index.json for prune: %w", err)
+	}
+	var typed struct {
+		Manifests []ociDescriptor `json:"manifests"`
+	}
+	var raw struct {
+		Manifests []json.RawMessage `json:"manifests"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return fmt.Errorf("parsing index.json for prune: %w", err)
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing index.json for prune: %w", err)
+	}
+	if len(typed.Manifests) != len(raw.Manifests) {
+		return fmt.Errorf("index.json manifest parse mismatch (%d vs %d)", len(typed.Manifests), len(raw.Manifests))
+	}
+	if len(typed.Manifests) == 1 {
+		// Common case after a prior prune: nothing to do, keep bytes stable.
+		if chosen := pickOCIDescriptor(typed.Manifests, "", ""); chosen != nil {
+		}
+	}
+
+	wantOS, wantArch := parseOCIPlatform(platform)
+	chosen := pickOCIDescriptor(typed.Manifests, wantOS, wantArch)
+	if chosen == nil {
+		return fmt.Errorf("no manifest for %s in index.json; refusing to prune", platform)
+	}
+	chosenIdx := -1
+	for i := range typed.Manifests {
+		if &typed.Manifests[i] == chosen {
+			chosenIdx = i
+			break
+		}
+	}
+	if chosenIdx < 0 {
+		return fmt.Errorf("internal: chosen descriptor not found in index")
+	}
+	if len(typed.Manifests) == 1 && chosenIdx == 0 {
+		return nil
+	}
+
+	out := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.index.v1+json",
+		"manifests":     []json.RawMessage{raw.Manifests[chosenIdx]},
+	}
+	pruned, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshaling pruned index.json: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".index-*.json")
+	if err != nil {
+		return fmt.Errorf("staging pruned index.json: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(pruned); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("writing pruned index.json: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("closing pruned index.json: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod pruned index.json: %w", err)
+	}
+	if err := os.Rename(tmpName, indexPath); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("replacing index.json: %w", err)
+	}
+	return nil
+}
+```
+
+Delete the leftover empty `if len(typed.Manifests) == 1 { ... }` block above `wantOS` — the real single-entry early-return is the `len==1 && chosenIdx==0` check. (It is shown here only so you notice it must NOT survive; the final function has exactly one single-entry check.)
+
+Then wire it into `buildImageToOCILayoutDirWithDocker` (`ocilayers.go:817`), after the successful build:
+
+```go
+	if err := buildImageWithBuildxOCIExport(ctx, cwd, dockerfile, platform, buildArgs, destDir, true, stdout, stderr); err != nil {
+		return err
+	}
+	// The export appended this build's manifest; drop every older entry so
+	// readers and GC see exactly one current image.
+	if err := pruneOCILayoutDirIndex(destDir, platform); err != nil {
+		return fmt.Errorf("pruning OCI layout index: %w", err)
+	}
+	return nil
+```
+
+(The current body `return buildImageWithBuildxOCIExport(...)` becomes the block above.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestPruneOCILayoutDirIndex -v && go test ./internal/cli/commands/`
+Expected: PASS, package green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/ocilayers.go go/internal/cli/commands/ocilayers_test.go
+git commit -m "fix(cli): prune superseded manifests from the OCI layout index after export
+
+Keeps index.json at exactly one current image manifest so readers and
+the blob GC agree on what the layout contains."
+```
+
+### Task 3: GC regression test — superseded build's blobs are collected, current kept
+
+**Files:**
+- Test: `go/internal/cli/commands/ocilayers_test.go` (extend; `gcOCILayoutDir` itself should need no change)
+
+**Interfaces:**
+- Consumes: `pruneOCILayoutDirIndex` (Task 2), `gcOCILayoutDir(dir string) error` (`ocilayers.go:467`), existing test helpers for writing blobs if present (otherwise the helper below).
+
+- [ ] **Step 1: Write the test**
+
+```go
+// writeBlob writes content under blobs/sha256/<sha256(content)> and returns
+// the digest string.
+func writeBlob(t *testing.T, dir string, content []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(content)
+	hexd := hex.EncodeToString(sum[:])
+	p := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(p, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(p, hexd), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return "sha256:" + hexd
+}
+
+func TestPruneThenGCDropsSupersededBuild(t *testing.T) {
+	dir := t.TempDir()
+	// Old build: config + one layer + manifest referencing them.
+	oldCfg := writeBlob(t, dir, []byte(`{"old":"config"}`))
+	oldLayer := writeBlob(t, dir, []byte("old-layer"))
+	oldManifest := writeBlob(t, dir, []byte(`{"config":{"digest":"`+oldCfg+`"},"layers":[{"digest":"`+oldLayer+`"}]}`))
+	// New build: shares nothing with the old one.
+	newCfg := writeBlob(t, dir, []byte(`{"new":"config"}`))
+	newLayer := writeBlob(t, dir, []byte("new-layer"))
+	newManifest := writeBlob(t, dir, []byte(`{"config":{"digest":"`+newCfg+`"},"layers":[{"digest":"`+newLayer+`"}]}`))
+
+	entry := func(digest string) string {
+		return `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + digest + `","size":1,"platform":{"architecture":"arm64","os":"linux"}}`
+	}
+	writeLayoutIndex(t, dir, entry(oldManifest), entry(newManifest))
+
+	if err := pruneOCILayoutDirIndex(dir, "linux/arm64"); err != nil {
+		t.Fatal(err)
+	}
+	if err := gcOCILayoutDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	mustExist := func(digest string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(dir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:"))); err != nil {
+			t.Fatalf("blob %s should survive GC: %v", digest, err)
+		}
+	}
+	mustBeGone := func(digest string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(dir, "blobs", "sha256", strings.TrimPrefix(digest, "sha256:"))); !os.IsNotExist(err) {
+			t.Fatalf("blob %s should be GC'd, stat err=%v", digest, err)
+		}
+	}
+	mustExist(newManifest)
+	mustExist(newCfg)
+	mustExist(newLayer)
+	mustBeGone(oldManifest)
+	mustBeGone(oldCfg)
+	mustBeGone(oldLayer)
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestPruneThenGCDropsSupersededBuild -v`
+Expected: PASS with Tasks 1–2 in place (this is a regression lock, not a new feature — if it fails, the prune or GC has a bug; fix there, not in the test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/internal/cli/commands/ocilayers_test.go
+git commit -m "test(cli): lock prune+GC contract for the OCI layout dir"
+```
+
+### Task 4: Deploy-fingerprint salt bump (invalidate poisoned fingerprints)
+
+**Files:**
+- Modify: `go/internal/cli/commands/deployfastpath.go:145`
+- Test: `go/internal/cli/commands/deployfastpath_test.go` (or the file holding existing `computeBuildInputHash` tests)
+
+**Interfaces:**
+- Consumes/produces: `computeBuildInputHash` signature unchanged; only the salt line changes.
+
+Why: deploys made while the bug was live recorded `saveDeployFingerprint(inputHash → stale image)`. After Tasks 1–2 the *next build* is correct, but an unchanged project hits the detached fast path (`run.go` `tryDeployFastPath`) and keeps running the stale container, because the device really does still hold the stale layers. Bumping the salt makes every pre-fix fingerprint miss exactly once, forcing one honest rebuild+deploy per app.
+
+- [ ] **Step 1: Write the failing tripwire test**
+
+```go
+func TestBuildInputHashSaltIsV2(t *testing.T) {
+	// The v1→v2 bump deliberately invalidates fingerprints recorded while
+	// the stale-manifest bug (2026-08-08) could pair a current input hash
+	// with a stale deploy. Do not revert to v1; bump again only with a
+	// matching migration rationale.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h, err := computeBuildInputHash(dir, "Dockerfile", "linux/arm64", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Recompute what v1 would have produced by checking the source constant
+	// is gone: the simplest stable assertion is on the salt itself.
+	data, err := os.ReadFile("deployfastpath.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"wendy-deploy-fingerprint-v2\n"`) {
+		t.Fatalf("deploy fingerprint salt must be v2 (see comment); hash was %s", h)
+	}
+	if strings.Contains(string(data), `"wendy-deploy-fingerprint-v1\n"`) {
+		t.Fatal("v1 salt string still present in deployfastpath.go")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestBuildInputHashSaltIsV2 -v`
+Expected: FAIL — salt still v1.
+
+- [ ] **Step 3: Bump the salt**
+
+In `deployfastpath.go:145`:
+
+```go
+	// v2: invalidates fingerprints recorded while the stale-manifest bug
+	// (fixed 2026-08-08 in this PR) could pair a fresh input hash with a
+	// stale deploy — forces one honest rebuild per app after upgrade.
+	io.WriteString(h, "wendy-deploy-fingerprint-v2\n")
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd go && go test ./internal/cli/commands/ -run "TestBuildInputHashSaltIsV2|TestComputeBuildInputHash" -v && go test ./internal/cli/commands/`
+Expected: PASS; if existing tests pinned a literal v1 hash value, update those fixtures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/deployfastpath.go go/internal/cli/commands/deployfastpath_test.go
+git commit -m "fix(cli): bump deploy fingerprint salt to v2
+
+Pre-fix fingerprints could pair a current input hash with a stale
+deploy; one forced rebuild per app clears them."
+```
+
+### Task 5: Full-suite check, on-device re-verify, PR text update (manual gate)
+
+**Files:**
+- Modify: PR #1608 description (via `gh pr edit 1608` or the web UI)
+
+- [ ] **Step 1: Full local gates**
+
+Run from `go/`: `gofmt -l .` (expect empty), `go build ./...`, `go test ./internal/cli/...`
+Expected: all green.
+
+- [ ] **Step 2: On-device deps-change re-verification (the exact scenario that failed)**
+
+On a provisioned device (Ethan-Orin-Nano used for the original find), from `Examples/MCPExample` with this branch's CLI:
+1. `rm -rf ~/Library/Caches/wendy/ocilayout/com.wendylabs.examples.mcp-example-linux_arm64` (clean start).
+2. `wendy run --detach` → app RUNNING, MCP serves.
+3. Append `six>=1.16.0` to `requirements.txt`; `wendy run --detach` again.
+4. Verify on device: `wendy device shell -- ls /run/containerd/io.containerd.runtime.v2.task/default/com.wendylabs.examples.mcp-example/rootfs/usr/local/lib/python3.11/site-packages/ | grep six` → present (this was MISSING pre-fix).
+5. Deploy once more with no changes → detached fast path may skip; then `git checkout -- requirements.txt`, deploy, verify six is gone again.
+6. Bonus (index hygiene): `python3 -c "import json;print(len(json.load(open('<layout dir>/index.json'))['manifests']))"` → `1` after every deploy.
+
+- [ ] **Step 3: Update PR #1608 description**
+
+Replace the "On-device verify pending" line with: the stale-manifest bug summary (one paragraph, link `specs/2026-08-08-oci-layout-stale-manifest-fix-plan.md`), the fix (newest-manifest resolver + post-export index prune + fingerprint salt v2), and the completed on-device verification results from Step 2. Note that #1610 must rebase onto this and re-run its deps-fallback (1.4) and kill-switch (1.5) tests before it can leave draft.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push origin ed/oci-layout-dir-export
+```
+
+---
+
+# Part 2 — Follow-up PR: `--debug` crash-loop, replace/stop races, missing crash logs
+
+Suggested branch: `ed/debug-crashloop-followups` off `main`. One PR, three independent tasks (F1 CLI-side, F2/F3 agent-side). Each is separately revertable.
+
+### Task F1: `--debug` deploys must not ship debugpy-less images through the chunk path
+
+**Context:** The registry-push path wraps the image via `injectDebugpy` (`go/internal/cli/commands/docker.go:596` — builds `FROM <image>\nUSER root\nRUN pip install debugpy`). The chunk-diff (CDC) path deploys the unmodified image while still passing the debug flag to the agent, whose `wrapWithDebugpy` (`go/internal/agent/containerd/client.go:836,1102`) rewrites the entrypoint to `python -m debugpy …`. Any image without debugpy — every Stagefile-built Python app — crash-loops instantly ("No module named debugpy", observed live 2026-08-08).
+
+**Files:**
+- Modify: `go/internal/cli/commands/run.go` — the chunk-path gate (`!isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff`, currently ~line 1533) and the detached fast-path gate (~line 1512)
+- Test: `go/internal/cli/commands/run_test.go` (or wherever run-path gating helpers are tested)
+
+**Interfaces:**
+- Consumes: `runOptions.debug bool` (verify the exact field name with `grep -n "debug" go/internal/cli/commands/run.go | head`; it is the flag behind `--debug`).
+- Produces: extracted helper `chunkDeployEligible(opts runOptions, isDarwinAgent bool) bool` used by both gates.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestChunkDeployIneligibleWithDebug(t *testing.T) {
+	opts := runOptions{detach: true, chunking: chunkingAuto, debug: true}
+	if chunkDeployEligible(opts, false) {
+		t.Fatal("--debug must route through the registry path (debugpy injection)")
+	}
+	opts.debug = false
+	if !chunkDeployEligible(opts, false) {
+		t.Fatal("non-debug detached deploy should stay on the chunk path")
+	}
+}
+```
+
+(Adjust the `runOptions` literal to the real field names/zero values — compile errors here are the point of Step 2.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestChunkDeployIneligibleWithDebug -v`
+Expected: FAIL — `chunkDeployEligible` undefined.
+
+- [ ] **Step 3: Extract the helper and gate both paths**
+
+```go
+// chunkDeployEligible reports whether this run may use the chunk-diff (CDC)
+// deploy path. --debug is excluded: only the registry-push path wraps the
+// image with debugpy (injectDebugpy), and deploying an unwrapped image with
+// the agent-side debug entrypoint rewrite crash-loops any image that does
+// not bundle debugpy (every Stagefile Python app).
+func chunkDeployEligible(opts runOptions, isDarwinAgent bool) bool {
+	return !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff && !opts.debug
+}
+```
+
+Use it at both call sites (chunk gate and the `tryDeployFastPath` gate — the fast path just restarts the existing container, which under a debug-flag change would run the wrong entrypoint mode). Keep the existing `run.go:1472` user note ("--debug requires debugpy…") — it now only concerns user-authored Dockerfiles on the registry path.
+
+- [ ] **Step 4: Run tests, commit**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestChunkDeploy -v && go test ./internal/cli/commands/`
+
+```bash
+git add go/internal/cli/commands/run.go go/internal/cli/commands/run_test.go
+git commit -m "fix(cli): route --debug deploys through the registry path
+
+The chunk-diff path shipped unwrapped images while the agent injected a
+debugpy entrypoint, crash-looping every Stagefile Python app run with
+--debug."
+```
+
+- [ ] **Step 5: On-device verify**
+
+`wendy run --detach --debug` on MCPExample → app RUNNING (not CRASH_LOOPING), `wendy device apps list` clean; without `--debug` the chunk path still runs (log shows "Diffing … layer(s)").
+
+### Task F2: Container replace/stop must win against the restart monitor
+
+**Context (observed live):** replacing or stopping a crash-looping app races `ContainerMonitor.restartSingle` (`go/internal/agent/container/monitor.go:258,296`): `existing.Delete` in the replace path (`go/internal/agent/containerd/client.go:993`) fails with "cannot delete running task … failed precondition" when the monitor restarts the task between the kill and the delete; a half-dead task (runc state dir missing) wedges both stop and `ctr tasks rm -f` until the empty dir is recreated.
+
+**Files:**
+- Modify: `go/internal/agent/container/monitor.go` (add suppression API), `go/internal/agent/containerd/client.go` (replace path ~971-1003, stop path, `forceDeleteTask`)
+- Test: `go/internal/agent/container/monitor_test.go`, `go/internal/agent/containerd/client_test.go`
+
+**Interfaces:**
+- Produces: `(*ContainerMonitor).Suppress(containerName string) (resume func())` — while suppressed, exit events for that container are ignored (no restart scheduled). The containerd client calls it at the top of replace/stop and `defer resume()`.
+- Produces: retry-once-on-`errdefs.IsFailedPrecondition` around `existing.Delete`, re-running `terminateTask` before the retry.
+- Produces: `forceDeleteTask` tolerates the missing-runc-state-dir error by `os.MkdirAll(/run/containerd/runc/<ns>/<id>, 0o711)` and retrying the delete once (linux-only; guard with the existing platform split `client_linux.go`).
+
+- [ ] **Step 1: Write the failing monitor test**
+
+```go
+func TestMonitorSuppressSkipsRestart(t *testing.T) {
+	// Construct the monitor exactly as the existing monitor tests do (reuse
+	// their fake client/fixtures). Then:
+	resume := m.Suppress("com.example.app")
+	deliverExitEvent(t, m, "com.example.app") // reuse the test's event-injection helper
+	assertNoRestartScheduled(t, m, "com.example.app")
+	resume()
+	deliverExitEvent(t, m, "com.example.app")
+	assertRestartScheduled(t, m, "com.example.app")
+}
+```
+
+(The three helpers exist in some form in `monitor_test.go` — mirror the file's existing fake/assert patterns; if event injection has a different shape there, adapt while keeping the assertion pair: suppressed → no restart, resumed → restart.)
+
+- [ ] **Step 2: Run to verify it fails; implement Suppress**
+
+Run: `cd go && go test ./internal/agent/container/ -run TestMonitorSuppress -v`
+
+Implementation sketch — a `suppressed map[string]int` (counter, not bool: concurrent replaces of different services of one app) guarded by the monitor's existing mutex; the exit-event handler checks it before scheduling `restartSingle`:
+
+```go
+// Suppress makes the monitor ignore exit events for containerName until the
+// returned resume func runs. Replace/stop paths hold this while they kill
+// and delete the task so the monitor cannot resurrect it mid-operation.
+func (m *ContainerMonitor) Suppress(containerName string) func() {
+	m.mu.Lock()
+	m.suppressed[containerName]++
+	m.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.mu.Lock()
+			if m.suppressed[containerName]--; m.suppressed[containerName] <= 0 {
+				delete(m.suppressed, containerName)
+			}
+			m.mu.Unlock()
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Wire suppression + delete retry into the client**
+
+In the replace block (`client.go:971-1003`) and the stop path (find with `grep -n "func (c \*Client) StopContainer" go/internal/agent/containerd/client.go`):
+
+```go
+	if c.monitor != nil {
+		resume := c.monitor.Suppress(containerName)
+		defer resume()
+	}
+```
+
+(Check how the client references the monitor — `grep -n "monitor" go/internal/agent/containerd/client.go | head`; if the client has no handle, add the narrow interface it needs: `type restartSuppressor interface{ Suppress(string) func() }` set during wiring in `bridge_wiring.go`.)
+
+Around the delete:
+
+```go
+	delErr := existing.Delete(ctx, containerd.WithSnapshotCleanup)
+	if delErr != nil && errdefs.IsFailedPrecondition(delErr) {
+		// The task came back between kill and delete (crash-loop restart
+		// racing us before suppression, or an in-flight start). Kill again
+		// and retry once.
+		if task, taskErr := existing.Task(ctx, nil); taskErr == nil {
+			_ = c.terminateTask(ctx, task, containerName, syscall.SIGKILL, killWaitTimeout, killWaitTimeout)
+		}
+		delErr = existing.Delete(ctx, containerd.WithSnapshotCleanup)
+	}
+	if delErr != nil && !errdefs.IsNotFound(delErr) {
+		return fmt.Errorf("deleting existing container %q during replace: %w", containerName, delErr)
+	}
+```
+
+For the wedged runc state dir, in `forceDeleteTask` (find with `grep -n "func (c \*Client) forceDeleteTask" go/internal/agent/containerd/client.go`): on an error containing `"cannot open directory"` and `"/run/containerd/runc/"`, `os.MkdirAll` the missing dir (mode 0o711) and retry the task-service delete once. Unit-test the error-classification helper (`isMissingRuncStateDir(err) (dir string, ok bool)`) with the literal error string observed live: `cannot open directory `+"`"+`/run/containerd/runc/default/com.wendylabs.examples.mcp-example`+"`"+`: No such file or directory`.
+
+- [ ] **Step 4: Tests + linux pre-verify + commit**
+
+Run: `cd go && go test ./internal/agent/container/ ./internal/agent/containerd/` and `docker run --rm -v "$PWD/..":/src -w /src golang:1.26 go test ./go/internal/agent/...`
+
+```bash
+git add go/internal/agent/container/monitor.go go/internal/agent/container/monitor_test.go go/internal/agent/containerd/client.go go/internal/agent/containerd/client_test.go go/internal/agent/containerd/bridge_wiring.go
+git commit -m "fix(agent): replace/stop suppress the restart monitor and retry racing deletes
+
+A crash-looping app's restart cycle could beat replace/stop to the task
+('cannot delete running task: failed precondition'); a half-dead task
+with a missing runc state dir wedged deletion entirely."
+```
+
+- [ ] **Step 5: On-device verify**
+
+Deploy a deliberately crash-looping app (e.g. MCPExample with `raise SystemExit(1)` at the top of `main.py`), wait for CRASH_LOOPING with failures > 3, then: `wendy device apps stop <app>` succeeds first try; redeploy (`wendy run --detach` with fixed code) replaces first try. Repeat 5×.
+
+### Task F3: Live crash-loop output must reach `device logs --tail`
+
+**Context (observed live):** during an active crash loop (failureCount 2→56 while watched), `wendy device logs --app <app> --tail 20` replayed only the *previous day's* crash batches; the current loop's stderr ("No module named debugpy") never appeared. `TelemetryBuffer.ReadLastNMatching` (`go/internal/agent/services/telemetry_buffer.go:614`) is correct (segments newest→oldest, trailing frames, ascending return) — so the strong hypothesis is that output from monitor-restarted tasks never reaches the telemetry buffer: `restartSingle` (`go/internal/agent/container/monitor.go:296`) claims to drain output to the log manager; something in that chain drops it.
+
+This task is investigate-then-fix; the repro is cheap and the verification is unambiguous.
+
+**Files:**
+- Investigate: `go/internal/agent/container/monitor.go:296` (restartSingle drain), `go/internal/agent/services/container_log_manager.go`, `go/internal/agent/containerd/client.go:1466` (`StartContainer` output channel)
+- Modify: whichever link drops restarted-task output
+- Test: `go/internal/agent/services/container_log_manager_test.go` and/or `monitor_test.go`
+
+- [ ] **Step 1: Reproduce and localize**
+
+On-device (or in the linux docker test env with a containerd fake if the fixtures support it):
+1. Deploy an app that prints one line to stderr and exits 1 (`import sys; print("boom-<N>", file=sys.stderr); sys.exit(1)`).
+2. Let the monitor restart it ≥3 times (`wendy device apps list` failureCount ≥ 3).
+3. `wendy device logs --app <app> --tail 10` — count distinct `boom` lines. Pre-fix expectation per the live observation: only the first (pre-restart) lines appear.
+4. Localize: instrument or read the drain path — does `restartSingle`'s output channel get consumed into `container_log_manager`, and does the manager publish to the `TelemetryBuffer` (the `--tail` source), or only to live subscribers?
+
+- [ ] **Step 2: Write the failing test at the seam Step 1 identified**
+
+Target shape (adapt to the real seam — the log manager's publish path is likelier unit-testable than the monitor):
+
+```go
+func TestRestartedTaskOutputReachesTelemetryBuffer(t *testing.T) {
+	// Arrange the log manager with a fake telemetry buffer (the file's
+	// existing test fakes), simulate: start → output "boom-1" → exit →
+	// monitor-style restart → output "boom-2".
+	// Assert the buffer received BOTH lines, not just boom-1.
+}
+```
+
+- [ ] **Step 3: Fix the dropped link, keep the test green**
+
+Likely shapes (pick what Step 1 proved): re-register the restarted task's output stream with the log manager under the same app/service key; or fix the manager to keep its buffer-publish subscription across container generations instead of binding to the first task's pipe.
+
+- [ ] **Step 4: Commit + on-device verify**
+
+```bash
+git add go/internal/agent/...
+git commit -m "fix(agent): keep crash-looping container output flowing to the log buffer
+
+Monitor-restarted tasks lost their stderr/stdout capture, so 'device
+logs --tail' replayed stale history while an active crash loop stayed
+invisible."
+```
+
+On-device: repeat Step 1's repro — `--tail 10` now shows the latest `boom` lines (one per recent restart), newest last.
+
+### Follow-up PR assembly
+
+- [ ] Branch `ed/debug-crashloop-followups` off current `main`; land F1–F3 as separate commits (already structured that way).
+- [ ] PR body: link `specs/2026-08-08-on-device-test-plan.md` findings 1–3 and this plan file (Part 2); note F1 changes `--debug` deploy routing (perf under debug is registry-path speed, accepted).
+- [ ] Full gates before push: `gofmt -l .` empty from `go/`; `go test ./internal/...`; linux agent tests via `docker run golang:1.26`.
+
+---
+
+## Self-review notes (done at write time)
+
+- Coverage: bug link 1 (append) → Task 2 prune; link 2 (oldest-match resolver) → Task 1; link 3 (GC deletes fresh build) → guarded by Tasks 2+3; link 4 (fingerprint lock-in) → Task 4; the failed on-device scenario → Task 5 Step 2 re-verify. Findings 1/2/3 → F1/F2/F3. #1610 interaction: explicitly deferred to #1610's rebase (Task 5 Step 3 notes it) — its adoption/splice inherit correctness once the reader resolves newest-first and the index holds one entry.
+- Type consistency: `pruneOCILayoutDirIndex(dir, platform string) error` used identically in Tasks 2, 3; `chunkDeployEligible(opts runOptions, isDarwinAgent bool) bool` defined and consumed only in F1; `Suppress(containerName string) func()` defined F2 Step 2, consumed F2 Step 3.
+- Known judgment calls left to implementers: exact `runOptions` field names (F1 Step 1 verifies by compile), the client→monitor handle (F2 Step 3 gives the wiring fallback), and F3's seam (Step 1 localizes before the test is written — the plan constrains the assertion, not the file).
+- Deliberate scope exclusions: no BuildKit/builder version pinning (the wendy-oci builder was exonerated), no dockerignore changes (exonerated), no `--debug` auto-injection into Stagefile compiles (F1's routing fix restores parity; auto-injection is a UX enhancement for the Stagefile DSL work, jo's #1606 track).


### PR DESCRIPTION
## Summary

The chunk-diff deploy path (`wendy run` fast path) exported the **entire image as an OCI tar on every build** — base layers included — so per-iteration cost scaled with image size (~202 MB/s: ~0.5 s at 73 MB, 5.6 s at 1.1 GB, extrapolated ~25 s for a 5 GB CUDA/Torch image **per one-line source edit**). This PR switches the docker-buildx backend to `--output type=oci,tar=false` into a **persistent per-app layout directory**: BuildKit skips blobs already present in the destination, so a warm rebuild writes only the changed layers.

Measured through the real code path (`buildImageToOCILayoutDirWithDocker` → `readOCILayoutDirLayers` → `gcOCILayoutDir`) on MCPExample (73 MB image, Apple Silicon, Docker Desktop 28.5.1 / BuildKit v0.31.2):

| Scenario | tar export (before) | layout dir (after) | bytes written/iteration |
|---|---|---|---|
| no-change rebuild | ~485 ms | **168 ms** | 0 |
| source-change rebuild | ~530 ms | **232 ms** | +16 KB (3 blobs) |
| 1.12 GB synthetic image, source change | **5.6 s** | **~0.5 s** | +16 KB |

The gap grows linearly with image size — GPU/LLM images benefit the most (est. ~25 s → ~0.5 s per iteration), and the multi-GB tar churn in tmp on every `wendy watch` iteration disappears entirely.

## Design

- `chunkExportPlan` dispatches per backend: **docker → layout dir**; apple-container and on-device buildctl keep their temp-tar path unchanged; `WENDY_CHUNK_EXPORT=tar` is an escape hatch back to the legacy behavior.
- Destination: `<UserCacheDir>/wendy/ocilayout/<app>-<platform>/`, guarded by a cross-process flock held across build → read → push → GC. The lock file sits **beside** the dir so self-heal can never delete a held lock.
- `readOCILayoutDirLayers` mirrors the tar reader (shared platform-resolution via `ociImageFromIndex`); blob sizes are validated against manifest descriptors so a partially-written blob (killed export) fails loudly.
- **Self-heal:** an unreadable layout dir is wiped and rebuilt from scratch exactly once — identical to today's cold behavior.
- **GC:** after each deploy, blobs unreachable from `index.json` (nested indexes and attestation manifests are kept) are pruned, so the dir holds ~one image's worth of blobs.
- The buildx invocation itself is unchanged apart from the output flag (same builder, cache flags, scrubbed `DOCKER_CONFIG`, build lock); the arg construction is factored onto a pure, tested `buildxOCIExportArgs`.

## Testing

- Unit tests: dir reader (round-trip, size-mismatch, missing index), GC (orphan pruning, no-op on missing dir), lock exclusion (`-race`), dispatcher modes, arg construction, `chunkLayoutDir` sanitization. Full `./go/internal/cli/...` suite green; `gofmt` clean.
- Live verification (local Docker, real code path): numbers above; GC verified to prune exactly the superseded blobs and leave the layout deployable (post-GC rebuild 168 ms).
- **On-device verification (2026-08-08, Orin Nano) found and fixed a critical bug.** BuildKit's `tar=false` dir export *appends* each build's manifest to the layout dir's `index.json`, while the platform resolver picked the *first* (oldest) match — so after the first build, deps changes (e.g. a `requirements.txt` edit) silently never deployed: readers shipped the first-ever build, and the post-deploy GC deleted the fresh build's blobs. Fix (plan: `specs/2026-08-08-oci-layout-stale-manifest-fix-plan.md`): `pickOCIDescriptor` resolves the newest matching manifest (and its fallback skips attestation entries); `pruneOCILayoutDirIndex` rewrites the index to exactly one current manifest after every dir export (prune failure is a warning — hygiene, not correctness); a prune→GC regression test locks the contract; the deploy-fingerprint salt bumps v1→v2 so fingerprints recorded while the bug was live miss once and force one honest rebuild.
- **On-device re-verify (Orin Nano, Ethan-Orin-Nano):** deps-change round-trip now works — `six` appears in the running container's site-packages after a requirements edit and disappears after revert; `index.json` holds exactly one manifest after every deploy; full CLI suite + gofmt green. Note: MCPExample crash-loops on *this branch's base* regardless of these changes (main's Stagefile compiler emits an `/app` layout the agent runs from `/`; proven pre-existing at the plan-doc commit; resolved by the #1585/#1609/#1610 stack) — deploy-pipeline verification above is unaffected.
- Heads-up for #1610: it must rebase onto this and re-run its deps-fallback and kill-switch on-device tests before leaving draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)