### PR TITLE
perf: native app-layer rebuilds for Stagefile projects (skip buildx on copy-only changes)

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -179,8 +179,11 @@ func computeBuildInputHash(cwd, dockerfile, platform string, buildArgs map[strin
 	io.WriteString(h, fmt.Sprintf("dockerfile %d\n", len(dfData)))
 	h.Write(dfData)
 
-	// Hash the build context, honoring .dockerignore.
-	ignore := loadDockerIgnore(cwd)
+	// Hash the build context, honoring the ignore file the build itself uses:
+	// BuildKit gives <dockerfile>.dockerignore precedence over .dockerignore
+	// (the Stagefile flow derives a deny-all allowlist there), so the walk must
+	// follow the same file or it hashes paths the build can never see.
+	ignore := loadDockerIgnoreForBuild(cwd, dfPath)
 	var files []string
 	err = filepath.WalkDir(cwd, func(p string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -239,8 +242,25 @@ type dockerIgnore struct {
 }
 
 func loadDockerIgnore(cwd string) *dockerIgnore {
+	return loadDockerIgnoreFile(filepath.Join(cwd, ".dockerignore"))
+}
+
+// loadDockerIgnoreForBuild picks the ignore file BuildKit would use for this
+// dockerfile: <dockerfile>.dockerignore when present, else the context's
+// .dockerignore.
+func loadDockerIgnoreForBuild(cwd, dockerfilePath string) *dockerIgnore {
+	if dockerfilePath != "" {
+		perDockerfile := dockerfilePath + ".dockerignore"
+		if fi, err := os.Stat(perDockerfile); err == nil && fi.Mode().IsRegular() {
+			return loadDockerIgnoreFile(perDockerfile)
+		}
+	}
+	return loadDockerIgnore(cwd)
+}
+
+func loadDockerIgnoreFile(path string) *dockerIgnore {
 	di := &dockerIgnore{}
-	f, err := os.Open(filepath.Join(cwd, ".dockerignore"))
+	f, err := os.Open(path)
 	if err != nil {
 		return di
 	}
@@ -276,8 +296,16 @@ func loadDockerIgnore(cwd string) *dockerIgnore {
 // keeps the matcher safe — it can only over-hash, never under-detect a change.
 func (di *dockerIgnore) matches(rel string) bool {
 	clean := strings.TrimSuffix(rel, "/")
+	isDir := strings.HasSuffix(rel, "/")
 	for _, neg := range di.negations {
 		if matchIgnorePattern(neg, clean) {
+			return false
+		}
+		// A directory with a re-included descendant must stay walkable: with
+		// "*" + "!src/app.py", skipping src/ wholesale would hide the allowlisted
+		// file's changes (the unsafe direction — a missed change, not an extra
+		// rebuild).
+		if isDir && strings.HasPrefix(neg, clean+"/") {
 			return false
 		}
 	}

--- a/go/internal/cli/commands/deployfastpath_test.go
+++ b/go/internal/cli/commands/deployfastpath_test.go
@@ -95,6 +95,65 @@ func TestComputeBuildInputHash_HonorsDockerignore(t *testing.T) {
 	}
 }
 
+// The fingerprint must hash the build's REAL input set: when the resolved
+// dockerfile carries its own <dockerfile>.dockerignore (BuildKit's
+// per-Dockerfile precedence — the Stagefile flow derives a deny-all allowlist
+// there), that file governs the walk, not the context's .dockerignore.
+// Otherwise editing a README invalidates the fingerprint and forces a rebuild
+// of an identical image.
+func TestComputeBuildInputHash_PerDockerfileIgnoreAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile.generated", "FROM python:3.11-slim\nCOPY main.py main.py\n")
+	writeFile(t, dir, "Dockerfile.generated.dockerignore", "*\n!main.py\n!requirements.txt\n")
+	writeFile(t, dir, "main.py", "print('v1')\n")
+	writeFile(t, dir, "requirements.txt", "mcp\n")
+	writeFile(t, dir, "README.md", "docs v1\n")
+
+	hash := func() string {
+		t.Helper()
+		h, err := computeBuildInputHash(dir, "Dockerfile.generated", "linux/arm64", nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	base := hash()
+	writeFile(t, dir, "README.md", "docs v2\n")
+	if got := hash(); got != base {
+		t.Fatal("hash changed after editing a file excluded by the per-Dockerfile allowlist")
+	}
+	writeFile(t, dir, "main.py", "print('v2')\n")
+	if got := hash(); got == base {
+		t.Fatal("hash unchanged after editing an allowlisted file")
+	}
+}
+
+// A directory with a re-included descendant must stay walkable: with
+// "*" + "!src/app.py", the walk may not SkipDir at src/ or the allowlisted
+// file's changes would be missed entirely (stale-skip, the unsafe direction).
+func TestComputeBuildInputHash_NestedNegationDescends(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile.generated", "FROM python:3.11-slim\nCOPY src/app.py app.py\n")
+	writeFile(t, dir, "Dockerfile.generated.dockerignore", "*\n!src/app.py\n")
+	writeFile(t, dir, "src/app.py", "print('v1')\n")
+
+	hash := func() string {
+		t.Helper()
+		h, err := computeBuildInputHash(dir, "Dockerfile.generated", "linux/arm64", nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	base := hash()
+	writeFile(t, dir, "src/app.py", "print('v2')\n")
+	if got := hash(); got == base {
+		t.Fatal("hash unchanged after editing a re-included file inside an excluded directory")
+	}
+}
+
 func TestDockerIgnoreMatcher(t *testing.T) {
 	di := &dockerIgnore{patterns: []string{"node_modules", "*.pyc", "dist", "secrets/key.pem"}}
 	cases := []struct {

--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -1,0 +1,278 @@
+package commands
+
+// Native app-layer builds for Stagefile projects: when an iteration changes
+// only `copy: from: local` files, the CLI rebuilds those COPY layers itself —
+// deterministically, without Docker — and splices them into the persistent
+// OCI layout directory the chunk-diff deploy already maintains. Everything
+// here mirrors what BuildKit's COPY would produce semantically (same files,
+// same modes, root:root ownership) but NOT byte-identically: native layers
+// zero the mtimes, so the same input files always produce the same diff ID on
+// any machine.
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/gzip"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// nativeLayerEpoch is the fixed modification time stamped on every entry of a
+// native layer. Zeroed times are what make the layer a pure function of the
+// input file contents (BuildKit's COPY preserves source mtimes, which defeats
+// cross-machine and post-checkout dedup).
+var nativeLayerEpoch = time.Unix(0, 0).UTC()
+
+// nativeLayer is one deterministically-built COPY layer, gzip-compressed.
+type nativeLayer struct {
+	Blob      []byte   // gzip-compressed tar
+	Digest    string   // "sha256:<hex>" of Blob (the manifest/blob digest)
+	DiffID    string   // "sha256:<hex>" of the uncompressed tar
+	FileNames []string // sorted tar entry names (dirs carry a trailing "/")
+}
+
+// nativeTarEntry is one pending tar entry, keyed by its (slash-form, no
+// leading slash) tar path in the entries map.
+type nativeTarEntry struct {
+	hdr  tar.Header
+	data []byte
+}
+
+// buildNativeCopyLayer materializes one Stagefile `copy` entry (from: local)
+// as an OCI gzip layer with Docker COPY semantics:
+//
+//   - dest defaults to Paths[0]; a multi-source copy treats dest as a
+//     directory (mirroring codegen's trailing-slash fix-up)
+//   - a relative dest resolves against workDir (the image config's
+//     WorkingDir; "/" when empty), exactly as COPY does
+//   - a directory source copies its CONTENTS into dest
+//   - modes are preserved, ownership is numeric root:root, parent directories
+//     are synthesized 0755, symlinks stay symlinks
+//
+// Entries are emitted in sorted path order with fixed mtimes, so identical
+// input files yield a byte-identical blob.
+func buildNativeCopyLayer(cwd string, entry spec.CopyEntry, workDir string) (*nativeLayer, error) {
+	if len(entry.Paths) == 0 {
+		return nil, fmt.Errorf("copy entry has no paths")
+	}
+	dest := entry.Dest
+	if dest == "" {
+		dest = entry.Paths[0]
+	}
+	// Mirrors codegen.copyLines: multiple sources make the dest a directory.
+	destIsDir := strings.HasSuffix(dest, "/") || len(entry.Paths) > 1
+	if !path.IsAbs(dest) {
+		wd := workDir
+		if wd == "" {
+			wd = "/"
+		}
+		if !path.IsAbs(wd) {
+			wd = "/" + wd
+		}
+		dest = path.Join(wd, dest)
+	} else {
+		dest = path.Clean(dest)
+	}
+
+	entries := map[string]*nativeTarEntry{}
+
+	// tarName converts an absolute in-image path to its tar entry name.
+	tarName := func(p string) string {
+		return strings.TrimPrefix(path.Clean(p), "/")
+	}
+
+	addDirChain := func(imgPath string) {
+		// Synthesize each missing ancestor of imgPath as a 0755 root dir.
+		clean := tarName(imgPath)
+		if clean == "" || clean == "." {
+			return
+		}
+		segs := strings.Split(clean, "/")
+		for i := 1; i < len(segs); i++ {
+			name := strings.Join(segs[:i], "/") + "/"
+			if _, ok := entries[name]; ok {
+				continue
+			}
+			entries[name] = &nativeTarEntry{hdr: tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     name,
+				Mode:     0o755,
+				ModTime:  nativeLayerEpoch,
+			}}
+		}
+	}
+
+	addDir := func(imgPath string, mode os.FileMode) {
+		name := tarName(imgPath)
+		if name == "" || name == "." {
+			return
+		}
+		addDirChain(imgPath)
+		entries[name+"/"] = &nativeTarEntry{hdr: tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     name + "/",
+			Mode:     int64(mode.Perm()),
+			ModTime:  nativeLayerEpoch,
+		}}
+	}
+
+	addFile := func(absSrc, imgPath string, mode os.FileMode) error {
+		data, err := os.ReadFile(absSrc)
+		if err != nil {
+			return err
+		}
+		addDirChain(imgPath)
+		name := tarName(imgPath)
+		entries[name] = &nativeTarEntry{
+			hdr: tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     name,
+				Mode:     int64(mode.Perm()),
+				Size:     int64(len(data)),
+				ModTime:  nativeLayerEpoch,
+			},
+			data: data,
+		}
+		return nil
+	}
+
+	addSymlink := func(absSrc, imgPath string) error {
+		target, err := os.Readlink(absSrc)
+		if err != nil {
+			return err
+		}
+		addDirChain(imgPath)
+		name := tarName(imgPath)
+		entries[name] = &nativeTarEntry{hdr: tar.Header{
+			Typeflag: tar.TypeSymlink,
+			Name:     name,
+			Linkname: target,
+			Mode:     0o777,
+			ModTime:  nativeLayerEpoch,
+		}}
+		return nil
+	}
+
+	for _, src := range entry.Paths {
+		rel := filepath.ToSlash(filepath.Clean(filepath.FromSlash(src)))
+		if path.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, "../") {
+			return nil, fmt.Errorf("copy path %q escapes the project directory", src)
+		}
+		abs := filepath.Join(cwd, filepath.FromSlash(rel))
+		fi, err := os.Lstat(abs)
+		if err != nil {
+			return nil, fmt.Errorf("copy source %q: %w", src, err)
+		}
+
+		switch {
+		case fi.IsDir():
+			// Docker COPY copies a directory source's CONTENTS into dest.
+			addDir(dest, fi.Mode())
+			err := filepath.WalkDir(abs, func(p string, d os.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				childRel, err := filepath.Rel(abs, p)
+				if err != nil {
+					return err
+				}
+				if childRel == "." {
+					return nil
+				}
+				imgPath := path.Join(dest, filepath.ToSlash(childRel))
+				info, err := d.Info()
+				if err != nil {
+					return err
+				}
+				switch {
+				case d.IsDir():
+					addDir(imgPath, info.Mode())
+					return nil
+				case info.Mode()&os.ModeSymlink != 0:
+					return addSymlink(p, imgPath)
+				case info.Mode().IsRegular():
+					return addFile(p, imgPath, info.Mode())
+				default:
+					return fmt.Errorf("copy source %q: unsupported file type %v", p, info.Mode())
+				}
+			})
+			if err != nil {
+				return nil, err
+			}
+
+		case fi.Mode()&os.ModeSymlink != 0:
+			imgPath := dest
+			if destIsDir {
+				imgPath = path.Join(dest, path.Base(rel))
+			}
+			if err := addSymlink(abs, imgPath); err != nil {
+				return nil, err
+			}
+
+		case fi.Mode().IsRegular():
+			imgPath := dest
+			if destIsDir {
+				imgPath = path.Join(dest, path.Base(rel))
+			}
+			if err := addFile(abs, imgPath, fi.Mode()); err != nil {
+				return nil, err
+			}
+
+		default:
+			return nil, fmt.Errorf("copy source %q: unsupported file type %v", src, fi.Mode())
+		}
+	}
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var rawTar bytes.Buffer
+	tw := tar.NewWriter(&rawTar)
+	for _, name := range names {
+		e := entries[name]
+		if err := tw.WriteHeader(&e.hdr); err != nil {
+			return nil, fmt.Errorf("writing tar header %q: %w", name, err)
+		}
+		if len(e.data) > 0 {
+			if _, err := tw.Write(e.data); err != nil {
+				return nil, fmt.Errorf("writing tar entry %q: %w", name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("finishing layer tar: %w", err)
+	}
+
+	var blob bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&blob, gzip.DefaultCompression)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := gw.Write(rawTar.Bytes()); err != nil {
+		return nil, fmt.Errorf("compressing layer: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return nil, fmt.Errorf("compressing layer: %w", err)
+	}
+
+	rawSum := sha256.Sum256(rawTar.Bytes())
+	blobSum := sha256.Sum256(blob.Bytes())
+	return &nativeLayer{
+		Blob:      blob.Bytes(),
+		Digest:    "sha256:" + hex.EncodeToString(blobSum[:]),
+		DiffID:    "sha256:" + hex.EncodeToString(rawSum[:]),
+		FileNames: names,
+	}, nil
+}

--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -14,7 +14,9 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,6 +27,200 @@ import (
 	"github.com/klauspost/compress/gzip"
 	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
 )
+
+// nativeDepsHash covers every build input EXCEPT the final stage's local copy
+// files: the generated Dockerfile bytes, the Stagefile lockfile, every
+// install-referenced file (pip requirements, package.json + lockfile), local
+// copies feeding NON-final stages, the platform, and the sorted build args.
+// Any change here means the deps layers may differ → the buildx path must run.
+func nativeDepsHash(cwd, dockerfile, platform string, buildArgs map[string]string, sf *spec.File) (string, error) {
+	h := sha256.New()
+	io.WriteString(h, "wendy-native-deps-v1\n")
+	io.WriteString(h, "platform="+platform+"\n")
+
+	keys := make([]string, 0, len(buildArgs))
+	for k := range buildArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		io.WriteString(h, "arg "+k+"="+buildArgs[k]+"\n")
+	}
+
+	dfPath, err := confinedDockerfilePath(cwd, dockerfile)
+	if err != nil {
+		return "", err
+	}
+	dfData, err := os.ReadFile(dfPath)
+	if err != nil {
+		return "", fmt.Errorf("reading dockerfile for deps hash: %w", err)
+	}
+	fmt.Fprintf(h, "dockerfile %d\n", len(dfData))
+	h.Write(dfData)
+
+	// The lockfile pins base-image digests; absent is a valid state (hashed as
+	// absent — creating it later changes the hash, correctly).
+	if lockData, err := os.ReadFile(filepath.Join(cwd, stagefileLockName)); err == nil {
+		fmt.Fprintf(h, "lock %d\n", len(lockData))
+		h.Write(lockData)
+	}
+
+	for _, p := range nativeDepsPaths(sf) {
+		if err := hashContextPath(h, cwd, p); err != nil {
+			return "", err
+		}
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// nativeDepsPaths lists the local paths that feed deps layers: every stage's
+// install-referenced files plus local copies of NON-final stages. The final
+// stage's local copies are the app inputs and are deliberately excluded.
+func nativeDepsPaths(sf *spec.File) []string {
+	if len(sf.Stages) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var paths []string
+	add := func(p string) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	lastIdx := len(sf.Stages) - 1
+	for i := range sf.Stages {
+		s := &sf.Stages[i]
+		if s.Install != nil {
+			if s.Install.Pip != nil {
+				add(s.Install.Pip.Requirements)
+			}
+			if s.Install.Npm != nil {
+				add("package.json")
+				add(spec.NpmLockfile(s.Install.Npm.Manager))
+			}
+		}
+		if i == lastIdx {
+			continue
+		}
+		for _, c := range s.Copy {
+			if c.From != "local" {
+				continue
+			}
+			for _, p := range c.Paths {
+				add(p)
+			}
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// hashContextPath streams the content of a file (or a sorted walk of a
+// directory) rooted at rel into h. A missing input is an error — the caller
+// treats it as "not natively buildable" and falls back to buildx.
+func hashContextPath(h io.Writer, cwd, rel string) error {
+	abs := filepath.Join(cwd, filepath.FromSlash(rel))
+	fi, err := os.Stat(abs)
+	if err != nil {
+		return fmt.Errorf("deps input %q: %w", rel, err)
+	}
+	hashOne := func(name, file string) error {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("deps input %q: %w", name, err)
+		}
+		fmt.Fprintf(h, "file %s %d\n", name, len(data))
+		h.Write(data)
+		return nil
+	}
+	if !fi.IsDir() {
+		return hashOne(rel, abs)
+	}
+	var files []string
+	err = filepath.WalkDir(abs, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type().IsRegular() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("deps input %q: %w", rel, err)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		relName, err := filepath.Rel(cwd, f)
+		if err != nil {
+			return err
+		}
+		if err := hashOne(filepath.ToSlash(relName), f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// nativeStateName is the bookkeeping file inside the layout dir recording what
+// the native path last built. It sits at the dir root, out of GC's reach
+// (GC only touches blobs/sha256).
+const nativeStateName = "state.json"
+
+// nativeState records the native path's ground truth: the deps-input hash the
+// current layout was built against, the manifest we last wrote (or adopted),
+// and OUR app-layer digests in copy-entry order. A later run may go native
+// only when all three still match reality.
+type nativeState struct {
+	DepsHash        string   `json:"deps_hash"`
+	ManifestDigest  string   `json:"manifest_digest"`
+	AppLayerDigests []string `json:"app_layer_digests"`
+}
+
+// loadNativeState returns the recorded state, or (nil, false) on any miss or
+// malformation — never an error, since the fallback (buildx) is always valid.
+func loadNativeState(dir string) (*nativeState, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, nativeStateName))
+	if err != nil {
+		return nil, false
+	}
+	var s nativeState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, false
+	}
+	if s.DepsHash == "" || s.ManifestDigest == "" || len(s.AppLayerDigests) == 0 {
+		return nil, false
+	}
+	return &s, true
+}
+
+// saveNativeState persists s atomically (temp + rename, 0600).
+func saveNativeState(dir string, s nativeState) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".state-*.json")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), filepath.Join(dir, nativeStateName))
+}
 
 // nativeLayerEpoch is the fixed modification time stamped on every entry of a
 // native layer. Zeroed times are what make the layer a pure function of the

--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -222,6 +222,53 @@ func saveNativeState(dir string, s nativeState) error {
 	return os.Rename(tmp.Name(), filepath.Join(dir, nativeStateName))
 }
 
+// nativeLayersEnv disables the native fast path when set to "off" (escape
+// hatch; the buildx path then always runs).
+const nativeLayersEnv = "WENDY_NATIVE_LAYERS"
+
+// nativeBuildEligibility decides whether this build may use the native
+// app-layer path. All must hold: the resolved dockerfile is the compiled
+// Stagefile output, the Stagefile parses, the final stage does not compile
+// (`build:`), it has at least one `from: local` copy, and every local copy
+// comes after all cross-stage copies — the local copies must be the image's
+// LAST layers for the adoption mapping to hold.
+func nativeBuildEligibility(cwd, dockerfile string) (*spec.File, bool) {
+	if os.Getenv(nativeLayersEnv) == "off" {
+		return nil, false
+	}
+	if filepath.Base(dockerfile) != generatedDockerfileName {
+		return nil, false
+	}
+	data, err := os.ReadFile(filepath.Join(cwd, stagefileSourceName))
+	if err != nil {
+		return nil, false
+	}
+	sf, err := spec.Parse(data)
+	if err != nil || len(sf.Stages) == 0 {
+		return nil, false
+	}
+	final := sf.Stages[len(sf.Stages)-1]
+	if final.Build != nil {
+		return nil, false
+	}
+	locals := 0
+	for _, c := range final.Copy {
+		if c.From == "local" {
+			locals++
+			continue
+		}
+		if locals > 0 {
+			// A cross-stage copy after a local one breaks the "local copies are
+			// the last layers" invariant.
+			return nil, false
+		}
+	}
+	if locals == 0 {
+		return nil, false
+	}
+	return sf, true
+}
+
 // ociManifest captures the standard OCI image-manifest fields the splice
 // mutates. Annotations are preserved; anything nonstandard would be dropped,
 // which buildx-produced image manifests don't carry.

--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -222,6 +222,429 @@ func saveNativeState(dir string, s nativeState) error {
 	return os.Rename(tmp.Name(), filepath.Join(dir, nativeStateName))
 }
 
+// ociManifest captures the standard OCI image-manifest fields the splice
+// mutates. Annotations are preserved; anything nonstandard would be dropped,
+// which buildx-produced image manifests don't carry.
+type ociManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType,omitempty"`
+	Config        ociManifestDesc   `json:"config"`
+	Layers        []ociManifestDesc `json:"layers"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+type ociManifestDesc struct {
+	MediaType   string            `json:"mediaType,omitempty"`
+	Digest      string            `json:"digest"`
+	Size        int64             `json:"size"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+const nativeLayerMediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+// ociLayoutDirManifest resolves the layout dir's index to the image manifest
+// for the target platform and returns its raw bytes plus digest.
+func ociLayoutDirManifest(dir, platform string) (manifestData []byte, manifestDigest string, err error) {
+	indexJSON, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		return nil, "", fmt.Errorf("read OCI layout index: %w", err)
+	}
+	var index struct {
+		Manifests []ociDescriptor `json:"manifests"`
+	}
+	if err := json.Unmarshal(indexJSON, &index); err != nil {
+		return nil, "", fmt.Errorf("parsing index.json: %w", err)
+	}
+	getBlob := func(hexDigest string) ([]byte, error) {
+		return os.ReadFile(filepath.Join(dir, "blobs", "sha256", hexDigest))
+	}
+	wantOS, wantArch := parseOCIPlatform(platform)
+	manifestData, err = resolveOCIImageManifest(index.Manifests, getBlob, wantOS, wantArch, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(manifestData)
+	return manifestData, "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// writeLayoutBlob content-addresses data into the layout dir's blob store
+// (no-op when already present) and returns its digest.
+func writeLayoutBlob(dir string, data []byte) (string, error) {
+	sum := sha256.Sum256(data)
+	hexDigest := hex.EncodeToString(sum[:])
+	blobsDir := filepath.Join(dir, "blobs", "sha256")
+	p := filepath.Join(blobsDir, hexDigest)
+	if _, err := os.Stat(p); err == nil {
+		return "sha256:" + hexDigest, nil
+	}
+	if err := os.MkdirAll(blobsDir, 0o700); err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(blobsDir, ".blob-*")
+	if err != nil {
+		return "", err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := os.Rename(tmp.Name(), p); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	return "sha256:" + hexDigest, nil
+}
+
+// spliceNativeLayers rewrites the layout dir's image for the target platform:
+// the layers whose digests are `replace` (matched BY DIGEST, in order) become
+// `with`, the config's rootfs.diff_ids follow 1:1, and index.json atomically
+// points at the rewritten manifest (any attestation entries are dropped —
+// provenance no longer describes the spliced image). Superseded blobs stay on
+// disk for the deploy-time GC. Returns the new manifest digest.
+func spliceNativeLayers(dir, platform string, replace []string, with []*nativeLayer) (string, error) {
+	if len(replace) != len(with) {
+		return "", fmt.Errorf("splice: %d digests to replace but %d layers given", len(replace), len(with))
+	}
+	manifestData, _, err := ociLayoutDirManifest(dir, platform)
+	if err != nil {
+		return "", err
+	}
+	var m ociManifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		return "", fmt.Errorf("parsing manifest for splice: %w", err)
+	}
+
+	cfgHex, err := digestToHex(m.Config.Digest)
+	if err != nil {
+		return "", fmt.Errorf("splice: invalid config digest %q: %w", m.Config.Digest, err)
+	}
+	cfgData, err := os.ReadFile(filepath.Join(dir, "blobs", "sha256", cfgHex))
+	if err != nil {
+		return "", fmt.Errorf("splice: config blob: %w", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(cfgData, &cfg); err != nil {
+		return "", fmt.Errorf("splice: parsing config: %w", err)
+	}
+	rootfs, _ := cfg["rootfs"].(map[string]any)
+	diffIDs, _ := rootfs["diff_ids"].([]any)
+	if rootfs == nil || len(diffIDs) != len(m.Layers) {
+		return "", fmt.Errorf("splice: config diff_ids (%d) do not align with manifest layers (%d)", len(diffIDs), len(m.Layers))
+	}
+
+	// Locate every replace digest, in order.
+	positions := make([]int, 0, len(replace))
+	next := 0
+	for i := range m.Layers {
+		if next < len(replace) && m.Layers[i].Digest == replace[next] {
+			positions = append(positions, i)
+			next++
+		}
+	}
+	if next != len(replace) {
+		return "", fmt.Errorf("splice: layer %q not found in manifest", replace[next])
+	}
+
+	for j, pos := range positions {
+		nl := with[j]
+		if _, err := writeLayoutBlob(dir, nl.Blob); err != nil {
+			return "", fmt.Errorf("splice: writing native layer: %w", err)
+		}
+		m.Layers[pos] = ociManifestDesc{
+			MediaType: nativeLayerMediaType,
+			Digest:    nl.Digest,
+			Size:      int64(len(nl.Blob)),
+		}
+		diffIDs[pos] = nl.DiffID
+	}
+
+	newCfg, err := json.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	cfgDigest, err := writeLayoutBlob(dir, newCfg)
+	if err != nil {
+		return "", fmt.Errorf("splice: writing config: %w", err)
+	}
+	m.Config.Digest = cfgDigest
+	m.Config.Size = int64(len(newCfg))
+
+	newManifest, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	manifestDigest, err := writeLayoutBlob(dir, newManifest)
+	if err != nil {
+		return "", fmt.Errorf("splice: writing manifest: %w", err)
+	}
+
+	wantOS, wantArch := parseOCIPlatform(platform)
+	index := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.index.v1+json",
+		"manifests": []map[string]any{{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest":    manifestDigest,
+			"size":      len(newManifest),
+			"platform":  map[string]any{"os": wantOS, "architecture": wantArch},
+		}},
+	}
+	indexData, err := json.Marshal(index)
+	if err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(dir, ".index-*.json")
+	if err != nil {
+		return "", err
+	}
+	if _, err := tmp.Write(indexData); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := os.Rename(tmp.Name(), filepath.Join(dir, "index.json")); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	return manifestDigest, nil
+}
+
+// nativeAppCopyEntries returns the final stage's `from: local` copy entries —
+// the instructions whose layers the native path owns.
+func nativeAppCopyEntries(sf *spec.File) []spec.CopyEntry {
+	if len(sf.Stages) == 0 {
+		return nil
+	}
+	var out []spec.CopyEntry
+	for _, c := range sf.Stages[len(sf.Stages)-1].Copy {
+		if c.From == "local" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// configWorkingDir extracts config.WorkingDir from a raw image config blob
+// ("" when unset — COPY then resolves against "/").
+func configWorkingDir(cfgData []byte) string {
+	var cfg struct {
+		Config struct {
+			WorkingDir string `json:"WorkingDir"`
+		} `json:"config"`
+	}
+	_ = json.Unmarshal(cfgData, &cfg)
+	return cfg.Config.WorkingDir
+}
+
+// buildNativeAppLayers materializes every final-stage local copy entry.
+func buildNativeAppLayers(cwd string, sf *spec.File, workDir string) ([]*nativeLayer, error) {
+	entries := nativeAppCopyEntries(sf)
+	layers := make([]*nativeLayer, 0, len(entries))
+	for _, e := range entries {
+		nl, err := buildNativeCopyLayer(cwd, e, workDir)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, nl)
+	}
+	return layers, nil
+}
+
+// layoutLayerFileNames decompresses a layout-dir layer blob and returns its
+// non-directory tar entry names.
+func layoutLayerFileNames(dir string, desc ociManifestDesc) (map[string]bool, error) {
+	hexDigest, err := digestToHex(desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "blobs", "sha256", hexDigest))
+	if err != nil {
+		return nil, err
+	}
+	r, cleanup, err := layerTarReader(bytes.NewReader(data), desc.MediaType)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	names := map[string]bool{}
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+		names[strings.TrimPrefix(path.Clean(hdr.Name), "./")] = true
+	}
+	return names, nil
+}
+
+// nativeNonDirNames filters a native layer's entry list down to files/links.
+func nativeNonDirNames(l *nativeLayer) map[string]bool {
+	names := map[string]bool{}
+	for _, n := range l.FileNames {
+		if !strings.HasSuffix(n, "/") {
+			names[n] = true
+		}
+	}
+	return names
+}
+
+// adoptNativeLayers runs after a successful buildx build of an eligible
+// project: it rebuilds each final-stage local copy entry natively, sanity
+// checks the manifest's LAST M layers against them (the file-name sets must
+// match — this is the one place the position→instruction assumption is
+// trusted, and only under verification), splices, and records state. Returns
+// false with no error when the check rejects; the buildx layers then ship
+// as-is and the native path stays disabled until the next buildx build.
+func adoptNativeLayers(dir, platform, cwd string, sf *spec.File, depsHash string) (bool, error) {
+	entries := nativeAppCopyEntries(sf)
+	if len(entries) == 0 {
+		return false, nil
+	}
+	manifestData, _, err := ociLayoutDirManifest(dir, platform)
+	if err != nil {
+		return false, nil
+	}
+	var m ociManifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		return false, nil
+	}
+	if len(m.Layers) < len(entries) {
+		return false, nil
+	}
+	cfgHex, err := digestToHex(m.Config.Digest)
+	if err != nil {
+		return false, nil
+	}
+	cfgData, err := os.ReadFile(filepath.Join(dir, "blobs", "sha256", cfgHex))
+	if err != nil {
+		return false, nil
+	}
+
+	native, err := buildNativeAppLayers(cwd, sf, configWorkingDir(cfgData))
+	if err != nil {
+		return false, nil
+	}
+
+	base := len(m.Layers) - len(entries)
+	replace := make([]string, len(entries))
+	for i, nl := range native {
+		got, err := layoutLayerFileNames(dir, m.Layers[base+i])
+		if err != nil {
+			return false, nil
+		}
+		want := nativeNonDirNames(nl)
+		if len(got) != len(want) {
+			cliLogln("native layers: buildx layer %d file set differs from copy entry %d; keeping buildx layers", base+i, i)
+			return false, nil
+		}
+		for n := range want {
+			if !got[n] {
+				cliLogln("native layers: buildx layer %d is missing %q; keeping buildx layers", base+i, n)
+				return false, nil
+			}
+		}
+		replace[i] = m.Layers[base+i].Digest
+	}
+
+	manifestDigest, err := spliceNativeLayers(dir, platform, replace, native)
+	if err != nil {
+		return false, err
+	}
+	digests := make([]string, len(native))
+	for i, nl := range native {
+		digests[i] = nl.Digest
+	}
+	if err := saveNativeState(dir, nativeState{
+		DepsHash:        depsHash,
+		ManifestDigest:  manifestDigest,
+		AppLayerDigests: digests,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// tryNativeRebuild is the buildx-free iteration: with deps unchanged and the
+// layout still exactly what we last wrote, rebuild the app layers from disk
+// and splice them in. Any doubt returns (false, nil) and the buildx path runs.
+func tryNativeRebuild(dir, platform, cwd string, sf *spec.File, st *nativeState) (bool, error) {
+	_, manifestDigest, err := ociLayoutDirManifest(dir, platform)
+	if err != nil || manifestDigest != st.ManifestDigest {
+		return false, nil
+	}
+	entries := nativeAppCopyEntries(sf)
+	if len(entries) == 0 || len(entries) != len(st.AppLayerDigests) {
+		return false, nil
+	}
+	cfgData, _, err := ociLayoutDirConfig(dir, platform)
+	if err != nil {
+		return false, nil
+	}
+	native, err := buildNativeAppLayers(cwd, sf, configWorkingDir(cfgData))
+	if err != nil {
+		return false, nil
+	}
+	newDigest, err := spliceNativeLayers(dir, platform, st.AppLayerDigests, native)
+	if err != nil {
+		return false, nil
+	}
+	digests := make([]string, len(native))
+	for i, nl := range native {
+		digests[i] = nl.Digest
+	}
+	if err := saveNativeState(dir, nativeState{
+		DepsHash:        st.DepsHash,
+		ManifestDigest:  newDigest,
+		AppLayerDigests: digests,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ociLayoutDirConfig returns the raw image config blob and its digest for the
+// platform's manifest in the layout dir.
+func ociLayoutDirConfig(dir, platform string) ([]byte, string, error) {
+	manifestData, _, err := ociLayoutDirManifest(dir, platform)
+	if err != nil {
+		return nil, "", err
+	}
+	var m ociManifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		return nil, "", err
+	}
+	cfgHex, err := digestToHex(m.Config.Digest)
+	if err != nil {
+		return nil, "", err
+	}
+	cfgData, err := os.ReadFile(filepath.Join(dir, "blobs", "sha256", cfgHex))
+	if err != nil {
+		return nil, "", err
+	}
+	return cfgData, m.Config.Digest, nil
+}
+
 // nativeLayerEpoch is the fixed modification time stamped on every entry of a
 // native layer. Zeroed times are what make the layer a pure function of the
 // input file contents (BuildKit's COPY preserves source mtimes, which defeats

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -4,11 +4,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
@@ -301,6 +303,202 @@ func TestNativeStateRoundTrip(t *testing.T) {
 	}
 	if _, ok := loadNativeState(dir); ok {
 		t.Fatal("corrupt state must load as not-ok")
+	}
+}
+
+// tarBytes builds an uncompressed tar with the given entries (a trailing "/"
+// in the name makes a directory entry).
+func tarBytes(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	names := make([]string, 0, len(entries))
+	for n := range entries {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		hdr := &tar.Header{Name: n, Mode: 0o644, Size: int64(len(entries[n]))}
+		if strings.HasSuffix(n, "/") {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Mode = 0o755
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Typeflag != tar.TypeDir {
+			if _, err := tw.Write([]byte(entries[n])); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// writeTwoLayerLayoutDir builds a layout dir whose image has a deps layer and
+// an app layer (both uncompressed tars), with aligned diff_ids and the given
+// WorkingDir. Returns the app layer's digest.
+func writeTwoLayerLayoutDir(t *testing.T, dir string, depsTar, appTar []byte, workingDir string) (appDigest string) {
+	t.Helper()
+	depsDigest := "sha256:" + sha256Hex(depsTar)
+	appDigest = "sha256:" + sha256Hex(appTar)
+	config := []byte(`{"architecture":"arm64","os":"linux","config":{"Entrypoint":["python","main.py"],"WorkingDir":"` + workingDir + `"},"rootfs":{"type":"layers","diff_ids":["` + depsDigest + `","` + appDigest + `"]}}`)
+	configDigest := "sha256:" + sha256Hex(config)
+	manifest := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",` +
+		`"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"` + configDigest + `","size":` + fmt.Sprint(len(config)) + `},` +
+		`"layers":[` +
+		`{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"` + depsDigest + `","size":` + fmt.Sprint(len(depsTar)) + `},` +
+		`{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"` + appDigest + `","size":` + fmt.Sprint(len(appTar)) + `}]}`)
+	manifestDigest := sha256Hex(manifest)
+	index := []byte(`{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:` + manifestDigest + `","size":` + fmt.Sprint(len(manifest)) + `,"platform":{"os":"linux","architecture":"arm64"}}]}`)
+	writeOCILayoutDir(t, dir, map[string][]byte{
+		"oci-layout":                        []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		"index.json":                        index,
+		"blobs/sha256/" + manifestDigest:    manifest,
+		"blobs/sha256/" + sha256Hex(config): config,
+		"blobs/sha256/" + sha256Hex(depsTar): depsTar,
+		"blobs/sha256/" + sha256Hex(appTar):  appTar,
+	})
+	return appDigest
+}
+
+func TestAdoptAndSpliceNativeLayers(t *testing.T) {
+	proj := t.TempDir()
+	writeFile(t, proj, "main.py", "print('v1')\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "python:3.11-slim",
+		Copy: []spec.CopyEntry{{From: "local", Paths: []string{"main.py"}, Dest: "app/"}},
+	}}}
+
+	dir := t.TempDir()
+	depsTar := tarBytes(t, map[string]string{"usr/lib/python/dep.py": "dep"})
+	appTar := tarBytes(t, map[string]string{"app/": "", "app/main.py": "print('v1')\n"})
+	oldAppDigest := writeTwoLayerLayoutDir(t, dir, depsTar, appTar, "")
+
+	ok, err := adoptNativeLayers(dir, "linux/arm64", proj, sf, "sha256:deps1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("adoption should accept a matching file set")
+	}
+
+	st, stOK := loadNativeState(dir)
+	if !stOK || st.DepsHash != "sha256:deps1" || len(st.AppLayerDigests) != 1 {
+		t.Fatalf("state not recorded: %+v ok=%v", st, stOK)
+	}
+	if st.AppLayerDigests[0] == oldAppDigest {
+		t.Fatal("adopted app layer should be the native rebuild, not the buildx layer")
+	}
+
+	// The layout must remain readable and now expose the native layer with the
+	// deps layer untouched.
+	layers, cfg, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layers) != 2 {
+		t.Fatalf("want 2 layers, got %d", len(layers))
+	}
+	if layers[0].Digest != "sha256:"+sha256Hex(depsTar) {
+		t.Fatal("deps layer must be untouched")
+	}
+	if layers[1].Digest != st.AppLayerDigests[0] {
+		t.Fatal("manifest must reference the native app layer")
+	}
+	if !bytes.Contains(cfg, []byte(`"Entrypoint":["python","main.py"]`)) {
+		t.Fatal("config runtime fields must survive the splice")
+	}
+	if !bytes.Contains(cfg, []byte(layers[1].DiffID)) {
+		t.Fatal("config diff_ids must reference the native layer's diff ID")
+	}
+
+	// Now the iteration loop: edit the app file, rebuild natively without any
+	// buildx involvement.
+	writeFile(t, proj, "main.py", "print('v2')\n")
+	rebuilt, err := tryNativeRebuild(dir, "linux/arm64", proj, sf, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rebuilt {
+		t.Fatal("native rebuild should succeed after an app-only edit")
+	}
+	layers2, cfg2, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layers2[1].Digest == layers[1].Digest {
+		t.Fatal("app layer digest should change after the edit")
+	}
+	if layers2[0].Digest != layers[0].Digest {
+		t.Fatal("deps layer must still be untouched")
+	}
+	if !bytes.Contains(cfg2, []byte(layers2[1].DiffID)) {
+		t.Fatal("config diff_ids must track the rebuilt layer")
+	}
+	st2, _ := loadNativeState(dir)
+	if st2 == nil || st2.AppLayerDigests[0] != layers2[1].Digest {
+		t.Fatal("state must track the rebuilt layer")
+	}
+}
+
+func TestAdoptNativeLayersRejectsFileSetMismatch(t *testing.T) {
+	proj := t.TempDir()
+	writeFile(t, proj, "main.py", "print('v1')\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "python:3.11-slim",
+		Copy: []spec.CopyEntry{{From: "local", Paths: []string{"main.py"}, Dest: "app/"}},
+	}}}
+
+	dir := t.TempDir()
+	depsTar := tarBytes(t, map[string]string{"usr/lib/python/dep.py": "dep"})
+	// The "buildx" app layer holds an extra file the copy entry doesn't declare
+	// — the position→instruction assumption is wrong, adoption must refuse.
+	appTar := tarBytes(t, map[string]string{"app/": "", "app/main.py": "m", "app/surprise.py": "s"})
+	writeTwoLayerLayoutDir(t, dir, depsTar, appTar, "")
+
+	before, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	ok, err := adoptNativeLayers(dir, "linux/arm64", proj, sf, "sha256:deps1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("adoption must reject a mismatched file set")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "index.json"))
+	if !bytes.Equal(before, after) {
+		t.Fatal("a rejected adoption must leave the layout untouched")
+	}
+	if _, stOK := loadNativeState(dir); stOK {
+		t.Fatal("a rejected adoption must not record state")
+	}
+}
+
+func TestTryNativeRebuildRefusesExternalManifestChange(t *testing.T) {
+	proj := t.TempDir()
+	writeFile(t, proj, "main.py", "print('v1')\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "python:3.11-slim",
+		Copy: []spec.CopyEntry{{From: "local", Paths: []string{"main.py"}, Dest: "app/"}},
+	}}}
+	dir := t.TempDir()
+	depsTar := tarBytes(t, map[string]string{"dep.py": "dep"})
+	appTar := tarBytes(t, map[string]string{"app/": "", "app/main.py": "print('v1')\n"})
+	writeTwoLayerLayoutDir(t, dir, depsTar, appTar, "")
+
+	// A state whose manifest digest doesn't match the dir (someone rebuilt
+	// behind our back) must refuse the native path.
+	stale := &nativeState{DepsHash: "sha256:d", ManifestDigest: "sha256:not-the-real-one", AppLayerDigests: []string{"sha256:x"}}
+	ok, err := tryNativeRebuild(dir, "linux/arm64", proj, sf, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("native rebuild must refuse when the manifest changed externally")
 	}
 }
 

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -192,6 +192,118 @@ func TestBuildNativeCopyLayerDeterministic(t *testing.T) {
 	}
 }
 
+// nativeDepsHash must cover every build input EXCEPT the final stage's local
+// copy files: those are the app inputs whose changes the native path handles
+// without buildx.
+func TestNativeDepsHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile.generated", "FROM python@sha256:abc\nCOPY requirements.txt requirements.txt\nRUN pip install -r requirements.txt\nCOPY main.py main.py\n")
+	writeFile(t, dir, "build.stagefile.lock.yaml", "version: 1\nimages:\n  python:3.11-slim: sha256:abc\n")
+	writeFile(t, dir, "requirements.txt", "mcp\n")
+	writeFile(t, dir, "main.py", "print('v1')\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{{
+		Name:    "app",
+		From:    "python:3.11-slim",
+		Install: &spec.Install{Pip: &spec.PipInstall{Requirements: "requirements.txt"}},
+		Copy:    []spec.CopyEntry{{From: "local", Paths: []string{"main.py"}}},
+	}}}
+
+	hash := func(args map[string]string, platform string) string {
+		t.Helper()
+		h, err := nativeDepsHash(dir, "Dockerfile.generated", platform, args, sf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	base := hash(nil, "linux/arm64")
+	if got := hash(nil, "linux/arm64"); got != base {
+		t.Fatal("deps hash not stable")
+	}
+	writeFile(t, dir, "main.py", "print('v2')\n")
+	if got := hash(nil, "linux/arm64"); got != base {
+		t.Fatal("deps hash must ignore final-stage copy files (app inputs)")
+	}
+	writeFile(t, dir, "requirements.txt", "mcp\nuvicorn\n")
+	afterReqs := hash(nil, "linux/arm64")
+	if afterReqs == base {
+		t.Fatal("deps hash unchanged after requirements.txt edit")
+	}
+	writeFile(t, dir, "Dockerfile.generated", "FROM python@sha256:def\n")
+	afterDF := hash(nil, "linux/arm64")
+	if afterDF == afterReqs {
+		t.Fatal("deps hash unchanged after Dockerfile.generated edit")
+	}
+	if got := hash(map[string]string{"K": "V"}, "linux/arm64"); got == afterDF {
+		t.Fatal("deps hash unchanged after build-arg change")
+	}
+	if got := hash(nil, "linux/amd64"); got == afterDF {
+		t.Fatal("deps hash unchanged after platform change")
+	}
+}
+
+// Local copies in NON-final stages feed deps layers and must be part of the
+// deps hash (only the final stage's local copies are app inputs).
+func TestNativeDepsHashIncludesNonFinalCopies(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile.generated", "FROM base\n")
+	writeFile(t, dir, "settings.conf", "cfg v1\n")
+	writeFile(t, dir, "main.py", "print('v1')\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "cfg", From: "python:3.11-slim", Copy: []spec.CopyEntry{{From: "local", Paths: []string{"settings.conf"}, Dest: "/etc/app/"}}},
+		{Name: "app", From: "python:3.11-slim", Copy: []spec.CopyEntry{
+			{From: "cfg", Paths: []string{"/etc/app"}, Dest: "/etc/app"},
+			{From: "local", Paths: []string{"main.py"}},
+		}},
+	}}
+
+	hash := func() string {
+		t.Helper()
+		h, err := nativeDepsHash(dir, "Dockerfile.generated", "linux/arm64", nil, sf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	base := hash()
+	writeFile(t, dir, "main.py", "print('v2')\n")
+	if got := hash(); got != base {
+		t.Fatal("final-stage copy file must not affect the deps hash")
+	}
+	writeFile(t, dir, "settings.conf", "cfg v2\n")
+	if got := hash(); got == base {
+		t.Fatal("non-final-stage copy file must affect the deps hash")
+	}
+}
+
+func TestNativeStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := loadNativeState(dir); ok {
+		t.Fatal("missing state must load as not-ok")
+	}
+	want := nativeState{
+		DepsHash:        "sha256:aaa",
+		ManifestDigest:  "sha256:bbb",
+		AppLayerDigests: []string{"sha256:ccc"},
+	}
+	if err := saveNativeState(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := loadNativeState(dir)
+	if !ok || got.DepsHash != want.DepsHash || got.ManifestDigest != want.ManifestDigest || len(got.AppLayerDigests) != 1 || got.AppLayerDigests[0] != "sha256:ccc" {
+		t.Fatalf("round-trip mismatch: %+v ok=%v", got, ok)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadNativeState(dir); ok {
+		t.Fatal("corrupt state must load as not-ok")
+	}
+}
+
 func TestBuildNativeCopyLayerRejectsEscapes(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"../outside"}}, ""); err == nil {

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -1,0 +1,206 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// readLayerEntries un-gzips a native layer blob and returns name → header/data
+// for every tar entry, plus the raw uncompressed bytes.
+func readLayerEntries(t *testing.T, blob []byte) (map[string]*tar.Header, map[string][]byte, []byte) {
+	t.Helper()
+	gr, err := gzip.NewReader(bytes.NewReader(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrs := map[string]*tar.Header{}
+	data := map[string][]byte{}
+	tr := tar.NewReader(bytes.NewReader(raw))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdrs[hdr.Name] = hdr
+		data[hdr.Name] = b
+	}
+	return hdrs, data, raw
+}
+
+func TestBuildNativeCopyLayerFileToFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.py", "print('hello')\n")
+
+	l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"main.py"}}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrs, data, raw := readLayerEntries(t, l.Blob)
+
+	h, ok := hdrs["main.py"]
+	if !ok {
+		t.Fatalf("missing main.py entry; have %v", l.FileNames)
+	}
+	if string(data["main.py"]) != "print('hello')\n" {
+		t.Fatal("content mismatch")
+	}
+	if h.Uid != 0 || h.Gid != 0 || h.Uname != "" || h.Gname != "" {
+		t.Fatalf("ownership must be numeric root:root, got %d:%d %q:%q", h.Uid, h.Gid, h.Uname, h.Gname)
+	}
+	if !h.ModTime.Equal(nativeLayerEpoch) {
+		t.Fatalf("mtime must be the fixed epoch, got %v", h.ModTime)
+	}
+	if want := "sha256:" + sha256Hex(raw); l.DiffID != want {
+		t.Fatalf("DiffID = %s, want %s", l.DiffID, want)
+	}
+	if want := "sha256:" + sha256Hex(l.Blob); l.Digest != want {
+		t.Fatalf("Digest = %s, want %s", l.Digest, want)
+	}
+}
+
+func TestBuildNativeCopyLayerDestForms(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.py", "m\n")
+	writeFile(t, dir, "util.py", "u\n")
+
+	t.Run("file into dir dest", func(t *testing.T) {
+		l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"main.py"}, Dest: "app/"}, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdrs, _, _ := readLayerEntries(t, l.Blob)
+		if _, ok := hdrs["app/main.py"]; !ok {
+			t.Fatalf("want app/main.py, have %v", l.FileNames)
+		}
+		if d, ok := hdrs["app/"]; !ok || d.Typeflag != tar.TypeDir {
+			t.Fatal("missing synthesized parent dir entry app/")
+		}
+	})
+
+	t.Run("multi-source forces dir dest", func(t *testing.T) {
+		l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"main.py", "util.py"}, Dest: "app"}, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdrs, _, _ := readLayerEntries(t, l.Blob)
+		if _, ok := hdrs["app/main.py"]; !ok {
+			t.Fatalf("want app/main.py, have %v", l.FileNames)
+		}
+		if _, ok := hdrs["app/util.py"]; !ok {
+			t.Fatal("want app/util.py")
+		}
+	})
+
+	t.Run("relative dest resolves against workdir", func(t *testing.T) {
+		l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"main.py"}}, "/srv")
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdrs, _, _ := readLayerEntries(t, l.Blob)
+		if _, ok := hdrs["srv/main.py"]; !ok {
+			t.Fatalf("want srv/main.py, have %v", l.FileNames)
+		}
+	})
+}
+
+func TestBuildNativeCopyLayerDirSourceCopiesContents(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "srcpkg/mod.py", "mod\n")
+	writeFile(t, dir, "srcpkg/sub/deep.py", "deep\n")
+
+	l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"srcpkg"}, Dest: "/app"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrs, _, _ := readLayerEntries(t, l.Blob)
+	for _, want := range []string{"app/", "app/mod.py", "app/sub/", "app/sub/deep.py"} {
+		if _, ok := hdrs[want]; !ok {
+			t.Fatalf("missing %q; have %v", want, l.FileNames)
+		}
+	}
+	if _, ok := hdrs["app/srcpkg/mod.py"]; ok {
+		t.Fatal("dir source must copy CONTENTS, not the dir itself")
+	}
+}
+
+func TestBuildNativeCopyLayerPreservesModeAndSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("modes/symlinks not applicable on windows")
+	}
+	dir := t.TempDir()
+	writeFile(t, dir, "tool/run.sh", "#!/bin/sh\n")
+	if err := os.Chmod(filepath.Join(dir, "tool", "run.sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("run.sh", filepath.Join(dir, "tool", "alias")); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"tool"}, Dest: "/tool"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdrs, _, _ := readLayerEntries(t, l.Blob)
+	if h := hdrs["tool/run.sh"]; h == nil || h.Mode&0o777 != 0o755 {
+		t.Fatalf("mode not preserved: %+v", h)
+	}
+	if h := hdrs["tool/alias"]; h == nil || h.Typeflag != tar.TypeSymlink || h.Linkname != "run.sh" {
+		t.Fatalf("symlink not preserved: %+v", h)
+	}
+}
+
+func TestBuildNativeCopyLayerDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a/x.py", "x\n")
+	writeFile(t, dir, "a/y.py", "y\n")
+	writeFile(t, dir, "main.py", "m\n")
+
+	entry := spec.CopyEntry{From: "local", Paths: []string{"main.py", "a"}, Dest: "app/"}
+	l1, err := buildNativeCopyLayer(dir, entry, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l2, err := buildNativeCopyLayer(dir, entry, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(l1.Blob, l2.Blob) {
+		t.Fatal("two builds of identical inputs must be byte-identical")
+	}
+	if !sort.StringsAreSorted(l1.FileNames) {
+		t.Fatalf("FileNames must be sorted: %v", l1.FileNames)
+	}
+}
+
+func TestBuildNativeCopyLayerRejectsEscapes(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"../outside"}}, ""); err == nil {
+		t.Fatal("want error for source escaping the context")
+	}
+	if _, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"/etc/passwd"}}, ""); err == nil {
+		t.Fatal("want error for absolute source path")
+	}
+	if _, err := buildNativeCopyLayer(dir, spec.CopyEntry{From: "local", Paths: []string{"missing.py"}}, ""); err == nil {
+		t.Fatal("want error for missing source")
+	}
+}

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -356,10 +356,10 @@ func writeTwoLayerLayoutDir(t *testing.T, dir string, depsTar, appTar []byte, wo
 	manifestDigest := sha256Hex(manifest)
 	index := []byte(`{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:` + manifestDigest + `","size":` + fmt.Sprint(len(manifest)) + `,"platform":{"os":"linux","architecture":"arm64"}}]}`)
 	writeOCILayoutDir(t, dir, map[string][]byte{
-		"oci-layout":                        []byte(`{"imageLayoutVersion":"1.0.0"}`),
-		"index.json":                        index,
-		"blobs/sha256/" + manifestDigest:    manifest,
-		"blobs/sha256/" + sha256Hex(config): config,
+		"oci-layout":                         []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		"index.json":                         index,
+		"blobs/sha256/" + manifestDigest:     manifest,
+		"blobs/sha256/" + sha256Hex(config):  config,
 		"blobs/sha256/" + sha256Hex(depsTar): depsTar,
 		"blobs/sha256/" + sha256Hex(appTar):  appTar,
 	})
@@ -500,6 +500,68 @@ func TestTryNativeRebuildRefusesExternalManifestChange(t *testing.T) {
 	if ok {
 		t.Fatal("native rebuild must refuse when the manifest changed externally")
 	}
+}
+
+func TestNativeBuildEligibility(t *testing.T) {
+	t.Setenv("WENDY_NATIVE_LAYERS", "")
+
+	eligibleYAML := "version: 1\nstages:\n  - name: app\n    from: python:3.11-slim\n    install:\n      pip:\n        requirements: requirements.txt\n    copy:\n      - from: local\n        paths: [main.py]\n    entrypoint:\n      exec: [python, main.py]\n"
+
+	t.Run("eligible python project", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", eligibleYAML)
+		sf, ok := nativeBuildEligibility(dir, "Dockerfile.generated")
+		if !ok || sf == nil {
+			t.Fatal("python-style stagefile project should be eligible")
+		}
+	})
+
+	t.Run("plain dockerfile name is ineligible", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", eligibleYAML)
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile"); ok {
+			t.Fatal("non-generated dockerfile must be ineligible")
+		}
+	})
+
+	t.Run("no stagefile is ineligible", func(t *testing.T) {
+		if _, ok := nativeBuildEligibility(t.TempDir(), "Dockerfile.generated"); ok {
+			t.Fatal("missing stagefile must be ineligible")
+		}
+	})
+
+	t.Run("final-stage build.lang is ineligible", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", "version: 1\nstages:\n  - name: app\n    from: rust:1\n    copy:\n      - from: local\n        paths: [src]\n    build:\n      lang: rust\n")
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); ok {
+			t.Fatal("a compiling final stage must be ineligible")
+		}
+	})
+
+	t.Run("no local copies is ineligible", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", "version: 1\nstages:\n  - name: builder\n    from: golang:1\n    copy:\n      - from: local\n        paths: [main.go]\n  - name: app\n    from: debian:12\n    copy:\n      - from: builder\n        paths: [/out]\n        dest: /out\n")
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); ok {
+			t.Fatal("a final stage without local copies must be ineligible")
+		}
+	})
+
+	t.Run("local copy before a stage copy is ineligible", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", "version: 1\nstages:\n  - name: builder\n    from: golang:1\n    copy:\n      - from: local\n        paths: [main.go]\n  - name: app\n    from: debian:12\n    copy:\n      - from: local\n        paths: [main.go]\n      - from: builder\n        paths: [/out]\n        dest: /out\n")
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); ok {
+			t.Fatal("local copies must be the final layers to be eligible")
+		}
+	})
+
+	t.Run("env kill switch", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "build.stagefile.yaml", eligibleYAML)
+		t.Setenv("WENDY_NATIVE_LAYERS", "off")
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); ok {
+			t.Fatal("WENDY_NATIVE_LAYERS=off must disable the native path")
+		}
+	})
 }
 
 func TestBuildNativeCopyLayerRejectsEscapes(t *testing.T) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -2341,24 +2341,64 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		build := func(stream, logw io.Writer) error {
 			return buildImageToOCILayoutDirWithDocker(ctx, cwd, dockerfile, platform, buildArgs, layoutDir, stream, logw)
 		}
-		if err := runBuild(build); err != nil {
-			return nil, err
+
+		// Native fast path: for a Stagefile project whose deps inputs are
+		// unchanged since the layout dir's last build, rebuild only the app COPY
+		// layer(s) in-process and splice them into the layout — no Docker at
+		// all. Every guard failure silently falls through to buildx.
+		sf, nativeEligible := nativeBuildEligibility(cwd, dockerfile)
+		var depsHash string
+		if nativeEligible {
+			if h, hashErr := nativeDepsHash(cwd, dockerfile, platform, buildArgs, sf); hashErr == nil {
+				depsHash = h
+			} else {
+				nativeEligible = false
+			}
 		}
-		mark("build (oci export)")
+		nativeDone := false
+		if nativeEligible {
+			if st, ok := loadNativeState(layoutDir); ok && st.DepsHash == depsHash {
+				if done, rebuildErr := tryNativeRebuild(layoutDir, platform, cwd, sf, st); rebuildErr == nil && done {
+					nativeDone = true
+					cliLogln("App layer(s) rebuilt natively (deps unchanged; buildx skipped)")
+				}
+			}
+		}
+
+		if nativeDone {
+			mark("build (native layers)")
+		} else {
+			if err := runBuild(build); err != nil {
+				return nil, err
+			}
+			mark("build (oci export)")
+		}
 		layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform)
 		if err != nil {
 			// Self-heal exactly once: a corrupt or partially-written layout dir is
 			// wiped and rebuilt from scratch, which is precisely the legacy cold
-			// behavior. A second failure is a real bug and surfaces.
+			// behavior. A second failure is a real bug and surfaces. The wipe also
+			// removes state.json, so the native path stays off until re-adoption.
 			cliLogln("OCI layout cache unreadable (%v); rebuilding it from scratch", err)
 			if rmErr := os.RemoveAll(layoutDir); rmErr != nil {
 				return nil, fmt.Errorf("resetting OCI layout cache %s: %w", layoutDir, rmErr)
 			}
+			nativeDone = false
 			if err := runBuild(build); err != nil {
 				return nil, err
 			}
 			if layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform); err != nil {
 				return nil, err
+			}
+		}
+		if nativeEligible && !nativeDone {
+			// After a buildx build, take ownership of the app layers: replace them
+			// with deterministic native rebuilds (verified against the buildx
+			// layers' file sets) so every following iteration can skip buildx.
+			if adopted, adoptErr := adoptNativeLayers(layoutDir, platform, cwd, sf, depsHash); adoptErr == nil && adopted {
+				if layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform); err != nil {
+					return nil, err
+				}
 			}
 		}
 		// Prune blobs superseded by this build once the deploy is done with them.


### PR DESCRIPTION
## Summary

Stacked on #1585 and #1608 (both merged into this branch; retarget to `main` once they land). With the persistent OCI layout dir from #1608 in place, this PR makes the copy-only iteration loop of a Stagefile project **skip Docker entirely**: the CLI rebuilds the app COPY layer(s) deterministically in-process and splices them into the layout dir's manifest/config/index, then the existing chunk push ships only the changed bytes.

Measured on MCPExample (Apple Silicon), per source-change iteration, build phase only:

| Path | time |
|---|---|
| tar export (pre-#1608) | ~530 ms |
| layout dir, buildx (#1608) | ~230 ms |
| **native rebuild (this PR)** | **~1 ms** |

The bigger prize is the dependency cut: once a project's deps layers exist in the layout dir, the `wendy watch` loop needs **no Docker Desktop at all** for interpreted apps — buildx only runs when deps inputs change.

## How it works

- **Eligibility** (`nativeBuildEligibility`): dockerfile is the compiled `Dockerfile.generated`, the Stagefile parses, the final stage has no `build:` (compiled languages recompile every change — they keep buildx), has ≥1 `copy: from: local`, and local copies are the final layers. `WENDY_NATIVE_LAYERS=off` is the kill switch.
- **Deps hash** (`nativeDepsHash`): generated Dockerfile bytes + Stagefile lock + install-referenced files + non-final-stage local copies + platform + build args. Any change → the normal buildx path runs.
- **Adoption** (`adoptNativeLayers`): after every buildx build of an eligible project, the CLI rebuilds each final-stage copy entry natively and — only if each buildx layer's actual decompressed **file set matches** the corresponding native layer's — replaces the last-M layers and records `state.json` (deps hash + our layer digests). This is the one place the position→instruction mapping is trusted, and only under verification; any mismatch keeps the buildx layers and ships them unchanged. Verified live against a real BuildKit COPY layer.
- **Iteration** (`tryNativeRebuild`): deps hash matches + the layout's manifest digest is exactly what we last wrote → rebuild the M layers from disk, splice by digest (never by position), update state. Any doubt at any step falls back to buildx silently.
- **Layers are deterministic**: sorted entries, zeroed mtimes, numeric root:root, Docker COPY semantics (contents-of-dir, workdir-relative dests, mode + symlink preservation, synthesized 0755 parents) — identical inputs yield identical diff IDs on any machine, so device-side layer dedup works across checkouts.
- Splicing rewrites index.json atomically to the new manifest (dropping buildx attestation entries — provenance no longer describes the spliced image); superseded blobs are collected by #1608's deploy-time GC.

## Also in this PR

`computeBuildInputHash` now walks the context with the ignore file BuildKit actually uses (`<dockerfile>.dockerignore` beats `.dockerignore`) — previously a README edit on a Stagefile project invalidated the deploy fingerprint and forced a rebuild of an identical image. The conservative matcher also now keeps directories with re-included descendants walkable (`*` + `!src/app.py` no longer SkipDir's `src/`), fixing a latent stale-skip hazard.

## Testing

- Unit: COPY-semantics table tests (dest forms, dir contents, modes, symlinks, escapes, determinism), deps-hash sensitivity/exclusion, state round-trip, splice + adoption accept/reject on synthetic layouts, external-manifest-change refusal, eligibility matrix, fingerprint allowlist + nested-negation tests. Full `./go/internal/cli/...` green, `gofmt` clean.
- Live (local Docker, real BuildKit output): buildx build → **adoption accepted the real COPY layer** → main.py edit → native rebuild 1 ms → layout re-read valid → GC → still deployable; deps-change detection flips the hash.
- Pending before ready: on-device end-to-end (`wendy run` + container actually starts on the Orin Nano) — the spliced image is spec-compliant but the agent's AssembleImage path should see a real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)