### PR TITLE
agent: prefer a standard picture aspect for "device default" camera size

### DIFF
--- a/go/internal/agent/services/video_default_aspect_test.go
+++ b/go/internal/agent/services/video_default_aspect_test.go
@@ -1,0 +1,53 @@
+package services
+
+import "testing"
+
+// TestHasStandardAspect pins the rule that keeps "device default" off a
+// metadata-carrying mode. The thermal entries are the real advertised list from
+// a TOPDON TC001 on wendy-box-theta / ccr1.
+func TestHasStandardAspect(t *testing.T) {
+	standard := [][2]uint32{
+		{320, 240}, {640, 480}, {1280, 720}, {1920, 1080}, {800, 600},
+		{256, 192},  // thermal sensor native, 4:3
+		{512, 384},  // thermal image-only, 4:3 — the mode we want chosen
+		{1280, 800}, // 16:10
+		{720, 480},  // 3:2
+	}
+	for _, s := range standard {
+		if !hasStandardAspect(s[0], s[1]) {
+			t.Errorf("%dx%d should be a standard aspect", s[0], s[1])
+		}
+	}
+
+	nonStandard := [][2]uint32{
+		{512, 484}, // image + ~100 metadata rows — the one that caused the green band
+		{256, 392}, // image + data stacked (portrait)
+		{256, 196}, // sensor + 4 metadata rows
+		{520, 192},
+		{644, 384},
+		{4, 12305}, // malformed descriptor
+		{60, 3299}, // malformed descriptor
+		{0, 0},
+	}
+	for _, s := range nonStandard {
+		if hasStandardAspect(s[0], s[1]) {
+			t.Errorf("%dx%d should NOT be a standard aspect", s[0], s[1])
+		}
+	}
+}
+
+// TestStandardAspectBeatsLargerArea is the regression this change exists for:
+// 512x484 has the larger area, but 512x384 is the actual picture.
+func TestStandardAspectBeatsLargerArea(t *testing.T) {
+	withMeta := uint64(512) * uint64(484)
+	imageOnly := uint64(512) * uint64(384)
+	if withMeta <= imageOnly {
+		t.Fatal("premise wrong: the metadata mode should have the larger area")
+	}
+	if !hasStandardAspect(512, 384) {
+		t.Fatal("512x384 must be selectable as standard")
+	}
+	if hasStandardAspect(512, 484) {
+		t.Fatal("512x484 must not be selectable as standard")
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -122,8 +122,40 @@ type v4l2FrmSizeEnum struct {
 // a common Arducam module, versus the 640x480+ the same camera offers. A
 // caller asking for "no preference" wants the device's best sensible mode, not
 // its worst, so enumerate and choose rather than letting the driver clamp.
+// hasStandardAspect reports whether w:h is a normal picture aspect ratio.
+//
+// This is how we avoid picking a mode that carries non-image data. Thermal
+// modules in the TOPDON TC001 / InfiRay family advertise their sensor size AND
+// a taller variant with metadata rows stacked on top of the picture — the same
+// image plus ~100 rows of raw temperature. That variant has the LARGER area, so
+// a pure largest-area rule picks it and the caller gets a band of false-colour
+// noise across the top of every frame. Observed on wendy-box-theta and ccr1:
+// 512x484 was selected over 512x384, and the extra 100 rows rendered as a green
+// stripe in both the CLI viewer and the companion app.
+//
+// Real picture modes are 4:3, 16:9, 16:10, 3:2 or 5:4; the stacked variants land
+// on none of them (512x484 is 1.058). Tolerance is loose enough for sizes that
+// do not divide exactly (e.g. 644x384 = 1.677 is not 16:9 and is correctly
+// excluded, while 320x240 and 1280x720 match exactly).
+func hasStandardAspect(w, h uint32) bool {
+	if w == 0 || h == 0 {
+		return false
+	}
+	ratio := float64(w) / float64(h)
+	for _, std := range []float64{4.0 / 3.0, 16.0 / 9.0, 16.0 / 10.0, 3.0 / 2.0, 5.0 / 4.0} {
+		if math.Abs(ratio-std) <= 0.02 {
+			return true
+		}
+	}
+	return false
+}
+
 func bestDefaultFrameSize(fd int, pixfmt uint32) (uint32, uint32) {
-	var bestW, bestH uint32
+	// Tracked separately so a standard-aspect mode always wins, even when a
+	// non-standard one is larger. Falling back to the largest-area mode keeps
+	// behaviour unchanged for cameras that advertise nothing standard.
+	var bestW, bestH uint32         // best standard-aspect mode
+	var fallbackW, fallbackH uint32 // best of any aspect
 	for index := uint32(0); index < 64; index++ {
 		fse := v4l2FrmSizeEnum{Index: index, PixelFormat: pixfmt}
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocEnumFramesizes,
@@ -136,11 +168,19 @@ func bestDefaultFrameSize(fd int, pixfmt uint32) (uint32, uint32) {
 		if fse.Width > defaultMaxDefaultWidth || fse.Height > defaultMaxDefaultHeight {
 			continue
 		}
-		if uint64(fse.Width)*uint64(fse.Height) > uint64(bestW)*uint64(bestH) {
+		area := uint64(fse.Width) * uint64(fse.Height)
+		if area > uint64(fallbackW)*uint64(fallbackH) {
+			fallbackW, fallbackH = fse.Width, fse.Height
+		}
+		if hasStandardAspect(fse.Width, fse.Height) &&
+			area > uint64(bestW)*uint64(bestH) {
 			bestW, bestH = fse.Width, fse.Height
 		}
 	}
-	return bestW, bestH
+	if bestW != 0 {
+		return bestW, bestH
+	}
+	return fallbackW, fallbackH
 }
 
 // bestDefaultFrameSizeForDevice opens path just long enough to ask what the


### PR DESCRIPTION
Fixes the green band across the top of thermal camera frames in the CLI viewer and the companion iOS app.

### The bug

`bestDefaultFrameSize` picks the largest area ≤720p. Thermal modules in the TOPDON TC001 / InfiRay family advertise their picture size **and** a taller variant with ~100 rows of raw temperature stacked above it. The stacked variant has the **larger** area, so it won:

| mode | area | aspect | |
|---|---|---|---|
| **512×484** | **247,808** | 1.058 | ← picked: image **+ metadata rows** |
| 512×384 | 196,608 | **1.333 = 4:3** | the actual picture |

Callers sending `width/height = 0` — which the companion app always does — had no way to avoid it.

### Evidence

Reported from a phone on `wendy-box-theta`: a recognisable thermal scene with a green stripe over the top fifth. Reproduced with the CLI on both theta and ccr1. Requesting `512x384` explicitly gave a clean frame, confirming the mode choice was the whole problem.

### The fix

A standard picture aspect (4:3, 16:9, 16:10, 3:2, 5:4, ±0.02) wins over a larger non-standard one. Cameras advertising nothing standard fall back to the previous largest-area behaviour, so nothing changes for them.

### Verified on hardware

Deployed to theta. The default path now negotiates **512×384** — confirmed with `ffprobe` on the live stream — and the decoded frame is a clean thermal image with no band.

### Tests

The aspect rule is pinned against the module's real advertised list, including the malformed `4x12305` / `60x3299` descriptors, plus the regression itself: the metadata mode has the larger area and must still lose.

### Note

This does not make thermal *look* good — that needs normalisation and a colormap, which the agent's generic H.264 path deliberately does not do. Measured on ccr1, a thermal scene spans ~16 of 256 grey levels, so it renders flat. Worth considering a thermal render mode separately, now that two devices carry these modules.

Follows #1600 (per-device resolution validation), which is what made explicit requests for these modes possible in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
