### PR TITLE
fix(agent): un-hang TestWaitForAudioSession — CI is red on every branch

### DIFF
--- a/go/internal/agent/bluetooth/manager_linux.go
+++ b/go/internal/agent/bluetooth/manager_linux.go
@@ -920,11 +920,14 @@ var audioSessionTimeout = 4 * time.Minute
 
 // waitForAudioSession blocks until the user session's PipeWire socket appears.
 // It reports false only when ctx is cancelled — a timeout still returns true so
-// the reconnect is attempted rather than silently skipped.
+// the reconnect is attempted rather than silently skipped. The probe goes
+// through audio.Available (not RuntimeDir directly) so tests can stub session
+// presence: RuntimeDir only trusts a socket owned by the wendy user, which no
+// test environment can fabricate.
 func waitForAudioSession(ctx context.Context) bool {
 	deadline := time.Now().Add(audioSessionTimeout)
 	for {
-		if audio.RuntimeDir() != "" {
+		if audio.Available() {
 			return true
 		}
 		if time.Now().After(deadline) {

--- a/go/internal/agent/bluetooth/manager_linux_test.go
+++ b/go/internal/agent/bluetooth/manager_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -623,53 +622,41 @@ func TestClaimBootReconnectUnwritable(t *testing.T) {
 }
 
 func TestWaitForAudioSession(t *testing.T) {
-	dir := t.TempDir()
-	origGlob, origTimeout := audio.SocketGlob, audioSessionTimeout
-	t.Cleanup(func() { audio.SocketGlob, audioSessionTimeout = origGlob, origTimeout })
-	audio.SocketGlob = filepath.Join(dir, "user-*", "pipewire-0")
-
-	// A plain file is not a session; only a listening socket is.
-	if err := os.MkdirAll(filepath.Join(dir, "user-1000"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "user-1000", "pipewire-0"), nil, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	stale, cancelStale := context.WithCancel(context.Background())
-	cancelStale()
-	if waitForAudioSession(stale) {
-		t.Error("a regular file must not count as a session")
-	}
+	origAvailable, origTimeout := audio.Available, audioSessionTimeout
+	t.Cleanup(func() { audio.Available, audioSessionTimeout = origAvailable, origTimeout })
 
 	// Present already: returns immediately, which is the agent-restart case on
-	// a machine whose audio has been up for weeks.
-	socketDir, err := os.MkdirTemp("/tmp", "pw")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(socketDir) })
-	if err := os.MkdirAll(filepath.Join(socketDir, "user-1000"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	l, err := net.Listen("unix", filepath.Join(socketDir, "user-1000", "pipewire-0"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { l.Close() })
-	audio.SocketGlob = filepath.Join(socketDir, "user-*", "pipewire-0")
+	// a machine whose audio has been up for weeks. (What counts as a session —
+	// a listening socket owned by the wendy user, not a plain file — is the
+	// audio package's contract, covered by its own RuntimeDir tests; here the
+	// seam is stubbed because no test environment can own a socket as wendy.)
+	audio.Available = func() bool { return true }
 	if !waitForAudioSession(context.Background()) {
-		t.Error("should report ready when the socket already exists")
+		t.Error("should report ready when the session is already up")
 	}
 
-	// Cancellation is the only false: a timeout still proceeds, so a board
-	// with no working audio stack still attempts the reconnect.
-	audio.SocketGlob = filepath.Join(dir, "never-*", "pipewire-0")
+	// Appears later: the wait polls until the session comes up.
+	probes := 0
+	audio.Available = func() bool { probes++; return probes >= 2 }
+	audioSessionTimeout = time.Minute
+	if !waitForAudioSession(context.Background()) {
+		t.Error("should become ready once the session appears")
+	}
+	if probes < 2 {
+		t.Errorf("expected repeated probes, got %d", probes)
+	}
+
+	// Cancellation is the only false: the reconnect is skipped only when the
+	// agent is shutting down.
+	audio.Available = func() bool { return false }
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	if waitForAudioSession(ctx) {
 		t.Error("cancelled context should report not-ready")
 	}
 
+	// A timeout still proceeds, so a board with no working audio stack still
+	// attempts the reconnect.
 	audioSessionTimeout = 0
 	if !waitForAudioSession(context.Background()) {
 		t.Error("timeout should proceed anyway rather than skip the reconnect")


### PR DESCRIPTION
## Summary

Every branch's "Go Tests" run is currently failing with `panic: test timed out after 2m0s` in `go/internal/agent/bluetooth` (e.g. [this run on jo/try-stagefile](https://github.com/wendylabsinc/WendyOS/actions/runs/31237155445) and [this one on ed/oci-layout-dir-export](https://github.com/wendylabsinc/WendyOS/actions/runs/31238780933)).

**Root cause:** `TestWaitForAudioSession` (added with the boot-time audio reconnect) points `audio.SocketGlob` at a socket it creates — but `audio.RuntimeDir()` only trusts a socket **owned by the `wendy` user's UID** (`expectedUID`, deliberately package-private). No CI runner or dev machine can fabricate that ownership, so the "socket already exists" case never becomes ready, and the 4-minute `audioSessionTimeout` outlives `go test`'s 2-minute timeout — panicking the entire package. Being linux-only, the test never ran on the author's macOS machine; only CI executes it.

**Fix:** `waitForAudioSession` now probes via `audio.Available` — the overridable seam the audio package already exposes for exactly this — and the test stubs it per scenario (ready-immediately, appears-later polling, cancellation, timeout-proceeds). What counts as a session (listening socket, wendy-owned, not a plain file) remains covered where it belongs: the audio package's own `RuntimeDir` tests. Production behavior is unchanged (`Available()` is literally `RuntimeDir() != ""`).

## Testing

Ran the linux-only suite in a `golang:1.26` container: `go test ./go/internal/agent/bluetooth/ ./go/internal/agent/audio/` — both pass, bluetooth in 2.0s (was 120s+ panic). `GOOS=linux go build`/`go vet` clean, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)