### PR TITLE
TLS 1.3 session resumption: repeat CLI→agent connects skip the ML-DSA handshake

### DIFF
--- a/Documentation/2026-08-07-tls-session-resumption-design.md
+++ b/Documentation/2026-08-07-tls-session-resumption-design.md
@@ -1,0 +1,156 @@
+# TLS 1.3 Session Resumption for CLI → Agent mTLS Connections
+
+**Date:** 2026-08-07
+**Status:** Approved (design), implementation pending
+**Branch:** `ed/tls-session-resumption`
+
+## Problem
+
+Every `wendy` CLI invocation is a fresh process that performs a full mTLS
+handshake against the agent. Provisioned devices use ML-DSA (post-quantum)
+certificate chains, and the full handshake — multi-KB certificate flights plus
+custom ML-DSA chain verification — costs **~2.2s on a quiet Jetson/Pi and can
+exceed 3s under load** (documented at `go/internal/cli/commands/helpers.go`,
+`mtlsProbeTimeout`). This cost is paid on *every* command, because nothing is
+cached across CLI processes: the client sets no `tls.Config.ClientSessionCache`.
+
+A resumed TLS 1.3 handshake is PSK-only: no certificate exchange, no ML-DSA
+math on the device, one round trip of symmetric crypto. Repeat connects should
+drop from ~2.2s to single-digit/low-tens of milliseconds on LAN.
+
+## Goals
+
+- Repeat CLI → agent connects skip the certificate exchange via TLS 1.3
+  session tickets, persisted across CLI process invocations.
+- Security posture: full ML-DSA chain trust is anchored at the original
+  handshake; resumed connections get **cheap re-checks** (client cert validity
+  window) and stale tickets **downgrade to a full handshake**, never a
+  connection error.
+- Zero behavior change when no ticket exists, the ticket is invalid, the agent
+  restarted, or either side predates this feature (old CLI ↔ new agent and new
+  CLI ↔ old agent both fall back to today's full handshake).
+
+## Non-goals
+
+- Per-device "last known good" connection-parameter cache (separate follow-up;
+  note: resumption makes the *successful* rung of the cert×port probe ladder
+  nearly free, but wasted rungs before it still pay full handshakes).
+- QUIC/HTTP-3 transport (separate spike + benchmark after this ships).
+- Persisting agent-side ticket keys across restarts (weakens forward secrecy
+  for key-management convenience; an agent restart costing one full handshake
+  per device is acceptable).
+- Proto or RPC changes (there are none).
+
+## Design
+
+### 1. Client session cache — new package `go/internal/cli/tlscache`
+
+Implements `tls.ClientSessionCache`, disk-backed under
+`~/.wendy/tls-sessions/` (via `config.ConfigDir()`).
+
+- **Keying:** each `ConnectWithTLSAndPins` call constructs a cache instance
+  bound to a precomputed disk key
+  `SHA256(host:port | SHA256(client leaf cert DER))`. The `sessionKey` string
+  Go passes to `Get`/`Put` (remote address) is ignored. Keying by client cert
+  is a **correctness requirement**: the ticket embeds the client identity
+  verified at the original handshake, so a ticket obtained with org A's cert
+  must never be offered when dialing with org B's cert.
+- **Serialization:** `ClientSessionState.ResumptionState()` →
+  `SessionState.Bytes()` on `Put`; `tls.ParseSessionState` +
+  `tls.NewResumptionState` on `Get` (Go 1.21+ APIs; module is on Go 1.26).
+- **Files:** `<hex(diskKey)>.tlssession`, mode `0600`, directory `0700`.
+  Atomic writes (temp file + rename); concurrent CLI processes are
+  last-writer-wins, which is safe. Opportunistic pruning of files older than
+  7 days (Go's `maxSessionTicketLifetime`) on `Put`.
+- **Failure behavior:** any read/parse/IO error returns "no session" (and
+  best-effort deletes the bad file). The worst case is always a full
+  handshake — i.e. today's behavior. Cache errors are never surfaced.
+- **Self-refresh:** Go's TLS 1.3 server issues a fresh ticket on every
+  connection, including resumed ones, so the file is rewritten on each
+  connect and never goes stale while in regular use.
+
+### 2. Client wiring — `go/internal/cli/grpcclient/client.go`
+
+`ConnectWithTLSAndPins` sets
+`tlsCfg.ClientSessionCache = tlscache.ForTarget(address, certInfo)`.
+
+- The existing `certs.BuildServerVerifyConnection` verifier runs on resumed
+  connections too (Go restores `PeerCertificates` into `ConnectionState` from
+  the cached session), so server-identity checks, pin checks, org checks, and
+  the `OnServerIdentity` sink are unchanged. Its ML-DSA re-verification costs
+  ~1ms on the desktop CLI; the device side is what resumption saves.
+- Under `WENDY_TLS_DEBUG`, log `resumed=true/false` from
+  `ConnectionState.DidResume` (observed inside the verify-connection hook).
+
+### 3. Server — `go/internal/agent/mtls/server.go`
+
+`NewTLSConfig` gains `WrapSession`/`UnwrapSession` implementations built on
+the exported `(*tls.Config).EncryptTicket` / `DecryptTicket` helpers:
+
+- **WrapSession** (original handshake): append a small encoding of the
+  verified client leaf's `{NotBefore, NotAfter}` to `SessionState.Extra`,
+  then `EncryptTicket`. Encoding: a `wendy-mtls/1:`-prefixed entry holding the
+  two Unix-seconds values (`Extra` is a shared list — the prefix lets our
+  entry coexist with any other component's and makes unknown versions
+  detectable, which `UnwrapSession` treats as "decline").
+- **UnwrapSession** (resumption attempt): `DecryptTicket`; if the ticket is
+  undecryptable, the Extra metadata is missing/garbled, or the validity
+  window has lapsed — applying the same `notBeforeFloor` clock-skew
+  semantics the existing `buildVerifyPeerCertificate` uses — **decline
+  resumption by returning `(nil, nil)`**. Go then continues with a full
+  handshake, where `VerifyPeerCertificate` re-runs the complete ML-DSA
+  verification and surfaces the existing, well-understood errors if the cert
+  is genuinely bad. A stale ticket therefore self-heals silently instead of
+  producing a hard failure loop.
+- Go's server already refuses to resume a session carrying no client
+  certificate when `ClientAuth >= RequireAnyClientCert`, and the per-RPC mTLS
+  interceptors keep seeing `PeerCertificates` (restored from the ticket), so
+  org enforcement is unchanged. Both facts are pinned by integration tests.
+- Ticket keys remain Go's per-process defaults: agent restart invalidates all
+  outstanding tickets (one full handshake per device afterwards).
+
+### 4. Mesh bonus — `NewClientTLSConfig`
+
+The agent→agent mesh client config gets a one-line in-memory
+`tls.NewLRUClientSessionCache`; the agent is a long-lived process, so
+in-memory is sufficient there and reconnects benefit for free.
+
+## Error handling summary
+
+| Failure | Outcome |
+| --- | --- |
+| No/corrupt/unreadable session file | Full handshake (today's path) |
+| Agent restarted (ticket keys rotated) | Ticket undecryptable → full handshake |
+| Client cert window lapsed inside ticket | Server declines → full handshake → normal cert errors if genuinely expired |
+| Ticket from wrong client cert | Never offered (disk key includes cert fingerprint) |
+| Old agent (no Wrap/Unwrap) ↔ new CLI | Default ticket flow or none; full handshake at worst |
+| Concurrent CLI processes | Atomic rename, last-writer-wins |
+
+## Testing
+
+**Unit (`tlscache`):** Put/Get round-trip across two cache instances
+(simulates separate CLI processes); cert-fingerprint keying isolation (cert A's
+ticket invisible when bound to cert B); corrupt file → nil + file removed;
+pruning of >7-day files; `0600`/`0700` permissions; atomic write.
+
+**Integration (in-process TLS client + `mtls.NewTLSConfig` server over a real
+listener, plus a gRPC-level pass using `mtls.NewServer`):**
+
+1. Second connection resumes: `DidResume == true` on both ends;
+   `VerifyPeerCertificate` counter shows exactly one full verification.
+2. mTLS interceptors still observe the peer identity on a resumed connection.
+3. Expired/garbled ticket metadata → `DidResume == false`, connection still
+   succeeds via full handshake (decline, not error).
+4. `notBeforeFloor` semantics honored in `UnwrapSession`.
+5. Session-tickets-disabled server (old-agent stand-in) → full handshake both
+   times, no errors.
+
+**On-device verification (PR gate):** before/after `WENDY_TIMING` runs on the
+Orin Nano showing the mTLS-attempts phase drop from ~2.2s to milliseconds on
+repeat connects.
+
+## Expected effect
+
+Warm connect ≈ TCP (1 RTT) + TLS 1.3 PSK (1 RTT) + first RPC (1 RTT) —
+roughly 5–30ms on LAN versus ~2.2s today, on every repeat `wendy` command
+against a provisioned device.

--- a/go/internal/agent/mtls/mesh_resumption_pin_test.go
+++ b/go/internal/agent/mtls/mesh_resumption_pin_test.go
@@ -1,0 +1,202 @@
+package mtls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// meshPeerCert signs a leaf certificate carrying urn as its wendy identity SAN
+// (the same shape testPeerLeafRaw produces for VerifyPeerCertificate-only
+// tests), returned as a servable tls.Certificate so it can back a real TLS
+// listener — this test needs an actual handshake (and a real session ticket)
+// rather than a raw VerifyPeerCertificate call.
+func meshPeerCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, urn string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating leaf key: %v", err)
+	}
+	u, err := url.Parse(urn)
+	if err != nil {
+		t.Fatalf("parsing urn %q: %v", urn, err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "mesh-peer"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		// Both EKUs: the peer's VerifyPeerCertificate chain check (built by
+		// NewTLSConfig for the server-verifying-client role) requires
+		// ExtKeyUsageClientAuth even though this cert is presented in the
+		// server role of the TLS handshake below — mirroring real mesh device
+		// certs, which serve as both mesh client and mesh server.
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		URIs:        []*url.URL{u},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("creating leaf cert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// startMeshPeerServer runs a bare TLS 1.3 server presenting cert with Go's
+// default session-ticket behavior (no custom WrapSession/UnwrapSession): this
+// test is entirely about what the CLIENT does with a resumed session, not the
+// agent's own server-side ticket logic (covered by resumption_test.go), so a
+// plain tls.Config is the more faithful "any mesh peer" stand-in. Each
+// accepted connection writes one byte after the handshake and waits for the
+// client to close, mirroring the pattern in resumption_test.go and
+// tlscache's cache_test.go so that a client Read after Dial reliably
+// observes the post-handshake NewSessionTicket message before the ticket is
+// needed for the next dial.
+func startMeshPeerServer(t *testing.T, cert tls.Certificate) string {
+	t.Helper()
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc := tls.Server(c, cfg)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				tc.Write([]byte{1})
+				buf := make([]byte, 1)
+				tc.Read(buf)
+			}(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// dialMeshPeer dials addr with cfg and, on success, reads the one byte the
+// server writes post-handshake so the caller can rely on the session
+// ticket having been processed (Put on the client's session cache) before
+// the connection is closed or another dial is attempted.
+func dialMeshPeer(t *testing.T, addr string, cfg *tls.Config) (*tls.Conn, error) {
+	t.Helper()
+	conn, err := tls.Dial("tcp", addr, cfg)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// TestNewClientTLSConfigExpectingPeerRejectsPinMismatchOnResume is the
+// regression test for the "mesh peer pin bypassed on resumed connections"
+// finding: NewClientTLSConfigExpectingPeer enforced the mesh anti-MITM pin
+// (org + asset ID, see its doc comment) only inside VerifyPeerCertificate,
+// which Go skips entirely on a resumed TLS 1.3 handshake — only
+// VerifyConnection runs, with ConnectionState.PeerCertificates restored from
+// the cached ticket rather than freshly presented. Because all mesh dials
+// share one process-wide meshSessionCache AND one constant gRPC authority
+// ("passthrough:///mesh-peer", see mesh_dialer.go's meshDialTarget), a ticket
+// cached while dialing one asset could previously be resumed while a LATER
+// dial "expects" a completely different asset, performing ZERO client-side
+// verification of the peer's actual certificate.
+//
+// This test reproduces the shared-cache scenario directly against a real TLS
+// server rather than through the gRPC/mesh-dialer plumbing: one physical
+// server presents a fixed identity (asset 100 in org 7). Two
+// NewClientTLSConfigExpectingPeer configs share one tls.ClientSessionCache —
+// one correctly pinned to asset 100, one (mis)pinned to a different asset
+// 999 — simulating two mesh dials to different devices that land on the same
+// cache slot. The mispinned dial must fail once it resumes a session
+// actually established with asset 100.
+//
+// Ordering note: Go's client evicts a ClientSessionCache entry whenever a
+// handshake that attempted resumption subsequently fails (see
+// crypto/tls/handshake_client.go's clientHandshake, RFC 5077 §3.2 ticket
+// disposal on failure) — so the "legitimate resumption still works"
+// assertion runs BEFORE the mispinned dial, not after: once the mispinned
+// dial fails as expected, Go throws away the now-suspect cached ticket,
+// which is a reasonable side effect but would make a THIRD, post-attack
+// assertion meaningless (it would force a full handshake for an unrelated
+// reason, telling us nothing about the pin-mismatch fix).
+func TestNewClientTLSConfigExpectingPeerRejectsPinMismatchOnResume(t *testing.T) {
+	ca, caKey, chainPEM := testCAKeyPair(t)
+	peerCert := meshPeerCert(t, ca, caKey, "urn:wendy:org:7:asset:100")
+	addr := startMeshPeerServer(t, peerCert)
+
+	// The dialing side's own identity is irrelevant to peer pinning; the bare
+	// server above never requests a client certificate.
+	ownCertPEM, ownKeyPEM := testLeafCertificate(t, "dialer")
+
+	cache := tls.NewLRUClientSessionCache(4)
+
+	cfgX, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, 7, "100")
+	if err != nil {
+		t.Fatalf("NewClientTLSConfigExpectingPeer(asset 100): %v", err)
+	}
+	cfgX.ClientSessionCache = cache
+
+	// Dial 1: full handshake, correctly pinned to the server's real identity.
+	// Must succeed, must NOT resume (nothing cached yet), and caches a ticket.
+	conn1, err := dialMeshPeer(t, addr, cfgX)
+	if err != nil {
+		t.Fatalf("first dial (correct pin, full handshake) failed: %v", err)
+	}
+	if conn1.ConnectionState().DidResume {
+		t.Error("first connection unexpectedly resumed")
+	}
+	conn1.Close()
+
+	// Dial 2: same cfgX, same cache. Must resume — this is the "no false
+	// positives" check: the VerifyConnection re-verify added by the fix must
+	// not break ordinary resumption to the SAME correctly pinned peer.
+	conn2, err := dialMeshPeer(t, addr, cfgX)
+	if err != nil {
+		t.Fatalf("second dial (correct pin, expected resume) failed: %v", err)
+	}
+	if !conn2.ConnectionState().DidResume {
+		t.Error("second connection with the correct pin did not resume")
+	}
+	conn2.Close()
+
+	// Dial 3: a DIFFERENT NewClientTLSConfigExpectingPeer, pinned to a
+	// DIFFERENT asset (999), but wired to the SAME session cache — simulating
+	// a later mesh dial to a different device sharing meshSessionCache and
+	// the constant mesh dial authority. The cache holds a ticket for the
+	// server's real identity (asset 100, refreshed by dial 2's post-handshake
+	// ticket), so the server will happily accept resumption; the fix must
+	// catch the pin mismatch in VerifyConnection and fail the handshake.
+	cfgY, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, 7, "999")
+	if err != nil {
+		t.Fatalf("NewClientTLSConfigExpectingPeer(asset 999): %v", err)
+	}
+	cfgY.ClientSessionCache = cache
+
+	conn3, err := dialMeshPeer(t, addr, cfgY)
+	if err == nil {
+		conn3.Close()
+		t.Fatal("dial pinned to a different asset than the resumed session succeeded — the peer pin was bypassed on resumption")
+	}
+}

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -158,6 +158,26 @@ func maxTime(a, b time.Time) time.Time {
 	return b
 }
 
+// effectiveVerificationTime returns the clock used for NotBefore checks.
+// effectiveNow applies the NotBefore floor; when the device clock is behind
+// notBeforeFloor (NTP not yet synced), it additionally advances up to the
+// cert's NotBefore so a cert issued just after provisioning is not spuriously
+// rejected — capped at notBeforeFloor+maxClockSkewTolerance so a cert whose
+// NotBefore is further in the future is still rejected on a stuck clock.
+// Shared by the full ML-DSA verifier and the session-ticket re-check
+// (session_ticket.go) so the two can never drift apart.
+func effectiveVerificationTime(realNow, notBeforeFloor, certNotBefore time.Time) time.Time {
+	effectiveNow := maxTime(realNow, notBeforeFloor)
+	if realNow.Before(notBeforeFloor) {
+		advanced := certNotBefore
+		if cap := notBeforeFloor.Add(maxClockSkewTolerance); advanced.After(cap) {
+			advanced = cap
+		}
+		effectiveNow = maxTime(effectiveNow, advanced)
+	}
+	return effectiveNow
+}
+
 // buildVerifyPeerCertificate returns a VerifyPeerCertificate callback that
 // handles both standard (RSA/ECDSA) and ML-DSA-signed certificate chains.
 // logger may be nil, in which case no logging is performed.
@@ -177,22 +197,8 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 			return fmt.Errorf("parsing client certificate: %w", err)
 		}
 
-		// Capture the real clock once to avoid TOCTOU between the expiry pre-check
-		// and the verification call. effectiveNow applies the NotBefore floor only.
 		realNow := time.Now()
-		effectiveNow := maxTime(realNow, notBeforeFloor)
-		// When the device clock is behind notBeforeFloor (NTP not yet synced),
-		// advance effectiveNow up to the cert's NotBefore so a cert issued just
-		// after provisioning is not spuriously rejected. Cap the advancement at
-		// notBeforeFloor+maxClockSkewTolerance: a cert whose NotBefore is further
-		// in the future than that is not accepted by a device with a stuck clock.
-		if realNow.Before(notBeforeFloor) {
-			advanced := leaf.NotBefore
-			if cap := notBeforeFloor.Add(maxClockSkewTolerance); advanced.After(cap) {
-				advanced = cap
-			}
-			effectiveNow = maxTime(effectiveNow, advanced)
-		}
+		effectiveNow := effectiveVerificationTime(realNow, notBeforeFloor, leaf.NotBefore)
 
 		// Pre-reject expired certs before any further processing. The floor must
 		// not mask real-time expiry: checking here with realNow eliminates any

--- a/go/internal/agent/mtls/resumption_test.go
+++ b/go/internal/agent/mtls/resumption_test.go
@@ -82,15 +82,39 @@ func newResumptionPKI(t *testing.T) resumptionPKI {
 
 // resumptionEnv serves the given config and reports each connection's
 // server-side DidResume; verifies counts full VerifyPeerCertificate runs.
+//
+// crypto/tls documents that a *tls.Config must not be modified after it is
+// first used, and reads fields like WrapSession/UnwrapSession/
+// SessionTicketsDisabled unguarded during each handshake. The accept-loop
+// goroutine below starts using cfg as soon as newResumptionEnv launches it,
+// so tests must never assign to cfg fields afterwards — that would race with
+// the handshake goroutines under the Go memory model (a data race exists
+// whether or not `go test -race` happens to observe it on a given run). All
+// hook functions are therefore installed exactly once, before the accept
+// loop starts; tests that need to change behavior mid-run do so only through
+// the synchronized `now` / `stripWindow` indirection below, which the
+// installed hooks consult via atomic loads on every handshake.
 type resumptionEnv struct {
 	addr        string
 	cfg         *tls.Config
 	clientCert  tls.Certificate
 	verifyCount *atomic.Int32
 	srvResumed  chan bool
+
+	// now backs the UnwrapSession clock; tests swap it via now.Store to
+	// simulate time passing without touching cfg after the accept loop starts.
+	now atomic.Pointer[func() time.Time]
+	// stripWindow, when true, makes the installed WrapSession skip stamping
+	// the client cert window — simulating a garbled/foreign ticket.
+	stripWindow atomic.Bool
 }
 
-func newResumptionEnv(t *testing.T) *resumptionEnv {
+// newResumptionEnv builds the PKI, wires the server TLS config, and starts
+// the accept loop. ticketsDisabled must be decided up front (rather than by
+// mutating env.cfg.SessionTicketsDisabled after the fact) because that field,
+// like the other cfg fields here, is read unguarded by the handshake
+// goroutine once the accept loop is running.
+func newResumptionEnv(t *testing.T, ticketsDisabled bool) *resumptionEnv {
 	t.Helper()
 	pki := newResumptionPKI(t)
 	cfg, err := NewTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil, time.Time{})
@@ -98,11 +122,38 @@ func newResumptionEnv(t *testing.T) *resumptionEnv {
 		t.Fatalf("NewTLSConfig: %v", err)
 	}
 	env := &resumptionEnv{cfg: cfg, verifyCount: new(atomic.Int32), srvResumed: make(chan bool, 16)}
+	realNow := time.Now
+	env.now.Store(&realNow)
+
 	inner := cfg.VerifyPeerCertificate
 	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
 		env.verifyCount.Add(1)
 		return inner(rawCerts, chains)
 	}
+
+	// Re-wire WrapSession/UnwrapSession exactly once, before the accept loop
+	// starts. The injected clock indirects through env.now so
+	// TestResumptionDeclinedWhenCertWindowLapses can advance time later by
+	// swapping the atomic pointer instead of re-wiring cfg.
+	wireSessionTicketChecks(cfg, time.Time{}, func() time.Time {
+		nowFn := env.now.Load()
+		return (*nowFn)()
+	})
+	// Layer the stripWindow override on top of the just-installed WrapSession,
+	// still before the accept loop starts. When stripWindow is set,
+	// TestResumptionDeclinedWithoutWindowMetadata's tickets skip the window
+	// stamp entirely, simulating a garbled/foreign ticket.
+	baseWrap := cfg.WrapSession
+	cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+		if env.stripWindow.Load() {
+			return cfg.EncryptTicket(cs, ss)
+		}
+		return baseWrap(cs, ss)
+	}
+	if ticketsDisabled {
+		cfg.SessionTicketsDisabled = true
+	}
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -157,7 +208,7 @@ func (env *resumptionEnv) dial(t *testing.T, cache tls.ClientSessionCache) (clie
 }
 
 func TestResumptionSecondConnectionResumes(t *testing.T) {
-	env := newResumptionEnv(t)
+	env := newResumptionEnv(t, false)
 	cache := tls.NewLRUClientSessionCache(4)
 
 	c1, s1 := env.dial(t, cache)
@@ -174,15 +225,17 @@ func TestResumptionSecondConnectionResumes(t *testing.T) {
 }
 
 func TestResumptionDeclinedWhenCertWindowLapses(t *testing.T) {
-	env := newResumptionEnv(t)
+	env := newResumptionEnv(t, false)
 	cache := tls.NewLRUClientSessionCache(4)
 	env.dial(t, cache)
 
-	// Re-wire with a clock far past the client cert's NotAfter: the server
-	// must DECLINE the ticket and complete a FULL handshake — not error out.
-	wireSessionTicketChecks(env.cfg, time.Time{}, func() time.Time {
-		return time.Now().Add(3 * 365 * 24 * time.Hour)
-	})
+	// Swap the clock the installed UnwrapSession checks against to far past
+	// the client cert's NotAfter: the server must DECLINE the ticket and
+	// complete a FULL handshake — not error out. This only swaps the
+	// synchronized env.now atomic pointer; it never re-wires or mutates
+	// env.cfg itself, which the accept-loop goroutine is already using.
+	future := func() time.Time { return time.Now().Add(3 * 365 * 24 * time.Hour) }
+	env.now.Store(&future)
 	c2, s2 := env.dial(t, cache)
 	if c2 || s2 {
 		t.Fatalf("stale-window ticket resumed (client=%v server=%v)", c2, s2)
@@ -193,14 +246,15 @@ func TestResumptionDeclinedWhenCertWindowLapses(t *testing.T) {
 }
 
 func TestResumptionDeclinedWithoutWindowMetadata(t *testing.T) {
-	env := newResumptionEnv(t)
+	env := newResumptionEnv(t, false)
 	cache := tls.NewLRUClientSessionCache(4)
 
 	// Issue tickets WITHOUT the window stamp (simulates a garbled/foreign
 	// ticket): resumption must be declined, connection must still succeed.
-	env.cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
-		return env.cfg.EncryptTicket(cs, ss)
-	}
+	// This only flips the synchronized env.stripWindow flag consulted by the
+	// WrapSession wrapper installed once in newResumptionEnv; env.cfg itself
+	// is never mutated after the accept loop starts.
+	env.stripWindow.Store(true)
 	env.dial(t, cache)
 	c2, s2 := env.dial(t, cache)
 	if c2 || s2 {
@@ -209,8 +263,9 @@ func TestResumptionDeclinedWithoutWindowMetadata(t *testing.T) {
 }
 
 func TestResumptionTicketsDisabledStillConnects(t *testing.T) {
-	env := newResumptionEnv(t)
-	env.cfg.SessionTicketsDisabled = true
+	// ticketsDisabled must be set before the accept loop starts (see
+	// newResumptionEnv), so it is passed in rather than assigned afterwards.
+	env := newResumptionEnv(t, true)
 	cache := tls.NewLRUClientSessionCache(4)
 
 	env.dial(t, cache)

--- a/go/internal/agent/mtls/resumption_test.go
+++ b/go/internal/agent/mtls/resumption_test.go
@@ -1,0 +1,221 @@
+package mtls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type resumptionPKI struct {
+	serverCertPEM, serverKeyPEM, caPEM string
+	clientCert                         tls.Certificate
+}
+
+func newResumptionPKI(t *testing.T) resumptionPKI {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Resumption Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leaf := func(cn string, eku x509.ExtKeyUsage) (string, string, tls.Certificate) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("gen key: %v", err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("create leaf: %v", err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatalf("marshal key: %v", err)
+		}
+		certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+		keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+		return certPEM, keyPEM, tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	}
+
+	serverCertPEM, serverKeyPEM, _ := leaf("resumption-server", x509.ExtKeyUsageServerAuth)
+	_, _, clientCert := leaf("resumption-client", x509.ExtKeyUsageClientAuth)
+	return resumptionPKI{
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		caPEM:         string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+		clientCert:    clientCert,
+	}
+}
+
+// resumptionEnv serves the given config and reports each connection's
+// server-side DidResume; verifies counts full VerifyPeerCertificate runs.
+type resumptionEnv struct {
+	addr        string
+	cfg         *tls.Config
+	clientCert  tls.Certificate
+	verifyCount *atomic.Int32
+	srvResumed  chan bool
+}
+
+func newResumptionEnv(t *testing.T) *resumptionEnv {
+	t.Helper()
+	pki := newResumptionPKI(t)
+	cfg, err := NewTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil, time.Time{})
+	if err != nil {
+		t.Fatalf("NewTLSConfig: %v", err)
+	}
+	env := &resumptionEnv{cfg: cfg, verifyCount: new(atomic.Int32), srvResumed: make(chan bool, 16)}
+	inner := cfg.VerifyPeerCertificate
+	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
+		env.verifyCount.Add(1)
+		return inner(rawCerts, chains)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	env.addr = ln.Addr().String()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc := tls.Server(c, cfg)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				env.srvResumed <- tc.ConnectionState().DidResume
+				tc.Write([]byte{1})
+				buf := make([]byte, 1)
+				tc.Read(buf)
+			}(c)
+		}
+	}()
+	// The client mirrors grpcclient's config shape: cert presented,
+	// hostname verification off (test CA has no SANs for 127.0.0.1).
+	env.clientCert = pki.clientCert
+	return env
+}
+
+func (env *resumptionEnv) dial(t *testing.T, cache tls.ClientSessionCache) (clientResumed, serverResumed bool) {
+	t.Helper()
+	conn, err := tls.Dial("tcp", env.addr, &tls.Config{
+		Certificates:       []tls.Certificate{env.clientCert},
+		InsecureSkipVerify: true,
+		ClientSessionCache: cache,
+		MinVersion:         tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if v := conn.ConnectionState().Version; v != tls.VersionTLS13 {
+		t.Fatalf("negotiated TLS %x, want TLS 1.3", v)
+	}
+	return conn.ConnectionState().DidResume, <-env.srvResumed
+}
+
+func TestResumptionSecondConnectionResumes(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+
+	c1, s1 := env.dial(t, cache)
+	if c1 || s1 {
+		t.Fatalf("first connection resumed (client=%v server=%v)", c1, s1)
+	}
+	c2, s2 := env.dial(t, cache)
+	if !c2 || !s2 {
+		t.Fatalf("second connection did not resume (client=%v server=%v)", c2, s2)
+	}
+	if n := env.verifyCount.Load(); n != 1 {
+		t.Errorf("full ML-DSA verification ran %d times, want exactly 1", n)
+	}
+}
+
+func TestResumptionDeclinedWhenCertWindowLapses(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+	env.dial(t, cache)
+
+	// Re-wire with a clock far past the client cert's NotAfter: the server
+	// must DECLINE the ticket and complete a FULL handshake — not error out.
+	wireSessionTicketChecks(env.cfg, time.Time{}, func() time.Time {
+		return time.Now().Add(3 * 365 * 24 * time.Hour)
+	})
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("stale-window ticket resumed (client=%v server=%v)", c2, s2)
+	}
+	if n := env.verifyCount.Load(); n != 2 {
+		t.Errorf("full verification ran %d times, want 2 (decline forces re-verify)", n)
+	}
+}
+
+func TestResumptionDeclinedWithoutWindowMetadata(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+
+	// Issue tickets WITHOUT the window stamp (simulates a garbled/foreign
+	// ticket): resumption must be declined, connection must still succeed.
+	env.cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+		return env.cfg.EncryptTicket(cs, ss)
+	}
+	env.dial(t, cache)
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("metadata-less ticket resumed (client=%v server=%v)", c2, s2)
+	}
+}
+
+func TestResumptionTicketsDisabledStillConnects(t *testing.T) {
+	env := newResumptionEnv(t)
+	env.cfg.SessionTicketsDisabled = true
+	cache := tls.NewLRUClientSessionCache(4)
+
+	env.dial(t, cache)
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("resumed with tickets disabled (client=%v server=%v)", c2, s2)
+	}
+}

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -227,7 +227,7 @@ func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *z
 	// With this fix in place, every resumed mesh connection re-verifies the
 	// full chain + identity pin, so a client that let session tickets chain
 	// indefinitely across resumptions (extending trust well past a single
-	// handshake's ML-DSA verification — see tlscache.Cache.MarkResumed's doc
+	// handshake's ML-DSA verification — see tlscache.Cache.SetResumed's doc
 	// for why the CLI↔agent path guards against exactly that) is harmless
 	// here: the in-memory meshSessionCache needs no equivalent guard.
 	base.VerifyConnection = func(cs tls.ConnectionState) error {

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -113,6 +113,12 @@ func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFl
 	return grpc.NewServer(opts...), nil
 }
 
+// meshSessionCache lets agent→agent mesh dials resume TLS sessions. One
+// process-wide cache: mesh TLS configs are constructed per dial, so a
+// per-config cache would never produce a hit, and the agent presents a single
+// client identity so cross-identity ticket reuse cannot arise.
+var meshSessionCache = tls.NewLRUClientSessionCache(64)
+
 // NewClientTLSConfig returns a TLS config for one agent dialing another
 // agent's mTLS port (mesh LAN path): it presents this device's asset
 // certificate and verifies the peer's chain with the same custom verifier the
@@ -134,6 +140,7 @@ func NewClientTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger) (*
 		MinVersion:            base.MinVersion,
 		InsecureSkipVerify:    true, // verification is NOT disabled: VerifyPeerCertificate below performs the full (ML-DSA-aware) chain check
 		VerifyPeerCertificate: base.VerifyPeerCertificate,
+		ClientSessionCache:    meshSessionCache,
 	}, nil
 }
 

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -54,7 +54,7 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBefor
 	}
 	caPool.AppendCertsFromPEM([]byte(certPEM))
 
-	return &tls.Config{
+	cfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		// RequireAnyClientCert requires the client to present a cert but defers
 		// chain verification to VerifyPeerCertificate, which handles ML-DSA.
@@ -69,7 +69,11 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBefor
 		ClientCAs:             nil,
 		MinVersion:            tls.VersionTLS12,
 		VerifyPeerCertificate: buildVerifyPeerCertificate(caPool, caCerts, logger, notBeforeFloor),
-	}, nil
+	}
+	// Session resumption: stamp the client cert window into tickets and
+	// decline stale ones (see session_ticket.go for the security rationale).
+	wireSessionTicketChecks(cfg, notBeforeFloor, time.Now)
+	return cfg, nil
 }
 
 // NewServer creates a gRPC server with mTLS credentials.

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -135,13 +135,33 @@ func NewClientTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger) (*
 		// replaces Go's built-in one; never hand out a config without it.
 		return nil, errors.New("mtls: base TLS config has no peer verifier")
 	}
-	return &tls.Config{
+	chainVerify := base.VerifyPeerCertificate
+	cfg := &tls.Config{
 		Certificates:          base.Certificates,
 		MinVersion:            base.MinVersion,
 		InsecureSkipVerify:    true, // verification is NOT disabled: VerifyPeerCertificate below performs the full (ML-DSA-aware) chain check
-		VerifyPeerCertificate: base.VerifyPeerCertificate,
+		VerifyPeerCertificate: chainVerify,
 		ClientSessionCache:    meshSessionCache,
-	}, nil
+	}
+	// Defense in depth: on a resumed TLS 1.3 handshake Go skips
+	// VerifyPeerCertificate entirely (no certificate exchange happens) and
+	// only calls VerifyConnection, with ConnectionState.PeerCertificates
+	// restored from the cached session ticket rather than freshly presented.
+	// Without re-running the chain check here, a resumed mesh connection
+	// would perform zero client-side verification of the peer's certificate.
+	// On a full handshake VerifyPeerCertificate already ran, so there is
+	// nothing to redo.
+	cfg.VerifyConnection = func(cs tls.ConnectionState) error {
+		if !cs.DidResume {
+			return nil
+		}
+		rawCerts := make([][]byte, len(cs.PeerCertificates))
+		for i, c := range cs.PeerCertificates {
+			rawCerts[i] = c.Raw
+		}
+		return chainVerify(rawCerts, nil)
+	}
+	return cfg, nil
 }
 
 // NewClientTLSConfigExpectingPeer is like NewClientTLSConfig but additionally
@@ -161,7 +181,7 @@ func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *z
 		return nil, err
 	}
 	chainVerify := base.VerifyPeerCertificate
-	base.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	pinnedVerify := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		if err := chainVerify(rawCerts, verifiedChains); err != nil {
 			return err
 		}
@@ -187,6 +207,38 @@ func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *z
 				wantAssetID, wantOrgID, ident.EntityID, ident.OrgID)
 		}
 		return nil
+	}
+	base.VerifyPeerCertificate = pinnedVerify
+	// CRITICAL: a resumed TLS 1.3 handshake skips VerifyPeerCertificate
+	// entirely — Go only calls VerifyConnection, with
+	// ConnectionState.PeerCertificates restored from the cached session
+	// ticket. All mesh dials share one process-wide meshSessionCache AND one
+	// constant gRPC authority (passthrough:///mesh-peer), so without this,
+	// a ticket cached while dialing asset A could be resumed while
+	// "expecting" asset B, silently bypassing the anti-MITM pin above (see
+	// meshDialLAN's doc in mesh_dialer.go). Re-run the SAME pinned verify
+	// closure against the resumed connection's restored peer certs; on a
+	// full handshake (DidResume false) VerifyPeerCertificate already ran
+	// this check, so there is nothing to redo. A pin mismatch here hard-fails
+	// the connection rather than silently declining to resume: a full
+	// handshake to the wrong peer would fail this same pin check, so there
+	// is no decline-vs-fail asymmetry to preserve.
+	//
+	// With this fix in place, every resumed mesh connection re-verifies the
+	// full chain + identity pin, so a client that let session tickets chain
+	// indefinitely across resumptions (extending trust well past a single
+	// handshake's ML-DSA verification — see tlscache.Cache.MarkResumed's doc
+	// for why the CLI↔agent path guards against exactly that) is harmless
+	// here: the in-memory meshSessionCache needs no equivalent guard.
+	base.VerifyConnection = func(cs tls.ConnectionState) error {
+		if !cs.DidResume {
+			return nil
+		}
+		rawCerts := make([][]byte, len(cs.PeerCertificates))
+		for i, c := range cs.PeerCertificates {
+			rawCerts[i] = c.Raw
+		}
+		return pinnedVerify(rawCerts, nil)
 	}
 	return base, nil
 }

--- a/go/internal/agent/mtls/session_ticket.go
+++ b/go/internal/agent/mtls/session_ticket.go
@@ -18,12 +18,37 @@ const ticketMetaPrefix = "wendy-mtls/1:"
 //
 // Rationale: a resumed TLS 1.3 handshake skips the certificate exchange, so
 // the full ML-DSA chain verification from the original handshake is trusted
-// for the ticket's lifetime (≤7 days, less on agent restart). The cheap
-// re-check here bounds that trust by the cert's own validity window. Declining
-// (returning nil, nil) downgrades to a full handshake, where
-// VerifyPeerCertificate re-runs the complete verification and surfaces the
-// existing error paths if the cert is genuinely bad — a stale ticket
-// self-heals instead of hard-failing on every retry.
+// for as long as the client keeps offering a resumable ticket. The cheap
+// re-check here bounds that trust to the cert's own validity window on EVERY
+// resumption attempt, not just the first. Declining (returning nil, nil)
+// downgrades to a full handshake, where VerifyPeerCertificate re-runs the
+// complete verification and surfaces the existing error paths if the cert is
+// genuinely bad — a stale ticket self-heals instead of hard-failing on every
+// retry.
+//
+// The design spec's documented "≤7 days, less on agent restart" trust bound
+// is NOT enforced by ticket lifetime alone: Go's TLS 1.3 server reissues a
+// fresh ticket on EVERY connection, including resumed ones, so a client that
+// simply overwrote its cached ticket on each connect could chain tickets
+// indefinitely and never trigger another full ML-DSA verification, no matter
+// how old the original handshake was. The actual bound is enforced
+// CLIENT-side (go/internal/cli/tlscache.Cache): the client keeps only the
+// ticket from its last FULL handshake and discards tickets minted on resumed
+// connections (Cache.MarkResumed/Put). Combined with Go's own
+// maxSessionTicketLifetime (7 days) check on both this server and the client,
+// that forces a full handshake — and therefore a full ML-DSA re-verification
+// — at least once a week, even for a client that connects every day. The
+// per-resumption cert-window re-check in this file and the client-side
+// no-chaining rule are two independent layers of the same bound: this one
+// catches a cert that expires mid-week; the client-side rule caps how long a
+// still-valid cert's trust can be extended by resumption alone.
+//
+// Mesh dials are exempt from the chaining risk in a different way: with the
+// anti-MITM peer pin fix in server.go's NewClientTLSConfigExpectingPeer
+// (VerifyConnection re-running the pin+chain check on every resumed mesh
+// connection), a resumed mesh connection re-verifies as much as a full one
+// does, so ticket chaining in the in-memory meshSessionCache is harmless and
+// needs no equivalent no-overwrite rule.
 //
 // now is injectable for handshake-level tests; production passes time.Now.
 func wireSessionTicketChecks(cfg *tls.Config, notBeforeFloor time.Time, now func() time.Time) {

--- a/go/internal/agent/mtls/session_ticket.go
+++ b/go/internal/agent/mtls/session_ticket.go
@@ -34,7 +34,7 @@ const ticketMetaPrefix = "wendy-mtls/1:"
 // how old the original handshake was. The actual bound is enforced
 // CLIENT-side (go/internal/cli/tlscache.Cache): the client keeps only the
 // ticket from its last FULL handshake and discards tickets minted on resumed
-// connections (Cache.MarkResumed/Put). Combined with Go's own
+// connections (Cache.SetResumed/Put). Combined with Go's own
 // maxSessionTicketLifetime (7 days) check on both this server and the client,
 // that forces a full handshake — and therefore a full ML-DSA re-verification
 // — at least once a week, even for a client that connects every day. The

--- a/go/internal/agent/mtls/session_ticket.go
+++ b/go/internal/agent/mtls/session_ticket.go
@@ -1,0 +1,84 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"time"
+)
+
+// ticketMetaPrefix tags this package's entry in SessionState.Extra. Extra is a
+// shared list any component may append to, so the prefix both namespaces our
+// entry and versions its layout; UnwrapSession treats an absent or
+// unknown-version entry as "decline resumption".
+const ticketMetaPrefix = "wendy-mtls/1:"
+
+// wireSessionTicketChecks installs WrapSession/UnwrapSession on a server TLS
+// config so that session tickets carry the verified client cert's validity
+// window and resumption is DECLINED — never failed — once that window lapses.
+//
+// Rationale: a resumed TLS 1.3 handshake skips the certificate exchange, so
+// the full ML-DSA chain verification from the original handshake is trusted
+// for the ticket's lifetime (≤7 days, less on agent restart). The cheap
+// re-check here bounds that trust by the cert's own validity window. Declining
+// (returning nil, nil) downgrades to a full handshake, where
+// VerifyPeerCertificate re-runs the complete verification and surfaces the
+// existing error paths if the cert is genuinely bad — a stale ticket
+// self-heals instead of hard-failing on every retry.
+//
+// now is injectable for handshake-level tests; production passes time.Now.
+func wireSessionTicketChecks(cfg *tls.Config, notBeforeFloor time.Time, now func() time.Time) {
+	cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+		appendClientCertWindow(ss, cs)
+		return cfg.EncryptTicket(cs, ss)
+	}
+	cfg.UnwrapSession = func(identity []byte, cs tls.ConnectionState) (*tls.SessionState, error) {
+		ss, err := cfg.DecryptTicket(identity, cs)
+		if err != nil || ss == nil {
+			return nil, nil // undecryptable (e.g. pre-restart ticket) → full handshake
+		}
+		notBefore, notAfter, ok := clientCertWindowFromExtra(ss)
+		if !ok || !resumableClientWindow(notBefore, notAfter, now(), notBeforeFloor) {
+			return nil, nil
+		}
+		return ss, nil
+	}
+}
+
+// appendClientCertWindow stamps the verified client leaf's validity window
+// into the session state. With no peer cert (should not happen under
+// RequireAnyClientCert) nothing is appended, which UnwrapSession later reads
+// as "decline".
+func appendClientCertWindow(ss *tls.SessionState, cs tls.ConnectionState) {
+	if len(cs.PeerCertificates) == 0 {
+		return
+	}
+	leaf := cs.PeerCertificates[0]
+	meta := make([]byte, len(ticketMetaPrefix)+16)
+	copy(meta, ticketMetaPrefix)
+	binary.BigEndian.PutUint64(meta[len(ticketMetaPrefix):], uint64(leaf.NotBefore.Unix()))
+	binary.BigEndian.PutUint64(meta[len(ticketMetaPrefix)+8:], uint64(leaf.NotAfter.Unix()))
+	ss.Extra = append(ss.Extra, meta)
+}
+
+func clientCertWindowFromExtra(ss *tls.SessionState) (notBefore, notAfter time.Time, ok bool) {
+	for _, entry := range ss.Extra {
+		if len(entry) != len(ticketMetaPrefix)+16 || string(entry[:len(ticketMetaPrefix)]) != ticketMetaPrefix {
+			continue
+		}
+		nb := int64(binary.BigEndian.Uint64(entry[len(ticketMetaPrefix):]))
+		na := int64(binary.BigEndian.Uint64(entry[len(ticketMetaPrefix)+8:]))
+		return time.Unix(nb, 0), time.Unix(na, 0), true
+	}
+	return time.Time{}, time.Time{}, false
+}
+
+// resumableClientWindow mirrors buildVerifyPeerCertificate's clock handling:
+// expiry is checked against the real clock (the floor must never mask real
+// expiry), NotBefore against effectiveVerificationTime (the floor rescues
+// devices whose clock lags NTP).
+func resumableClientWindow(notBefore, notAfter, realNow, floor time.Time) bool {
+	if realNow.After(notAfter) {
+		return false
+	}
+	return !effectiveVerificationTime(realNow, floor, notBefore).Before(notBefore)
+}

--- a/go/internal/agent/mtls/session_ticket_test.go
+++ b/go/internal/agent/mtls/session_ticket_test.go
@@ -1,0 +1,80 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+func TestClientCertWindowRoundTrip(t *testing.T) {
+	nb := time.Unix(1700000000, 0)
+	na := time.Unix(1710000000, 0)
+	ss := &tls.SessionState{}
+	appendClientCertWindow(ss, tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{NotBefore: nb, NotAfter: na}},
+	})
+	gotNB, gotNA, ok := clientCertWindowFromExtra(ss)
+	if !ok {
+		t.Fatal("window not found after append")
+	}
+	if !gotNB.Equal(nb) || !gotNA.Equal(na) {
+		t.Errorf("window = [%v, %v], want [%v, %v]", gotNB, gotNA, nb, na)
+	}
+}
+
+func TestClientCertWindowNoPeerCertAppendsNothing(t *testing.T) {
+	ss := &tls.SessionState{}
+	appendClientCertWindow(ss, tls.ConnectionState{})
+	if len(ss.Extra) != 0 {
+		t.Errorf("Extra = %v, want empty", ss.Extra)
+	}
+	if _, _, ok := clientCertWindowFromExtra(ss); ok {
+		t.Error("found a window in an empty session state")
+	}
+}
+
+func TestClientCertWindowIgnoresForeignAndMalformedEntries(t *testing.T) {
+	nb := time.Unix(1700000000, 0)
+	na := time.Unix(1710000000, 0)
+	ss := &tls.SessionState{Extra: [][]byte{
+		[]byte("some-other-component:opaque"),
+		[]byte(ticketMetaPrefix + "short"),      // right prefix, wrong length
+		[]byte("wendy-mtls/2:0123456789abcdef"), // future version — must not parse as v1
+	}}
+	if _, _, ok := clientCertWindowFromExtra(ss); ok {
+		t.Fatal("parsed a window out of foreign/malformed entries")
+	}
+	appendClientCertWindow(ss, tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{NotBefore: nb, NotAfter: na}},
+	})
+	gotNB, _, ok := clientCertWindowFromExtra(ss)
+	if !ok || !gotNB.Equal(nb) {
+		t.Errorf("valid entry not found among foreign entries: ok=%v nb=%v", ok, gotNB)
+	}
+}
+
+func TestResumableClientWindow(t *testing.T) {
+	base := time.Unix(1700000000, 0)
+	nb, na := base, base.Add(30*24*time.Hour)
+	cases := []struct {
+		name    string
+		realNow time.Time
+		floor   time.Time
+		want    bool
+	}{
+		{"inside window", base.Add(time.Hour), time.Time{}, true},
+		{"expired", na.Add(time.Second), time.Time{}, false},
+		{"expired despite floor", na.Add(time.Second), na.Add(48 * time.Hour), false},
+		{"not yet valid, no floor", base.Add(-time.Hour), time.Time{}, false},
+		{"stuck clock rescued by floor", base.Add(-30 * 24 * time.Hour), base, true},
+		// Floor advancement is capped at floor+maxClockSkewTolerance: a cert
+		// starting further in the future than that stays non-resumable.
+		{"future cert beyond skew cap", base.Add(-30 * 24 * time.Hour), base.Add(-2 * maxClockSkewTolerance), false},
+	}
+	for _, tc := range cases {
+		if got := resumableClientWindow(nb, na, tc.realNow, tc.floor); got != tc.want {
+			t.Errorf("%s: resumable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/go/internal/agent/mtls/session_ticket_test.go
+++ b/go/internal/agent/mtls/session_ticket_test.go
@@ -78,3 +78,21 @@ func TestResumableClientWindow(t *testing.T) {
 		}
 	}
 }
+
+func TestNewClientTLSConfigSharesSessionCache(t *testing.T) {
+	pki := newResumptionPKI(t)
+	a, err := NewClientTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil)
+	if err != nil {
+		t.Fatalf("NewClientTLSConfig: %v", err)
+	}
+	b, err := NewClientTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil)
+	if err != nil {
+		t.Fatalf("NewClientTLSConfig: %v", err)
+	}
+	if a.ClientSessionCache == nil {
+		t.Fatal("ClientSessionCache not set on mesh client config")
+	}
+	if a.ClientSessionCache != b.ClientSessionCache {
+		t.Error("mesh client configs do not share one session cache; per-config caches never hit (configs are built per dial)")
+	}
+}

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -9,11 +9,13 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tlscache"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -44,6 +46,10 @@ const (
 	grpcKeepaliveTime    = 15 * time.Minute
 	grpcKeepaliveTimeout = 10 * time.Second
 )
+
+// tlsDebugWriter is where WENDY_TLS_DEBUG resumption logging is written.
+// Overridable in tests to capture output.
+var tlsDebugWriter io.Writer = os.Stderr
 
 type AgentConnection struct {
 	Conn           *grpc.ClientConn
@@ -135,7 +141,10 @@ func ConnectWithTLS(ctx context.Context, address string, certInfo *config.Certif
 	return ConnectWithTLSAndPins(ctx, address, certInfo, nil)
 }
 
-func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker) (*AgentConnection, error) {
+// newAgentTLSConfig builds the client TLS config for one agent target,
+// including the persistent session cache that lets repeat CLI invocations
+// skip the full ML-DSA handshake (see specs/2026-08-07-tls-session-resumption-design.md).
+func newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins certs.PinChecker, observedOrg *atomic.Int32) (*tls.Config, error) {
 	// Only load the leaf cert — not the chain. Go's TLS library calls
 	// x509.ParseCertificate on every cert sent in the handshake, and ML-DSA
 	// chain certs (from pki-core) cause parse failures on the agent's server.
@@ -148,7 +157,6 @@ func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
-	observedOrg := new(atomic.Int32)
 	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
 		ChainPEM:      certInfo.PemCertificateChain,
 		ExpectedOrgID: int32(certInfo.OrganizationID),
@@ -162,11 +170,33 @@ func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config
 	if err != nil {
 		return nil, fmt.Errorf("building TLS verifier: %w", err)
 	}
+	if os.Getenv("WENDY_TLS_DEBUG") != "" {
+		inner := verifyConn
+		verifyConn = func(cs tls.ConnectionState) error {
+			fmt.Fprintf(tlsDebugWriter, "[tls-debug] %s resumed=%v\n", address, cs.DidResume)
+			return inner(cs)
+		}
+	}
 	tlsCfg := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true, //nolint:gosec — hostname bypass only; VerifyConnection validates server cert against Wendy PKI
 		VerifyConnection:   verifyConn,
 		MinVersion:         tls.VersionTLS12,
+	}
+	// Session resumption: nil means caching is disabled — leaving the field
+	// unset is required then, because a typed-nil *Cache in the interface
+	// would panic inside crypto/tls.
+	if cache := tlscache.ForTarget(address, cert.Certificate[0]); cache != nil {
+		tlsCfg.ClientSessionCache = cache
+	}
+	return tlsCfg, nil
+}
+
+func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker) (*AgentConnection, error) {
+	observedOrg := new(atomic.Int32)
+	tlsCfg, err := newAgentTLSConfig(address, certInfo, pins, observedOrg)
+	if err != nil {
+		return nil, err
 	}
 
 	conn, err := grpc.NewClient(

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -180,14 +180,33 @@ func newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins ce
 	tlsCfg := &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true, //nolint:gosec — hostname bypass only; VerifyConnection validates server cert against Wendy PKI
-		VerifyConnection:   verifyConn,
 		MinVersion:         tls.VersionTLS12,
 	}
 	// Session resumption: nil means caching is disabled — leaving the field
 	// unset is required then, because a typed-nil *Cache in the interface
 	// would panic inside crypto/tls.
-	if cache := tlscache.ForTarget(address, cert.Certificate[0]); cache != nil {
+	cache := tlscache.ForTarget(address, cert.Certificate[0])
+	if cache != nil {
 		tlsCfg.ClientSessionCache = cache
+	}
+	// Always-on wrapper — not gated behind WENDY_TLS_DEBUG, which only nests
+	// as an inner logging layer above (verifyConn already includes it when
+	// set). Marks the cache when THIS connection resumed, before delegating
+	// to the inner verifier, so a subsequent Put for the fresh ticket Go
+	// issues even on a resumed connection does not overwrite the ticket from
+	// the last full handshake (see tlscache.Cache.MarkResumed's doc — without
+	// this, clients would chain tickets forever and never re-run the full
+	// ML-DSA verification). VerifyConnection runs synchronously inside the
+	// handshake, strictly BEFORE crypto/tls processes the server's
+	// post-handshake NewSessionTicket message (that happens lazily on a later
+	// Read), so marking always happens-before the Put it needs to affect —
+	// no race between the two.
+	innerVerify := verifyConn
+	tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+		if cache != nil && cs.DidResume {
+			cache.MarkResumed()
+		}
+		return innerVerify(cs)
 	}
 	return tlsCfg, nil
 }

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -191,20 +191,27 @@ func newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins ce
 	}
 	// Always-on wrapper — not gated behind WENDY_TLS_DEBUG, which only nests
 	// as an inner logging layer above (verifyConn already includes it when
-	// set). Marks the cache when THIS connection resumed, before delegating
-	// to the inner verifier, so a subsequent Put for the fresh ticket Go
-	// issues even on a resumed connection does not overwrite the ticket from
-	// the last full handshake (see tlscache.Cache.MarkResumed's doc — without
-	// this, clients would chain tickets forever and never re-run the full
-	// ML-DSA verification). VerifyConnection runs synchronously inside the
-	// handshake, strictly BEFORE crypto/tls processes the server's
-	// post-handshake NewSessionTicket message (that happens lazily on a later
-	// Read), so marking always happens-before the Put it needs to affect —
-	// no race between the two.
+	// set). Records THIS connection's resumption outcome on every handshake
+	// (not just resumed ones), before delegating to the inner verifier, so a
+	// subsequent Put for the fresh ticket Go issues even on a resumed
+	// connection does not overwrite the ticket from the last full handshake
+	// (see tlscache.Cache.SetResumed's doc — without this, clients would
+	// chain tickets forever and never re-run the full ML-DSA verification).
+	// Calling SetResumed unconditionally (rather than only when DidResume is
+	// true) matters because a single *Cache is reused by a grpc.ClientConn
+	// across its internal reconnect handshakes: a later legitimate FULL
+	// handshake on that same connection must clear a stale resumed=true from
+	// an earlier handshake, or its fresh ticket would never persist.
+	// VerifyConnection runs synchronously inside the handshake, strictly
+	// BEFORE crypto/tls processes the server's post-handshake
+	// NewSessionTicket message (that happens lazily on a later Read), and
+	// gRPC dials/handshakes a ClientConn's transports sequentially, so
+	// marking always happens-before the Put it needs to affect for that
+	// handshake — no race between the two.
 	innerVerify := verifyConn
 	tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
-		if cache != nil && cs.DidResume {
-			cache.MarkResumed()
+		if cache != nil {
+			cache.SetResumed(cs.DidResume)
 		}
 		return innerVerify(cs)
 	}

--- a/go/internal/cli/grpcclient/resumption_integration_test.go
+++ b/go/internal/cli/grpcclient/resumption_integration_test.go
@@ -1,0 +1,169 @@
+package grpcclient_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/interceptor"
+	"github.com/wendylabsinc/wendy/go/internal/agent/mtls"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+// versionService records the TLS resumption state of each call's transport.
+type versionService struct {
+	agentpb.UnimplementedWendyAgentServiceServer
+	mu      sync.Mutex
+	resumed []bool
+}
+
+func (s *versionService) GetAgentVersion(ctx context.Context, _ *agentpb.GetAgentVersionRequest) (*agentpb.GetAgentVersionResponse, error) {
+	p, _ := peer.FromContext(ctx)
+	info := p.AuthInfo.(credentials.TLSInfo)
+	s.mu.Lock()
+	s.resumed = append(s.resumed, info.State.DidResume)
+	s.mu.Unlock()
+	return &agentpb.GetAgentVersionResponse{Version: "test"}, nil
+}
+
+func TestConnectWithTLSResumesAcrossConnections(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+
+	pki := newIntegrationPKI(t) // same generator as Task 7, PEM for client too
+	srv, err := mtls.NewServer(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM,
+		zap.NewNop(), time.Time{}, 0, interceptor.OrgModeOff)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	svc := &versionService{}
+	agentpb.RegisterWendyAgentServiceServer(srv, svc)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go srv.Serve(ln)
+	t.Cleanup(srv.Stop)
+
+	certInfo := &config.CertificateInfo{
+		PemCertificate:      pki.clientCertPEM,
+		PemPrivateKey:       pki.clientKeyPEM,
+		PemCertificateChain: pki.caPEM,
+	}
+	call := func() {
+		conn, err := grpcclient.ConnectWithTLSAndPins(context.Background(), ln.Addr().String(), certInfo, nil)
+		if err != nil {
+			t.Fatalf("connect: %v", err)
+		}
+		defer conn.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{}); err != nil {
+			t.Fatalf("GetAgentVersion: %v", err)
+		}
+	}
+
+	call() // full handshake; ticket persists asynchronously afterwards
+
+	// The Cache lives inside the connection we just closed; its async persist
+	// races this second dial. Poll until resumption is observed (bounded).
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		call()
+		svc.mu.Lock()
+		n := len(svc.resumed)
+		resumed := svc.resumed[n-1]
+		svc.mu.Unlock()
+		if resumed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no connection resumed within 10s — ticket never persisted or offered")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.resumed[0] {
+		t.Error("first connection unexpectedly resumed")
+	}
+}
+
+type integrationPKI struct {
+	serverCertPEM, serverKeyPEM, caPEM string
+	clientCertPEM, clientKeyPEM        string
+}
+
+func newIntegrationPKI(t *testing.T) integrationPKI {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Resumption E2E CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leaf := func(cn string, eku x509.ExtKeyUsage) (certPEM, keyPEM string) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("gen key: %v", err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("create leaf: %v", err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatalf("marshal key: %v", err)
+		}
+		return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+			string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	}
+
+	serverCertPEM, serverKeyPEM := leaf("resumption-e2e-server", x509.ExtKeyUsageServerAuth)
+	clientCertPEM, clientKeyPEM := leaf("resumption-e2e-client", x509.ExtKeyUsageClientAuth)
+	return integrationPKI{
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		caPEM:         string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+		clientCertPEM: clientCertPEM,
+		clientKeyPEM:  clientKeyPEM,
+	}
+}

--- a/go/internal/cli/grpcclient/tls_config_test.go
+++ b/go/internal/cli/grpcclient/tls_config_test.go
@@ -1,0 +1,113 @@
+package grpcclient
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// testCertInfo builds a self-contained ECDSA CA + client leaf and returns the
+// CertificateInfo shape ConnectWithTLSAndPins consumes.
+func testCertInfo(t *testing.T) *config.CertificateInfo {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "TLS Config Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "tls-config-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	return &config.CertificateInfo{
+		PemCertificate:      string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})),
+		PemPrivateKey:       string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})),
+		PemCertificateChain: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+	}
+}
+func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.ClientSessionCache == nil {
+		t.Error("ClientSessionCache not set")
+	}
+}
+
+func TestNewAgentTLSConfigHonorsStoreOff(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.ClientSessionCache != nil {
+		t.Errorf("ClientSessionCache = %v, want nil with store=off", cfg.ClientSessionCache)
+	}
+}
+
+func TestNewAgentTLSConfigDebugLogsResumption(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	t.Setenv("WENDY_TLS_DEBUG", "1")
+	var buf bytes.Buffer
+	origWriter := tlsDebugWriter
+	tlsDebugWriter = &buf
+	defer func() { tlsDebugWriter = origWriter }()
+
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	// The wrapped VerifyConnection must log DidResume before delegating; an
+	// empty ConnectionState fails the inner verifier, which is fine here.
+	cfg.VerifyConnection(tls.ConnectionState{DidResume: true})
+	if !strings.Contains(buf.String(), "resumed=true") {
+		t.Errorf("debug output %q missing resumed=true", buf.String())
+	}
+}

--- a/go/internal/cli/tlscache/cache.go
+++ b/go/internal/cli/tlscache/cache.go
@@ -25,32 +25,43 @@ type Cache struct {
 	store    sessionStore
 	wg       sync.WaitGroup
 
-	// resumed is set via MarkResumed when the connection this Cache is bound
-	// to resumed a previous session rather than performing a full handshake.
-	// Go's TLS 1.3 server reissues a fresh ticket on EVERY connection,
-	// including resumed ones (see the design spec's "Self-refresh" note), so
-	// without this flag Put would overwrite the stored full-handshake ticket
-	// with a resumed-connection ticket on every call. That would let tickets
-	// chain indefinitely across resumed connections and defeat the periodic
-	// full ML-DSA re-verification the 7-day ticket lifetime is meant to force
-	// (see session_ticket.go's trust-model comment on the agent side). Put(nil)
-	// — session eviction — ignores this flag: crypto/tls uses it to drop
-	// broken/failed sessions and that must always take effect.
+	// resumed reflects the MOST RECENT handshake performed on the connection
+	// this Cache is bound to — set via SetResumed on every handshake, not just
+	// resumed ones. A single *tls.Config (and its ClientSessionCache) is
+	// reused by a grpc.ClientConn across internal reconnects, so "resumed"
+	// must track the latest handshake rather than sticking true forever: a
+	// later legitimate FULL handshake on that same connection has to be able
+	// to persist its fresh ticket again. Go's TLS 1.3 server reissues a fresh
+	// ticket on EVERY connection, including resumed ones (see the design
+	// spec's "Self-refresh" note), so without this flag Put would overwrite
+	// the stored full-handshake ticket with a resumed-connection ticket on
+	// every call. That would let tickets chain indefinitely across resumed
+	// connections and defeat the periodic full ML-DSA re-verification the
+	// 7-day ticket lifetime is meant to force (see session_ticket.go's
+	// trust-model comment on the agent side). Put(nil) — session eviction —
+	// ignores this flag: crypto/tls uses it to drop broken/failed sessions and
+	// that must always take effect.
 	resumed atomic.Bool
 }
 
-// MarkResumed records that the connection this Cache is bound to resumed a
-// previous session. The next Put call with a non-nil session (the fresh
-// ticket Go issues even on a resumed connection) is then a no-op, keeping
-// whichever ticket was stored by the last FULL handshake instead.
+// SetResumed records whether the connection this Cache is bound to resumed a
+// previous session (true) or performed a full handshake (false) on its most
+// recent handshake. When true, the next Put call with a non-nil session (the
+// fresh ticket Go issues even on a resumed connection) is a no-op, keeping
+// whichever ticket was stored by the last FULL handshake instead. When false,
+// Put persists normally — this is what lets a later full handshake on a
+// ClientConn that previously resumed still refresh the stored ticket.
 //
-// Callers must invoke this from a VerifyConnection hook, which crypto/tls
-// runs synchronously inside the handshake — strictly before it processes the
-// server's post-handshake NewSessionTicket message and calls Put (ticket
-// processing happens lazily on a later Read, after Handshake/VerifyConnection
-// has already returned). That ordering means there is no race between
-// marking and persisting for a single connection.
-func (c *Cache) MarkResumed() { c.resumed.Store(true) }
+// Callers must invoke this from a VerifyConnection hook on EVERY handshake
+// (not only when resumed is true), which crypto/tls runs synchronously inside
+// the handshake — strictly before it processes the server's post-handshake
+// NewSessionTicket message and calls Put (ticket processing happens lazily on
+// a later Read, after Handshake/VerifyConnection has already returned). gRPC
+// dials/handshakes transports on a ClientConn sequentially, so that per-
+// handshake VerifyConnection-before-Put ordering holds even though the Cache
+// is shared and reused across reconnects — there is no race between marking
+// and persisting for a single connection.
+func (c *Cache) SetResumed(resumed bool) { c.resumed.Store(resumed) }
 
 // ForTarget returns a Cache bound to the target address and client leaf cert
 // (DER), or nil when session caching is disabled (WENDY_TLS_SESSION_STORE=off
@@ -99,10 +110,11 @@ func (c *Cache) Get(string) (*tls.ClientSessionState, bool) {
 // connection's record-processing path, so persistence (a Keychain subprocess
 // on macOS) happens on a background goroutine; a ticket lost to process exit
 // just means a full handshake next time. Put(nil) evicts (crypto/tls uses
-// that on certain handshake failures) and always runs, even when MarkResumed
-// was called — a broken session must still be dropped regardless of how the
-// prior handshake went. A non-nil session on an already-resumed connection is
-// dropped instead of stored; see MarkResumed's doc.
+// that on certain handshake failures) and always runs, even when the most
+// recent SetResumed call reported true — a broken session must still be
+// dropped regardless of how the prior handshake went. A non-nil session on an
+// already-resumed connection is dropped instead of stored; see SetResumed's
+// doc.
 func (c *Cache) Put(_ string, cs *tls.ClientSessionState) {
 	if cs == nil {
 		c.async(func() { c.store.delete(c.storeKey) })

--- a/go/internal/cli/tlscache/cache.go
+++ b/go/internal/cli/tlscache/cache.go
@@ -1,0 +1,126 @@
+package tlscache
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/binary"
+	"encoding/hex"
+	"sync"
+)
+
+// blobMagic versions the on-disk/on-keychain blob layout:
+// "WTS1" | uint32 BE ticket length | ticket | SessionState.Bytes().
+const blobMagic = "WTS1"
+
+// Cache implements tls.ClientSessionCache for a single (target address, client
+// certificate) pair, persisting the most recent session via a sessionStore.
+//
+// The store key binds the client leaf certificate on purpose: a session ticket
+// embeds the client identity verified at the original handshake, so a ticket
+// obtained with one org's cert must never be offered when dialing with
+// another's. Go's own sessionKey (the remote address) is ignored.
+type Cache struct {
+	storeKey string
+	store    sessionStore
+	wg       sync.WaitGroup
+}
+
+// ForTarget returns a Cache bound to the target address and client leaf cert
+// (DER), or nil when session caching is disabled (WENDY_TLS_SESSION_STORE=off
+// or no usable backend). Callers must skip the tls.Config wiring on nil — a
+// nil *Cache inside a non-nil interface value would panic in crypto/tls.
+func ForTarget(address string, clientLeafDER []byte) *Cache {
+	store := newDefaultStore()
+	if store == nil {
+		return nil
+	}
+	return newCache(address, clientLeafDER, store)
+}
+
+func newCache(address string, clientLeafDER []byte, store sessionStore) *Cache {
+	certSum := sha256.Sum256(clientLeafDER)
+	sum := sha256.Sum256(append([]byte(address+"|"), certSum[:]...))
+	return &Cache{storeKey: hex.EncodeToString(sum[:]), store: store}
+}
+
+// Get implements tls.ClientSessionCache. Any decode failure evicts the entry
+// and reports a miss; the caller then performs a full handshake.
+func (c *Cache) Get(string) (*tls.ClientSessionState, bool) {
+	blob := c.store.get(c.storeKey)
+	if blob == nil {
+		return nil, false
+	}
+	ticket, stateBytes, ok := decodeSessionBlob(blob)
+	if !ok {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	state, err := tls.ParseSessionState(stateBytes)
+	if err != nil {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	cs, err := tls.NewResumptionState(ticket, state)
+	if err != nil {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	return cs, true
+}
+
+// Put implements tls.ClientSessionCache. crypto/tls calls it from the
+// connection's record-processing path, so persistence (a Keychain subprocess
+// on macOS) happens on a background goroutine; a ticket lost to process exit
+// just means a full handshake next time. Put(nil) evicts (crypto/tls uses
+// that on certain handshake failures).
+func (c *Cache) Put(_ string, cs *tls.ClientSessionState) {
+	if cs == nil {
+		c.async(func() { c.store.delete(c.storeKey) })
+		return
+	}
+	ticket, state, err := cs.ResumptionState()
+	if err != nil || state == nil {
+		return
+	}
+	stateBytes, err := state.Bytes()
+	if err != nil {
+		return
+	}
+	blob := encodeSessionBlob(ticket, stateBytes)
+	c.async(func() { c.store.put(c.storeKey, blob) })
+}
+
+// Flush blocks until all pending async persists complete. Tests rely on it;
+// callers may use it before exit to make best-effort persistence certain.
+func (c *Cache) Flush() { c.wg.Wait() }
+
+func (c *Cache) async(fn func()) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		fn()
+	}()
+}
+
+func encodeSessionBlob(ticket, state []byte) []byte {
+	blob := make([]byte, 0, len(blobMagic)+4+len(ticket)+len(state))
+	blob = append(blob, blobMagic...)
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(ticket)))
+	blob = append(blob, l[:]...)
+	blob = append(blob, ticket...)
+	blob = append(blob, state...)
+	return blob
+}
+
+func decodeSessionBlob(blob []byte) (ticket, state []byte, ok bool) {
+	header := len(blobMagic) + 4
+	if len(blob) < header || string(blob[:len(blobMagic)]) != blobMagic {
+		return nil, nil, false
+	}
+	n := binary.BigEndian.Uint32(blob[len(blobMagic):header])
+	if uint32(len(blob)-header) < n {
+		return nil, nil, false
+	}
+	return blob[header : header+int(n)], blob[header+int(n):], true
+}

--- a/go/internal/cli/tlscache/cache.go
+++ b/go/internal/cli/tlscache/cache.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"sync"
+	"sync/atomic"
 )
 
 // blobMagic versions the on-disk/on-keychain blob layout:
@@ -23,7 +24,33 @@ type Cache struct {
 	storeKey string
 	store    sessionStore
 	wg       sync.WaitGroup
+
+	// resumed is set via MarkResumed when the connection this Cache is bound
+	// to resumed a previous session rather than performing a full handshake.
+	// Go's TLS 1.3 server reissues a fresh ticket on EVERY connection,
+	// including resumed ones (see the design spec's "Self-refresh" note), so
+	// without this flag Put would overwrite the stored full-handshake ticket
+	// with a resumed-connection ticket on every call. That would let tickets
+	// chain indefinitely across resumed connections and defeat the periodic
+	// full ML-DSA re-verification the 7-day ticket lifetime is meant to force
+	// (see session_ticket.go's trust-model comment on the agent side). Put(nil)
+	// — session eviction — ignores this flag: crypto/tls uses it to drop
+	// broken/failed sessions and that must always take effect.
+	resumed atomic.Bool
 }
+
+// MarkResumed records that the connection this Cache is bound to resumed a
+// previous session. The next Put call with a non-nil session (the fresh
+// ticket Go issues even on a resumed connection) is then a no-op, keeping
+// whichever ticket was stored by the last FULL handshake instead.
+//
+// Callers must invoke this from a VerifyConnection hook, which crypto/tls
+// runs synchronously inside the handshake — strictly before it processes the
+// server's post-handshake NewSessionTicket message and calls Put (ticket
+// processing happens lazily on a later Read, after Handshake/VerifyConnection
+// has already returned). That ordering means there is no race between
+// marking and persisting for a single connection.
+func (c *Cache) MarkResumed() { c.resumed.Store(true) }
 
 // ForTarget returns a Cache bound to the target address and client leaf cert
 // (DER), or nil when session caching is disabled (WENDY_TLS_SESSION_STORE=off
@@ -72,10 +99,16 @@ func (c *Cache) Get(string) (*tls.ClientSessionState, bool) {
 // connection's record-processing path, so persistence (a Keychain subprocess
 // on macOS) happens on a background goroutine; a ticket lost to process exit
 // just means a full handshake next time. Put(nil) evicts (crypto/tls uses
-// that on certain handshake failures).
+// that on certain handshake failures) and always runs, even when MarkResumed
+// was called — a broken session must still be dropped regardless of how the
+// prior handshake went. A non-nil session on an already-resumed connection is
+// dropped instead of stored; see MarkResumed's doc.
 func (c *Cache) Put(_ string, cs *tls.ClientSessionState) {
 	if cs == nil {
 		c.async(func() { c.store.delete(c.storeKey) })
+		return
+	}
+	if c.resumed.Load() {
 		return
 	}
 	ticket, state, err := cs.ResumptionState()

--- a/go/internal/cli/tlscache/cache_test.go
+++ b/go/internal/cli/tlscache/cache_test.go
@@ -1,0 +1,180 @@
+package tlscache
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memStore is an in-memory sessionStore recording deletes.
+type memStore struct {
+	mu      sync.Mutex
+	m       map[string][]byte
+	deletes int
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) get(key string) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.m[key]
+}
+func (s *memStore) put(key string, blob []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = blob
+}
+func (s *memStore) delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	s.deletes++
+}
+
+// startTLSServer runs a minimal TLS 1.3 server issuing session tickets;
+// each accepted conn handshakes, reports DidResume on ch, writes one byte.
+func startTLSServer(t *testing.T) (addr string, ch <-chan bool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "tlscache-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		MinVersion:   tls.VersionTLS13,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	resumed := make(chan bool, 16)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc := tls.Server(c, cfg)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				resumed <- tc.ConnectionState().DidResume
+				tc.Write([]byte{1}) // flushes the session ticket to the client
+				buf := make([]byte, 1)
+				tc.Read(buf) // wait for client close so the ticket is processed
+			}(c)
+		}
+	}()
+	return ln.Addr().String(), resumed
+}
+
+func dialWithCache(t *testing.T, addr string, cache *Cache) bool {
+	t.Helper()
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		ClientSessionCache: cache,
+		MinVersion:         tls.VersionTLS13,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil { // ensures NewSessionTicket has arrived
+		t.Fatalf("read: %v", err)
+	}
+	return conn.ConnectionState().DidResume
+}
+
+func TestCacheRoundTripAcrossInstances(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+	leafDER := []byte("client-leaf-der") // identity input only; any bytes work here
+
+	c1 := newCache("cache-test", leafDER, store)
+	if resumed := dialWithCache(t, addr, c1); resumed {
+		t.Fatal("first connection unexpectedly resumed")
+	}
+	<-srvResumed
+	c1.Flush() // wait for the async persist
+
+	// A separate Cache instance over the same store simulates a new CLI process.
+	c2 := newCache("cache-test", leafDER, store)
+	if resumed := dialWithCache(t, addr, c2); !resumed {
+		t.Fatal("second connection did not resume from persisted session")
+	}
+	if got := <-srvResumed; !got {
+		t.Fatal("server did not observe resumption")
+	}
+}
+
+func TestCacheKeyedByClientCert(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+
+	c1 := newCache("cache-test", []byte("cert-A"), store)
+	dialWithCache(t, addr, c1)
+	<-srvResumed
+	c1.Flush()
+
+	// Same target, different client cert → different store key → no resumption.
+	c2 := newCache("cache-test", []byte("cert-B"), store)
+	if resumed := dialWithCache(t, addr, c2); resumed {
+		t.Fatal("session resumed across different client certs")
+	}
+	<-srvResumed
+}
+
+func TestCacheCorruptBlobIsMissAndDeleted(t *testing.T) {
+	store := newMemStore()
+	c := newCache("cache-test", []byte("cert"), store)
+	store.put(c.storeKey, []byte("WTS1garbage-not-a-session"))
+	if _, ok := c.Get("ignored"); ok {
+		t.Fatal("corrupt blob returned a session")
+	}
+	if store.deletes == 0 {
+		t.Error("corrupt blob was not deleted")
+	}
+}
+
+func TestCachePutNilEvicts(t *testing.T) {
+	store := newMemStore()
+	c := newCache("cache-test", []byte("cert"), store)
+	store.put(c.storeKey, []byte("whatever"))
+	c.Put("ignored", nil)
+	c.Flush()
+	if store.get(c.storeKey) != nil {
+		t.Error("Put(nil) did not evict the stored session")
+	}
+}
+
+func TestForTargetOffReturnsNil(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	if c := ForTarget("host:50052", []byte("cert")); c != nil {
+		t.Errorf("ForTarget with store=off = %v, want nil", c)
+	}
+}

--- a/go/internal/cli/tlscache/cache_test.go
+++ b/go/internal/cli/tlscache/cache_test.go
@@ -1,6 +1,7 @@
 package tlscache
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -169,6 +170,69 @@ func TestCachePutNilEvicts(t *testing.T) {
 	c.Flush()
 	if store.get(c.storeKey) != nil {
 		t.Error("Put(nil) did not evict the stored session")
+	}
+}
+
+// TestMarkResumedSkipsOverwriteOnPut is the regression test for the ticket-
+// chaining finding: without MarkResumed, Put overwrites the stored ticket on
+// every connection — including resumed ones — because Go's TLS 1.3 server
+// reissues a fresh ticket even on a resumed handshake. A client that kept
+// doing that could chain tickets forever and never re-run the full ML-DSA
+// verification the design's ≤7-day trust bound depends on. The fix: once
+// MarkResumed is called (simulating the always-on VerifyConnection wrapper in
+// grpcclient.newAgentTLSConfig observing DidResume), Put must keep the ticket
+// from the last FULL handshake instead of overwriting it.
+func TestMarkResumedSkipsOverwriteOnPut(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+	c := newCache("cache-test", []byte("client-leaf-der"), store)
+
+	// First connection: full handshake, persists a ticket.
+	if resumed := dialWithCache(t, addr, c); resumed {
+		t.Fatal("first connection unexpectedly resumed")
+	}
+	<-srvResumed
+	c.Flush()
+
+	stored := store.get(c.storeKey)
+	if stored == nil {
+		t.Fatal("first full handshake did not persist a session")
+	}
+	wantUnchanged := append([]byte(nil), stored...)
+
+	// Simulate the always-on VerifyConnection wrapper having observed
+	// DidResume on the connection that is about to call Put.
+	c.MarkResumed()
+
+	// Second connection: the ticket persisted above is still valid, so this
+	// resumes at the TLS layer, and the server (per Go's TLS 1.3 behavior)
+	// issues a fresh ticket that crypto/tls delivers via a REAL Put call —
+	// exercising the actual code path Put must guard, not a fabricated
+	// ClientSessionState.
+	if resumed := dialWithCache(t, addr, c); !resumed {
+		t.Fatal("second connection did not resume — can't exercise MarkResumed's effect on a resumed-connection Put")
+	}
+	<-srvResumed
+	c.Flush()
+
+	if got := store.get(c.storeKey); !bytes.Equal(got, wantUnchanged) {
+		t.Error("Put overwrote the full-handshake ticket after MarkResumed; stored blob changed on a resumed connection")
+	}
+}
+
+// TestCachePutNilEvictsEvenWhenMarkedResumed covers the other half of
+// MarkResumed's contract: eviction (Put(nil)) must always run regardless of
+// the resumed flag — crypto/tls uses Put(nil) to drop sessions it has
+// determined are broken, and skipping that would leave a bad ticket cached.
+func TestCachePutNilEvictsEvenWhenMarkedResumed(t *testing.T) {
+	store := newMemStore()
+	c := newCache("cache-test", []byte("cert"), store)
+	store.put(c.storeKey, []byte("whatever"))
+	c.MarkResumed()
+	c.Put("ignored", nil)
+	c.Flush()
+	if store.get(c.storeKey) != nil {
+		t.Error("Put(nil) did not evict the stored session even though MarkResumed had been called")
 	}
 }
 

--- a/go/internal/cli/tlscache/cache_test.go
+++ b/go/internal/cli/tlscache/cache_test.go
@@ -173,16 +173,16 @@ func TestCachePutNilEvicts(t *testing.T) {
 	}
 }
 
-// TestMarkResumedSkipsOverwriteOnPut is the regression test for the ticket-
-// chaining finding: without MarkResumed, Put overwrites the stored ticket on
-// every connection — including resumed ones — because Go's TLS 1.3 server
-// reissues a fresh ticket even on a resumed handshake. A client that kept
-// doing that could chain tickets forever and never re-run the full ML-DSA
-// verification the design's ≤7-day trust bound depends on. The fix: once
-// MarkResumed is called (simulating the always-on VerifyConnection wrapper in
-// grpcclient.newAgentTLSConfig observing DidResume), Put must keep the ticket
-// from the last FULL handshake instead of overwriting it.
-func TestMarkResumedSkipsOverwriteOnPut(t *testing.T) {
+// TestSetResumedSkipsOverwriteOnPut is the regression test for the ticket-
+// chaining finding: without SetResumed(true), Put overwrites the stored
+// ticket on every connection — including resumed ones — because Go's TLS 1.3
+// server reissues a fresh ticket even on a resumed handshake. A client that
+// kept doing that could chain tickets forever and never re-run the full
+// ML-DSA verification the design's ≤7-day trust bound depends on. The fix:
+// once SetResumed(true) is called (simulating the always-on VerifyConnection
+// wrapper in grpcclient.newAgentTLSConfig observing DidResume), Put must keep
+// the ticket from the last FULL handshake instead of overwriting it.
+func TestSetResumedSkipsOverwriteOnPut(t *testing.T) {
 	addr, srvResumed := startTLSServer(t)
 	store := newMemStore()
 	c := newCache("cache-test", []byte("client-leaf-der"), store)
@@ -202,7 +202,7 @@ func TestMarkResumedSkipsOverwriteOnPut(t *testing.T) {
 
 	// Simulate the always-on VerifyConnection wrapper having observed
 	// DidResume on the connection that is about to call Put.
-	c.MarkResumed()
+	c.SetResumed(true)
 
 	// Second connection: the ticket persisted above is still valid, so this
 	// resumes at the TLS layer, and the server (per Go's TLS 1.3 behavior)
@@ -210,29 +210,97 @@ func TestMarkResumedSkipsOverwriteOnPut(t *testing.T) {
 	// exercising the actual code path Put must guard, not a fabricated
 	// ClientSessionState.
 	if resumed := dialWithCache(t, addr, c); !resumed {
-		t.Fatal("second connection did not resume — can't exercise MarkResumed's effect on a resumed-connection Put")
+		t.Fatal("second connection did not resume — can't exercise SetResumed's effect on a resumed-connection Put")
 	}
 	<-srvResumed
 	c.Flush()
 
 	if got := store.get(c.storeKey); !bytes.Equal(got, wantUnchanged) {
-		t.Error("Put overwrote the full-handshake ticket after MarkResumed; stored blob changed on a resumed connection")
+		t.Error("Put overwrote the full-handshake ticket after SetResumed(true); stored blob changed on a resumed connection")
 	}
 }
 
 // TestCachePutNilEvictsEvenWhenMarkedResumed covers the other half of
-// MarkResumed's contract: eviction (Put(nil)) must always run regardless of
+// SetResumed's contract: eviction (Put(nil)) must always run regardless of
 // the resumed flag — crypto/tls uses Put(nil) to drop sessions it has
 // determined are broken, and skipping that would leave a bad ticket cached.
 func TestCachePutNilEvictsEvenWhenMarkedResumed(t *testing.T) {
 	store := newMemStore()
 	c := newCache("cache-test", []byte("cert"), store)
 	store.put(c.storeKey, []byte("whatever"))
-	c.MarkResumed()
+	c.SetResumed(true)
 	c.Put("ignored", nil)
 	c.Flush()
 	if store.get(c.storeKey) != nil {
-		t.Error("Put(nil) did not evict the stored session even though MarkResumed had been called")
+		t.Error("Put(nil) did not evict the stored session even though SetResumed(true) had been called")
+	}
+}
+
+// TestSetResumedFalseAllowsPutAfterLaterFullHandshake is the regression test
+// for the sticky-flag finding: MarkResumed used to only ever set resumed
+// true, so a grpc.ClientConn's shared *Cache — reused across the ClientConn's
+// internal reconnect handshakes — would never persist a ticket from a LATER
+// legitimate full handshake once any earlier handshake on that connection had
+// resumed. The fix is SetResumed(bool): the always-on VerifyConnection
+// wrapper now calls it on every handshake with cs.DidResume, so a later full
+// handshake (DidResume=false) clears the flag and Put persists again.
+//
+// This drives the scenario with real dials plus one direct SetResumed(false)
+// standing in for the wrapper's call on a later full handshake (there is no
+// grpc.ClientConn here to force a real third TLS 1.3 dial to skip
+// resumption on a still-valid ticket): dial 1 is a full handshake and
+// persists; SetResumed(true) simulates the wrapper observing the resumed
+// dial 2 would produce; the store entry is then evicted out-of-band (as if
+// the ticket expired or the server rotated its STEK) so dial 3 is forced to
+// be a full handshake; SetResumed(false) simulates the wrapper observing
+// that dial 3's DidResume; and Put's subsequent persist of dial 3's fresh
+// ticket must succeed. Verified to fail against the old sticky MarkResumed
+// semantics (permanent regression-test doc note; see the residual-fix report
+// for the negative-verification run).
+func TestSetResumedFalseAllowsPutAfterLaterFullHandshake(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+	c := newCache("cache-test", []byte("client-leaf-der"), store)
+
+	// Dial 1: full handshake, persists a ticket.
+	if resumed := dialWithCache(t, addr, c); resumed {
+		t.Fatal("first connection unexpectedly resumed")
+	}
+	<-srvResumed
+	c.Flush()
+	if store.get(c.storeKey) == nil {
+		t.Fatal("first full handshake did not persist a session")
+	}
+
+	// Simulate the always-on VerifyConnection wrapper observing a resumed
+	// handshake on this same Cache (as would happen on a grpc.ClientConn
+	// internal reconnect that resumes).
+	c.SetResumed(true)
+
+	// The ticket persisted above is evicted out-of-band here (standing in for
+	// expiry/STEK rotation) so the next dial is forced into a full handshake
+	// without needing a second real server or clock manipulation.
+	store.delete(c.storeKey)
+	c.wg.Wait() // no pending async work from the delete above; keeps ordering explicit
+
+	// Simulate the wrapper observing dial 3's full handshake — this is the
+	// exact call that must reset the sticky flag from the resumed dial 2
+	// simulated above.
+	c.SetResumed(false)
+
+	// Dial 3: the store entry is gone, so this must be a full handshake, and
+	// its fresh ticket must persist — this is the case the old sticky
+	// MarkResumed (set-only-true, never reset) got wrong: once any handshake
+	// on this Cache had resumed, no later full handshake's ticket would ever
+	// be saved again.
+	if resumed := dialWithCache(t, addr, c); resumed {
+		t.Fatal("third connection unexpectedly resumed — test setup did not force a full handshake")
+	}
+	<-srvResumed
+	c.Flush()
+
+	if store.get(c.storeKey) == nil {
+		t.Error("later full handshake's ticket was not persisted after an earlier resumed handshake on the same Cache — SetResumed did not reset")
 	}
 }
 

--- a/go/internal/cli/tlscache/store.go
+++ b/go/internal/cli/tlscache/store.go
@@ -1,0 +1,14 @@
+// Package tlscache persists TLS 1.3 session tickets across CLI invocations so
+// repeat connects to a provisioned agent resume the session instead of redoing
+// the full ML-DSA mTLS handshake (~2.2s on device hardware; see
+// specs/2026-08-07-tls-session-resumption-design.md).
+package tlscache
+
+// A sessionStore persists opaque session blobs by key. Implementations treat
+// every failure as a cache miss and never return errors: resumption is an
+// optimization whose universal fallback is a full handshake.
+type sessionStore interface {
+	get(key string) []byte // nil on miss or any error
+	put(key string, blob []byte)
+	delete(key string)
+}

--- a/go/internal/cli/tlscache/store.go
+++ b/go/internal/cli/tlscache/store.go
@@ -4,6 +4,8 @@
 // specs/2026-08-07-tls-session-resumption-design.md).
 package tlscache
 
+import "os"
+
 // A sessionStore persists opaque session blobs by key. Implementations treat
 // every failure as a cache miss and never return errors: resumption is an
 // optimization whose universal fallback is a full handshake.
@@ -11,4 +13,20 @@ type sessionStore interface {
 	get(key string) []byte // nil on miss or any error
 	put(key string, blob []byte)
 	delete(key string)
+}
+
+// newDefaultStore picks the ticket store backend. WENDY_TLS_SESSION_STORE
+// forces one: "off" disables caching (right for CI), "file"/"keychain" force a
+// backend. Anything else gets the platform default (Keychain on macOS, files
+// elsewhere). A nil return disables session caching entirely.
+func newDefaultStore() sessionStore {
+	switch os.Getenv("WENDY_TLS_SESSION_STORE") {
+	case "off":
+		return nil
+	case "file":
+		return newFileStore()
+	case "keychain":
+		return newKeychainStore()
+	}
+	return newPlatformStore()
 }

--- a/go/internal/cli/tlscache/store_file.go
+++ b/go/internal/cli/tlscache/store_file.go
@@ -1,0 +1,97 @@
+package tlscache
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// sessionFileMaxAge matches crypto/tls's maxSessionTicketLifetime: a ticket
+// older than 7 days can never resume, so its file is dead weight.
+const sessionFileMaxAge = 7 * 24 * time.Hour
+
+// fileStore keeps one 0600 file per session under a 0700 directory. It is the
+// default backend on platforms without a secret store; the client's ML-DSA
+// private key already lives unencrypted in ~/.wendy/config.json there, so a
+// 0600 ticket file adds no new exposure class.
+type fileStore struct{ dir string }
+
+func newFileStore() sessionStore {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return nil
+	}
+	return &fileStore{dir: filepath.Join(dir, "tls-sessions")}
+}
+
+func (s *fileStore) path(key string) string {
+	return filepath.Join(s.dir, key+".tlssession")
+}
+
+func (s *fileStore) get(key string) []byte {
+	blob, err := os.ReadFile(s.path(key))
+	if err != nil {
+		return nil
+	}
+	return blob
+}
+
+func (s *fileStore) put(key string, blob []byte) {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return
+	}
+	// Atomic replace: concurrent CLI processes are last-writer-wins, and a
+	// reader never observes a partial file.
+	tmp, err := os.CreateTemp(s.dir, key+".tmp*")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(blob); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, s.path(key)); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	s.prune()
+}
+
+func (s *fileStore) delete(key string) {
+	os.Remove(s.path(key))
+}
+
+// prune drops session files old enough that their tickets can no longer
+// resume. Best-effort by design.
+func (s *fileStore) prune() {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-sessionFileMaxAge)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".tlssession" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			os.Remove(filepath.Join(s.dir, e.Name()))
+		}
+	}
+}

--- a/go/internal/cli/tlscache/store_file_test.go
+++ b/go/internal/cli/tlscache/store_file_test.go
@@ -1,0 +1,84 @@
+package tlscache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	s := &fileStore{dir: filepath.Join(t.TempDir(), "tls-sessions")}
+	if got := s.get("k1"); got != nil {
+		t.Fatalf("get on empty store = %q, want nil", got)
+	}
+	s.put("k1", []byte("blob-1"))
+	if got := string(s.get("k1")); got != "blob-1" {
+		t.Fatalf("get after put = %q, want blob-1", got)
+	}
+	s.put("k1", []byte("blob-2")) // overwrite
+	if got := string(s.get("k1")); got != "blob-2" {
+		t.Fatalf("get after overwrite = %q, want blob-2", got)
+	}
+	s.delete("k1")
+	if got := s.get("k1"); got != nil {
+		t.Fatalf("get after delete = %q, want nil", got)
+	}
+	s.delete("k1") // deleting a missing key must not panic
+}
+
+func TestFileStorePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("k1", []byte("secret"))
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Errorf("dir perm = %o, want 700", perm)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "k1.tlssession"))
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %o, want 600", perm)
+	}
+}
+
+func TestFileStorePrunesOldSessions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("old", []byte("stale"))
+	oldPath := filepath.Join(dir, "old.tlssession")
+	past := time.Now().Add(-sessionFileMaxAge - time.Hour)
+	if err := os.Chtimes(oldPath, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	s.put("fresh", []byte("new")) // put triggers pruning
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("expected old session pruned, stat err = %v", err)
+	}
+	if got := string(s.get("fresh")); got != "new" {
+		t.Errorf("fresh session lost by pruning: %q", got)
+	}
+}
+
+func TestFileStoreNoTempFileLeftovers(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("k1", []byte("blob"))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "k1.tlssession" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("dir contents = %v, want exactly [k1.tlssession]", names)
+	}
+}

--- a/go/internal/cli/tlscache/store_keychain_darwin.go
+++ b/go/internal/cli/tlscache/store_keychain_darwin.go
@@ -1,0 +1,65 @@
+package tlscache
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// keychainService names the Keychain items holding wendy session tickets.
+const keychainService = "wendy-tls-session"
+
+const securityTimeout = 5 * time.Second
+
+// runSecurity invokes /usr/bin/security (same pattern as
+// wifi_scan_darwin.go's lookupKeychainPassword). Swapped in tests.
+var runSecurity = func(ctx context.Context, stdin string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	return cmd.Output()
+}
+
+// keychainStore keeps session tickets in the user's login Keychain. A ticket
+// is a bearer resumption secret, so it goes in the platform secret store
+// rather than a file. Items are created by (and read back through)
+// /usr/bin/security itself, whose default ACL covers it — reads must never
+// prompt; any prompt/denial surfaces as a plain cache miss.
+type keychainStore struct{}
+
+func newKeychainStore() sessionStore { return keychainStore{} }
+
+func (keychainStore) get(key string) []byte {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	out, err := runSecurity(ctx, "", "find-generic-password", "-s", keychainService, "-a", key, "-w")
+	if err != nil {
+		return nil // not found, denied, or security failed — cache miss
+	}
+	blob, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		return nil
+	}
+	return blob
+}
+
+func (keychainStore) put(key string, blob []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	// `security -i` reads the command from stdin so the ticket secret never
+	// appears on argv (argv is world-readable via ps). base64 and the hex key
+	// contain no whitespace, so no quoting is needed.
+	cmdLine := fmt.Sprintf("add-generic-password -U -s %s -a %s -j wendy-cli-tls-session -w %s\n",
+		keychainService, key, base64.StdEncoding.EncodeToString(blob))
+	_, _ = runSecurity(ctx, cmdLine, "-i")
+}
+
+func (keychainStore) delete(key string) {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	_, _ = runSecurity(ctx, "", "delete-generic-password", "-s", keychainService, "-a", key)
+}

--- a/go/internal/cli/tlscache/store_keychain_darwin_test.go
+++ b/go/internal/cli/tlscache/store_keychain_darwin_test.go
@@ -1,0 +1,106 @@
+package tlscache
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeSecurity records invocations of the security CLI and returns canned output.
+type fakeSecurity struct {
+	calls []struct {
+		stdin string
+		args  []string
+	}
+	out []byte
+	err error
+}
+
+func (f *fakeSecurity) run(_ context.Context, stdin string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, struct {
+		stdin string
+		args  []string
+	}{stdin, args})
+	return f.out, f.err
+}
+
+func TestKeychainGetDecodesBase64(t *testing.T) {
+	blob := []byte("session-blob")
+	fake := &fakeSecurity{out: []byte(base64.StdEncoding.EncodeToString(blob) + "\n")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+
+	got := newKeychainStore().get("abc123")
+	if string(got) != "session-blob" {
+		t.Fatalf("get = %q, want session-blob", got)
+	}
+	args := fake.calls[0].args
+	want := []string{"find-generic-password", "-s", "wendy-tls-session", "-a", "abc123", "-w"}
+	if strings.Join(args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+func TestKeychainGetMissOrDenied(t *testing.T) {
+	fake := &fakeSecurity{err: errors.New("exit status 44")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	if got := newKeychainStore().get("abc123"); got != nil {
+		t.Errorf("get on security error = %q, want nil", got)
+	}
+}
+
+func TestKeychainGetBadBase64(t *testing.T) {
+	fake := &fakeSecurity{out: []byte("!!! not base64 !!!")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	if got := newKeychainStore().get("abc123"); got != nil {
+		t.Errorf("get on undecodable payload = %q, want nil", got)
+	}
+}
+
+func TestKeychainPutKeepsSecretOffArgv(t *testing.T) {
+	fake := &fakeSecurity{}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+
+	blob := []byte("ticket-secret")
+	newKeychainStore().put("abc123", blob)
+
+	call := fake.calls[0]
+	// The whole add command rides stdin via `security -i`; argv holds only the flag.
+	if strings.Join(call.args, " ") != "-i" {
+		t.Fatalf("argv = %v, want [-i]", call.args)
+	}
+	b64 := base64.StdEncoding.EncodeToString(blob)
+	for _, frag := range []string{"add-generic-password", "-U", "-s wendy-tls-session", "-a abc123", "-w " + b64} {
+		if !strings.Contains(call.stdin, frag) {
+			t.Errorf("stdin %q missing %q", call.stdin, frag)
+		}
+	}
+}
+
+func TestKeychainDelete(t *testing.T) {
+	fake := &fakeSecurity{}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	newKeychainStore().delete("abc123")
+	want := []string{"delete-generic-password", "-s", "wendy-tls-session", "-a", "abc123"}
+	if strings.Join(fake.calls[0].args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", fake.calls[0].args, want)
+	}
+}
+
+func TestDarwinDefaultIsKeychain(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "")
+	if _, ok := newDefaultStore().(keychainStore); !ok {
+		t.Errorf("darwin default = %T, want keychainStore", newDefaultStore())
+	}
+}

--- a/go/internal/cli/tlscache/store_select_darwin.go
+++ b/go/internal/cli/tlscache/store_select_darwin.go
@@ -1,0 +1,3 @@
+package tlscache
+
+func newPlatformStore() sessionStore { return newKeychainStore() }

--- a/go/internal/cli/tlscache/store_select_other.go
+++ b/go/internal/cli/tlscache/store_select_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package tlscache
+
+func newPlatformStore() sessionStore { return newFileStore() }
+
+// newKeychainStore has no non-darwin implementation; an explicit
+// WENDY_TLS_SESSION_STORE=keychain falls back to files rather than failing.
+func newKeychainStore() sessionStore { return newFileStore() }

--- a/go/internal/cli/tlscache/store_select_test.go
+++ b/go/internal/cli/tlscache/store_select_test.go
@@ -1,0 +1,22 @@
+package tlscache
+
+import "testing"
+
+func TestNewDefaultStoreEnvOverrides(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // keep newFileStore off the real ~/.wendy
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	if s := newDefaultStore(); s != nil {
+		t.Errorf("store=off: got %T, want nil", s)
+	}
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+	if _, ok := newDefaultStore().(*fileStore); !ok {
+		t.Errorf("store=file: got %T, want *fileStore", newDefaultStore())
+	}
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "bogus")
+	if s := newDefaultStore(); s == nil {
+		t.Error("store=bogus: got nil, want platform default store")
+	}
+}

--- a/specs/2026-08-07-tls-session-resumption-design.md
+++ b/specs/2026-08-07-tls-session-resumption-design.md
@@ -39,17 +39,27 @@ drop from ~2.2s to single-digit/low-tens of milliseconds on LAN.
 - Persisting agent-side ticket keys across restarts (weakens forward secrecy
   for key-management convenience; an agent restart costing one full handshake
   per device is acceptable).
+- Secret-Service (Linux) / DPAPI (Windows) ticket-store backends — the
+  `sessionStore` interface leaves room for them, but the `0600` file default
+  matches those platforms' existing key-storage posture for now.
+- Moving the client certificate/private key out of `~/.wendy/config.json`
+  into platform secret stores — worth doing for consistency someday, but a
+  separate change with its own migration concerns.
 - Proto or RPC changes (there are none).
 
 ## Design
 
 ### 1. Client session cache — new package `go/internal/cli/tlscache`
 
-Implements `tls.ClientSessionCache`, disk-backed under
-`~/.wendy/tls-sessions/` (via `config.ConfigDir()`).
+Implements `tls.ClientSessionCache` on top of a small `sessionStore`
+interface (`Get(key) []byte`, `Put(key, blob)`, `Delete(key)`), with
+platform-appropriate backends. A session ticket is a bearer resumption
+secret — possession lets the holder connect as the original client identity
+for up to 7 days — so it goes into the platform secret store where one
+exists.
 
 - **Keying:** each `ConnectWithTLSAndPins` call constructs a cache instance
-  bound to a precomputed disk key
+  bound to a precomputed store key
   `SHA256(host:port | SHA256(client leaf cert DER))`. The `sessionKey` string
   Go passes to `Get`/`Put` (remote address) is ignored. Keying by client cert
   is a **correctness requirement**: the ticket embeds the client identity
@@ -58,16 +68,42 @@ Implements `tls.ClientSessionCache`, disk-backed under
 - **Serialization:** `ClientSessionState.ResumptionState()` →
   `SessionState.Bytes()` on `Put`; `tls.ParseSessionState` +
   `tls.NewResumptionState` on `Get` (Go 1.21+ APIs; module is on Go 1.26).
-- **Files:** `<hex(diskKey)>.tlssession`, mode `0600`, directory `0700`.
-  Atomic writes (temp file + rename); concurrent CLI processes are
-  last-writer-wins, which is safe. Opportunistic pruning of files older than
-  7 days (Go's `maxSessionTicketLifetime`) on `Put`.
-- **Failure behavior:** any read/parse/IO error returns "no session" (and
-  best-effort deletes the bad file). The worst case is always a full
+- **macOS backend (default on darwin): Keychain**, via
+  `/usr/bin/security add-generic-password -U` / `find-generic-password -w` /
+  `delete-generic-password` — the same subprocess pattern
+  `wifi_scan_darwin.go` already uses. Service name `wendy-tls-session`,
+  account = hex store key, data = base64 session blob. Items are created so
+  that our own reads never trigger a Keychain prompt (no `-A`
+  any-application grant; exact ACL flags verified on a real Mac during
+  implementation — a prompting hot path would be a regression, and any
+  prompt-or-denied read is treated as a cache miss). The Secure Enclave
+  itself is not applicable: it protects asymmetric keys, not arbitrary
+  secrets; the Keychain is the right primitive for a ticket blob. The
+  `security` subprocess costs ~30–80ms on `Get` — noise next to the ~2.2s
+  it saves, and the file backend is an env-var flip away if it ever matters.
+- **Linux/Windows backend (default): file**,
+  `~/.wendy/tls-sessions/<hex(storeKey)>.tlssession`, mode `0600`, directory
+  `0700`, atomic temp-file + rename writes (concurrent CLI processes are
+  last-writer-wins, which is safe), opportunistic pruning of files older
+  than 7 days (Go's `maxSessionTicketLifetime`) on `Put`. Rationale: the
+  client's ML-DSA private key already lives unencrypted in
+  `~/.wendy/config.json`, so a `0600` ticket file adds no new exposure class
+  on these platforms; a Secret-Service (D-Bus) or DPAPI backend can slot
+  into the same interface later without touching callers.
+- **Override:** `WENDY_TLS_SESSION_STORE=keychain|file|off` forces a backend
+  or disables ticket caching entirely (`off` is also the right setting for
+  CI).
+- **Async `Put`:** Go invokes `Put` while processing the server's
+  post-handshake `NewSessionTicket` message; a blocking Keychain write there
+  would stall the connection's read loop. `Put` snapshots the blob and
+  persists on a background goroutine. If the process exits first, the ticket
+  is lost and the next connect does a full handshake — harmless.
+- **Failure behavior:** any read/parse/store error returns "no session" (and
+  best-effort deletes the bad entry). The worst case is always a full
   handshake — i.e. today's behavior. Cache errors are never surfaced.
 - **Self-refresh:** Go's TLS 1.3 server issues a fresh ticket on every
-  connection, including resumed ones, so the file is rewritten on each
-  connect and never goes stale while in regular use.
+  connection, including resumed ones, so the stored blob is rewritten on
+  each connect and never goes stale while in regular use.
 
 ### 2. Client wiring — `go/internal/cli/grpcclient/client.go`
 
@@ -119,7 +155,9 @@ in-memory is sufficient there and reconnects benefit for free.
 
 | Failure | Outcome |
 | --- | --- |
-| No/corrupt/unreadable session file | Full handshake (today's path) |
+| No/corrupt/unreadable session entry | Full handshake (today's path) |
+| Keychain read prompts, is denied, or `security` fails | Treated as cache miss → full handshake |
+| Process exits before async `Put` persists | Ticket lost → full handshake next time |
 | Agent restarted (ticket keys rotated) | Ticket undecryptable → full handshake |
 | Client cert window lapsed inside ticket | Server declines → full handshake → normal cert errors if genuinely expired |
 | Ticket from wrong client cert | Never offered (disk key includes cert fingerprint) |
@@ -128,10 +166,15 @@ in-memory is sufficient there and reconnects benefit for free.
 
 ## Testing
 
-**Unit (`tlscache`):** Put/Get round-trip across two cache instances
-(simulates separate CLI processes); cert-fingerprint keying isolation (cert A's
-ticket invisible when bound to cert B); corrupt file → nil + file removed;
-pruning of >7-day files; `0600`/`0700` permissions; atomic write.
+**Unit (`tlscache`):** cache logic tested against an in-memory fake
+`sessionStore`: Put/Get round-trip across two cache instances (simulates
+separate CLI processes); cert-fingerprint keying isolation (cert A's ticket
+invisible when bound to cert B); corrupt blob → nil + entry deleted; async
+`Put` completion. File backend: pruning of >7-day files, `0600`/`0700`
+permissions, atomic write. Keychain backend: unit-tested against a faked
+`security` runner (argument construction, miss/denial handling); real
+Keychain behavior — including **zero prompts on the hot path** — is part of
+the on-device/manual verification gate below.
 
 **Integration (in-process TLS client + `mtls.NewTLSConfig` server over a real
 listener, plus a gRPC-level pass using `mtls.NewServer`):**

--- a/specs/2026-08-07-tls-session-resumption-design.md
+++ b/specs/2026-08-07-tls-session-resumption-design.md
@@ -43,8 +43,10 @@ drop from ~2.2s to single-digit/low-tens of milliseconds on LAN.
   `sessionStore` interface leaves room for them, but the `0600` file default
   matches those platforms' existing key-storage posture for now.
 - Moving the client certificate/private key out of `~/.wendy/config.json`
-  into platform secret stores — worth doing for consistency someday, but a
-  separate change with its own migration concerns.
+  into platform secret stores — **planned follow-up PR** (own spec: Keychain
+  on macOS, migration of existing configs, headless/Linux behavior). The
+  `sessionStore` interface introduced here should be designed so that PR can
+  reuse it.
 - Proto or RPC changes (there are none).
 
 ## Design

--- a/specs/2026-08-07-tls-session-resumption-design.md
+++ b/specs/2026-08-07-tls-session-resumption-design.md
@@ -25,7 +25,23 @@ drop from ~2.2s to single-digit/low-tens of milliseconds on LAN.
 - Security posture: full ML-DSA chain trust is anchored at the original
   handshake; resumed connections get **cheap re-checks** (client cert validity
   window) and stale tickets **downgrade to a full handshake**, never a
-  connection error.
+  connection error. Full re-verification recurs at least weekly by
+  construction, not merely by ticket lifetime: Go's TLS 1.3 server reissues a
+  fresh ticket on *every* connection, including resumed ones, so a client
+  that simply overwrote its cached ticket on each connect could chain
+  resumptions indefinitely and never trigger another full handshake. Instead,
+  `tlscache.Cache` keeps only the ticket produced by its **last full
+  handshake** and discards (does not persist) any ticket minted on a resumed
+  connection. Combined with Go's own `maxSessionTicketLifetime` (7 days,
+  enforced by both client and server), that forces a full handshake — and a
+  full ML-DSA re-verification — at least once a week, even for a client that
+  connects every day; the agent's per-resumption client-cert-window check
+  (§3) is a second, independent layer that also catches a cert expiring
+  mid-week. Mesh agent-to-agent dials get the property differently: a resumed
+  mesh connection re-runs the peer identity pin and full chain check on every
+  connection (`NewClientTLSConfigExpectingPeer`'s `VerifyConnection`), so
+  ticket chaining is harmless there and the in-memory mesh session cache
+  needs no equivalent no-overwrite rule.
 - Zero behavior change when no ticket exists, the ticket is invalid, the agent
   restarted, or either side predates this feature (old CLI ↔ new agent and new
   CLI ↔ old agent both fall back to today's full handshake).
@@ -83,6 +99,13 @@ exists.
   secrets; the Keychain is the right primitive for a ticket blob. The
   `security` subprocess costs ~30–80ms on `Get` — noise next to the ~2.2s
   it saves, and the file backend is an env-var flip away if it ever matters.
+  Honest caveat: a Keychain item's ACL trusts `/usr/bin/security` itself, so
+  any process running as the same macOS user can read the item promptlessly
+  via the same CLI we use — this is not protection against same-user
+  malware. What the Keychain buys over a `0600` file is at-rest encryption
+  while the keychain is locked (screen-locked/powered-off device) plus
+  exclusion from Time Machine and iCloud backups; it is not a stronger
+  same-user access boundary than the file backend.
 - **Linux/Windows backend (default): file**,
   `~/.wendy/tls-sessions/<hex(storeKey)>.tlssession`, mode `0600`, directory
   `0700`, atomic temp-file + rename writes (concurrent CLI processes are

--- a/specs/2026-08-07-tls-session-resumption-plan.md
+++ b/specs/2026-08-07-tls-session-resumption-plan.md
@@ -1,0 +1,1966 @@
+# TLS 1.3 Session Resumption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repeat `wendy` CLI connects to a provisioned agent resume TLS 1.3 sessions instead of redoing the ~2.2s ML-DSA mTLS handshake.
+
+**Architecture:** A new `go/internal/cli/tlscache` package persists session tickets across CLI processes (macOS Keychain via `/usr/bin/security`; `0600` files elsewhere) and plugs into `ConnectWithTLSAndPins` as a `tls.ClientSessionCache`. The agent's `mtls.NewTLSConfig` gains `WrapSession`/`UnwrapSession` that stamp the verified client cert's validity window into the ticket and *decline* (never fail) resumption when the window has lapsed. Spec: `specs/2026-08-07-tls-session-resumption-design.md`.
+
+**Tech Stack:** Go 1.26 `crypto/tls` session APIs (`ClientSessionState.ResumptionState`, `tls.NewResumptionState`, `SessionState.Bytes`, `tls.ParseSessionState`, `Config.EncryptTicket`/`DecryptTicket`, `WrapSession`/`UnwrapSession`), grpc-go, macOS `security` CLI.
+
+## Global Constraints
+
+- Module root is the **repo root** (`go.mod`: `module github.com/wendylabsinc/wendy`, `go 1.26.5`); packages live under `go/...`. Run all `go` commands from the repo root.
+- Repo-root `docs/` is a **symlink into `go/internal/cli/assets/docs`** (embedded CLI assets) — never write docs there; specs/plans go in top-level `specs/`.
+- Cache/store failures must NEVER surface as errors — every failure path is "no session → full handshake".
+- The server must NEVER fail a handshake because of a bad/stale ticket — it declines resumption (`UnwrapSession` returns `nil, nil`) and continues with a full handshake.
+- Env override: `WENDY_TLS_SESSION_STORE=keychain|file|off` (exact values; `off` disables caching; unknown values = platform default).
+- Keychain writes must not put the secret on argv (visible in `ps`) — use `security -i` with the command on stdin.
+- All tests: standard `go test` (no build tags needed except darwin-only files); before pushing run `gofmt -l .` from repo root and `gofmt -w` anything listed.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: `sessionStore` interface + file backend
+
+**Files:**
+- Create: `go/internal/cli/tlscache/store.go`
+- Create: `go/internal/cli/tlscache/store_file.go`
+- Test: `go/internal/cli/tlscache/store_file_test.go`
+
+**Interfaces:**
+- Consumes: `config.ConfigDir()` from `go/internal/shared/config` (returns `~/.wendy`, creating it).
+- Produces: `type sessionStore interface { get(key string) []byte; put(key string, blob []byte); delete(key string) }`; `newFileStore() sessionStore` (nil if no home dir); `type fileStore struct{ dir string }` (tests construct it directly with a temp dir); `const sessionFileMaxAge = 7 * 24 * time.Hour`. Task 2 adds `newDefaultStore()`/`newKeychainStore()`/`newPlatformStore()`; Task 3 consumes `sessionStore`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`go/internal/cli/tlscache/store_file_test.go`:
+
+```go
+package tlscache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	s := &fileStore{dir: filepath.Join(t.TempDir(), "tls-sessions")}
+	if got := s.get("k1"); got != nil {
+		t.Fatalf("get on empty store = %q, want nil", got)
+	}
+	s.put("k1", []byte("blob-1"))
+	if got := string(s.get("k1")); got != "blob-1" {
+		t.Fatalf("get after put = %q, want blob-1", got)
+	}
+	s.put("k1", []byte("blob-2")) // overwrite
+	if got := string(s.get("k1")); got != "blob-2" {
+		t.Fatalf("get after overwrite = %q, want blob-2", got)
+	}
+	s.delete("k1")
+	if got := s.get("k1"); got != nil {
+		t.Fatalf("get after delete = %q, want nil", got)
+	}
+	s.delete("k1") // deleting a missing key must not panic
+}
+
+func TestFileStorePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("k1", []byte("secret"))
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Errorf("dir perm = %o, want 700", perm)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "k1.tlssession"))
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %o, want 600", perm)
+	}
+}
+
+func TestFileStorePrunesOldSessions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("old", []byte("stale"))
+	oldPath := filepath.Join(dir, "old.tlssession")
+	past := time.Now().Add(-sessionFileMaxAge - time.Hour)
+	if err := os.Chtimes(oldPath, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	s.put("fresh", []byte("new")) // put triggers pruning
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("expected old session pruned, stat err = %v", err)
+	}
+	if got := string(s.get("fresh")); got != "new" {
+		t.Errorf("fresh session lost by pruning: %q", got)
+	}
+}
+
+func TestFileStoreNoTempFileLeftovers(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls-sessions")
+	s := &fileStore{dir: dir}
+	s.put("k1", []byte("blob"))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "k1.tlssession" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("dir contents = %v, want exactly [k1.tlssession]", names)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go/internal/cli/tlscache/ -run TestFileStore -v`
+Expected: FAIL to build — `fileStore` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`go/internal/cli/tlscache/store.go`:
+
+```go
+// Package tlscache persists TLS 1.3 session tickets across CLI invocations so
+// repeat connects to a provisioned agent resume the session instead of redoing
+// the full ML-DSA mTLS handshake (~2.2s on device hardware; see
+// specs/2026-08-07-tls-session-resumption-design.md).
+package tlscache
+
+// A sessionStore persists opaque session blobs by key. Implementations treat
+// every failure as a cache miss and never return errors: resumption is an
+// optimization whose universal fallback is a full handshake.
+type sessionStore interface {
+	get(key string) []byte // nil on miss or any error
+	put(key string, blob []byte)
+	delete(key string)
+}
+```
+
+`go/internal/cli/tlscache/store_file.go`:
+
+```go
+package tlscache
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// sessionFileMaxAge matches crypto/tls's maxSessionTicketLifetime: a ticket
+// older than 7 days can never resume, so its file is dead weight.
+const sessionFileMaxAge = 7 * 24 * time.Hour
+
+// fileStore keeps one 0600 file per session under a 0700 directory. It is the
+// default backend on platforms without a secret store; the client's ML-DSA
+// private key already lives unencrypted in ~/.wendy/config.json there, so a
+// 0600 ticket file adds no new exposure class.
+type fileStore struct{ dir string }
+
+func newFileStore() sessionStore {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return nil
+	}
+	return &fileStore{dir: filepath.Join(dir, "tls-sessions")}
+}
+
+func (s *fileStore) path(key string) string {
+	return filepath.Join(s.dir, key+".tlssession")
+}
+
+func (s *fileStore) get(key string) []byte {
+	blob, err := os.ReadFile(s.path(key))
+	if err != nil {
+		return nil
+	}
+	return blob
+}
+
+func (s *fileStore) put(key string, blob []byte) {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return
+	}
+	// Atomic replace: concurrent CLI processes are last-writer-wins, and a
+	// reader never observes a partial file.
+	tmp, err := os.CreateTemp(s.dir, key+".tmp*")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(blob); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, s.path(key)); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	s.prune()
+}
+
+func (s *fileStore) delete(key string) {
+	os.Remove(s.path(key))
+}
+
+// prune drops session files old enough that their tickets can no longer
+// resume. Best-effort by design.
+func (s *fileStore) prune() {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-sessionFileMaxAge)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".tlssession" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			os.Remove(filepath.Join(s.dir, e.Name()))
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./go/internal/cli/tlscache/ -run TestFileStore -v`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/tlscache/
+git commit -m "feat(tlscache): sessionStore interface + 0600 file backend
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Keychain backend (darwin) + backend selection
+
+**Files:**
+- Create: `go/internal/cli/tlscache/store_keychain_darwin.go`
+- Create: `go/internal/cli/tlscache/store_select_darwin.go`
+- Create: `go/internal/cli/tlscache/store_select_other.go`
+- Modify: `go/internal/cli/tlscache/store.go` (add `newDefaultStore`)
+- Test: `go/internal/cli/tlscache/store_keychain_darwin_test.go`
+- Test: `go/internal/cli/tlscache/store_select_test.go`
+
+**Interfaces:**
+- Consumes: `sessionStore`, `newFileStore()` from Task 1.
+- Produces: `newDefaultStore() sessionStore` (nil = caching disabled) honoring `WENDY_TLS_SESSION_STORE=keychain|file|off`; darwin-only `newKeychainStore() sessionStore` and swappable `var runSecurity func(ctx context.Context, stdin string, args ...string) ([]byte, error)`. Task 3 consumes `newDefaultStore`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`go/internal/cli/tlscache/store_select_test.go` (all platforms):
+
+```go
+package tlscache
+
+import "testing"
+
+func TestNewDefaultStoreEnvOverrides(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // keep newFileStore off the real ~/.wendy
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	if s := newDefaultStore(); s != nil {
+		t.Errorf("store=off: got %T, want nil", s)
+	}
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+	if _, ok := newDefaultStore().(*fileStore); !ok {
+		t.Errorf("store=file: got %T, want *fileStore", newDefaultStore())
+	}
+
+	t.Setenv("WENDY_TLS_SESSION_STORE", "bogus")
+	if s := newDefaultStore(); s == nil {
+		t.Error("store=bogus: got nil, want platform default store")
+	}
+}
+```
+
+`go/internal/cli/tlscache/store_keychain_darwin_test.go`:
+
+```go
+package tlscache
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeSecurity records invocations of the security CLI and returns canned output.
+type fakeSecurity struct {
+	calls []struct {
+		stdin string
+		args  []string
+	}
+	out []byte
+	err error
+}
+
+func (f *fakeSecurity) run(_ context.Context, stdin string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, struct {
+		stdin string
+		args  []string
+	}{stdin, args})
+	return f.out, f.err
+}
+
+func TestKeychainGetDecodesBase64(t *testing.T) {
+	blob := []byte("session-blob")
+	fake := &fakeSecurity{out: []byte(base64.StdEncoding.EncodeToString(blob) + "\n")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+
+	got := newKeychainStore().get("abc123")
+	if string(got) != "session-blob" {
+		t.Fatalf("get = %q, want session-blob", got)
+	}
+	args := fake.calls[0].args
+	want := []string{"find-generic-password", "-s", "wendy-tls-session", "-a", "abc123", "-w"}
+	if strings.Join(args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+func TestKeychainGetMissOrDenied(t *testing.T) {
+	fake := &fakeSecurity{err: errors.New("exit status 44")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	if got := newKeychainStore().get("abc123"); got != nil {
+		t.Errorf("get on security error = %q, want nil", got)
+	}
+}
+
+func TestKeychainGetBadBase64(t *testing.T) {
+	fake := &fakeSecurity{out: []byte("!!! not base64 !!!")}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	if got := newKeychainStore().get("abc123"); got != nil {
+		t.Errorf("get on undecodable payload = %q, want nil", got)
+	}
+}
+
+func TestKeychainPutKeepsSecretOffArgv(t *testing.T) {
+	fake := &fakeSecurity{}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+
+	blob := []byte("ticket-secret")
+	newKeychainStore().put("abc123", blob)
+
+	call := fake.calls[0]
+	// The whole add command rides stdin via `security -i`; argv holds only the flag.
+	if strings.Join(call.args, " ") != "-i" {
+		t.Fatalf("argv = %v, want [-i]", call.args)
+	}
+	b64 := base64.StdEncoding.EncodeToString(blob)
+	for _, frag := range []string{"add-generic-password", "-U", "-s wendy-tls-session", "-a abc123", "-w " + b64} {
+		if !strings.Contains(call.stdin, frag) {
+			t.Errorf("stdin %q missing %q", call.stdin, frag)
+		}
+	}
+}
+
+func TestKeychainDelete(t *testing.T) {
+	fake := &fakeSecurity{}
+	orig := runSecurity
+	runSecurity = fake.run
+	defer func() { runSecurity = orig }()
+	newKeychainStore().delete("abc123")
+	want := []string{"delete-generic-password", "-s", "wendy-tls-session", "-a", "abc123"}
+	if strings.Join(fake.calls[0].args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", fake.calls[0].args, want)
+	}
+}
+
+func TestDarwinDefaultIsKeychain(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "")
+	if _, ok := newDefaultStore().(keychainStore); !ok {
+		t.Errorf("darwin default = %T, want keychainStore", newDefaultStore())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go/internal/cli/tlscache/ -run 'TestKeychain|TestNewDefaultStore|TestDarwinDefault' -v`
+Expected: FAIL to build — `runSecurity`, `newKeychainStore`, `newDefaultStore` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `go/internal/cli/tlscache/store.go`:
+
+```go
+import "os"
+
+// newDefaultStore picks the ticket store backend. WENDY_TLS_SESSION_STORE
+// forces one: "off" disables caching (right for CI), "file"/"keychain" force a
+// backend. Anything else gets the platform default (Keychain on macOS, files
+// elsewhere). A nil return disables session caching entirely.
+func newDefaultStore() sessionStore {
+	switch os.Getenv("WENDY_TLS_SESSION_STORE") {
+	case "off":
+		return nil
+	case "file":
+		return newFileStore()
+	case "keychain":
+		return newKeychainStore()
+	}
+	return newPlatformStore()
+}
+```
+
+`go/internal/cli/tlscache/store_select_darwin.go`:
+
+```go
+package tlscache
+
+func newPlatformStore() sessionStore { return newKeychainStore() }
+```
+
+`go/internal/cli/tlscache/store_select_other.go`:
+
+```go
+//go:build !darwin
+
+package tlscache
+
+func newPlatformStore() sessionStore { return newFileStore() }
+
+// newKeychainStore has no non-darwin implementation; an explicit
+// WENDY_TLS_SESSION_STORE=keychain falls back to files rather than failing.
+func newKeychainStore() sessionStore { return newFileStore() }
+```
+
+`go/internal/cli/tlscache/store_keychain_darwin.go`:
+
+```go
+package tlscache
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// keychainService names the Keychain items holding wendy session tickets.
+const keychainService = "wendy-tls-session"
+
+const securityTimeout = 5 * time.Second
+
+// runSecurity invokes /usr/bin/security (same pattern as
+// wifi_scan_darwin.go's lookupKeychainPassword). Swapped in tests.
+var runSecurity = func(ctx context.Context, stdin string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	return cmd.Output()
+}
+
+// keychainStore keeps session tickets in the user's login Keychain. A ticket
+// is a bearer resumption secret, so it goes in the platform secret store
+// rather than a file. Items are created by (and read back through)
+// /usr/bin/security itself, whose default ACL covers it — reads must never
+// prompt; any prompt/denial surfaces as a plain cache miss.
+type keychainStore struct{}
+
+func newKeychainStore() sessionStore { return keychainStore{} }
+
+func (keychainStore) get(key string) []byte {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	out, err := runSecurity(ctx, "", "find-generic-password", "-s", keychainService, "-a", key, "-w")
+	if err != nil {
+		return nil // not found, denied, or security failed — cache miss
+	}
+	blob, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		return nil
+	}
+	return blob
+}
+
+func (keychainStore) put(key string, blob []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	// `security -i` reads the command from stdin so the ticket secret never
+	// appears on argv (argv is world-readable via ps). base64 and the hex key
+	// contain no whitespace, so no quoting is needed.
+	cmdLine := fmt.Sprintf("add-generic-password -U -s %s -a %s -j wendy-cli-tls-session -w %s\n",
+		keychainService, key, base64.StdEncoding.EncodeToString(blob))
+	_, _ = runSecurity(ctx, cmdLine, "-i")
+}
+
+func (keychainStore) delete(key string) {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	_, _ = runSecurity(ctx, "", "delete-generic-password", "-s", keychainService, "-a", key)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./go/internal/cli/tlscache/ -v`
+Expected: all PASS (file + keychain + selection).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/tlscache/
+git commit -m "feat(tlscache): macOS Keychain backend + WENDY_TLS_SESSION_STORE selection
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `Cache` — the `tls.ClientSessionCache` implementation
+
+**Files:**
+- Create: `go/internal/cli/tlscache/cache.go`
+- Test: `go/internal/cli/tlscache/cache_test.go`
+
+**Interfaces:**
+- Consumes: `sessionStore`, `newDefaultStore()`.
+- Produces: `func ForTarget(address string, clientLeafDER []byte) *Cache` (nil when caching disabled); `(*Cache) Get(string) (*tls.ClientSessionState, bool)`; `(*Cache) Put(string, *tls.ClientSessionState)`; `(*Cache) Flush()` (waits for async persists; used by tests and available to callers at shutdown). Task 4 consumes `ForTarget`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`go/internal/cli/tlscache/cache_test.go` — the round-trip test uses a real loopback TLS 1.3 handshake because `tls.ClientSessionState` cannot be fabricated:
+
+```go
+package tlscache
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memStore is an in-memory sessionStore recording deletes.
+type memStore struct {
+	mu      sync.Mutex
+	m       map[string][]byte
+	deletes int
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) get(key string) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.m[key]
+}
+func (s *memStore) put(key string, blob []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = blob
+}
+func (s *memStore) delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	s.deletes++
+}
+
+// startTLSServer runs a minimal TLS 1.3 server issuing session tickets;
+// each accepted conn handshakes, reports DidResume on ch, writes one byte.
+func startTLSServer(t *testing.T) (addr string, ch <-chan bool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "tlscache-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		MinVersion:   tls.VersionTLS13,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	resumed := make(chan bool, 16)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc := tls.Server(c, cfg)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				resumed <- tc.ConnectionState().DidResume
+				tc.Write([]byte{1}) // flushes the session ticket to the client
+				buf := make([]byte, 1)
+				tc.Read(buf) // wait for client close so the ticket is processed
+			}(c)
+		}
+	}()
+	return ln.Addr().String(), resumed
+}
+
+func dialWithCache(t *testing.T, addr string, cache *Cache) bool {
+	t.Helper()
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		ClientSessionCache: cache,
+		MinVersion:         tls.VersionTLS13,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil { // ensures NewSessionTicket has arrived
+		t.Fatalf("read: %v", err)
+	}
+	return conn.ConnectionState().DidResume
+}
+
+func TestCacheRoundTripAcrossInstances(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+	leafDER := []byte("client-leaf-der") // identity input only; any bytes work here
+
+	c1 := newCache("cache-test", leafDER, store)
+	if resumed := dialWithCache(t, addr, c1); resumed {
+		t.Fatal("first connection unexpectedly resumed")
+	}
+	<-srvResumed
+	c1.Flush() // wait for the async persist
+
+	// A separate Cache instance over the same store simulates a new CLI process.
+	c2 := newCache("cache-test", leafDER, store)
+	if resumed := dialWithCache(t, addr, c2); !resumed {
+		t.Fatal("second connection did not resume from persisted session")
+	}
+	if got := <-srvResumed; !got {
+		t.Fatal("server did not observe resumption")
+	}
+}
+
+func TestCacheKeyedByClientCert(t *testing.T) {
+	addr, srvResumed := startTLSServer(t)
+	store := newMemStore()
+
+	c1 := newCache("cache-test", []byte("cert-A"), store)
+	dialWithCache(t, addr, c1)
+	<-srvResumed
+	c1.Flush()
+
+	// Same target, different client cert → different store key → no resumption.
+	c2 := newCache("cache-test", []byte("cert-B"), store)
+	if resumed := dialWithCache(t, addr, c2); resumed {
+		t.Fatal("session resumed across different client certs")
+	}
+	<-srvResumed
+}
+
+func TestCacheCorruptBlobIsMissAndDeleted(t *testing.T) {
+	store := newMemStore()
+	c := newCache("cache-test", []byte("cert"), store)
+	store.put(c.storeKey, []byte("WTS1garbage-not-a-session"))
+	if _, ok := c.Get("ignored"); ok {
+		t.Fatal("corrupt blob returned a session")
+	}
+	if store.deletes == 0 {
+		t.Error("corrupt blob was not deleted")
+	}
+}
+
+func TestCachePutNilEvicts(t *testing.T) {
+	store := newMemStore()
+	c := newCache("cache-test", []byte("cert"), store)
+	store.put(c.storeKey, []byte("whatever"))
+	c.Put("ignored", nil)
+	c.Flush()
+	if store.get(c.storeKey) != nil {
+		t.Error("Put(nil) did not evict the stored session")
+	}
+}
+
+func TestForTargetOffReturnsNil(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	if c := ForTarget("host:50052", []byte("cert")); c != nil {
+		t.Errorf("ForTarget with store=off = %v, want nil", c)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go/internal/cli/tlscache/ -run TestCache -v`
+Expected: FAIL to build — `Cache`, `newCache`, `ForTarget` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`go/internal/cli/tlscache/cache.go`:
+
+```go
+package tlscache
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/binary"
+	"encoding/hex"
+	"sync"
+)
+
+// blobMagic versions the on-disk/on-keychain blob layout:
+// "WTS1" | uint32 BE ticket length | ticket | SessionState.Bytes().
+const blobMagic = "WTS1"
+
+// Cache implements tls.ClientSessionCache for a single (target address, client
+// certificate) pair, persisting the most recent session via a sessionStore.
+//
+// The store key binds the client leaf certificate on purpose: a session ticket
+// embeds the client identity verified at the original handshake, so a ticket
+// obtained with one org's cert must never be offered when dialing with
+// another's. Go's own sessionKey (the remote address) is ignored.
+type Cache struct {
+	storeKey string
+	store    sessionStore
+	wg       sync.WaitGroup
+}
+
+// ForTarget returns a Cache bound to the target address and client leaf cert
+// (DER), or nil when session caching is disabled (WENDY_TLS_SESSION_STORE=off
+// or no usable backend). Callers must skip the tls.Config wiring on nil — a
+// nil *Cache inside a non-nil interface value would panic in crypto/tls.
+func ForTarget(address string, clientLeafDER []byte) *Cache {
+	store := newDefaultStore()
+	if store == nil {
+		return nil
+	}
+	return newCache(address, clientLeafDER, store)
+}
+
+func newCache(address string, clientLeafDER []byte, store sessionStore) *Cache {
+	certSum := sha256.Sum256(clientLeafDER)
+	sum := sha256.Sum256(append([]byte(address+"|"), certSum[:]...))
+	return &Cache{storeKey: hex.EncodeToString(sum[:]), store: store}
+}
+
+// Get implements tls.ClientSessionCache. Any decode failure evicts the entry
+// and reports a miss; the caller then performs a full handshake.
+func (c *Cache) Get(string) (*tls.ClientSessionState, bool) {
+	blob := c.store.get(c.storeKey)
+	if blob == nil {
+		return nil, false
+	}
+	ticket, stateBytes, ok := decodeSessionBlob(blob)
+	if !ok {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	state, err := tls.ParseSessionState(stateBytes)
+	if err != nil {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	cs, err := tls.NewResumptionState(ticket, state)
+	if err != nil {
+		c.store.delete(c.storeKey)
+		return nil, false
+	}
+	return cs, true
+}
+
+// Put implements tls.ClientSessionCache. crypto/tls calls it from the
+// connection's record-processing path, so persistence (a Keychain subprocess
+// on macOS) happens on a background goroutine; a ticket lost to process exit
+// just means a full handshake next time. Put(nil) evicts (crypto/tls uses
+// that on certain handshake failures).
+func (c *Cache) Put(_ string, cs *tls.ClientSessionState) {
+	if cs == nil {
+		c.async(func() { c.store.delete(c.storeKey) })
+		return
+	}
+	ticket, state, err := cs.ResumptionState()
+	if err != nil || state == nil {
+		return
+	}
+	stateBytes, err := state.Bytes()
+	if err != nil {
+		return
+	}
+	blob := encodeSessionBlob(ticket, stateBytes)
+	c.async(func() { c.store.put(c.storeKey, blob) })
+}
+
+// Flush blocks until all pending async persists complete. Tests rely on it;
+// callers may use it before exit to make best-effort persistence certain.
+func (c *Cache) Flush() { c.wg.Wait() }
+
+func (c *Cache) async(fn func()) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		fn()
+	}()
+}
+
+func encodeSessionBlob(ticket, state []byte) []byte {
+	blob := make([]byte, 0, len(blobMagic)+4+len(ticket)+len(state))
+	blob = append(blob, blobMagic...)
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(ticket)))
+	blob = append(blob, l[:]...)
+	blob = append(blob, ticket...)
+	blob = append(blob, state...)
+	return blob
+}
+
+func decodeSessionBlob(blob []byte) (ticket, state []byte, ok bool) {
+	header := len(blobMagic) + 4
+	if len(blob) < header || string(blob[:len(blobMagic)]) != blobMagic {
+		return nil, nil, false
+	}
+	n := binary.BigEndian.Uint32(blob[len(blobMagic):header])
+	if uint32(len(blob)-header) < n {
+		return nil, nil, false
+	}
+	return blob[header : header+int(n)], blob[header+int(n):], true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./go/internal/cli/tlscache/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/tlscache/
+git commit -m "feat(tlscache): persistent ClientSessionCache keyed by target + client cert
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire the cache into `ConnectWithTLSAndPins` + WENDY_TLS_DEBUG logging
+
+**Files:**
+- Modify: `go/internal/cli/grpcclient/client.go:138-195` (`ConnectWithTLSAndPins`)
+- Test: `go/internal/cli/grpcclient/tls_config_test.go`
+
+**Interfaces:**
+- Consumes: `tlscache.ForTarget(address string, clientLeafDER []byte) *Cache`.
+- Produces: unexported `newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins certs.PinChecker, observedOrg *atomic.Int32) (*tls.Config, error)` — extracted from `ConnectWithTLSAndPins` so the config is testable; `var tlsDebugWriter io.Writer = os.Stderr` for test capture. Task 8's integration test drives `ConnectWithTLSAndPins` end-to-end.
+
+- [ ] **Step 1: Write the failing tests**
+
+`go/internal/cli/grpcclient/tls_config_test.go` (package `grpcclient`); imports: `bytes`, `crypto/ecdsa`, `crypto/elliptic`, `crypto/rand`, `crypto/tls`, `crypto/x509`, `crypto/x509/pkix`, `encoding/pem`, `math/big`, `strings`, `sync/atomic`, `testing`, `time`, and the repo's `internal/shared/config`:
+
+```go
+// testCertInfo builds a self-contained ECDSA CA + client leaf and returns the
+// CertificateInfo shape ConnectWithTLSAndPins consumes.
+func testCertInfo(t *testing.T) *config.CertificateInfo {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "TLS Config Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "tls-config-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	return &config.CertificateInfo{
+		PemCertificate:      string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})),
+		PemPrivateKey:       string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})),
+		PemCertificateChain: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+	}
+}
+func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.ClientSessionCache == nil {
+		t.Error("ClientSessionCache not set")
+	}
+}
+
+func TestNewAgentTLSConfigHonorsStoreOff(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.ClientSessionCache != nil {
+		t.Errorf("ClientSessionCache = %v, want nil with store=off", cfg.ClientSessionCache)
+	}
+}
+
+func TestNewAgentTLSConfigDebugLogsResumption(t *testing.T) {
+	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
+	t.Setenv("WENDY_TLS_DEBUG", "1")
+	var buf bytes.Buffer
+	origWriter := tlsDebugWriter
+	tlsDebugWriter = &buf
+	defer func() { tlsDebugWriter = origWriter }()
+
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32))
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	// The wrapped VerifyConnection must log DidResume before delegating; an
+	// empty ConnectionState fails the inner verifier, which is fine here.
+	cfg.VerifyConnection(tls.ConnectionState{DidResume: true})
+	if !strings.Contains(buf.String(), "resumed=true") {
+		t.Errorf("debug output %q missing resumed=true", buf.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go/internal/cli/grpcclient/ -run TestNewAgentTLSConfig -v`
+Expected: FAIL to build — `newAgentTLSConfig`, `tlsDebugWriter` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `go/internal/cli/grpcclient/client.go`, add `var tlsDebugWriter io.Writer = os.Stderr` at package level (imports: `io`, `os`), then extract the existing tlsCfg construction from `ConnectWithTLSAndPins` (the `tls.X509KeyPair` call through the `tlsCfg := &tls.Config{...}` literal) into:
+
+```go
+// newAgentTLSConfig builds the client TLS config for one agent target,
+// including the persistent session cache that lets repeat CLI invocations
+// skip the full ML-DSA handshake (see specs/2026-08-07-tls-session-resumption-design.md).
+func newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins certs.PinChecker, observedOrg *atomic.Int32) (*tls.Config, error) {
+	// Only load the leaf cert — not the chain. Go's TLS library calls
+	// x509.ParseCertificate on every cert sent in the handshake, and ML-DSA
+	// chain certs (from pki-core) cause parse failures on the agent's server.
+	// The agent's VerifyPeerCertificate callback verifies the client cert via
+	// its own ML-DSA-aware CA pool without needing the chain in the handshake.
+	cert, err := tls.X509KeyPair(
+		[]byte(certInfo.PemCertificate),
+		[]byte(certInfo.PemPrivateKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading TLS cert: %w", err)
+	}
+	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+		ChainPEM:      certInfo.PemCertificateChain,
+		ExpectedOrgID: int32(certInfo.OrganizationID),
+		PinStore:      pins,
+		OnServerIdentity: func(id certs.WendyIdentity) {
+			if id.OrgID != 0 {
+				observedOrg.Store(id.OrgID)
+			}
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building TLS verifier: %w", err)
+	}
+	if os.Getenv("WENDY_TLS_DEBUG") != "" {
+		inner := verifyConn
+		verifyConn = func(cs tls.ConnectionState) error {
+			fmt.Fprintf(tlsDebugWriter, "[tls-debug] %s resumed=%v\n", address, cs.DidResume)
+			return inner(cs)
+		}
+	}
+	tlsCfg := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true, //nolint:gosec — hostname bypass only; VerifyConnection validates server cert against Wendy PKI
+		VerifyConnection:   verifyConn,
+		MinVersion:         tls.VersionTLS12,
+	}
+	// Session resumption: nil means caching is disabled — leaving the field
+	// unset is required then, because a typed-nil *Cache in the interface
+	// would panic inside crypto/tls.
+	if cache := tlscache.ForTarget(address, cert.Certificate[0]); cache != nil {
+		tlsCfg.ClientSessionCache = cache
+	}
+	return tlsCfg, nil
+}
+```
+
+`ConnectWithTLSAndPins` becomes: create `observedOrg := new(atomic.Int32)`, call `newAgentTLSConfig(address, certInfo, pins, observedOrg)`, keep everything from `grpc.NewClient` onward unchanged. Import `"github.com/wendylabsinc/wendy/go/internal/cli/tlscache"`.
+
+- [ ] **Step 4: Run tests, including the untouched existing ones**
+
+Run: `go test ./go/internal/cli/grpcclient/ -v`
+Expected: all PASS (new + pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/grpcclient/
+git commit -m "feat(grpcclient): persistent TLS session cache + resumed= debug logging
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Extract `effectiveVerificationTime` (behavior-preserving refactor)
+
+**Files:**
+- Modify: `go/internal/agent/mtls/mldsa_verify.go:180-195` (inside `buildVerifyPeerCertificate`)
+
+**Interfaces:**
+- Produces: `func effectiveVerificationTime(realNow, notBeforeFloor, certNotBefore time.Time) time.Time` in package `mtls`. Task 6 consumes it so the ticket re-check can never drift from the full verifier's clock-skew semantics.
+
+- [ ] **Step 1: Extract the helper**
+
+In `mldsa_verify.go`, replace the body between `realNow := time.Now()` and the expiry pre-check with a call to the new helper, moving the existing comments with the code:
+
+```go
+// effectiveVerificationTime returns the clock used for NotBefore checks.
+// effectiveNow applies the NotBefore floor; when the device clock is behind
+// notBeforeFloor (NTP not yet synced), it additionally advances up to the
+// cert's NotBefore so a cert issued just after provisioning is not spuriously
+// rejected — capped at notBeforeFloor+maxClockSkewTolerance so a cert whose
+// NotBefore is further in the future is still rejected on a stuck clock.
+// Shared by the full ML-DSA verifier and the session-ticket re-check
+// (session_ticket.go) so the two can never drift apart.
+func effectiveVerificationTime(realNow, notBeforeFloor, certNotBefore time.Time) time.Time {
+	effectiveNow := maxTime(realNow, notBeforeFloor)
+	if realNow.Before(notBeforeFloor) {
+		advanced := certNotBefore
+		if cap := notBeforeFloor.Add(maxClockSkewTolerance); advanced.After(cap) {
+			advanced = cap
+		}
+		effectiveNow = maxTime(effectiveNow, advanced)
+	}
+	return effectiveNow
+}
+```
+
+and in `buildVerifyPeerCertificate`:
+
+```go
+	realNow := time.Now()
+	effectiveNow := effectiveVerificationTime(realNow, notBeforeFloor, leaf.NotBefore)
+```
+
+- [ ] **Step 2: Run the existing floor tests as the refactor guard**
+
+Run: `go test ./go/internal/agent/mtls/ -v`
+Expected: all PASS unchanged (`TestBuildVerifyPeerCertificate_StandardPathHonorsNotBeforeFloor`, `TestBuildVerifyPeerCertificate_ClientCertIssuedAfterFloor`, and the rest).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/internal/agent/mtls/mldsa_verify.go
+git commit -m "refactor(mtls): extract effectiveVerificationTime for reuse by ticket checks
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Server `WrapSession`/`UnwrapSession` with cert-window decline
+
+**Files:**
+- Create: `go/internal/agent/mtls/session_ticket.go`
+- Modify: `go/internal/agent/mtls/server.go:57-72` (`NewTLSConfig` return)
+- Test: `go/internal/agent/mtls/session_ticket_test.go`
+
+**Interfaces:**
+- Consumes: `effectiveVerificationTime` (Task 5), `maxClockSkewTolerance`.
+- Produces: `func wireSessionTicketChecks(cfg *tls.Config, notBeforeFloor time.Time, now func() time.Time)`; `const ticketMetaPrefix = "wendy-mtls/1:"`; pure helpers `appendClientCertWindow(ss *tls.SessionState, cs tls.ConnectionState)`, `clientCertWindowFromExtra(ss *tls.SessionState) (notBefore, notAfter time.Time, ok bool)`, `resumableClientWindow(notBefore, notAfter, realNow, floor time.Time) bool`. Task 7 re-wires with a fake `now` for handshake-level tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+`go/internal/agent/mtls/session_ticket_test.go`:
+
+```go
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+func TestClientCertWindowRoundTrip(t *testing.T) {
+	nb := time.Unix(1700000000, 0)
+	na := time.Unix(1710000000, 0)
+	ss := &tls.SessionState{}
+	appendClientCertWindow(ss, tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{NotBefore: nb, NotAfter: na}},
+	})
+	gotNB, gotNA, ok := clientCertWindowFromExtra(ss)
+	if !ok {
+		t.Fatal("window not found after append")
+	}
+	if !gotNB.Equal(nb) || !gotNA.Equal(na) {
+		t.Errorf("window = [%v, %v], want [%v, %v]", gotNB, gotNA, nb, na)
+	}
+}
+
+func TestClientCertWindowNoPeerCertAppendsNothing(t *testing.T) {
+	ss := &tls.SessionState{}
+	appendClientCertWindow(ss, tls.ConnectionState{})
+	if len(ss.Extra) != 0 {
+		t.Errorf("Extra = %v, want empty", ss.Extra)
+	}
+	if _, _, ok := clientCertWindowFromExtra(ss); ok {
+		t.Error("found a window in an empty session state")
+	}
+}
+
+func TestClientCertWindowIgnoresForeignAndMalformedEntries(t *testing.T) {
+	nb := time.Unix(1700000000, 0)
+	na := time.Unix(1710000000, 0)
+	ss := &tls.SessionState{Extra: [][]byte{
+		[]byte("some-other-component:opaque"),
+		[]byte(ticketMetaPrefix + "short"),       // right prefix, wrong length
+		[]byte("wendy-mtls/2:0123456789abcdef"),  // future version — must not parse as v1
+	}}
+	if _, _, ok := clientCertWindowFromExtra(ss); ok {
+		t.Fatal("parsed a window out of foreign/malformed entries")
+	}
+	appendClientCertWindow(ss, tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{NotBefore: nb, NotAfter: na}},
+	})
+	gotNB, _, ok := clientCertWindowFromExtra(ss)
+	if !ok || !gotNB.Equal(nb) {
+		t.Errorf("valid entry not found among foreign entries: ok=%v nb=%v", ok, gotNB)
+	}
+}
+
+func TestResumableClientWindow(t *testing.T) {
+	base := time.Unix(1700000000, 0)
+	nb, na := base, base.Add(30*24*time.Hour)
+	cases := []struct {
+		name    string
+		realNow time.Time
+		floor   time.Time
+		want    bool
+	}{
+		{"inside window", base.Add(time.Hour), time.Time{}, true},
+		{"expired", na.Add(time.Second), time.Time{}, false},
+		{"expired despite floor", na.Add(time.Second), na.Add(48 * time.Hour), false},
+		{"not yet valid, no floor", base.Add(-time.Hour), time.Time{}, false},
+		{"stuck clock rescued by floor", base.Add(-30 * 24 * time.Hour), base, true},
+		// Floor advancement is capped at floor+maxClockSkewTolerance: a cert
+		// starting further in the future than that stays non-resumable.
+		{"future cert beyond skew cap", base.Add(-30 * 24 * time.Hour), base.Add(-2 * maxClockSkewTolerance), false},
+	}
+	for _, tc := range cases {
+		if got := resumableClientWindow(nb, na, tc.realNow, tc.floor); got != tc.want {
+			t.Errorf("%s: resumable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go/internal/agent/mtls/ -run 'TestClientCertWindow|TestResumableClientWindow' -v`
+Expected: FAIL to build — helpers undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`go/internal/agent/mtls/session_ticket.go`:
+
+```go
+package mtls
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"time"
+)
+
+// ticketMetaPrefix tags this package's entry in SessionState.Extra. Extra is a
+// shared list any component may append to, so the prefix both namespaces our
+// entry and versions its layout; UnwrapSession treats an absent or
+// unknown-version entry as "decline resumption".
+const ticketMetaPrefix = "wendy-mtls/1:"
+
+// wireSessionTicketChecks installs WrapSession/UnwrapSession on a server TLS
+// config so that session tickets carry the verified client cert's validity
+// window and resumption is DECLINED — never failed — once that window lapses.
+//
+// Rationale: a resumed TLS 1.3 handshake skips the certificate exchange, so
+// the full ML-DSA chain verification from the original handshake is trusted
+// for the ticket's lifetime (≤7 days, less on agent restart). The cheap
+// re-check here bounds that trust by the cert's own validity window. Declining
+// (returning nil, nil) downgrades to a full handshake, where
+// VerifyPeerCertificate re-runs the complete verification and surfaces the
+// existing error paths if the cert is genuinely bad — a stale ticket
+// self-heals instead of hard-failing on every retry.
+//
+// now is injectable for handshake-level tests; production passes time.Now.
+func wireSessionTicketChecks(cfg *tls.Config, notBeforeFloor time.Time, now func() time.Time) {
+	cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+		appendClientCertWindow(ss, cs)
+		return cfg.EncryptTicket(cs, ss)
+	}
+	cfg.UnwrapSession = func(identity []byte, cs tls.ConnectionState) (*tls.SessionState, error) {
+		ss, err := cfg.DecryptTicket(identity, cs)
+		if err != nil || ss == nil {
+			return nil, nil // undecryptable (e.g. pre-restart ticket) → full handshake
+		}
+		notBefore, notAfter, ok := clientCertWindowFromExtra(ss)
+		if !ok || !resumableClientWindow(notBefore, notAfter, now(), notBeforeFloor) {
+			return nil, nil
+		}
+		return ss, nil
+	}
+}
+
+// appendClientCertWindow stamps the verified client leaf's validity window
+// into the session state. With no peer cert (should not happen under
+// RequireAnyClientCert) nothing is appended, which UnwrapSession later reads
+// as "decline".
+func appendClientCertWindow(ss *tls.SessionState, cs tls.ConnectionState) {
+	if len(cs.PeerCertificates) == 0 {
+		return
+	}
+	leaf := cs.PeerCertificates[0]
+	meta := make([]byte, len(ticketMetaPrefix)+16)
+	copy(meta, ticketMetaPrefix)
+	binary.BigEndian.PutUint64(meta[len(ticketMetaPrefix):], uint64(leaf.NotBefore.Unix()))
+	binary.BigEndian.PutUint64(meta[len(ticketMetaPrefix)+8:], uint64(leaf.NotAfter.Unix()))
+	ss.Extra = append(ss.Extra, meta)
+}
+
+func clientCertWindowFromExtra(ss *tls.SessionState) (notBefore, notAfter time.Time, ok bool) {
+	for _, entry := range ss.Extra {
+		if len(entry) != len(ticketMetaPrefix)+16 || string(entry[:len(ticketMetaPrefix)]) != ticketMetaPrefix {
+			continue
+		}
+		nb := int64(binary.BigEndian.Uint64(entry[len(ticketMetaPrefix):]))
+		na := int64(binary.BigEndian.Uint64(entry[len(ticketMetaPrefix)+8:]))
+		return time.Unix(nb, 0), time.Unix(na, 0), true
+	}
+	return time.Time{}, time.Time{}, false
+}
+
+// resumableClientWindow mirrors buildVerifyPeerCertificate's clock handling:
+// expiry is checked against the real clock (the floor must never mask real
+// expiry), NotBefore against effectiveVerificationTime (the floor rescues
+// devices whose clock lags NTP).
+func resumableClientWindow(notBefore, notAfter, realNow, floor time.Time) bool {
+	if realNow.After(notAfter) {
+		return false
+	}
+	return !effectiveVerificationTime(realNow, floor, notBefore).Before(notBefore)
+}
+```
+
+In `server.go` `NewTLSConfig`, capture the config before returning and wire the checks:
+
+```go
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		// ... existing fields unchanged ...
+		VerifyPeerCertificate: buildVerifyPeerCertificate(caPool, caCerts, logger, notBeforeFloor),
+	}
+	// Session resumption: stamp the client cert window into tickets and
+	// decline stale ones (see session_ticket.go for the security rationale).
+	wireSessionTicketChecks(cfg, notBeforeFloor, time.Now)
+	return cfg, nil
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./go/internal/agent/mtls/ -v`
+Expected: all PASS (new + pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/agent/mtls/
+git commit -m "feat(mtls): session tickets carry client cert window; stale tickets decline to full handshake
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: TLS-level resumption integration tests (mtls server)
+
+**Files:**
+- Test: `go/internal/agent/mtls/resumption_test.go`
+
+**Interfaces:**
+- Consumes: `NewTLSConfig`, `wireSessionTicketChecks`, `buildVerifyPeerCertificate` (via config), test-PKI patterns from `server_test.go`.
+- Produces: proof of the spec's resumption guarantees at the handshake layer.
+
+- [ ] **Step 1: Write the tests**
+
+`go/internal/agent/mtls/resumption_test.go`. PKI helper — ECDSA CA + server leaf + client leaf, mirroring `server_test.go`'s templates:
+
+```go
+package mtls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type resumptionPKI struct {
+	serverCertPEM, serverKeyPEM, caPEM string
+	clientCert                         tls.Certificate
+}
+
+func newResumptionPKI(t *testing.T) resumptionPKI {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Resumption Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leaf := func(cn string, eku x509.ExtKeyUsage) (string, string, tls.Certificate) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("gen key: %v", err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("create leaf: %v", err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatalf("marshal key: %v", err)
+		}
+		certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+		keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+		return certPEM, keyPEM, tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+	}
+
+	serverCertPEM, serverKeyPEM, _ := leaf("resumption-server", x509.ExtKeyUsageServerAuth)
+	_, _, clientCert := leaf("resumption-client", x509.ExtKeyUsageClientAuth)
+	return resumptionPKI{
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		caPEM:         string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+		clientCert:    clientCert,
+	}
+}
+
+// resumptionEnv serves the given config and reports each connection's
+// server-side DidResume; verifies counts full VerifyPeerCertificate runs.
+type resumptionEnv struct {
+	addr        string
+	cfg         *tls.Config
+	clientCert  tls.Certificate
+	verifyCount *atomic.Int32
+	srvResumed  chan bool
+}
+
+func newResumptionEnv(t *testing.T) *resumptionEnv {
+	t.Helper()
+	pki := newResumptionPKI(t)
+	cfg, err := NewTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil, time.Time{})
+	if err != nil {
+		t.Fatalf("NewTLSConfig: %v", err)
+	}
+	env := &resumptionEnv{cfg: cfg, verifyCount: new(atomic.Int32), srvResumed: make(chan bool, 16)}
+	inner := cfg.VerifyPeerCertificate
+	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
+		env.verifyCount.Add(1)
+		return inner(rawCerts, chains)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	env.addr = ln.Addr().String()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc := tls.Server(c, cfg)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				env.srvResumed <- tc.ConnectionState().DidResume
+				tc.Write([]byte{1})
+				buf := make([]byte, 1)
+				tc.Read(buf)
+			}(c)
+		}
+	}()
+	// The client mirrors grpcclient's config shape: cert presented,
+	// hostname verification off (test CA has no SANs for 127.0.0.1).
+	env.clientCert = pki.clientCert
+	return env
+}
+```
+
+```go
+func (env *resumptionEnv) dial(t *testing.T, cache tls.ClientSessionCache) (clientResumed, serverResumed bool) {
+	t.Helper()
+	conn, err := tls.Dial("tcp", env.addr, &tls.Config{
+		Certificates:       []tls.Certificate{env.clientCert},
+		InsecureSkipVerify: true,
+		ClientSessionCache: cache,
+		MinVersion:         tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if v := conn.ConnectionState().Version; v != tls.VersionTLS13 {
+		t.Fatalf("negotiated TLS %x, want TLS 1.3", v)
+	}
+	return conn.ConnectionState().DidResume, <-env.srvResumed
+}
+
+func TestResumptionSecondConnectionResumes(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+
+	c1, s1 := env.dial(t, cache)
+	if c1 || s1 {
+		t.Fatalf("first connection resumed (client=%v server=%v)", c1, s1)
+	}
+	c2, s2 := env.dial(t, cache)
+	if !c2 || !s2 {
+		t.Fatalf("second connection did not resume (client=%v server=%v)", c2, s2)
+	}
+	if n := env.verifyCount.Load(); n != 1 {
+		t.Errorf("full ML-DSA verification ran %d times, want exactly 1", n)
+	}
+}
+
+func TestResumptionDeclinedWhenCertWindowLapses(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+	env.dial(t, cache)
+
+	// Re-wire with a clock far past the client cert's NotAfter: the server
+	// must DECLINE the ticket and complete a FULL handshake — not error out.
+	wireSessionTicketChecks(env.cfg, time.Time{}, func() time.Time {
+		return time.Now().Add(3 * 365 * 24 * time.Hour)
+	})
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("stale-window ticket resumed (client=%v server=%v)", c2, s2)
+	}
+	if n := env.verifyCount.Load(); n != 2 {
+		t.Errorf("full verification ran %d times, want 2 (decline forces re-verify)", n)
+	}
+}
+
+func TestResumptionDeclinedWithoutWindowMetadata(t *testing.T) {
+	env := newResumptionEnv(t)
+	cache := tls.NewLRUClientSessionCache(4)
+
+	// Issue tickets WITHOUT the window stamp (simulates a garbled/foreign
+	// ticket): resumption must be declined, connection must still succeed.
+	env.cfg.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+		return env.cfg.EncryptTicket(cs, ss)
+	}
+	env.dial(t, cache)
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("metadata-less ticket resumed (client=%v server=%v)", c2, s2)
+	}
+}
+
+func TestResumptionTicketsDisabledStillConnects(t *testing.T) {
+	env := newResumptionEnv(t)
+	env.cfg.SessionTicketsDisabled = true
+	cache := tls.NewLRUClientSessionCache(4)
+
+	env.dial(t, cache)
+	c2, s2 := env.dial(t, cache)
+	if c2 || s2 {
+		t.Fatalf("resumed with tickets disabled (client=%v server=%v)", c2, s2)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `go test ./go/internal/agent/mtls/ -run TestResumption -v`
+Expected: all PASS. If `TestResumptionSecondConnectionResumes` flakes on the ticket arriving after `Read` returns, the server's post-write `Read` (waiting for client close) is the synchronization point — verify it is present before debugging further.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/internal/agent/mtls/resumption_test.go
+git commit -m "test(mtls): handshake-level resumption, decline, and fallback coverage
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: gRPC end-to-end test — `ConnectWithTLSAndPins` resumes against `mtls.NewServer`
+
+**Files:**
+- Test: `go/internal/cli/grpcclient/resumption_integration_test.go`
+
+**Interfaces:**
+- Consumes: `mtls.NewServer(certPEM, chainPEM, keyPEM, logger, notBeforeFloor, expectedOrgID, orgMode, extraOpts...)`, `interceptor.OrgModeOff`, `grpcclient.ConnectWithTLSAndPins`, `config.CertificateInfo`, `agentpb`.
+- Produces: proof that the real CLI path (file store) resumes end-to-end and that the mTLS interceptors accept resumed connections.
+
+- [ ] **Step 1: Write the test**
+
+`go/internal/cli/grpcclient/resumption_integration_test.go`, package `grpcclient_test`. Reuse the PKI shape from Task 7 (CA + server leaf + client leaf as PEM; the client leaf/key also PEM-encoded this time). Key facts making this work: `ExpectedOrgID: 0` in the client verifier accepts any org, and `OrgModeOff` server-side skips org checks while still requiring verified mTLS peer credentials.
+
+```go
+package grpcclient_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/interceptor"
+	"github.com/wendylabsinc/wendy/go/internal/agent/mtls"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+// versionService records the TLS resumption state of each call's transport.
+type versionService struct {
+	agentpb.UnimplementedWendyAgentServiceServer
+	mu      sync.Mutex
+	resumed []bool
+}
+
+func (s *versionService) GetAgentVersion(ctx context.Context, _ *agentpb.GetAgentVersionRequest) (*agentpb.GetAgentVersionResponse, error) {
+	p, _ := peer.FromContext(ctx)
+	info := p.AuthInfo.(credentials.TLSInfo)
+	s.mu.Lock()
+	s.resumed = append(s.resumed, info.State.DidResume)
+	s.mu.Unlock()
+	return &agentpb.GetAgentVersionResponse{Version: "test"}, nil
+}
+
+func TestConnectWithTLSResumesAcrossConnections(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
+
+	pki := newIntegrationPKI(t) // same generator as Task 7, PEM for client too
+	srv, err := mtls.NewServer(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM,
+		nil, time.Time{}, 0, interceptor.OrgModeOff)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	svc := &versionService{}
+	agentpb.RegisterWendyAgentServiceServer(srv, svc)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go srv.Serve(ln)
+	t.Cleanup(srv.Stop)
+
+	certInfo := &config.CertificateInfo{
+		PemCertificate:      pki.clientCertPEM,
+		PemPrivateKey:       pki.clientKeyPEM,
+		PemCertificateChain: pki.caPEM,
+	}
+	call := func() {
+		conn, err := grpcclient.ConnectWithTLSAndPins(context.Background(), ln.Addr().String(), certInfo, nil)
+		if err != nil {
+			t.Fatalf("connect: %v", err)
+		}
+		defer conn.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{}); err != nil {
+			t.Fatalf("GetAgentVersion: %v", err)
+		}
+	}
+
+	call() // full handshake; ticket persists asynchronously afterwards
+
+	// The Cache lives inside the connection we just closed; its async persist
+	// races this second dial. Poll until resumption is observed (bounded).
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		call()
+		svc.mu.Lock()
+		n := len(svc.resumed)
+		resumed := svc.resumed[n-1]
+		svc.mu.Unlock()
+		if resumed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no connection resumed within 10s — ticket never persisted or offered")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.resumed[0] {
+		t.Error("first connection unexpectedly resumed")
+	}
+}
+```
+
+`newIntegrationPKI(t)` in the same file (Task 7's equivalent helper is in another package and deliberately unexported — do not export it across the agent/CLI boundary):
+
+```go
+type integrationPKI struct {
+	serverCertPEM, serverKeyPEM, caPEM string
+	clientCertPEM, clientKeyPEM        string
+}
+
+func newIntegrationPKI(t *testing.T) integrationPKI {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Resumption E2E CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leaf := func(cn string, eku x509.ExtKeyUsage) (certPEM, keyPEM string) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("gen key: %v", err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("create leaf: %v", err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatalf("marshal key: %v", err)
+		}
+		return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+			string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	}
+
+	serverCertPEM, serverKeyPEM := leaf("resumption-e2e-server", x509.ExtKeyUsageServerAuth)
+	clientCertPEM, clientKeyPEM := leaf("resumption-e2e-client", x509.ExtKeyUsageClientAuth)
+	return integrationPKI{
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		caPEM:         string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})),
+		clientCertPEM: clientCertPEM,
+		clientKeyPEM:  clientKeyPEM,
+	}
+}
+```
+
+(Add `crypto/ecdsa`, `crypto/elliptic`, `crypto/rand`, `crypto/x509`, `crypto/x509/pkix`, `encoding/pem`, `math/big` to the imports.)
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./go/internal/cli/grpcclient/ -run TestConnectWithTLSResumes -v`
+Expected: PASS. This also proves the mTLS interceptor accepted a resumed connection (the RPC would fail with Unauthenticated if `PeerCertificates` were missing).
+
+- [ ] **Step 3: Run both touched packages' full suites**
+
+Run: `go test ./go/internal/cli/grpcclient/ ./go/internal/agent/mtls/ ./go/internal/cli/tlscache/`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/internal/cli/grpcclient/resumption_integration_test.go
+git commit -m "test(grpcclient): end-to-end CLI→agent session resumption over gRPC
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Mesh client in-memory session cache
+
+**Files:**
+- Modify: `go/internal/agent/mtls/server.go:118-134` (`NewClientTLSConfig`)
+- Test: append to `go/internal/agent/mtls/session_ticket_test.go`
+
+**Interfaces:**
+- Consumes: existing `NewClientTLSConfig`.
+- Produces: package-level `var meshSessionCache = tls.NewLRUClientSessionCache(64)` shared by all mesh client configs (the agent is long-lived and holds a single client identity, so a process-wide cache is correct and per-config caches would never hit).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `session_ticket_test.go` (reuse `newResumptionPKI` from Task 7 — same package):
+
+```go
+func TestNewClientTLSConfigSharesSessionCache(t *testing.T) {
+	pki := newResumptionPKI(t)
+	a, err := NewClientTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil)
+	if err != nil {
+		t.Fatalf("NewClientTLSConfig: %v", err)
+	}
+	b, err := NewClientTLSConfig(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM, nil)
+	if err != nil {
+		t.Fatalf("NewClientTLSConfig: %v", err)
+	}
+	if a.ClientSessionCache == nil {
+		t.Fatal("ClientSessionCache not set on mesh client config")
+	}
+	if a.ClientSessionCache != b.ClientSessionCache {
+		t.Error("mesh client configs do not share one session cache; per-config caches never hit (configs are built per dial)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go/internal/agent/mtls/ -run TestNewClientTLSConfigShares -v`
+Expected: FAIL — `ClientSessionCache` nil.
+
+- [ ] **Step 3: Implement**
+
+In `server.go`, above `NewClientTLSConfig`:
+
+```go
+// meshSessionCache lets agent→agent mesh dials resume TLS sessions. One
+// process-wide cache: mesh TLS configs are constructed per dial, so a
+// per-config cache would never produce a hit, and the agent presents a single
+// client identity so cross-identity ticket reuse cannot arise.
+var meshSessionCache = tls.NewLRUClientSessionCache(64)
+```
+
+and add `ClientSessionCache: meshSessionCache,` to the `tls.Config` literal returned by `NewClientTLSConfig`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./go/internal/agent/mtls/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/agent/mtls/
+git commit -m "feat(mtls): shared in-memory session cache for mesh client dials
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Full verification, gofmt, push, draft PR
+
+**Files:**
+- No new files; verification + PR creation.
+
+- [ ] **Step 1: gofmt (mandatory pre-push)**
+
+Run from repo root: `gofmt -l .`
+Expected: no output. If files are listed: `gofmt -w <files>`, re-run tests for touched packages, `git commit -am "style: gofmt"` (with the Co-Authored-By trailer).
+
+- [ ] **Step 2: Build + full test pass on touched packages and their dependents**
+
+```bash
+go build ./go/...
+go test ./go/internal/cli/tlscache/ ./go/internal/cli/grpcclient/ ./go/internal/agent/mtls/ ./go/internal/cli/commands/ ./go/internal/agent/services/
+```
+Expected: build clean; all PASS. (`commands` and `services` are the main consumers of the modified constructors — they must still compile and pass.)
+
+- [ ] **Step 3: Push and open a draft PR**
+
+```bash
+git push -u origin ed/tls-session-resumption
+gh pr create --draft --title "TLS 1.3 session resumption: repeat CLI→agent connects skip the ML-DSA handshake" --body "$(cat <<'EOF'
+## Summary
+Every `wendy` invocation currently redoes the full ML-DSA mTLS handshake (~2.2s on Jetson/Pi). This PR persists TLS 1.3 session tickets across CLI processes so repeat connects resume with a PSK handshake instead.
+
+- **New `go/internal/cli/tlscache`**: `tls.ClientSessionCache` keyed by `SHA256(target | client-leaf-fingerprint)`. macOS stores tickets in the **Keychain** (via `security -i`, secret never on argv); Linux/Windows use `0600` files under `~/.wendy/tls-sessions/` (the client key already lives in `~/.wendy/config.json`, so no new exposure class). `WENDY_TLS_SESSION_STORE=keychain|file|off` overrides.
+- **Agent `mtls.NewTLSConfig`**: `WrapSession` stamps the verified client cert's validity window into the ticket (`wendy-mtls/1:` Extra entry); `UnwrapSession` **declines** (never fails) resumption when the window has lapsed — stale tickets self-heal into full handshakes, mirroring `notBeforeFloor` clock-skew semantics via the shared `effectiveVerificationTime`.
+- **Mesh**: agent→agent client configs share one in-memory LRU session cache.
+- `WENDY_TLS_DEBUG=1` now logs `resumed=true/false` per connection.
+
+Design: `specs/2026-08-07-tls-session-resumption-design.md`
+
+## Compatibility
+Old CLI ↔ new agent and new CLI ↔ old agent both simply full-handshake. Agent restart invalidates tickets (per-process ticket keys) → one full handshake per device.
+
+## Verification
+- [x] Unit + handshake-level integration tests (resume / decline / disabled / keyed-by-cert)
+- [x] gRPC end-to-end: `ConnectWithTLSAndPins` resumes against `mtls.NewServer`; interceptors accept resumed conns
+- [ ] On-device: `WENDY_TIMING=1` before/after on Orin Nano (expect mTLS-attempts phase ~2.2s → low ms on repeat connects)
+- [ ] macOS: confirm Keychain reads never prompt (`security find-generic-password` ACL) on a real Mac
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Update project memory** with the PR number and remaining on-device verification steps.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** cache pkg + keying (Tasks 1–3), Keychain default / file fallback / env override (Task 2), client wiring + debug logging (Task 4), server Wrap/Unwrap with floor semantics + decline-not-fail (Tasks 5–6), handshake + gRPC integration proofs incl. tickets-disabled compat (Tasks 7–8), mesh LRU (Task 9), on-device `WENDY_TIMING` gate (Task 10 PR checklist). Async `Put` (spec §1) is in Task 3 with `Flush()` for determinism.
+- **Known intentional duplication:** the ECDSA test-PKI generator appears in Tasks 3, 7, and 8 (different packages; kept unexported per package rather than exporting test helpers across the agent/CLI boundary).
+- **Verify during Task 2 execution:** the exact `security -i` stdin syntax against a real macOS Keychain (the fake only pins our invocation contract). The spec's "no prompts" property is a PR-checklist item, not a unit test.


### PR DESCRIPTION
## Summary
Every `wendy` invocation currently redoes the full ML-DSA mTLS handshake (~2.2s on Jetson/Pi). This PR persists TLS 1.3 session tickets across CLI processes so repeat connects resume with a PSK handshake instead.

- **New `go/internal/cli/tlscache`**: `tls.ClientSessionCache` keyed by `SHA256(target | client-leaf-fingerprint)`. macOS stores tickets in the **Keychain** (via `security -i`, secret never on argv); Linux/Windows use `0600` files under `~/.wendy/tls-sessions/` (the client key already lives in `~/.wendy/config.json`, so no new exposure class). `WENDY_TLS_SESSION_STORE=keychain|file|off` overrides.
- **Agent `mtls.NewTLSConfig`**: `WrapSession` stamps the verified client cert's validity window into the ticket (`wendy-mtls/1:` Extra entry); `UnwrapSession` **declines** (never fails) resumption when the window has lapsed — stale tickets self-heal into full handshakes, mirroring `notBeforeFloor` clock-skew semantics via the shared `effectiveVerificationTime`.
- **Mesh**: agent→agent client configs share one in-memory LRU session cache. `NewClientTLSConfigExpectingPeer`'s anti-MITM peer pin (org + asset ID) is re-verified in `VerifyConnection` on every *resumed* handshake too, not just full ones — Go skips `VerifyPeerCertificate` entirely on resumption, so without this a shared-cache ticket obtained while dialing one asset could be resumed while "expecting" a different one with zero client-side verification.
- **Security model — corrected trust horizon**: full ML-DSA re-verification is forced at least **weekly**, but not by ticket lifetime alone. Go's TLS 1.3 server reissues a fresh ticket on *every* connection, including resumed ones, so a client that simply kept overwriting its cached ticket could chain resumptions indefinitely and never redo a full handshake. The CLI's `tlscache.Cache` instead keeps only the ticket from its **last full handshake** (`Cache.MarkResumed`, wired via an always-on `VerifyConnection` hook in `grpcclient.newAgentTLSConfig`) and never persists a ticket minted on a resumed connection; combined with Go's own 7-day `maxSessionTicketLifetime` check on both ends, that's what actually bounds trust to ~7 days. The agent's per-resumption client-cert-window check is an independent second layer that also catches a cert expiring mid-week. Mesh dials get the property differently (see above): resumed mesh connections re-verify the full chain + pin every time, so ticket chaining is harmless there and needs no equivalent guard.
- `WENDY_TLS_DEBUG=1` now logs `resumed=true/false` per connection.

Design: `specs/2026-08-07-tls-session-resumption-design.md`

## Compatibility
Old CLI ↔ new agent and new CLI ↔ old agent both simply full-handshake. Agent restart invalidates tickets (per-process ticket keys) → one full handshake per device.

## Verification
- [x] Unit + handshake-level integration tests (resume / decline / disabled / keyed-by-cert)
- [x] gRPC end-to-end: `ConnectWithTLSAndPins` resumes against `mtls.NewServer`; interceptors accept resumed conns
- [x] Mesh peer-pin bypass on resumption: regression test dials a shared session cache with mismatched pinned identities, confirms the client rejects the mismatched resume and correctly-pinned resumption still succeeds
- [x] Ticket-chaining trust-horizon fix: `tlscache` unit tests confirm `Put` keeps the last full-handshake ticket once `MarkResumed` is set, and `Put(nil)` eviction still runs unconditionally
- [x] On-device: `WENDY_TIMING=1` before/after on Orin Nano — **verified 2026-08-08** (Jetson Orin Nano, WendyOS 0.16, pre-branch agent): mTLS phase full handshake **849ms** → resumed **141ms** (direct IP; ~6×). Note: dialing by `.local` name adds a constant ~1.2–1.4s of mDNS resolution on macOS that masks the win — that's the separate last-known-good-cache follow-up, not this PR.
- [x] macOS: Keychain reads never prompt — **verified 2026-08-08** with the real CLI binary on a real login Keychain (`wendy-tls-session` item created + read back promptlessly across processes; `resumed=true` on 2nd connect, also against a second device/AGX Thor).

## Follow-ups
- `interceptor.CheckMTLS` panics on a nil `*zap.Logger` despite the parameter being documented as legal to pass nil; production callers always pass a real logger today so this is latent, not a live bug.
- `mesh_dialer.go`'s mesh dials all use one constant `grpc.WithAuthority` (`passthrough:///mesh-peer`), so the shared `meshSessionCache` has effectively one session-cache slot across every peer instead of one per peer. This PR's fix makes that safe (every resumed mesh connection re-verifies the pin), but a per-peer authority would let each peer resume independently instead of contending for the same cache slot.
- macOS Keychain `wendy-tls-session` entries accumulate per (target address × client cert) pair with no pruning; unlike the file backend (which opportunistically prunes entries older than 7 days on `Put`), stale Keychain items are never cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

