### PR TITLE
Last-known-good connect: any-age cache, bounded dead-IP cost, mTLS-port + org-cert first

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1273,21 +1273,28 @@ func normalizeMDNSHost(host string) string {
 // deviceCacheLoadFn is a seam over discoverycache.Load for tests.
 var deviceCacheLoadFn = discoverycache.Load
 
-// cachedDeviceEntry returns the fresh (within discoverycache.TTL) device-
-// cache entry, if any, whose Hostname matches host (normalizeMDNSHost
-// equality). Shared by cachedDeviceIP's lookup and cacheConnectSuccess's
-// write path so a connect-success write always lands under a real device's
-// existing identity — a discovery scan's TXT-id-derived ID/DisplayName —
-// instead of minting a second row under a host-derived key for the same
-// physical device.
+// cachedDeviceEntry returns the device-cache entry, if any, whose Hostname
+// matches host (normalizeMDNSHost equality), regardless of the entry's age
+// — the connect fast path deliberately uses stale entries too (a stale IP
+// costs one bounded dial attempt; the stale-cache retry re-resolves). When
+// several entries' hostnames normalize equal (e.g. a device re-provisioned
+// under a new identity), the most recent LastSeen wins. Shared by
+// cachedDeviceIP's lookup and cacheConnectSuccess's write path so a
+// connect-success write always lands under a real device's existing
+// identity.
 func cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache.Entry, bool) {
 	want := normalizeMDNSHost(host)
-	for _, e := range cache.Fresh(time.Now()) {
-		if normalizeMDNSHost(e.Hostname) == want {
-			return e, true
+	var best discoverycache.Entry
+	var found bool
+	for _, e := range cache.Entries() {
+		if normalizeMDNSHost(e.Hostname) != want {
+			continue
+		}
+		if !found || e.LastSeen.After(best.LastSeen) {
+			best, found = e, true
 		}
 	}
-	return discoverycache.Entry{}, false
+	return best, found
 }
 
 // cachedDeviceIP returns the cached IP for host when a fresh device-cache

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1384,11 +1384,15 @@ func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.Agen
 	if err != nil || conn == nil || !conn.IsMTLS {
 		// The entry advertised mTLS; a plaintext downgrade here would be
 		// surprising, so route it through the ordinary path instead.
+		// Describe the reason before closing conn — two of the three cases
+		// carry no err at all, and reading conn.IsMTLS after Close would be
+		// reading a torn-down connection.
+		reason := lkgDialFailureReason(conn, mtlsErr, err)
 		if conn != nil {
 			conn.Close()
 		}
 		if tlsDebug {
-			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: direct dial failed: %v\n", addr, err)
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: direct dial failed: %s\n", addr, reason)
 		}
 		return nil, mtlsErr, lkgHandshakeFailed
 	}
@@ -1396,6 +1400,27 @@ func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.Agen
 		fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: connected\n", addr)
 	}
 	return conn, mtlsErr, lkgConnected
+}
+
+// lkgDialFailureReason describes, for WENDY_TLS_DEBUG output, why the LKG
+// ladder attempt didn't yield a usable mTLS connection. Only one of the three
+// failure modes actually carries a ladder error: a nil conn and a plaintext
+// downgrade both come back with err == nil, so formatting err alone printed a
+// bare "<nil>" for exactly the two cases whose cause is least obvious. The
+// downgrade case reports mtlsErr — the mTLS-probe diagnostic explaining why
+// the ladder fell back to plaintext — since that, not the (absent) ladder
+// error, is the reason the entry's advertised mTLS endpoint wasn't usable.
+func lkgDialFailureReason(conn *grpcclient.AgentConnection, mtlsErr, err error) string {
+	switch {
+	case err != nil:
+		return err.Error()
+	case conn == nil:
+		return "ladder returned no connection"
+	case mtlsErr != nil:
+		return fmt.Sprintf("ladder downgraded to plaintext though the cache entry advertised mTLS: %v", mtlsErr)
+	default:
+		return "ladder downgraded to plaintext though the cache entry advertised mTLS"
+	}
 }
 
 // dialAgentLKGFn is a seam over dialAgentLKG for connect-flow tests.

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1297,8 +1297,8 @@ func cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache
 	return best, found
 }
 
-// cachedDeviceIP returns the cached IP for host when a fresh device-cache
-// entry's hostname matches, else "". This is the device-cache fast path's
+// cachedDeviceIP returns the cached IP for host when a device-cache entry
+// (any age) matches the hostname, else "". This is the device-cache fast path's
 // lookup: a hit here lets connectWithAutoTLSDiagnostics skip resolveAddrOnce
 // (and the OS-resolver/mDNS-browse work it can do) entirely.
 func cachedDeviceIP(host string) string {
@@ -1357,7 +1357,7 @@ func defaultDeviceUnreachableError(hostname string, err error) error {
 
 // connectWithAutoTLSDiagnostics resolves plaintextAddr and runs the mTLS/
 // plaintext dial ladder (see dialAgentLadder) against it. A DNS/mDNS-name host
-// with a fresh device-cache entry (see cachedDeviceIP) skips resolution
+// with a device-cache entry (any age; see cachedDeviceEntry) skips resolution
 // entirely and dials the cached IP directly — the "instant connect" fast
 // path. That cached IP can be stale (the device moved, rebooted onto a new
 // DHCP lease, etc.), so a fast-path dial that doesn't actually answer is never
@@ -1490,7 +1490,7 @@ var cacheFastPathReachableFn = cacheFastPathReachable
 // probe, not a lazy plaintext "connect") — see
 // connectAgentAtAddressWithProvisionedHint, the sole caller.
 //
-// When an existing fresh entry already matches this hostname (by
+// When an existing entry (any age) already matches this hostname (by
 // normalizeMDNSHost equality — e.g. a discovery scan's TXT-id-keyed row),
 // this refreshes only that entry's IP/Port/LastSeen under its existing ID/
 // DisplayName, via Upsert's non-zero-wins merge — never minting a second row

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1572,6 +1572,15 @@ func cacheConnectSuccess(originalAddr string, conn *grpcclient.AgentConnection) 
 	if err != nil {
 		return
 	}
+	// Prefer the endpoint the connection actually dialed (mTLS port when the
+	// ladder stepped to port+1) over originalAddr's port — otherwise a
+	// default-device connect (plaintext :50051 in originalAddr) would clobber
+	// discovery's advertised mTLS port in the cache on every command.
+	if _, connPortStr, splitErr := net.SplitHostPort(conn.Addr); splitErr == nil {
+		if connPort, convErr := strconv.Atoi(connPortStr); convErr == nil {
+			port = connPort
+		}
+	}
 	cache, err := deviceCacheLoadFn()
 	if err != nil || cache == nil {
 		return
@@ -1580,6 +1589,10 @@ func cacheConnectSuccess(originalAddr string, conn *grpcclient.AgentConnection) 
 		Hostname: cacheHostnameForStorage(host),
 		IP:       conn.Host,
 		Port:     port,
+		MTLS:     conn.IsMTLS,
+	}
+	if org, ok := conn.ObservedServerOrg(); ok {
+		entry.OrgID = org
 	}
 	if existing, ok := cachedDeviceEntry(cache, host); ok {
 		entry.ID, entry.DisplayName = existing.ID, existing.DisplayName

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1279,7 +1279,7 @@ var deviceCacheLoadFn = discoverycache.Load
 // costs one bounded dial attempt; the stale-cache retry re-resolves). When
 // several entries' hostnames normalize equal (e.g. a device re-provisioned
 // under a new identity), the most recent LastSeen wins. Shared by
-// cachedDeviceIP's lookup and cacheConnectSuccess's write path so a
+// cachedDeviceHostEntry's lookup and cacheConnectSuccess's write path so a
 // connect-success write always lands under a real device's existing
 // identity.
 func cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache.Entry, bool) {
@@ -1297,20 +1297,73 @@ func cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache
 	return best, found
 }
 
-// cachedDeviceIP returns the cached IP for host when a device-cache entry
-// (any age) matches the hostname, else "". This is the device-cache fast path's
-// lookup: a hit here lets connectWithAutoTLSDiagnostics skip resolveAddrOnce
-// (and the OS-resolver/mDNS-browse work it can do) entirely.
-func cachedDeviceIP(host string) string {
+// cachedDeviceHostEntry loads the device cache and returns the entry whose
+// hostname matches host (any age, most recent wins). This is the device-cache
+// fast path's lookup: a hit here lets connectWithAutoTLSDiagnostics skip
+// resolveAddrOnce (and the OS-resolver/mDNS-browse work it can do) entirely.
+// Returns the empty entry and false when the cache is unavailable or nothing
+// matches.
+func cachedDeviceHostEntry(host string) (discoverycache.Entry, bool) {
 	cache, err := deviceCacheLoadFn()
 	if err != nil || cache == nil {
-		return ""
+		return discoverycache.Entry{}, false
 	}
-	if e, ok := cachedDeviceEntry(cache, host); ok {
-		return e.IP
-	}
-	return ""
+	return cachedDeviceEntry(cache, host)
 }
+
+// lkgTCPConnectTimeout bounds the last-known-good fast path's TCP
+// pre-check. A dead or reassigned cached IP must cost at most this before
+// the connect falls through to fresh resolution — without the bound, the
+// full ladder would burn its mtlsProbeTimeout budgets against a black hole.
+const lkgTCPConnectTimeout = 1 * time.Second
+
+// tcpDialTimeoutFn is a seam over net.DialTimeout for LKG fast-path tests.
+var tcpDialTimeoutFn = net.DialTimeout
+
+// loadAllCLICertsFn is a seam over loadAllCLICerts for LKG fast-path tests.
+var loadAllCLICertsFn = loadAllCLICerts
+
+// dialAgentLKG is the last-known-good direct dial: one bounded attempt at a
+// cached device's advertised mTLS endpoint with the entry's org's cert
+// first. ok=false means "fall through to the ordinary connect flow" — the
+// fast path never surfaces its own failures as the connect's outcome.
+// Trust is unchanged: the same certs, verifiers, and pins run here as on
+// the ordinary path; the cache contributes routing only.
+func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+	addr := hostPort(e.IP, e.Port)
+	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
+	raw, err := tcpDialTimeoutFn("tcp", addr, lkgTCPConnectTimeout)
+	if err != nil {
+		if tlsDebug {
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: tcp pre-check failed: %v\n", addr, err)
+		}
+		return nil, nil, false
+	}
+	raw.Close()
+	certs := rotateCertsForOrg(loadAllCLICertsFn(), e.OrgID)
+	if len(certs) == 0 {
+		return nil, nil, false
+	}
+	conn, mtlsErr, err := dialAgentLadderWithCertsFn(ctx, addr, certs)
+	if err != nil || conn == nil || !conn.IsMTLS {
+		// The entry advertised mTLS; a plaintext downgrade here would be
+		// surprising, so route it through the ordinary path instead.
+		if conn != nil {
+			conn.Close()
+		}
+		if tlsDebug {
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: direct dial failed: %v\n", addr, err)
+		}
+		return nil, mtlsErr, false
+	}
+	if tlsDebug {
+		fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: connected\n", addr)
+	}
+	return conn, mtlsErr, true
+}
+
+// dialAgentLKGFn is a seam over dialAgentLKG for connect-flow tests.
+var dialAgentLKGFn = dialAgentLKG
 
 // isMDNSShapedHost reports whether host is a plausible mDNS device name: a
 // bare hostname (no dot) other than the reserved loopback name "localhost",
@@ -1381,8 +1434,17 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 	originalAddr := plaintextAddr
 	fromCache := false
 	if plainHost, plainPort, splitErr := net.SplitHostPort(plaintextAddr); splitErr == nil && net.ParseIP(plainHost) == nil {
-		if ip := cachedDeviceIP(plainHost); ip != "" {
-			plaintextAddr, fromCache = net.JoinHostPort(ip, plainPort), true
+		if e, ok := cachedDeviceHostEntry(plainHost); ok && e.IP != "" {
+			// Last-known-good direct dial: the advertised mTLS endpoint with
+			// the entry's org's cert first, TCP-bounded so a dead IP costs at
+			// most lkgTCPConnectTimeout. Failures fall through to the
+			// cached-IP ladder + stale-cache retry below.
+			if e.MTLS && e.Port > 0 {
+				if conn, mtlsErr, ok := dialAgentLKGFn(ctx, e); ok {
+					return conn, mtlsErr, nil
+				}
+			}
+			plaintextAddr, fromCache = net.JoinHostPort(e.IP, plainPort), true
 		}
 	}
 	if !fromCache {
@@ -1475,7 +1537,7 @@ var cacheFastPathReachableFn = cacheFastPathReachable
 
 // cacheConnectSuccess best-effort upserts the device cache with the IP that
 // conn actually dialed for originalAddr's host, so subsequent connects to the
-// same DNS/mDNS name hit cachedDeviceIP's fast path. Guards, in order:
+// same DNS/mDNS name hit cachedDeviceHostEntry's fast path. Guards, in order:
 //   - only DNS/mDNS-name hosts — a literal-IP host has nothing to learn;
 //   - only hosts shaped like a real mDNS device name (isMDNSShapedHost) —
 //     FQDNs/tunnel relays and "localhost" are never advertised over mDNS, so
@@ -1483,7 +1545,7 @@ var cacheFastPathReachableFn = cacheFastPathReachable
 //   - only when conn actually dialed a literal IP — when resolution failed
 //     entirely, the raw hostname can fall all the way through to
 //     grpcclient.Connect unchanged, and storing a NAME in the IP field would
-//     poison the next cachedDeviceIP lookup with exactly the ".local"
+//     poison the next cachedDeviceHostEntry lookup with exactly the ".local"
 //     resolution gap issue #1155 exists to work around.
 //
 // Callers must only invoke this once liveness is actually confirmed (a real
@@ -1533,7 +1595,7 @@ func cacheConnectSuccess(originalAddr string, conn *grpcclient.AgentConnection) 
 // cacheHostnameForStorage normalizes a bare mDNS-style hostname (no dot) to
 // its ".local" form before it's cached, matching the shape a live mDNS
 // sighting stores (see discoverycache.EntryFromDevice). normalizeMDNSHost
-// equality means cachedDeviceIP's match doesn't actually depend on this, but
+// equality means cachedDeviceHostEntry's match doesn't actually depend on this, but
 // keeping the stored form consistent avoids a confusing on-disk mix of "orin"
 // and "orin.local" for the same device. Only called after isMDNSShapedHost
 // has already ruled out "localhost" and non-".local" dotted hosts.

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1320,29 +1320,65 @@ const lkgTCPConnectTimeout = 1 * time.Second
 // tcpDialTimeoutFn is a seam over net.DialTimeout for LKG fast-path tests.
 var tcpDialTimeoutFn = net.DialTimeout
 
+// lkgTCPAlive reports whether addr answers a bounded TCP connect within
+// lkgTCPConnectTimeout. It's the shared dead-IP bound: dialAgentLKG uses it
+// against the cached mTLS endpoint, and connectWithAutoTLSDiagnostics uses it
+// directly against the cached plaintext endpoint for LKG-ineligible entries
+// (MTLS=false or Port==0), which never call dialAgentLKG at all.
+func lkgTCPAlive(addr string) bool {
+	raw, err := tcpDialTimeoutFn("tcp", addr, lkgTCPConnectTimeout)
+	if err != nil {
+		return false
+	}
+	raw.Close()
+	return true
+}
+
 // loadAllCLICertsFn is a seam over loadAllCLICerts for LKG fast-path tests.
 var loadAllCLICertsFn = loadAllCLICerts
 
+// lkgOutcome distinguishes dialAgentLKG's three possible results so its
+// caller can tell a dead cached IP (never worth retrying against — fresh
+// resolution is strictly better) apart from a live host that simply failed
+// its handshake (worth the existing cached-IP ladder + stale-retry
+// diagnostics, because the host is proven reachable).
+type lkgOutcome int
+
+const (
+	// lkgConnected: the direct dial succeeded; conn is ready to use.
+	lkgConnected lkgOutcome = iota
+	// lkgDeadTCP: the TCP pre-check itself failed — the cached IP is dead
+	// or unreachable. The caller must not run the cached-IP ladder against
+	// it; fresh resolution is the only useful next step.
+	lkgDeadTCP
+	// lkgHandshakeFailed: TCP answered but the mTLS ladder didn't produce a
+	// usable mTLS connection (ladder error, nil conn, or a plaintext
+	// downgrade). The host is alive, so the ordinary cached-IP ladder and
+	// its diagnostics still have value.
+	lkgHandshakeFailed
+)
+
 // dialAgentLKG is the last-known-good direct dial: one bounded attempt at a
 // cached device's advertised mTLS endpoint with the entry's org's cert
-// first. ok=false means "fall through to the ordinary connect flow" — the
-// fast path never surfaces its own failures as the connect's outcome.
+// first. The returned lkgOutcome tells the caller how to fall through —
+// dialAgentLKG never surfaces its own failures as the connect's outcome.
 // Trust is unchanged: the same certs, verifiers, and pins run here as on
 // the ordinary path; the cache contributes routing only.
-func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
 	addr := hostPort(e.IP, e.Port)
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
-	raw, err := tcpDialTimeoutFn("tcp", addr, lkgTCPConnectTimeout)
-	if err != nil {
+	if !lkgTCPAlive(addr) {
 		if tlsDebug {
-			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: tcp pre-check failed: %v\n", addr, err)
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: tcp pre-check failed\n", addr)
 		}
-		return nil, nil, false
+		return nil, nil, lkgDeadTCP
 	}
-	raw.Close()
 	certs := rotateCertsForOrg(loadAllCLICertsFn(), e.OrgID)
 	if len(certs) == 0 {
-		return nil, nil, false
+		// TCP answered, so the host is alive — this just means there's
+		// nothing to dial with. Route through the ordinary path rather than
+		// treating it like a dead IP.
+		return nil, nil, lkgHandshakeFailed
 	}
 	conn, mtlsErr, err := dialAgentLadderWithCertsFn(ctx, addr, certs)
 	if err != nil || conn == nil || !conn.IsMTLS {
@@ -1354,12 +1390,12 @@ func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.Agen
 		if tlsDebug {
 			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: direct dial failed: %v\n", addr, err)
 		}
-		return nil, mtlsErr, false
+		return nil, mtlsErr, lkgHandshakeFailed
 	}
 	if tlsDebug {
 		fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: connected\n", addr)
 	}
-	return conn, mtlsErr, true
+	return conn, mtlsErr, lkgConnected
 }
 
 // dialAgentLKGFn is a seam over dialAgentLKG for connect-flow tests.
@@ -1413,13 +1449,26 @@ func defaultDeviceUnreachableError(hostname string, err error) error {
 // with a device-cache entry (any age; see cachedDeviceEntry) skips resolution
 // entirely and dials the cached IP directly — the "instant connect" fast
 // path. That cached IP can be stale (the device moved, rebooted onto a new
-// DHCP lease, etc.), so a fast-path dial that doesn't actually answer is never
-// treated as "device unreachable" (spec §4): it re-resolves exactly as the
-// cache-miss path would and retries the whole ladder once — unless the retry
-// can't possibly help (see the guards inline below), in which case the
-// original attempt's result is kept. The device-cache write for a confirmed-
-// live connection does NOT happen here — a lazy plaintext "success" from this
-// function proves nothing (see cacheFastPathReachable's doc); it happens at
+// DHCP lease, etc.), so this distinguishes a dead cached IP from a live one
+// that simply failed its handshake:
+//
+//   - A dead cached IP (dialAgentLKG's TCP pre-check fails, or — for entries
+//     ineligible for the LKG direct dial — lkgTCPAlive's own pre-check
+//     fails) never enters the cached-IP ladder at all: fromCache stays
+//     false and the flow below falls straight through to fresh resolution,
+//     bounding the dead-IP worst case at ~lkgTCPConnectTimeout instead of a
+//     full ladder against a black hole.
+//   - A live cached IP that fails its handshake (lkgHandshakeFailed, or an
+//     LKG-ineligible entry that passed its TCP pre-check) is never treated
+//     as "device unreachable" (spec §4) on that basis alone: it runs the
+//     cached-IP ladder, and if that doesn't answer, re-resolves exactly as
+//     the cache-miss path would and retries the whole ladder once — unless
+//     the retry can't possibly help (see the guards inline below), in which
+//     case the original attempt's result is kept.
+//
+// The device-cache write for a confirmed-live connection does NOT happen
+// here — a lazy plaintext "success" from this function proves nothing (see
+// cacheFastPathReachable's doc); it happens at
 // connectAgentAtAddressWithProvisionedHint's real post-connect proof of life.
 func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
 	// An admin-entitled on-device container reaches the agent over its local
@@ -1431,20 +1480,46 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 		return conn, nil, err
 	}
 
+	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	originalAddr := plaintextAddr
 	fromCache := false
 	if plainHost, plainPort, splitErr := net.SplitHostPort(plaintextAddr); splitErr == nil && net.ParseIP(plainHost) == nil {
 		if e, ok := cachedDeviceHostEntry(plainHost); ok && e.IP != "" {
-			// Last-known-good direct dial: the advertised mTLS endpoint with
-			// the entry's org's cert first, TCP-bounded so a dead IP costs at
-			// most lkgTCPConnectTimeout. Failures fall through to the
-			// cached-IP ladder + stale-cache retry below.
-			if e.MTLS && e.Port > 0 {
-				if conn, mtlsErr, ok := dialAgentLKGFn(ctx, e); ok {
+			cachedAddr := net.JoinHostPort(e.IP, plainPort)
+			switch {
+			case e.MTLS && e.Port > 0:
+				// Last-known-good direct dial: the advertised mTLS endpoint
+				// with the entry's org's cert first, TCP-bounded so a dead
+				// IP costs at most lkgTCPConnectTimeout.
+				switch conn, mtlsErr, outcome := dialAgentLKGFn(ctx, e); outcome {
+				case lkgConnected:
 					return conn, mtlsErr, nil
+				case lkgHandshakeFailed:
+					// The host answered TCP — it's alive, just didn't
+					// hand back a usable mTLS connection. The ordinary
+					// cached-IP ladder (and its diagnostics) still have
+					// value, so fall through to it verbatim.
+					plaintextAddr, fromCache = cachedAddr, true
+				case lkgDeadTCP:
+					// The cached IP didn't even answer TCP. Running the
+					// ladder against it would just burn its budget on a
+					// black hole, so skip the fromCache path entirely —
+					// fromCache stays false, and the flow below
+					// re-resolves originalAddr fresh, exactly like the
+					// stale-cache retry would have done, minus the
+					// wasted ladder attempt.
+				}
+			case lkgTCPAlive(cachedAddr):
+				// LKG-ineligible entry (no advertised mTLS endpoint to
+				// direct-dial), but the cached-IP fromCache ladder below
+				// still needs the same dead-IP bound the LKG path gets,
+				// otherwise a stale entry here is unbounded.
+				plaintextAddr, fromCache = cachedAddr, true
+			default:
+				if tlsDebug {
+					fmt.Fprintf(os.Stderr, "[tls-debug] lkg-ineligible %s: tcp pre-check failed, skipping cached-IP ladder\n", cachedAddr)
 				}
 			}
-			plaintextAddr, fromCache = net.JoinHostPort(e.IP, plainPort), true
 		}
 	}
 	if !fromCache {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1551,9 +1551,8 @@ func cacheHostnameForStorage(host string) string {
 // its own. connectWithAutoTLSDiagnostics calls it for every connect —
 // resolved-address and device-cache fast path alike, including the fast
 // path's stale-cache retry — so all three share this exact same ladder.
-func dialAgentLadder(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
+func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCerts []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
-	allCerts := loadAllCLICerts()
 	var lastMTLSErr error
 	recordMTLSErr := func(addr string, err error) {
 		if err != nil {
@@ -1649,10 +1648,43 @@ func dialAgentLadder(ctx context.Context, plaintextAddr string) (*grpcclient.Age
 	return conn, lastMTLSErr, err
 }
 
+// dialAgentLadder is dialAgentLadderWithCerts with the CLI's stored certs
+// in config order — the shape every non-fast-path caller wants.
+func dialAgentLadder(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
+	return dialAgentLadderWithCerts(ctx, plaintextAddr, loadAllCLICerts())
+}
+
+// dialAgentLadderWithCertsFn is a seam over dialAgentLadderWithCerts for
+// tests that need to observe the cert order the LKG fast path passes.
+var dialAgentLadderWithCertsFn = dialAgentLadderWithCerts
+
 // dialAgentLadderFn is a seam over dialAgentLadder for tests that need to
 // count or fake ladder invocations directly (e.g. proving a stale-cache
 // retry did or didn't redial) without standing up a real mTLS cert chain.
 var dialAgentLadderFn = dialAgentLadder
+
+// rotateCertsForOrg returns certs reordered so entries whose OrganizationID
+// matches orgID come first, preserving relative order within both groups
+// (a stable partition). orgID 0 (unknown) or no match returns certs
+// unchanged. Never mutates the input.
+func rotateCertsForOrg(certs []config.CertificateInfo, orgID int32) []config.CertificateInfo {
+	if orgID == 0 {
+		return certs
+	}
+	matched := make([]config.CertificateInfo, 0, len(certs))
+	rest := make([]config.CertificateInfo, 0, len(certs))
+	for _, c := range certs {
+		if int32(c.OrganizationID) == orgID {
+			matched = append(matched, c)
+		} else {
+			rest = append(rest, c)
+		}
+	}
+	if len(matched) == 0 {
+		return certs
+	}
+	return append(matched, rest...)
+}
 
 // isCertRejectionError reports whether a gRPC probe error is a server-sent TLS
 // alert rejecting the client certificate, as distinct from the client failing to

--- a/go/internal/cli/commands/helpers_lkg_test.go
+++ b/go/internal/cli/commands/helpers_lkg_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,11 +49,11 @@ func TestConnectFastPathStaleEntryZeroResolution(t *testing.T) {
 	}
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		if e.IP != "10.0.0.9" || e.Port != 50052 {
 			t.Errorf("LKG got entry %s:%d, want 10.0.0.9:50052", e.IP, e.Port)
 		}
-		return want, nil, true
+		return want, nil, lkgConnected
 	}
 	origLadder := dialAgentLadderFn
 	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
@@ -73,14 +74,19 @@ func TestConnectFastPathStaleEntryZeroResolution(t *testing.T) {
 	}
 }
 
-func TestConnectFastPathLKGFailureFallsThroughToLadder(t *testing.T) {
+// TestConnectFastPathLKGHandshakeFailedFallsThroughToLadder covers the
+// lkgHandshakeFailed outcome: TCP answered but the direct dial couldn't
+// produce a usable mTLS connection. The host is proven alive, so the
+// ordinary cached-IP ladder (plus its diagnostics and stale-cache retry)
+// must still run, against the CACHED IP.
+func TestConnectFastPathLKGHandshakeFailedFallsThroughToLadder(t *testing.T) {
 	seedLKGCache(t, discoverycache.Entry{
 		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true,
 	}, 0)
 
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
-		return nil, nil, false // dead IP: pre-check failed
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+		return nil, nil, lkgHandshakeFailed // host alive, handshake didn't pan out
 	}
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	var ladderAddr string
@@ -104,25 +110,144 @@ func TestConnectFastPathLKGFailureFallsThroughToLadder(t *testing.T) {
 	}
 }
 
-func TestConnectFastPathNonMTLSEntrySkipsLKG(t *testing.T) {
+// TestConnectFastPathLKGDeadTCPFallsThroughToFreshResolution covers the
+// lkgDeadTCP outcome (Finding 1): the cached IP didn't even answer TCP, so
+// the connect must NOT run the cached-IP ladder against that dead IP at
+// all — it must skip straight to fresh resolution (the OS resolver here)
+// and run the ladder against the newly-resolved address instead.
+func TestConnectFastPathLKGDeadTCPFallsThroughToFreshResolution(t *testing.T) {
 	seedLKGCache(t, discoverycache.Entry{
-		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
+		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true,
 	}, 0)
+
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
-		t.Error("LKG ran for a non-mTLS entry")
-		return nil, nil, false
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+		return nil, nil, lkgDeadTCP // cached IP is dead
+	}
+	origLookup, origBrowse := osLookupHostFn, lanBrowseFn
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		return []string{"10.9.9.9"}, nil // fresh resolution finds a new address
+	}
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		t.Error("mDNS browse ran despite a successful OS resolver hit")
+		return nil, errors.New("must not be reached")
 	}
 	want := &grpcclient.AgentConnection{IsMTLS: true}
+	var ladderAddrs []string
 	origLadder := dialAgentLadderFn
 	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		ladderAddrs = append(ladderAddrs, addr)
 		return want, nil, nil
 	}
 	origReach := cacheFastPathReachableFn
 	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
-	t.Cleanup(func() { dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach })
+	t.Cleanup(func() {
+		osLookupHostFn, lanBrowseFn = origLookup, origBrowse
+		dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach
+	})
 
-	if conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "pi.local:50051"); err != nil || conn != want {
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "orin.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection against the resolved address", conn, err)
+	}
+	if len(ladderAddrs) != 1 || ladderAddrs[0] != "10.9.9.9:50051" {
+		t.Fatalf("ladder addrs = %v, want exactly one call at the resolved address 10.9.9.9:50051", ladderAddrs)
+	}
+	for _, a := range ladderAddrs {
+		if a == "10.0.0.9:50052" || a == "10.0.0.9:50051" {
+			t.Fatalf("ladder ran against the dead cached IP %q — dead-TCP outcome must skip the cached-IP ladder entirely", a)
+		}
+	}
+}
+
+// TestConnectFastPathLKGIneligibleDeadTCPFallsThroughToFreshResolution
+// covers Finding 2 for an LKG-ineligible entry (MTLS: false, so
+// dialAgentLKG never runs): the cache-derived dial still needs the same
+// bounded TCP pre-check, and a dead result must fall through to fresh
+// resolution rather than an unbounded fromCache ladder.
+func TestConnectFastPathLKGIneligibleDeadTCPFallsThroughToFreshResolution(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
+	}, 0)
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+		t.Error("LKG ran for a non-mTLS entry")
+		return nil, nil, lkgDeadTCP
+	}
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		return nil, errors.New("no route to host") // pre-check fails: dead
+	}
+	origLookup, origBrowse := osLookupHostFn, lanBrowseFn
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		return []string{"10.9.9.7"}, nil
+	}
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		t.Error("mDNS browse ran despite a successful OS resolver hit")
+		return nil, errors.New("must not be reached")
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	var ladderAddr string
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = addr
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() {
+		osLookupHostFn, lanBrowseFn = origLookup, origBrowse
+		tcpDialTimeoutFn = origTCP
+		dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "pi.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection against the resolved address", conn, err)
+	}
+	if ladderAddr != "10.9.9.7:50051" {
+		t.Errorf("ladder addr = %q, want the freshly-resolved address 10.9.9.7:50051 (dead cached IP must not be dialed)", ladderAddr)
+	}
+}
+
+// TestConnectFastPathLKGIneligibleLiveTCPUsesCachedIP covers Finding 2's
+// success path: an LKG-ineligible entry whose cached IP DOES answer TCP
+// still gets the fromCache ladder at that cached IP, same as before this
+// fix — the new pre-check must not regress the common case.
+func TestConnectFastPathLKGIneligibleLiveTCPUsesCachedIP(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
+	}, 0)
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+		t.Error("LKG ran for a non-mTLS entry")
+		return nil, nil, lkgDeadTCP
+	}
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil // pre-check succeeds: alive
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	var ladderAddr string
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = addr
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() {
+		tcpDialTimeoutFn = origTCP
+		dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "pi.local:50051")
+	if err != nil || conn != want {
 		t.Fatalf("connect = (%v, %v), want ladder connection", conn, err)
+	}
+	if ladderAddr != "10.0.0.7:50051" {
+		t.Errorf("ladder addr = %q, want cached IP 10.0.0.7:50051", ladderAddr)
 	}
 }

--- a/go/internal/cli/commands/helpers_lkg_test.go
+++ b/go/internal/cli/commands/helpers_lkg_test.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// seedLKGCache installs a deviceCacheLoadFn serving one entry, stale by
+// stalenessFactor×TTL (0 = fresh).
+func seedLKGCache(t *testing.T, e discoverycache.Entry, stale time.Duration) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "devices.json")
+	c, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now().Add(-stale)
+	c.Upsert(e, now)
+	if err := c.Flush(now); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	orig := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
+	t.Cleanup(func() { deviceCacheLoadFn = orig })
+}
+
+func TestConnectFastPathStaleEntryZeroResolution(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2,
+	}, 3*discoverycache.TTL) // well past the display TTL
+
+	resolverCalls := 0
+	origLookup, origBrowse := osLookupHostFn, lanBrowseFn
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		resolverCalls++
+		return nil, errors.New("resolver must not run on an LKG hit")
+	}
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		resolverCalls++
+		return nil, errors.New("browse must not run on an LKG hit")
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		if e.IP != "10.0.0.9" || e.Port != 50052 {
+			t.Errorf("LKG got entry %s:%d, want 10.0.0.9:50052", e.IP, e.Port)
+		}
+		return want, nil, true
+	}
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		t.Errorf("general ladder ran despite LKG success (addr %s)", addr)
+		return nil, nil, errors.New("unreachable")
+	}
+	t.Cleanup(func() {
+		osLookupHostFn, lanBrowseFn = origLookup, origBrowse
+		dialAgentLKGFn, dialAgentLadderFn = origLKG, origLadder
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "orin.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want the LKG connection", conn, err)
+	}
+	if resolverCalls != 0 {
+		t.Errorf("resolver invoked %d times on a stale-entry LKG hit, want 0 (any-age fast path)", resolverCalls)
+	}
+}
+
+func TestConnectFastPathLKGFailureFallsThroughToLadder(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true,
+	}, 0)
+
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		return nil, nil, false // dead IP: pre-check failed
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	var ladderAddr string
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = addr
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() {
+		dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "orin.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection after LKG fall-through", conn, err)
+	}
+	if ladderAddr != "10.0.0.9:50051" {
+		t.Errorf("ladder addr = %q, want cached-IP fallback 10.0.0.9:50051", ladderAddr)
+	}
+}
+
+func TestConnectFastPathNonMTLSEntrySkipsLKG(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
+	}, 0)
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		t.Error("LKG ran for a non-mTLS entry")
+		return nil, nil, false
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() { dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach })
+
+	if conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "pi.local:50051"); err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection", conn, err)
+	}
+}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1385,7 +1385,7 @@ func TestConnectAgentAtAddressWithProvisionedHint_FailedProbeDoesNotWriteCache(t
 	}
 }
 
-func TestCachedDeviceIP(t *testing.T) {
+func TestCachedDeviceHostEntry(t *testing.T) {
 	orig := deviceCacheLoadFn
 	defer func() { deviceCacheLoadFn = orig }()
 
@@ -1395,18 +1395,18 @@ func TestCachedDeviceIP(t *testing.T) {
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
 
-	if got := cachedDeviceIP("orin.local"); got != "10.0.0.5" {
-		t.Errorf("cachedDeviceIP(fresh match) = %q, want %q", got, "10.0.0.5")
+	if e, ok := cachedDeviceHostEntry("orin.local"); !ok || e.IP != "10.0.0.5" {
+		t.Errorf("cachedDeviceHostEntry(fresh match) = %+v, %v; want IP %q, true", e, ok, "10.0.0.5")
 	}
-	if got := cachedDeviceIP("Orin.LOCAL."); got != "10.0.0.5" {
-		t.Errorf("cachedDeviceIP(case/dot-insensitive) = %q, want %q", got, "10.0.0.5")
+	if e, ok := cachedDeviceHostEntry("Orin.LOCAL."); !ok || e.IP != "10.0.0.5" {
+		t.Errorf("cachedDeviceHostEntry(case/dot-insensitive) = %+v, %v; want IP %q, true", e, ok, "10.0.0.5")
 	}
-	if got := cachedDeviceIP("other.local"); got != "" {
-		t.Errorf("cachedDeviceIP(no match) = %q, want empty", got)
+	if e, ok := cachedDeviceHostEntry("other.local"); ok {
+		t.Errorf("cachedDeviceHostEntry(no match) = %+v, %v; want false", e, ok)
 	}
 }
 
-func TestCachedDeviceIP_MatchesStaleEntry(t *testing.T) {
+func TestCachedDeviceHostEntry_MatchesStaleEntry(t *testing.T) {
 	orig := deviceCacheLoadFn
 	defer func() { deviceCacheLoadFn = orig }()
 
@@ -1422,18 +1422,107 @@ func TestCachedDeviceIP_MatchesStaleEntry(t *testing.T) {
 	}
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
 
-	if got := cachedDeviceIP("orin.local"); got != "10.0.0.5" {
-		t.Fatalf("cachedDeviceIP(stale entry) = %q, want 10.0.0.5 (connect lookup uses any-age entries)", got)
+	if e, ok := cachedDeviceHostEntry("orin.local"); !ok || e.IP != "10.0.0.5" {
+		t.Fatalf("cachedDeviceHostEntry(stale entry) = %+v, %v; want IP 10.0.0.5, true (connect lookup uses any-age entries)", e, ok)
 	}
 }
 
-func TestCachedDeviceIP_LoadErrorYieldsEmpty(t *testing.T) {
+func TestCachedDeviceHostEntry_LoadErrorYieldsEmpty(t *testing.T) {
 	orig := deviceCacheLoadFn
 	defer func() { deviceCacheLoadFn = orig }()
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return nil, errors.New("boom") }
 
-	if got := cachedDeviceIP("orin.local"); got != "" {
-		t.Fatalf("cachedDeviceIP(load error) = %q, want empty", got)
+	if e, ok := cachedDeviceHostEntry("orin.local"); ok {
+		t.Fatalf("cachedDeviceHostEntry(load error) = %+v, %v; want false", e, ok)
+	}
+}
+
+func TestDialAgentLKGSkipsOnTCPPrecheckFailure(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		if timeout != lkgTCPConnectTimeout {
+			t.Errorf("pre-check timeout = %v, want %v", timeout, lkgTCPConnectTimeout)
+		}
+		return nil, errors.New("no route to host")
+	}
+	ladderCalled := false
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		ladderCalled = true
+		return nil, nil, errors.New("must not be reached")
+	}
+	t.Cleanup(func() { tcpDialTimeoutFn = origTCP; dialAgentLadderWithCertsFn = origLadder })
+
+	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if ok {
+		t.Fatal("dialAgentLKG reported success despite failed TCP pre-check")
+	}
+	if ladderCalled {
+		t.Error("ladder dial ran after failed pre-check — dead IP must cost only the pre-check")
+	}
+}
+
+func TestDialAgentLKGRotatesCertsAndDialsMTLSPort(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
+	var gotAddr string
+	var gotOrgs []int
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		gotAddr = addr
+		for _, c := range certs {
+			gotOrgs = append(gotOrgs, c.OrganizationID)
+		}
+		return &grpcclient.AgentConnection{IsMTLS: true}, nil, nil
+	}
+	origCerts := loadAllCLICertsFn
+	loadAllCLICertsFn = func() []config.CertificateInfo {
+		return []config.CertificateInfo{{OrganizationID: 1}, {OrganizationID: 2}}
+	}
+	t.Cleanup(func() {
+		tcpDialTimeoutFn = origTCP
+		dialAgentLadderWithCertsFn = origLadder
+		loadAllCLICertsFn = origCerts
+	})
+
+	conn, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if !ok || conn == nil {
+		t.Fatal("dialAgentLKG failed on the happy path")
+	}
+	if gotAddr != "10.0.0.9:50052" {
+		t.Errorf("dialed %q, want the entry's mTLS endpoint 10.0.0.9:50052", gotAddr)
+	}
+	if fmt.Sprint(gotOrgs) != fmt.Sprint([]int{2, 1}) {
+		t.Errorf("cert org order = %v, want entry-org-first [2 1]", gotOrgs)
+	}
+}
+
+func TestDialAgentLKGFallsThroughOnPlaintextDowngrade(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		return grpcclient.NewFromConn(nil), nil, nil // IsMTLS=false: ladder fell to plaintext
+	}
+	origCerts := loadAllCLICertsFn
+	loadAllCLICertsFn = func() []config.CertificateInfo { return []config.CertificateInfo{{OrganizationID: 1}} }
+	t.Cleanup(func() {
+		tcpDialTimeoutFn = origTCP
+		dialAgentLadderWithCertsFn = origLadder
+		loadAllCLICertsFn = origCerts
+	})
+
+	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true})
+	if ok {
+		t.Fatal("LKG accepted a plaintext downgrade for an entry advertised as mTLS")
 	}
 }
 
@@ -1487,8 +1576,8 @@ func TestCacheConnectSuccess_SkipsLiteralIPHost(t *testing.T) {
 // Critical: when resolution fails entirely, dialAgentLadder's plaintext
 // fallback can fall through to grpcclient.Connect with the raw, unresolved
 // hostname, leaving conn.Host set to a NAME rather than an IP. Storing that
-// in the IP field would poison the next cachedDeviceIP lookup with exactly
-// the ".local" resolution gap issue #1155 exists to work around.
+// in the IP field would poison the next cachedDeviceHostEntry lookup with
+// exactly the ".local" resolution gap issue #1155 exists to work around.
 func TestCacheConnectSuccess_RejectsNonIPDialedHost(t *testing.T) {
 	orig := deviceCacheLoadFn
 	defer func() { deviceCacheLoadFn = orig }()
@@ -1538,7 +1627,7 @@ func TestCacheConnectSuccess_IgnoresLoadError(t *testing.T) {
 // Critical fix: cacheConnectSuccess must write under an EXISTING entry (any age)
 // identity (its discovery-assigned TXT-id ID/DisplayName) when one
 // matches this hostname, not mint a second row under a host-derived key —
-// otherwise the same physical device shows up twice and cachedDeviceIP's
+// otherwise the same physical device shows up twice and cachedDeviceHostEntry's
 // next lookup can nondeterministically return a different row for the same
 // device. Also covers Task 3's decision on record: this connect-only write
 // (no probed AgentVersion/OS) must Upsert, not Replace, so it never wipes

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1405,7 +1405,7 @@ func TestCachedDeviceIP(t *testing.T) {
 	}
 }
 
-func TestCachedDeviceIP_StaleEntryIgnored(t *testing.T) {
+func TestCachedDeviceIP_MatchesStaleEntry(t *testing.T) {
 	orig := deviceCacheLoadFn
 	defer func() { deviceCacheLoadFn = orig }()
 
@@ -1421,8 +1421,8 @@ func TestCachedDeviceIP_StaleEntryIgnored(t *testing.T) {
 	}
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
 
-	if got := cachedDeviceIP("orin.local"); got != "" {
-		t.Fatalf("cachedDeviceIP(stale entry) = %q, want empty", got)
+	if got := cachedDeviceIP("orin.local"); got != "10.0.0.5" {
+		t.Fatalf("cachedDeviceIP(stale entry) = %q, want 10.0.0.5 (connect lookup uses any-age entries)", got)
 	}
 }
 
@@ -1961,4 +1961,30 @@ func TestExternalProviderPickerItem(t *testing.T) {
 			t.Errorf("entry.provider = %#v, want the source provider", entry.provider)
 		}
 	})
+}
+
+func TestCachedDeviceEntryAnyAgeMostRecentWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	cache, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	old := time.Now().Add(-3 * discoverycache.TTL)
+	newer := time.Now().Add(-2 * discoverycache.TTL)
+	// Two distinct device identities sharing one hostname (e.g. a device
+	// re-provisioned under a new id): most recent LastSeen must win.
+	cache.Upsert(discoverycache.Entry{ID: "dev-old", Hostname: "orin.local", IP: "10.0.0.8"}, old)
+	cache.Upsert(discoverycache.Entry{ID: "dev-new", Hostname: "orin.local", IP: "10.0.0.9"}, newer)
+
+	e, ok := cachedDeviceEntry(cache, "orin.local")
+	if !ok {
+		t.Fatal("stale entries not matched — connect lookup must be any-age")
+	}
+	if e.IP != "10.0.0.9" {
+		t.Errorf("matched IP %q, want most-recent 10.0.0.9", e.IP)
+	}
+	// Bare-name form matches the .local stored form.
+	if _, ok := cachedDeviceEntry(cache, "orin"); !ok {
+		t.Error("bare hostname did not match .local entry")
+	}
 }

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1667,6 +1667,39 @@ func TestCacheConnectSuccess_ReusesExistingDiscoveryIdentity(t *testing.T) {
 	}
 }
 
+func TestCacheConnectSuccessStoresActualEndpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	seed, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now()
+	// Discovery stored the advertised mTLS port; a connect via the plaintext
+	// originalAddr port must NOT clobber it with 50051.
+	seed.Upsert(discoverycache.Entry{ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true}, now)
+	if err := seed.Flush(now); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	origLoad := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
+	t.Cleanup(func() { deviceCacheLoadFn = origLoad })
+
+	conn := &grpcclient.AgentConnection{Host: "10.0.0.9", IsMTLS: true, Addr: "10.0.0.9:50052"}
+	cacheConnectSuccess("orin.local:50051", conn)
+
+	after, _ := discoverycache.LoadFrom(path)
+	e, ok := cachedDeviceEntry(after, "orin.local")
+	if !ok {
+		t.Fatal("entry missing after write-back")
+	}
+	if e.Port != 50052 {
+		t.Errorf("Port = %d after mTLS connect on 50052, want 50052 (originalAddr's 50051 must not clobber)", e.Port)
+	}
+	if !e.MTLS {
+		t.Error("MTLS flag lost on write-back")
+	}
+}
+
 func TestProvisionedAgentUnauthorizedMentionsCLIUpgrade(t *testing.T) {
 	// A reachability timeout against an mTLS-advertised device should hint at
 	// both stale certs and a too-old CLI.

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -963,11 +963,12 @@ func TestConnectWithAutoTLSDiagnostics_CacheMissUsesOSResolver(t *testing.T) {
 func TestConnectWithAutoTLSDiagnostics_StaleCacheRetriesViaMDNS(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	origLoad, origLookup, origBrowse := deviceCacheLoadFn, osLookupHostFn, lanBrowseFn
+	origLoad, origLookup, origBrowse, origTCP := deviceCacheLoadFn, osLookupHostFn, lanBrowseFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		osLookupHostFn = origLookup
 		lanBrowseFn = origBrowse
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	realAddr := startPlaintextVersionAgent(t)
@@ -976,10 +977,7 @@ func TestConnectWithAutoTLSDiagnostics_StaleCacheRetriesViaMDNS(t *testing.T) {
 		t.Fatalf("split real address: %v", err)
 	}
 
-	// 127.0.0.2 is loopback but nothing is bound there. Dialing it on the real
-	// server's port simulates a stale cached IP: connection refused,
-	// immediately and deterministically — no OS-level dial timeout to wait
-	// out, and no risk of colliding with the real server's own port.
+	// 127.0.0.2 is loopback but nothing is bound there — a stale cached IP.
 	const staleIP = "127.0.0.2"
 
 	cachePath := filepath.Join(t.TempDir(), "devices.json")
@@ -987,6 +985,16 @@ func TestConnectWithAutoTLSDiagnostics_StaleCacheRetriesViaMDNS(t *testing.T) {
 		ID: "orin", DisplayName: "orin", Hostname: "orin.local", IP: staleIP, Port: 50051,
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2) before it ever
+	// reaches the ladder. Stub it dead — deterministic and instant, unlike a
+	// real dial to an unbound loopback address, whose refusal timing is
+	// environment-dependent — so the pre-check itself sends this straight to
+	// fresh resolution, exactly the stale-IP path this test means to cover.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		return nil, errors.New("no route to host")
+	}
 
 	// The OS resolver can't see the device (the Windows/Linux ".local" gap
 	// issue #1155 works around); only the mDNS browse fallback can — which is
@@ -1061,11 +1069,12 @@ func TestConnectWithAutoTLSDiagnostics_DoesNotWriteCacheDirectly(t *testing.T) {
 func TestConnectWithAutoTLSDiagnostics_RejectionClassNotRetried(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	origLoad, origLadder, origReachable := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn
+	origLoad, origLadder, origReachable, origTCP := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		dialAgentLadderFn = origLadder
 		cacheFastPathReachableFn = origReachable
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	cachePath := filepath.Join(t.TempDir(), "devices.json")
@@ -1073,6 +1082,16 @@ func TestConnectWithAutoTLSDiagnostics_RejectionClassNotRetried(t *testing.T) {
 		ID: "orin", DisplayName: "orin", Hostname: "orin.local", IP: "10.0.0.5", Port: 50051,
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2). Stub it live
+	// so the test still exercises the fromCache ladder + retry-skip logic
+	// below, not a real network dial.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
 
 	calls := 0
 	rejectionErr := newTLSHandshakeRejectedError(errors.New("cert rejected"))
@@ -1100,11 +1119,12 @@ func TestConnectWithAutoTLSDiagnostics_OrgMismatchNotRetried(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 	stubOrgNameResolver(t, nil)
 
-	origLoad, origLadder, origReachable := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn
+	origLoad, origLadder, origReachable, origTCP := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		dialAgentLadderFn = origLadder
 		cacheFastPathReachableFn = origReachable
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	cachePath := filepath.Join(t.TempDir(), "devices.json")
@@ -1112,6 +1132,16 @@ func TestConnectWithAutoTLSDiagnostics_OrgMismatchNotRetried(t *testing.T) {
 		ID: "orin", DisplayName: "orin", Hostname: "orin.local", IP: "10.0.0.5", Port: 50051,
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2). Stub it live
+	// so the test still exercises the fromCache ladder + retry-skip logic
+	// below, not a real network dial.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
 
 	calls := 0
 	certs := []config.CertificateInfo{{OrganizationID: 3}}
@@ -1141,12 +1171,13 @@ func TestConnectWithAutoTLSDiagnostics_OrgMismatchNotRetried(t *testing.T) {
 func TestConnectWithAutoTLSDiagnostics_SameAddressRetrySkipped(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	origLoad, origLookup, origLadder, origReachable := deviceCacheLoadFn, osLookupHostFn, dialAgentLadderFn, cacheFastPathReachableFn
+	origLoad, origLookup, origLadder, origReachable, origTCP := deviceCacheLoadFn, osLookupHostFn, dialAgentLadderFn, cacheFastPathReachableFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		osLookupHostFn = origLookup
 		dialAgentLadderFn = origLadder
 		cacheFastPathReachableFn = origReachable
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	const staleIP = "127.0.0.2"
@@ -1155,6 +1186,16 @@ func TestConnectWithAutoTLSDiagnostics_SameAddressRetrySkipped(t *testing.T) {
 		ID: "orin", DisplayName: "orin", Hostname: "orin.local", IP: staleIP, Port: 50051,
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2). Stub it live
+	// so the test still exercises the fromCache ladder + same-address-skip
+	// logic below, not a real network dial.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
 
 	// Re-resolution via the OS resolver yields the EXACT same (stale) IP —
 	// no new information for a retry to find.
@@ -1185,11 +1226,12 @@ func TestConnectWithAutoTLSDiagnostics_SameAddressRetrySkipped(t *testing.T) {
 func TestConnectWithAutoTLSDiagnostics_SkipsRetryWhenContextExpired(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	origLoad, origLadder, origReachable := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn
+	origLoad, origLadder, origReachable, origTCP := deviceCacheLoadFn, dialAgentLadderFn, cacheFastPathReachableFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		dialAgentLadderFn = origLadder
 		cacheFastPathReachableFn = origReachable
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	cachePath := filepath.Join(t.TempDir(), "devices.json")
@@ -1197,6 +1239,16 @@ func TestConnectWithAutoTLSDiagnostics_SkipsRetryWhenContextExpired(t *testing.T
 		ID: "orin", DisplayName: "orin", Hostname: "orin.local", IP: "127.0.0.2", Port: 50051,
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2). Stub it live
+	// so the test still exercises the expired-context retry-skip logic
+	// below, not a real network dial.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
 
 	calls := 0
 	dialAgentLadderFn = func(context.Context, string) (*grpcclient.AgentConnection, error, error) {
@@ -1290,11 +1342,12 @@ func TestIsMDNSShapedHost(t *testing.T) {
 func TestConnectAgentAtAddressWithProvisionedHint_SelfHealsExistingDiscoveryEntry(t *testing.T) {
 	setTempConfig(t, &config.Config{})
 
-	origLoad, origLookup, origBrowse := deviceCacheLoadFn, osLookupHostFn, lanBrowseFn
+	origLoad, origLookup, origBrowse, origTCP := deviceCacheLoadFn, osLookupHostFn, lanBrowseFn, tcpDialTimeoutFn
 	defer func() {
 		deviceCacheLoadFn = origLoad
 		osLookupHostFn = origLookup
 		lanBrowseFn = origBrowse
+		tcpDialTimeoutFn = origTCP
 	}()
 
 	realAddr := startPlaintextVersionAgent(t)
@@ -1311,6 +1364,14 @@ func TestConnectAgentAtAddressWithProvisionedHint_SelfHealsExistingDiscoveryEntr
 		IP: staleIP, Port: 50051, AgentVersion: "1.4.0", OS: "wendyos",
 	})
 	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(cachePath) }
+
+	// This entry is LKG-ineligible (MTLS unset), so the fromCache path now
+	// runs through the same TCP-bounded pre-check (Finding 2) first. Stub it
+	// dead — deterministic and instant — so the pre-check itself sends this
+	// straight to fresh resolution via the stubs below.
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		return nil, errors.New("no route to host")
+	}
 
 	osLookupHostFn = func(context.Context, string) ([]string, error) {
 		return nil, errors.New("no such host")
@@ -1453,9 +1514,9 @@ func TestDialAgentLKGSkipsOnTCPPrecheckFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { tcpDialTimeoutFn = origTCP; dialAgentLadderWithCertsFn = origLadder })
 
-	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
-	if ok {
-		t.Fatal("dialAgentLKG reported success despite failed TCP pre-check")
+	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if outcome != lkgDeadTCP {
+		t.Fatalf("dialAgentLKG outcome = %v, want lkgDeadTCP", outcome)
 	}
 	if ladderCalled {
 		t.Error("ladder dial ran after failed pre-check — dead IP must cost only the pre-check")
@@ -1489,9 +1550,9 @@ func TestDialAgentLKGRotatesCertsAndDialsMTLSPort(t *testing.T) {
 		loadAllCLICertsFn = origCerts
 	})
 
-	conn, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
-	if !ok || conn == nil {
-		t.Fatal("dialAgentLKG failed on the happy path")
+	conn, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if outcome != lkgConnected || conn == nil {
+		t.Fatalf("dialAgentLKG outcome = %v, conn = %v; want lkgConnected with a connection", outcome, conn)
 	}
 	if gotAddr != "10.0.0.9:50052" {
 		t.Errorf("dialed %q, want the entry's mTLS endpoint 10.0.0.9:50052", gotAddr)
@@ -1520,9 +1581,9 @@ func TestDialAgentLKGFallsThroughOnPlaintextDowngrade(t *testing.T) {
 		loadAllCLICertsFn = origCerts
 	})
 
-	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true})
-	if ok {
-		t.Fatal("LKG accepted a plaintext downgrade for an entry advertised as mTLS")
+	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true})
+	if outcome != lkgHandshakeFailed {
+		t.Fatalf("LKG outcome = %v, want lkgHandshakeFailed for a plaintext downgrade of an entry advertised as mTLS", outcome)
 	}
 }
 

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -1658,6 +1659,38 @@ func TestIsCertRejectionError(t *testing.T) {
 				t.Errorf("isCertRejectionError(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRotateCertsForOrg(t *testing.T) {
+	certs := []config.CertificateInfo{
+		{OrganizationID: 1}, {OrganizationID: 2}, {OrganizationID: 3}, {OrganizationID: 2},
+	}
+	orgs := func(cs []config.CertificateInfo) []int {
+		out := make([]int, len(cs))
+		for i, c := range cs {
+			out[i] = c.OrganizationID
+		}
+		return out
+	}
+	cases := []struct {
+		name  string
+		orgID int32
+		want  []int
+	}{
+		{"match moves first, stable within groups", 2, []int{2, 2, 1, 3}},
+		{"zero org = unchanged", 0, []int{1, 2, 3, 2}},
+		{"no match = unchanged", 9, []int{1, 2, 3, 2}},
+	}
+	for _, tc := range cases {
+		got := orgs(rotateCertsForOrg(certs, tc.orgID))
+		if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	// Input slice must not be mutated.
+	if fmt.Sprint(orgs(certs)) != fmt.Sprint([]int{1, 2, 3, 2}) {
+		t.Error("rotateCertsForOrg mutated its input")
 	}
 }
 

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1534,12 +1534,12 @@ func TestCacheConnectSuccess_IgnoresLoadError(t *testing.T) {
 	cacheConnectSuccess("orin.local:50051", &grpcclient.AgentConnection{Host: "10.0.0.9"})
 }
 
-// Critical fix: cacheConnectSuccess must write under an EXISTING fresh
-// entry's identity (its discovery-assigned TXT-id ID/DisplayName) when one
+// Critical fix: cacheConnectSuccess must write under an EXISTING entry (any age)
+// identity (its discovery-assigned TXT-id ID/DisplayName) when one
 // matches this hostname, not mint a second row under a host-derived key —
 // otherwise the same physical device shows up twice and cachedDeviceIP's
-// next lookup can nondeterministically return the stale row for the rest of
-// the TTL. Also covers Task 3's decision on record: this connect-only write
+// next lookup can nondeterministically return a different row for the same
+// device. Also covers Task 3's decision on record: this connect-only write
 // (no probed AgentVersion/OS) must Upsert, not Replace, so it never wipes
 // those fields.
 func TestCacheConnectSuccess_ReusesExistingDiscoveryIdentity(t *testing.T) {

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -953,9 +953,13 @@ func TestConnectWithAutoTLSDiagnostics_CacheMissUsesOSResolver(t *testing.T) {
 }
 
 // A stale cached IP that fails to answer must never make an otherwise
-// reachable device look unreachable (spec §4): the fast path must re-resolve
-// via the same mDNS-browse fallback the cache-miss path uses and retry once.
-// (The cache self-heal that a successful retry enables is a
+// reachable device look unreachable (spec §4): the fast path must fall
+// through to the same mDNS-browse fallback the cache-miss path uses. Here the
+// TCP pre-check is the thing that fails, so the cached-IP ladder is skipped
+// outright and the fall-through is the connect's first and only resolution —
+// no second ladder pass is involved (the stale-retry-after-a-live-but-failing
+// ladder path is covered separately by the LKG connect-flow tests).
+// (The cache self-heal that a successful fall-through enables is a
 // connectAgentAtAddressWithProvisionedHint-layer concern — see
 // TestConnectAgentAtAddressWithProvisionedHint_SelfHealsExistingDiscoveryEntry
 // — since connectWithAutoTLSDiagnostics's own "success" isn't proof of life
@@ -998,7 +1002,7 @@ func TestConnectWithAutoTLSDiagnostics_StaleCacheRetriesViaMDNS(t *testing.T) {
 
 	// The OS resolver can't see the device (the Windows/Linux ".local" gap
 	// issue #1155 works around); only the mDNS browse fallback can — which is
-	// what the retry must use.
+	// what the post-pre-check fall-through must use to reach the device.
 	osLookupHostFn = func(context.Context, string) ([]string, error) {
 		return nil, errors.New("no such host")
 	}

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -52,8 +52,12 @@ const (
 var tlsDebugWriter io.Writer = os.Stderr
 
 type AgentConnection struct {
-	Conn           *grpc.ClientConn
-	Host           string                  // hostname or IP of the connected agent
+	Conn *grpc.ClientConn
+	Host string // hostname or IP of the connected agent
+	// Addr is the full host:port this connection dialed — the endpoint that
+	// actually answered, mTLS port included. Empty for unix-socket and
+	// pre-built (NewFromConn) connections.
+	Addr           string
 	IsMTLS         bool                    // true when connected via mutual TLS
 	CertInfo       *config.CertificateInfo // cert used to establish mTLS; nil for plaintext
 	RegistryDialer func(context.Context, int) (net.Conn, error)
@@ -102,6 +106,7 @@ func Connect(ctx context.Context, address string) (*AgentConnection, error) {
 
 	ac := newAgentConnection(conn)
 	ac.Host = hostFromAddress(address)
+	ac.Addr = address
 	return ac, nil
 }
 
@@ -248,6 +253,7 @@ func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config
 
 	ac := newAgentConnection(conn)
 	ac.Host = hostFromAddress(address)
+	ac.Addr = address
 	ac.IsMTLS = true
 	ac.CertInfo = certInfo
 	ac.observedServerOrg = observedOrg

--- a/go/internal/shared/discoverycache/cache.go
+++ b/go/internal/shared/discoverycache/cache.go
@@ -131,6 +131,21 @@ func (c *Cache) Fresh(now time.Time) []Entry {
 	return fresh
 }
 
+// Entries returns every cached entry regardless of age, in any order. The
+// connect fast path uses it — a stale IP is still worth one bounded dial
+// attempt, with fallback to fresh resolution — while display surfaces
+// (picker, discovery) keep using Fresh so the TTL still bounds what users
+// see as "recently seen".
+func (c *Cache) Entries() []Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		out = append(out, e)
+	}
+	return out
+}
+
 // Upsert merges e into the cache under Key(e.ID, e.DisplayName) and stamps
 // LastSeen=now. Merge rule: a non-zero incoming field replaces the stored
 // one; a zero incoming field keeps the stored value (so a browse-only upsert

--- a/go/internal/shared/discoverycache/cache_test.go
+++ b/go/internal/shared/discoverycache/cache_test.go
@@ -198,3 +198,19 @@ func TestDeleteRemovesEntryFromFile(t *testing.T) {
 		t.Fatalf("deleted entry survived the flush: %+v", fresh)
 	}
 }
+
+func TestEntriesIncludesStale(t *testing.T) {
+	c, err := LoadFrom(filepath.Join(t.TempDir(), "devices.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now()
+	c.Upsert(Entry{ID: "fresh-dev", Hostname: "fresh.local", IP: "10.0.0.1"}, now)
+	c.Upsert(Entry{ID: "stale-dev", Hostname: "stale.local", IP: "10.0.0.2"}, now.Add(-2*TTL))
+	if got := len(c.Fresh(now)); got != 1 {
+		t.Fatalf("Fresh = %d entries, want 1 (display TTL must be unchanged)", got)
+	}
+	if got := len(c.Entries()); got != 2 {
+		t.Fatalf("Entries = %d, want 2 (stale included)", got)
+	}
+}

--- a/specs/2026-08-08-lkg-connect-cache-design.md
+++ b/specs/2026-08-08-lkg-connect-cache-design.md
@@ -1,122 +1,145 @@
-# Last-Known-Good Connect Cache
+# Last-Known-Good Connect Cache (delta over PR #1616)
 
 **Date:** 2026-08-08
-**Status:** Approved (design), implementation pending
-**Branch:** `ed/lkg-connect-cache` (stacked on `ed/instant-mdns-discovery`, PR #1616)
+**Status:** Approved (design); revised after base-branch exploration — the
+approved outcome and decisions are unchanged, but PR #1616's branch already
+implements the resolution half of this feature, so this spec now describes
+only the remaining delta.
+**Branch:** `ed/lkg-connect-cache` (stacked on `ed/instant-mdns-discovery`,
+PR #1616)
 
 ## Problem
 
-With TLS session resumption (PR #1612) in place, the mTLS handshake on a
-repeat connect costs ~141ms — but connecting to a device by its `.local`
-name still takes ~1.5s, measured live on macOS (Jetson Orin Nano over LAN):
-mDNS name resolution contributes a constant ~1.2–1.4s per CLI invocation,
-and on a cache-cold path the sequential cert × port probe ladder in
-`connectWithAutoTLSDiagnostics` adds more. The device's address, mTLS port,
-and org were almost always known from a previous command — nothing reuses
-them.
+With TLS session resumption (PR #1612), a repeat mTLS handshake costs
+~141ms, but connecting by `.local` name measured ~1.5s on macOS —
+resolution-dominated (~1.2–1.4s), plus the sequential cert × port probe
+ladder.
 
-PR #1616 already persists exactly this data: `discoverycache`
-(`~/.wendy/devices.json`) stores per-device `Hostname`, `IP`, `Port`,
-`MTLS`, `OrgID`, `LastSeen` with best-effort merge-on-flush semantics. This
-feature makes the connect path a reader (and refresher) of that cache.
+**What the base branch (PR #1616) already provides** in
+`connectWithAutoTLSDiagnostics` (`helpers.go`):
 
-## Decisions (made during design review)
+- `cachedDeviceIP(host)` — skips `resolveAddrOnce` entirely when a
+  device-cache entry's hostname matches (via `cachedDeviceEntry`, which is
+  **TTL-gated**: `cache.Fresh`, 1h).
+- A stale-cache retry: on an unreachable fast-path dial, re-resolve and
+  re-run the ladder once.
+- `cacheConnectSuccess` write-back (refresh under the existing discovery
+  identity; mDNS-shaped-host guards) — but it stores **`originalAddr`'s
+  port** (usually the 50051 plaintext port for a stored default device) and
+  never sets `MTLS`/`OrgID`, so a successful connect can clobber
+  discovery's advertised mTLS port in the cache via Upsert's
+  non-zero-wins merge.
 
-- **Stacked on PR #1616** and reusing `discoverycache` — one cache, one
-  file; discovery pre-warms connects, connects refresh discovery. Merge
-  order: #1616 first.
-- **Any-age fast path**: connect attempts use a cached IP regardless of the
-  cache's 1h TTL (the TTL remains a *display*-freshness bound for the
-  picker). Rationale: a stale IP costs ≤1s (bounded TCP connect) against a
-  guaranteed ~1.3s saving, and the fallback path does fresh resolution, so
-  staleness self-heals.
+**Remaining gaps this PR closes:**
 
-## Design
+1. **The 1h TTL cliff**: the first connect after any >1h gap pays full
+   resolution again — exactly the "morning first command" case.
+2. **Dead-IP cost**: the fast path runs the full ladder against the cached
+   IP with no TCP bound — an unreachable IP can burn up to ~2×7s mTLS
+   probes + 3s plaintext probe before the stale retry.
+3. **Ladder order**: the fast path still tries the plaintext port first and
+   every cert sequentially in config order; each wrong-cert attempt on the
+   mTLS port costs the device a full ML-DSA handshake (~1–2s each for
+   multi-org users).
+4. **Write-back fidelity**: the port-clobber wart above, and the cache
+   never learns `MTLS`/`OrgID` from connects.
 
-### 1. `discoverycache` additions: hostname lookup + refresh-only write-back
+## Decisions (made during design review; unchanged)
 
-- `func (c *Cache) ByHostname(host string) (Entry, bool)` — returns the
-  entry whose `Hostname` matches `host` after normalization on both sides
-  (lowercase, strip trailing dot, strip `.local` suffix — same rules as
-  `normalizeMDNSHost` in `helpers.go`). Requires a non-empty `IP`; when
-  several entries match (shouldn't happen, but the cache is keyed by device
-  id, not hostname), the most recent `LastSeen` wins.
-- Connect-path write-back **only refreshes existing entries**: after a
-  successful connect to hostname H at ip:port, look up `ByHostname(H)` and
-  `Upsert` that entry with the fresh `IP`, `Port`, `LastSeen` (and `OrgID`
-  when learned from the server cert). If no entry matches, write nothing —
-  discovery owns entry creation; synthesizing hostname-keyed entries would
-  pollute the picker's device-id identity space.
+- **Stacked on PR #1616**, reusing `discoverycache` — one cache; discovery
+  pre-warms connects, connects refresh discovery. Merge order: #1616 first.
+- **Any-age fast path** for connects: a cached IP is worth one bounded
+  attempt regardless of the 1h TTL (which remains the *display*-freshness
+  bound for the picker). A stale IP costs ≤1s against a ~1.3s+ saving, and
+  the existing stale-cache retry does fresh resolution, so staleness
+  self-heals.
 
-### 2. Connect fast path in `connectWithAutoTLSDiagnostics`
+## Design (delta)
 
-Located after the `WENDY_AGENT_SOCKET` bypass and before `resolveAddrOnce`:
+### 1. Any-age connect lookup
 
-- Applies only when the target host is a NAME (IP-literal targets and the
-  unix-socket path are untouched) and the CLI holds at least one client
-  cert.
-- On a cache hit: one direct mTLS attempt at the entry's `IP:Port` (the
-  cache stores the advertised port, which is the mTLS port for provisioned
-  devices — skip the fast path when the entry's `MTLS` flag is false).
-- **Cert rotation:** order the cert list so the cert whose org matches the
-  entry's `OrgID` is tried first (falling back to config order). This also
-  removes the N-cert sequential ladder for multi-org users on the fast
-  path.
-- **Budget split:** the fast-path dial uses a custom dialer with a ~1s TCP
-  connect timeout (`lkgTCPConnectTimeout`); once TCP is established, the
-  existing `mtlsProbeTimeout` governs the handshake + `GetAgentVersion`
-  probe, so a loaded device's slow full handshake is not artificially cut.
-  A dead/stale IP therefore costs ≤1s before falling through.
-- **Fallback:** on ANY fast-path failure (no cache entry, TCP timeout,
-  handshake rejection, probe failure) the function continues into today's
-  path unchanged — `resolveAddrOnce` (fresh resolution) + the full
-  cert × port ladder. Under `WENDY_TLS_DEBUG`, the fast path logs one line
-  stating hit/miss and the failure reason.
-- On fast-path success: the §1 write-back refreshes the entry, and the
-  connection is returned exactly as a ladder success would be (same
-  `AgentConnection` fields, `IsMTLS`, observed-org plumbing).
+`discoverycache` gains `func (c *Cache) Entries() []Entry` (all entries,
+any age). The connect path's `cachedDeviceEntry` switches from
+`cache.Fresh(now)` to `cache.Entries()` and, when several entries'
+hostnames normalize equal, picks the most recent `LastSeen`. The picker and
+discovery keep using `Fresh` — display freshness is unchanged.
 
-### 3. Trust model: the cache is a routing hint only
+### 2. LKG direct dial with cert rotation and a TCP bound
 
-Nothing about verification changes. The fast path presents the same client
-cert material, runs the same `BuildServerVerifyConnection` (ML-DSA chain +
-org + pins + `OnServerIdentity`), the same post-connect `enforceDevicePin`,
-and composes with #1612's session resumption (the resumption ticket cache
-is keyed by `address|cert`, so a cached-IP dial hits the same ticket the
-previous connect stored). A hijacked or reassigned IP fails server
-verification and falls through to fresh resolution — the failure mode is
-today's behavior plus ≤1s.
+When the matched entry has a non-empty `IP`, `Port > 0`, and `MTLS: true`,
+`connectWithAutoTLSDiagnostics` attempts, before its existing fast-path
+ladder:
 
-### 4. Expected effect (measured baselines, 2026-08-08)
+- **TCP pre-check**: `net.DialTimeout("tcp", ip:port, lkgTCPConnectTimeout)`
+  with `lkgTCPConnectTimeout = 1s`. Failure → skip the direct dial and fall
+  through to the existing flow (which for a dead IP proceeds to the stale
+  retry's fresh resolution). This bounds the dead-IP worst case at ~1s
+  instead of many seconds of ladder probes.
+- **Direct dial**: run the existing ladder mechanics against `ip:entry.Port`
+  (the advertised mTLS port) with the cert list rotated so certs whose
+  `OrganizationID` matches the entry's `OrgID` come first (stable order
+  otherwise; unknown/zero `OrgID` = unchanged order). Implemented by
+  extracting `dialAgentLadderWithCerts(ctx, addr, certs)` from
+  `dialAgentLadder` (which keeps its signature and behavior) plus a pure
+  `rotateCertsForOrg(certs, orgID)` helper.
+- **Fallback**: any direct-dial failure falls through to the existing
+  cached-IP ladder + stale-retry flow **verbatim** (one redundant handshake
+  attempt against the same mTLS port in that failure path is accepted).
+  `WENDY_TLS_DEBUG` logs one line for the LKG attempt: hit/skip and the
+  failure reason.
 
-| Path | Today | With fast path |
+### 3. Write-back fidelity
+
+`cacheConnectSuccess` gains the connection's actual endpoint facts,
+threaded from its call site (`helpers.go:964`, where the successful
+`conn` is in hand): the **actually-connected port** (not `originalAddr`'s),
+`MTLS: conn.IsMTLS`, and `OrgID` from `conn.ObservedServerOrg()` when
+non-zero. This both feeds §2's direct dial and fixes the base's
+port-clobber wart (a connect can no longer overwrite discovery's advertised
+mTLS port with the plaintext port).
+
+### 4. Trust model: unchanged (cache is a routing hint only)
+
+The direct dial presents the same client certs, runs the same
+`BuildServerVerifyConnection` (ML-DSA chain + org + pins), the same
+post-connect `enforceDevicePin`, and composes with #1612's resumption once
+both merge (the ticket cache is keyed by `address|cert`, so the cached-IP
+dial hits the ticket the previous connect stored). A hijacked or reassigned
+IP fails verification and falls through; the failure mode is today's
+behavior plus ≤1s.
+
+### 5. Expected effect (measured baselines, 2026-08-08)
+
+| Path | Base (#1616) | With this delta |
 | --- | --- | --- |
-| `.local` name, warm ticket | ~1.5s (resolution-dominated) | ~150–300ms |
-| `.local` name, cold ticket | ~2.2–2.9s | ~1s (direct dial, full handshake) |
-| IP literal | ~141ms resumed | unchanged |
-| Stale cached IP | n/a | today + ≤1s |
+| `.local`, cache fresh (<1h) | fast (resolution skipped) | same, minus plaintext-port ladder step |
+| `.local`, cache stale (>1h) | ~1.5s (full resolution) | ~fast-path cost (any-age) |
+| Dead/stale cached IP | up to ~17s of ladder probes before retry | ≤1s pre-check, then normal retry |
+| Multi-org, wrong-cert-first | +1–2s per wrong cert (device-side full handshake) | org-matched cert first |
+| IP literal / unix socket | unchanged | unchanged |
 
-### 5. Testing
+### 6. Testing
 
-- Unit (`discoverycache`): `ByHostname` normalization matrix
-  (`Wendy-X.local.` vs `wendy-x`, empty-IP exclusion, most-recent-wins),
-  refresh-only write-back (no entry → no write).
-- Unit (`commands`): cert rotation by org (match first, stable order
-  otherwise, no-match = unchanged order).
-- Integration (fake TLS agent on 127.0.0.1, as in the #1612 test
-  patterns): (a) fast-path hit connects with zero resolver invocations
-  (inject a resolver spy); (b) entry pointing at a dead IP falls back
-  within the budget and connects via the ladder; (c) entry with a stale IP
-  while the device answers on a new IP self-heals (fallback connects,
-  write-back stores the new IP).
-- On-device gate: repeat `wendy device info --device <name>.local` on this
-  LAN drops from ~1.5s to sub-300ms in the mTLS-attempts phase (after one
-  discovery or prior connect).
+- Unit (`discoverycache`): `Entries()` returns stale + fresh; existing
+  `Fresh` untouched.
+- Unit (`commands`): most-recent-wins hostname match across duplicate
+  hostnames; `rotateCertsForOrg` (match-first, stable, no-match =
+  unchanged); write-back stores actual port/MTLS/OrgID and no longer
+  clobbers an advertised mTLS port with a plaintext port.
+- Integration (fake TLS agent, existing test-seam style —
+  `deviceCacheLoadFn`, `cacheFastPathReachableFn`, resolver fns): (a)
+  any-age hit connects with zero resolver invocations; (b) dead-IP entry
+  falls through within ~1s (TCP pre-check) and the stale retry still
+  connects; (c) direct dial uses the rotated cert first (spy on cert order).
+- On-device gate: with a >1h-old cache entry, `wendy device info --device
+  <name>.local` skips resolution (fast path) on this LAN; dead-IP fallback
+  stays snappy.
 
 ## Non-goals
 
-- Creating cache entries from the connect path (discovery owns creation).
-- Changing the TTL or any picker/discovery behavior from #1616.
-- Caching across trust changes — pins and cert verification stay the
-  arbiters; no "trusted IP" concept exists.
+- Creating cache entries from the connect path beyond the base's existing
+  behavior (discovery owns creation; the base's synthesized-identity
+  fallback for never-discovered hosts is kept as-is).
+- Changing the picker/discovery TTL or any #1616 display behavior.
+- Caching across trust changes — verification and pins stay the arbiters.
 - QUIC (separate spike, queued after this).

--- a/specs/2026-08-08-lkg-connect-cache-design.md
+++ b/specs/2026-08-08-lkg-connect-cache-design.md
@@ -71,10 +71,8 @@ When the matched entry has a non-empty `IP`, `Port > 0`, and `MTLS: true`,
 ladder:
 
 - **TCP pre-check**: `net.DialTimeout("tcp", ip:port, lkgTCPConnectTimeout)`
-  with `lkgTCPConnectTimeout = 1s`. Failure → skip the direct dial and fall
-  through to the existing flow (which for a dead IP proceeds to the stale
-  retry's fresh resolution). This bounds the dead-IP worst case at ~1s
-  instead of many seconds of ladder probes.
+  with `lkgTCPConnectTimeout = 1s`, via a shared `lkgTCPAlive(addr)` helper
+  (see below).
 - **Direct dial**: run the existing ladder mechanics against `ip:entry.Port`
   (the advertised mTLS port) with the cert list rotated so certs whose
   `OrganizationID` matches the entry's `OrgID` come first (stable order
@@ -82,11 +80,37 @@ ladder:
   extracting `dialAgentLadderWithCerts(ctx, addr, certs)` from
   `dialAgentLadder` (which keeps its signature and behavior) plus a pure
   `rotateCertsForOrg(certs, orgID)` helper.
-- **Fallback**: any direct-dial failure falls through to the existing
-  cached-IP ladder + stale-retry flow **verbatim** (one redundant handshake
-  attempt against the same mTLS port in that failure path is accepted).
+- **Three-state fallback**: `dialAgentLKG` reports which of three outcomes it
+  hit (`lkgConnected`, `lkgDeadTCP`, `lkgHandshakeFailed`), and
+  `connectWithAutoTLSDiagnostics` branches on it:
+  - `lkgConnected` → return the connection as-is.
+  - `lkgHandshakeFailed` (TCP answered but the ladder didn't produce a
+    usable mTLS connection — ladder error, nil conn, or a surprising
+    plaintext downgrade) → the host is proven alive, so this falls through
+    to the existing cached-IP ladder + stale-retry flow **verbatim** (one
+    redundant handshake attempt against the same mTLS port in that failure
+    path is accepted).
+  - `lkgDeadTCP` (the pre-check itself failed) → the cached IP never enters
+    the cached-IP ladder at all. `fromCache` stays `false`, so the flow
+    proceeds straight to fresh resolution against the *original* host:port —
+    exactly what the stale-cache retry would have produced, minus the
+    wasted ladder attempt against a black hole. This is what actually bounds
+    the dead-IP worst case at ~1s instead of many seconds of ladder probes;
+    the base's naive "any LKG failure falls into the cached-IP ladder"
+    behavior would otherwise still pay the full ladder cost against a dead
+    IP before ever re-resolving.
   `WENDY_TLS_DEBUG` logs one line for the LKG attempt: hit/skip and the
   failure reason.
+- **LKG-ineligible cache dials get the same bound**: entries that don't
+  qualify for the direct dial (`MTLS: false` or `Port == 0`) never call
+  `dialAgentLKG`, but their cached-IP fromCache dial is otherwise exactly as
+  exposed to a dead IP as the LKG path is. `connectWithAutoTLSDiagnostics`
+  therefore runs the same `lkgTCPAlive` pre-check against `ip:plainPort`
+  before committing to `fromCache` for these entries too: alive → proceed
+  fromCache as before; dead → fall through to fresh resolution. Without this
+  bound, any-age lookup (§1) would let a stale LKG-ineligible entry (e.g. an
+  unprovisioned device that moved) feed an unbounded ladder attempt — a
+  regression versus the base's TTL gate.
 
 ### 3. Write-back fidelity
 
@@ -114,7 +138,7 @@ behavior plus ≤1s.
 | --- | --- | --- |
 | `.local`, cache fresh (<1h) | fast (resolution skipped) | same, minus plaintext-port ladder step |
 | `.local`, cache stale (>1h) | ~1.5s (full resolution) | ~fast-path cost (any-age) |
-| Dead/stale cached IP | up to ~17s of ladder probes before retry | ≤1s pre-check, then normal retry |
+| Dead/stale cached IP | up to ~17s of ladder probes before retry | ≤1s pre-check, then straight to fresh resolution (cached-IP ladder never runs against a dead IP) |
 | Multi-org, wrong-cert-first | +1–2s per wrong cert (device-side full handshake) | org-matched cert first |
 | IP literal / unix socket | unchanged | unchanged |
 
@@ -128,9 +152,16 @@ behavior plus ≤1s.
   clobbers an advertised mTLS port with a plaintext port.
 - Integration (fake TLS agent, existing test-seam style —
   `deviceCacheLoadFn`, `cacheFastPathReachableFn`, resolver fns): (a)
-  any-age hit connects with zero resolver invocations; (b) dead-IP entry
-  falls through within ~1s (TCP pre-check) and the stale retry still
-  connects; (c) direct dial uses the rotated cert first (spy on cert order).
+  any-age hit connects with zero resolver invocations; (b) a dead-IP LKG
+  entry never enters the cached-IP ladder — the pre-check (~1s) sends it
+  straight to fresh resolution, and the ladder is spied to assert it only
+  ever ran against the freshly-resolved address, never the dead cached IP
+  (`lkgDeadTCP`); a live-TCP-but-failed-handshake entry (`lkgHandshakeFailed`)
+  still gets the cached-IP ladder + stale retry, unchanged; (c) direct dial
+  uses the rotated cert first (spy on cert order); (d) an LKG-ineligible
+  entry (`MTLS: false`) gets the same pre-check bound before its fromCache
+  dial: dead → fresh resolution, alive → fromCache ladder at the cached IP,
+  same as before this delta.
 - On-device gate: with a >1h-old cache entry, `wendy device info --device
   <name>.local` skips resolution (fast path) on this LAN; dead-IP fallback
   stays snappy.

--- a/specs/2026-08-08-lkg-connect-cache-design.md
+++ b/specs/2026-08-08-lkg-connect-cache-design.md
@@ -1,0 +1,122 @@
+# Last-Known-Good Connect Cache
+
+**Date:** 2026-08-08
+**Status:** Approved (design), implementation pending
+**Branch:** `ed/lkg-connect-cache` (stacked on `ed/instant-mdns-discovery`, PR #1616)
+
+## Problem
+
+With TLS session resumption (PR #1612) in place, the mTLS handshake on a
+repeat connect costs ~141ms — but connecting to a device by its `.local`
+name still takes ~1.5s, measured live on macOS (Jetson Orin Nano over LAN):
+mDNS name resolution contributes a constant ~1.2–1.4s per CLI invocation,
+and on a cache-cold path the sequential cert × port probe ladder in
+`connectWithAutoTLSDiagnostics` adds more. The device's address, mTLS port,
+and org were almost always known from a previous command — nothing reuses
+them.
+
+PR #1616 already persists exactly this data: `discoverycache`
+(`~/.wendy/devices.json`) stores per-device `Hostname`, `IP`, `Port`,
+`MTLS`, `OrgID`, `LastSeen` with best-effort merge-on-flush semantics. This
+feature makes the connect path a reader (and refresher) of that cache.
+
+## Decisions (made during design review)
+
+- **Stacked on PR #1616** and reusing `discoverycache` — one cache, one
+  file; discovery pre-warms connects, connects refresh discovery. Merge
+  order: #1616 first.
+- **Any-age fast path**: connect attempts use a cached IP regardless of the
+  cache's 1h TTL (the TTL remains a *display*-freshness bound for the
+  picker). Rationale: a stale IP costs ≤1s (bounded TCP connect) against a
+  guaranteed ~1.3s saving, and the fallback path does fresh resolution, so
+  staleness self-heals.
+
+## Design
+
+### 1. `discoverycache` additions: hostname lookup + refresh-only write-back
+
+- `func (c *Cache) ByHostname(host string) (Entry, bool)` — returns the
+  entry whose `Hostname` matches `host` after normalization on both sides
+  (lowercase, strip trailing dot, strip `.local` suffix — same rules as
+  `normalizeMDNSHost` in `helpers.go`). Requires a non-empty `IP`; when
+  several entries match (shouldn't happen, but the cache is keyed by device
+  id, not hostname), the most recent `LastSeen` wins.
+- Connect-path write-back **only refreshes existing entries**: after a
+  successful connect to hostname H at ip:port, look up `ByHostname(H)` and
+  `Upsert` that entry with the fresh `IP`, `Port`, `LastSeen` (and `OrgID`
+  when learned from the server cert). If no entry matches, write nothing —
+  discovery owns entry creation; synthesizing hostname-keyed entries would
+  pollute the picker's device-id identity space.
+
+### 2. Connect fast path in `connectWithAutoTLSDiagnostics`
+
+Located after the `WENDY_AGENT_SOCKET` bypass and before `resolveAddrOnce`:
+
+- Applies only when the target host is a NAME (IP-literal targets and the
+  unix-socket path are untouched) and the CLI holds at least one client
+  cert.
+- On a cache hit: one direct mTLS attempt at the entry's `IP:Port` (the
+  cache stores the advertised port, which is the mTLS port for provisioned
+  devices — skip the fast path when the entry's `MTLS` flag is false).
+- **Cert rotation:** order the cert list so the cert whose org matches the
+  entry's `OrgID` is tried first (falling back to config order). This also
+  removes the N-cert sequential ladder for multi-org users on the fast
+  path.
+- **Budget split:** the fast-path dial uses a custom dialer with a ~1s TCP
+  connect timeout (`lkgTCPConnectTimeout`); once TCP is established, the
+  existing `mtlsProbeTimeout` governs the handshake + `GetAgentVersion`
+  probe, so a loaded device's slow full handshake is not artificially cut.
+  A dead/stale IP therefore costs ≤1s before falling through.
+- **Fallback:** on ANY fast-path failure (no cache entry, TCP timeout,
+  handshake rejection, probe failure) the function continues into today's
+  path unchanged — `resolveAddrOnce` (fresh resolution) + the full
+  cert × port ladder. Under `WENDY_TLS_DEBUG`, the fast path logs one line
+  stating hit/miss and the failure reason.
+- On fast-path success: the §1 write-back refreshes the entry, and the
+  connection is returned exactly as a ladder success would be (same
+  `AgentConnection` fields, `IsMTLS`, observed-org plumbing).
+
+### 3. Trust model: the cache is a routing hint only
+
+Nothing about verification changes. The fast path presents the same client
+cert material, runs the same `BuildServerVerifyConnection` (ML-DSA chain +
+org + pins + `OnServerIdentity`), the same post-connect `enforceDevicePin`,
+and composes with #1612's session resumption (the resumption ticket cache
+is keyed by `address|cert`, so a cached-IP dial hits the same ticket the
+previous connect stored). A hijacked or reassigned IP fails server
+verification and falls through to fresh resolution — the failure mode is
+today's behavior plus ≤1s.
+
+### 4. Expected effect (measured baselines, 2026-08-08)
+
+| Path | Today | With fast path |
+| --- | --- | --- |
+| `.local` name, warm ticket | ~1.5s (resolution-dominated) | ~150–300ms |
+| `.local` name, cold ticket | ~2.2–2.9s | ~1s (direct dial, full handshake) |
+| IP literal | ~141ms resumed | unchanged |
+| Stale cached IP | n/a | today + ≤1s |
+
+### 5. Testing
+
+- Unit (`discoverycache`): `ByHostname` normalization matrix
+  (`Wendy-X.local.` vs `wendy-x`, empty-IP exclusion, most-recent-wins),
+  refresh-only write-back (no entry → no write).
+- Unit (`commands`): cert rotation by org (match first, stable order
+  otherwise, no-match = unchanged order).
+- Integration (fake TLS agent on 127.0.0.1, as in the #1612 test
+  patterns): (a) fast-path hit connects with zero resolver invocations
+  (inject a resolver spy); (b) entry pointing at a dead IP falls back
+  within the budget and connects via the ladder; (c) entry with a stale IP
+  while the device answers on a new IP self-heals (fallback connects,
+  write-back stores the new IP).
+- On-device gate: repeat `wendy device info --device <name>.local` on this
+  LAN drops from ~1.5s to sub-300ms in the mTLS-attempts phase (after one
+  discovery or prior connect).
+
+## Non-goals
+
+- Creating cache entries from the connect path (discovery owns creation).
+- Changing the TTL or any picker/discovery behavior from #1616.
+- Caching across trust changes — pins and cert verification stay the
+  arbiters; no "trusted IP" concept exists.
+- QUIC (separate spike, queued after this).

--- a/specs/2026-08-08-lkg-connect-cache-plan.md
+++ b/specs/2026-08-08-lkg-connect-cache-plan.md
@@ -1,0 +1,810 @@
+# Last-Known-Good Connect Cache — Implementation Plan (delta over #1616)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four gaps the base branch leaves in its device-cache connect fast path: the 1h TTL cliff, the unbounded dead-IP cost, plaintext-first/config-order ladder on cache hits, and write-back that clobbers the advertised mTLS port.
+
+**Architecture:** All changes ride the existing machinery in `go/internal/cli/commands/helpers.go` (`cachedDeviceEntry`/`cachedDeviceIP`, `dialAgentLadder`, `cacheConnectSuccess`, seams `deviceCacheLoadFn`/`dialAgentLadderFn`/`cacheFastPathReachableFn`) plus one new `discoverycache` accessor. New pieces: `Entries()` (any-age), `rotateCertsForOrg`, `dialAgentLKG` (TCP pre-check + direct mTLS-port dial), and endpoint-faithful write-back via a new `AgentConnection.Addr` field. Spec: `specs/2026-08-08-lkg-connect-cache-design.md`.
+
+**Tech Stack:** Go 1.26; no new dependencies.
+
+## Global Constraints
+
+- Branch `ed/lkg-connect-cache` is **stacked on `ed/instant-mdns-discovery`**; the PR targets that branch.
+- Module root = repo root; packages under `go/...`; run `go` commands from repo root; specs/plans live in top-level `specs/` (root `docs/` is a symlink into embedded CLI assets).
+- The fast path NEVER changes trust: same certs, same verifiers, same pins. It is routing only; every failure falls through to the existing flow.
+- `lkgTCPConnectTimeout = 1 * time.Second` (exact name/value). The TCP pre-check bounds dead-IP cost; the handshake itself stays governed by `mtlsProbeTimeout`.
+- Display surfaces keep using `Fresh` — the 1h TTL is untouched for the picker/discovery; ONLY the connect lookup goes any-age.
+- `WENDY_TLS_DEBUG` (existing env) gates the new `[tls-debug] lkg …` lines; no new env vars.
+- Existing base-branch tests may assert the OLD TTL-gated connect behavior — update those assertions to the new any-age contract, changing nothing else about them; never weaken unrelated assertions.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Before pushing: `gofmt -l .` from repo root must be empty.
+
+---
+
+### Task 1: `Entries()` + any-age, most-recent-wins connect lookup
+
+**Files:**
+- Modify: `go/internal/shared/discoverycache/cache.go` (add `Entries`)
+- Modify: `go/internal/cli/commands/helpers.go:1276-1306` (`cachedDeviceEntry` doc + body)
+- Test: `go/internal/shared/discoverycache/cache_test.go`, `go/internal/cli/commands/helpers_test.go`
+
+**Interfaces:**
+- Consumes: existing `Cache.Fresh`, `normalizeMDNSHost`, `deviceCacheLoadFn` seam.
+- Produces: `func (c *Cache) Entries() []Entry`; `cachedDeviceEntry(cache, host)` now any-age + most-recent-wins (same signature). Tasks 3-4 rely on the entry's `IP`/`Port`/`MTLS`/`OrgID` fields being reachable through it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `go/internal/shared/discoverycache/cache_test.go`:
+
+```go
+func TestEntriesIncludesStale(t *testing.T) {
+	c, err := LoadFrom(filepath.Join(t.TempDir(), "devices.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now()
+	c.Upsert(Entry{ID: "fresh-dev", Hostname: "fresh.local", IP: "10.0.0.1"}, now)
+	c.Upsert(Entry{ID: "stale-dev", Hostname: "stale.local", IP: "10.0.0.2"}, now.Add(-2*TTL))
+	if got := len(c.Fresh(now)); got != 1 {
+		t.Fatalf("Fresh = %d entries, want 1 (display TTL must be unchanged)", got)
+	}
+	if got := len(c.Entries()); got != 2 {
+		t.Fatalf("Entries = %d, want 2 (stale included)", got)
+	}
+}
+```
+
+Append to `go/internal/cli/commands/helpers_test.go` (follow the file's existing pattern for seeding `deviceCacheLoadFn` with a `discoverycache.LoadFrom` temp file — see the existing `cacheConnectSuccess` tests around line 1446):
+
+```go
+func TestCachedDeviceEntryAnyAgeMostRecentWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	cache, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	old := time.Now().Add(-3 * discoverycache.TTL)
+	newer := time.Now().Add(-2 * discoverycache.TTL)
+	// Two distinct device identities sharing one hostname (e.g. a device
+	// re-provisioned under a new id): most recent LastSeen must win.
+	cache.Upsert(discoverycache.Entry{ID: "dev-old", Hostname: "orin.local", IP: "10.0.0.8"}, old)
+	cache.Upsert(discoverycache.Entry{ID: "dev-new", Hostname: "orin.local", IP: "10.0.0.9"}, newer)
+
+	e, ok := cachedDeviceEntry(cache, "orin.local")
+	if !ok {
+		t.Fatal("stale entries not matched — connect lookup must be any-age")
+	}
+	if e.IP != "10.0.0.9" {
+		t.Errorf("matched IP %q, want most-recent 10.0.0.9", e.IP)
+	}
+	// Bare-name form matches the .local stored form.
+	if _, ok := cachedDeviceEntry(cache, "orin"); !ok {
+		t.Error("bare hostname did not match .local entry")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./go/internal/shared/discoverycache/ ./go/internal/cli/commands/ -run 'TestEntriesIncludesStale|TestCachedDeviceEntryAnyAge' -v`
+Expected: FAIL — `Entries` undefined; any-age match fails.
+
+- [ ] **Step 3: Implement**
+
+`cache.go`, after `Fresh`:
+
+```go
+// Entries returns every cached entry regardless of age, in any order. The
+// connect fast path uses it — a stale IP is still worth one bounded dial
+// attempt, with fallback to fresh resolution — while display surfaces
+// (picker, discovery) keep using Fresh so the TTL still bounds what users
+// see as "recently seen".
+func (c *Cache) Entries() []Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		out = append(out, e)
+	}
+	return out
+}
+```
+
+`helpers.go` — replace `cachedDeviceEntry`'s body and update its doc comment (drop the "fresh (within discoverycache.TTL)" claim):
+
+```go
+// cachedDeviceEntry returns the device-cache entry, if any, whose Hostname
+// matches host (normalizeMDNSHost equality), regardless of the entry's age
+// — the connect fast path deliberately uses stale entries too (a stale IP
+// costs one bounded dial attempt; the stale-cache retry re-resolves). When
+// several entries' hostnames normalize equal (e.g. a device re-provisioned
+// under a new identity), the most recent LastSeen wins. Shared by
+// cachedDeviceIP's lookup and cacheConnectSuccess's write path so a
+// connect-success write always lands under a real device's existing
+// identity.
+func cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache.Entry, bool) {
+	want := normalizeMDNSHost(host)
+	var best discoverycache.Entry
+	var found bool
+	for _, e := range cache.Entries() {
+		if normalizeMDNSHost(e.Hostname) != want {
+			continue
+		}
+		if !found || e.LastSeen.After(best.LastSeen) {
+			best, found = e, true
+		}
+	}
+	return best, found
+}
+```
+
+- [ ] **Step 4: Run tests + update any base tests asserting TTL-gated connect lookups**
+
+Run: `go test ./go/internal/shared/discoverycache/ ./go/internal/cli/commands/ -count=1`
+If a pre-existing test asserts that a stale entry is NOT matched by `cachedDeviceEntry`/`cachedDeviceIP`, invert that specific assertion to the new any-age contract (and say so in the report); all other tests must pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/shared/discoverycache/ go/internal/cli/commands/
+git commit -m "feat(cli): any-age, most-recent-wins device-cache lookup for connects
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `dialAgentLadderWithCerts` extraction + `rotateCertsForOrg`
+
+**Files:**
+- Modify: `go/internal/cli/commands/helpers.go:1540-1700` (`dialAgentLadder`)
+- Test: `go/internal/cli/commands/helpers_test.go`
+
+**Interfaces:**
+- Consumes: existing `dialAgentLadder` body, `loadAllCLICerts`, `config.CertificateInfo`.
+- Produces: `func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCerts []config.CertificateInfo) (*grpcclient.AgentConnection, error, error)` (the old body, cert slice parameterized); `dialAgentLadder` keeps its exact signature/behavior as a one-line wrapper; `func rotateCertsForOrg(certs []config.CertificateInfo, orgID int32) []config.CertificateInfo`; `var dialAgentLadderWithCertsFn = dialAgentLadderWithCerts` (test seam, used by Task 3's `dialAgentLKG`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRotateCertsForOrg(t *testing.T) {
+	certs := []config.CertificateInfo{
+		{OrganizationID: 1}, {OrganizationID: 2}, {OrganizationID: 3}, {OrganizationID: 2},
+	}
+	orgs := func(cs []config.CertificateInfo) []int {
+		out := make([]int, len(cs))
+		for i, c := range cs {
+			out[i] = c.OrganizationID
+		}
+		return out
+	}
+	cases := []struct {
+		name  string
+		orgID int32
+		want  []int
+	}{
+		{"match moves first, stable within groups", 2, []int{2, 2, 1, 3}},
+		{"zero org = unchanged", 0, []int{1, 2, 3, 2}},
+		{"no match = unchanged", 9, []int{1, 2, 3, 2}},
+	}
+	for _, tc := range cases {
+		got := orgs(rotateCertsForOrg(certs, tc.orgID))
+		if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	// Input slice must not be mutated.
+	if fmt.Sprint(orgs(certs)) != fmt.Sprint([]int{1, 2, 3, 2}) {
+		t.Error("rotateCertsForOrg mutated its input")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./go/internal/cli/commands/ -run TestRotateCertsForOrg -v`
+Expected: FAIL to build.
+
+- [ ] **Step 3: Implement**
+
+In `helpers.go`:
+
+```go
+// rotateCertsForOrg returns certs reordered so entries whose OrganizationID
+// matches orgID come first, preserving relative order within both groups
+// (a stable partition). orgID 0 (unknown) or no match returns certs
+// unchanged. Never mutates the input.
+func rotateCertsForOrg(certs []config.CertificateInfo, orgID int32) []config.CertificateInfo {
+	if orgID == 0 {
+		return certs
+	}
+	matched := make([]config.CertificateInfo, 0, len(certs))
+	rest := make([]config.CertificateInfo, 0, len(certs))
+	for _, c := range certs {
+		if int32(c.OrganizationID) == orgID {
+			matched = append(matched, c)
+		} else {
+			rest = append(rest, c)
+		}
+	}
+	if len(matched) == 0 {
+		return certs
+	}
+	return append(matched, rest...)
+}
+```
+
+Rename the existing `dialAgentLadder` to `dialAgentLadderWithCerts` with the extra `allCerts []config.CertificateInfo` parameter, deleting only its internal `allCerts := loadAllCLICerts()` line (every other line unchanged, comments included), then add:
+
+```go
+// dialAgentLadder is dialAgentLadderWithCerts with the CLI's stored certs
+// in config order — the shape every non-fast-path caller wants.
+func dialAgentLadder(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
+	return dialAgentLadderWithCerts(ctx, plaintextAddr, loadAllCLICerts())
+}
+
+// dialAgentLadderWithCertsFn is a seam over dialAgentLadderWithCerts for
+// tests that need to observe the cert order the LKG fast path passes.
+var dialAgentLadderWithCertsFn = dialAgentLadderWithCerts
+```
+
+- [ ] **Step 4: Run the full package suite**
+
+Run: `go test ./go/internal/cli/commands/ -count=1`
+Expected: all PASS (extraction is behavior-preserving).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/
+git commit -m "refactor(cli): parameterize dial ladder certs + org-first rotation helper
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: LKG direct dial (TCP pre-check + mTLS-port-first) in the connect flow
+
+**Files:**
+- Modify: `go/internal/cli/commands/helpers.go:1293-1306` (`cachedDeviceIP` → entry-returning helper), `:1364-1383` (`connectWithAutoTLSDiagnostics` head)
+- Test: `go/internal/cli/commands/helpers_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's any-age `cachedDeviceEntry`, Task 2's `rotateCertsForOrg` + `dialAgentLadderWithCertsFn`, existing `deviceCacheLoadFn`, `hostPort`, `loadAllCLICerts`.
+- Produces: `const lkgTCPConnectTimeout = 1 * time.Second`; `func cachedDeviceHostEntry(host string) (discoverycache.Entry, bool)` (loads the cache via `deviceCacheLoadFn` and delegates to `cachedDeviceEntry`); `func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool)` + seam `var dialAgentLKGFn = dialAgentLKG`; `var tcpDialTimeoutFn = net.DialTimeout` (test seam). Task 5's integration tests drive these seams.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestDialAgentLKGSkipsOnTCPPrecheckFailure(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		if timeout != lkgTCPConnectTimeout {
+			t.Errorf("pre-check timeout = %v, want %v", timeout, lkgTCPConnectTimeout)
+		}
+		return nil, errors.New("no route to host")
+	}
+	ladderCalled := false
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		ladderCalled = true
+		return nil, nil, errors.New("must not be reached")
+	}
+	t.Cleanup(func() { tcpDialTimeoutFn = origTCP; dialAgentLadderWithCertsFn = origLadder })
+
+	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if ok {
+		t.Fatal("dialAgentLKG reported success despite failed TCP pre-check")
+	}
+	if ladderCalled {
+		t.Error("ladder dial ran after failed pre-check — dead IP must cost only the pre-check")
+	}
+}
+
+func TestDialAgentLKGRotatesCertsAndDialsMTLSPort(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
+	var gotAddr string
+	var gotOrgs []int
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		gotAddr = addr
+		for _, c := range certs {
+			gotOrgs = append(gotOrgs, c.OrganizationID)
+		}
+		return &grpcclient.AgentConnection{IsMTLS: true}, nil, nil
+	}
+	origCerts := loadAllCLICertsFn
+	loadAllCLICertsFn = func() []config.CertificateInfo {
+		return []config.CertificateInfo{{OrganizationID: 1}, {OrganizationID: 2}}
+	}
+	t.Cleanup(func() {
+		tcpDialTimeoutFn = origTCP
+		dialAgentLadderWithCertsFn = origLadder
+		loadAllCLICertsFn = origCerts
+	})
+
+	conn, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	if !ok || conn == nil {
+		t.Fatal("dialAgentLKG failed on the happy path")
+	}
+	if gotAddr != "10.0.0.9:50052" {
+		t.Errorf("dialed %q, want the entry's mTLS endpoint 10.0.0.9:50052", gotAddr)
+	}
+	if fmt.Sprint(gotOrgs) != fmt.Sprint([]int{2, 1}) {
+		t.Errorf("cert org order = %v, want entry-org-first [2 1]", gotOrgs)
+	}
+}
+
+func TestDialAgentLKGFallsThroughOnPlaintextDowngrade(t *testing.T) {
+	origTCP := tcpDialTimeoutFn
+	tcpDialTimeoutFn = func(network, addr string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		go c2.Close()
+		return c1, nil
+	}
+	origLadder := dialAgentLadderWithCertsFn
+	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		return grpcclient.NewFromConn(nil), nil, nil // IsMTLS=false: ladder fell to plaintext
+	}
+	origCerts := loadAllCLICertsFn
+	loadAllCLICertsFn = func() []config.CertificateInfo { return []config.CertificateInfo{{OrganizationID: 1}} }
+	t.Cleanup(func() {
+		tcpDialTimeoutFn = origTCP
+		dialAgentLadderWithCertsFn = origLadder
+		loadAllCLICertsFn = origCerts
+	})
+
+	_, _, ok := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true})
+	if ok {
+		t.Fatal("LKG accepted a plaintext downgrade for an entry advertised as mTLS")
+	}
+}
+```
+
+Note: these tests require a `loadAllCLICertsFn` seam. If `loadAllCLICerts` is called directly today, add `var loadAllCLICertsFn = loadAllCLICerts` and use the seam inside `dialAgentLKG` only (the ladder keeps calling `loadAllCLICerts` directly via `dialAgentLadder`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./go/internal/cli/commands/ -run TestDialAgentLKG -v`
+Expected: FAIL to build.
+
+- [ ] **Step 3: Implement**
+
+In `helpers.go`:
+
+```go
+// lkgTCPConnectTimeout bounds the last-known-good fast path's TCP
+// pre-check. A dead or reassigned cached IP must cost at most this before
+// the connect falls through to fresh resolution — without the bound, the
+// full ladder would burn its mtlsProbeTimeout budgets against a black hole.
+const lkgTCPConnectTimeout = 1 * time.Second
+
+// tcpDialTimeoutFn is a seam over net.DialTimeout for LKG fast-path tests.
+var tcpDialTimeoutFn = net.DialTimeout
+
+// loadAllCLICertsFn is a seam over loadAllCLICerts for LKG fast-path tests.
+var loadAllCLICertsFn = loadAllCLICerts
+
+// cachedDeviceHostEntry loads the device cache and returns the entry whose
+// hostname matches host (any age, most recent wins). The empty entry and
+// false when the cache is unavailable or nothing matches.
+func cachedDeviceHostEntry(host string) (discoverycache.Entry, bool) {
+	cache, err := deviceCacheLoadFn()
+	if err != nil || cache == nil {
+		return discoverycache.Entry{}, false
+	}
+	return cachedDeviceEntry(cache, host)
+}
+
+// dialAgentLKG is the last-known-good direct dial: one bounded attempt at a
+// cached device's advertised mTLS endpoint with the entry's org's cert
+// first. ok=false means "fall through to the ordinary connect flow" — the
+// fast path never surfaces its own failures as the connect's outcome.
+// Trust is unchanged: the same certs, verifiers, and pins run here as on
+// the ordinary path; the cache contributes routing only.
+func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+	addr := hostPort(e.IP, e.Port)
+	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
+	raw, err := tcpDialTimeoutFn("tcp", addr, lkgTCPConnectTimeout)
+	if err != nil {
+		if tlsDebug {
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: tcp pre-check failed: %v\n", addr, err)
+		}
+		return nil, nil, false
+	}
+	raw.Close()
+	certs := rotateCertsForOrg(loadAllCLICertsFn(), e.OrgID)
+	if len(certs) == 0 {
+		return nil, nil, false
+	}
+	conn, mtlsErr, err := dialAgentLadderWithCertsFn(ctx, addr, certs)
+	if err != nil || conn == nil || !conn.IsMTLS {
+		// The entry advertised mTLS; a plaintext downgrade here would be
+		// surprising, so route it through the ordinary path instead.
+		if conn != nil {
+			conn.Close()
+		}
+		if tlsDebug {
+			fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: direct dial failed: %v\n", addr, err)
+		}
+		return nil, mtlsErr, false
+	}
+	if tlsDebug {
+		fmt.Fprintf(os.Stderr, "[tls-debug] lkg %s: connected\n", addr)
+	}
+	return conn, mtlsErr, true
+}
+
+// dialAgentLKGFn is a seam over dialAgentLKG for connect-flow tests.
+var dialAgentLKGFn = dialAgentLKG
+```
+
+Rework the head of `connectWithAutoTLSDiagnostics` (keeping everything from `conn, mtlsErr, err := dialAgentLadderFn(...)` onward byte-identical):
+
+```go
+	originalAddr := plaintextAddr
+	fromCache := false
+	if plainHost, plainPort, splitErr := net.SplitHostPort(plaintextAddr); splitErr == nil && net.ParseIP(plainHost) == nil {
+		if e, ok := cachedDeviceHostEntry(plainHost); ok && e.IP != "" {
+			// Last-known-good direct dial: the advertised mTLS endpoint with
+			// the entry's org's cert first, TCP-bounded so a dead IP costs at
+			// most lkgTCPConnectTimeout. Failures fall through to the
+			// cached-IP ladder + stale-cache retry below.
+			if e.MTLS && e.Port > 0 {
+				if conn, mtlsErr, ok := dialAgentLKGFn(ctx, e); ok {
+					return conn, mtlsErr, nil
+				}
+			}
+			plaintextAddr, fromCache = net.JoinHostPort(e.IP, plainPort), true
+		}
+	}
+	if !fromCache {
+		plaintextAddr = resolveAddrOnce(ctx, plaintextAddr)
+	}
+```
+
+Delete `cachedDeviceIP` if this leaves it unreferenced outside tests (update those tests to `cachedDeviceHostEntry`); keep it as a thin wrapper only if other production call sites exist (check with grep and say which in the report).
+
+- [ ] **Step 4: Run the full package suite**
+
+Run: `go test ./go/internal/cli/commands/ -count=1`
+Expected: all PASS (new + pre-existing, including the base branch's fast-path/stale-retry tests, which exercise the `fromCache` flow this change preserves).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/
+git commit -m "feat(cli): last-known-good direct dial — TCP-bounded, mTLS-port-first, org-cert-first
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Endpoint-faithful write-back (fix the port-clobber wart)
+
+**Files:**
+- Modify: `go/internal/cli/grpcclient/client.go` (add `Addr` field; set in `Connect` and `ConnectWithTLSAndPins`)
+- Modify: `go/internal/cli/commands/helpers.go:1494-1524` (`cacheConnectSuccess`)
+- Test: `go/internal/cli/commands/helpers_test.go`
+
+**Interfaces:**
+- Consumes: existing `cacheConnectSuccess` call site (`helpers.go:964`, signature unchanged), `AgentConnection.IsMTLS`, `(*AgentConnection).ObservedServerOrg()`.
+- Produces: `AgentConnection.Addr string` — the full `host:port` this connection dialed (set by `Connect` and `ConnectWithTLSAndPins`; empty for `ConnectUnix`/`NewFromConn`). `cacheConnectSuccess` stores the actually-connected port, `MTLS: conn.IsMTLS`, and `OrgID` from `ObservedServerOrg()` when non-zero.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCacheConnectSuccessStoresActualEndpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	seed, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now()
+	// Discovery stored the advertised mTLS port; a connect via the plaintext
+	// originalAddr port must NOT clobber it with 50051.
+	seed.Upsert(discoverycache.Entry{ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true}, now)
+	if err := seed.Flush(now); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	origLoad := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
+	t.Cleanup(func() { deviceCacheLoadFn = origLoad })
+
+	conn := &grpcclient.AgentConnection{Host: "10.0.0.9", IsMTLS: true, Addr: "10.0.0.9:50052"}
+	cacheConnectSuccess("orin.local:50051", conn)
+
+	after, _ := discoverycache.LoadFrom(path)
+	e, ok := cachedDeviceEntry(after, "orin.local")
+	if !ok {
+		t.Fatal("entry missing after write-back")
+	}
+	if e.Port != 50052 {
+		t.Errorf("Port = %d after mTLS connect on 50052, want 50052 (originalAddr's 50051 must not clobber)", e.Port)
+	}
+	if !e.MTLS {
+		t.Error("MTLS flag lost on write-back")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./go/internal/cli/commands/ -run TestCacheConnectSuccessStoresActualEndpoint -v`
+Expected: FAIL — `Addr` undefined / Port clobbered to 50051.
+
+- [ ] **Step 3: Implement**
+
+`grpcclient/client.go`: add to the `AgentConnection` struct (near `Host`):
+
+```go
+	// Addr is the full host:port this connection dialed — the endpoint that
+	// actually answered, mTLS port included. Empty for unix-socket and
+	// pre-built (NewFromConn) connections.
+	Addr string
+```
+
+Set `ac.Addr = address` in `Connect` and in `ConnectWithTLSAndPins` (next to the existing `ac.Host = hostFromAddress(address)` lines).
+
+`helpers.go` — in `cacheConnectSuccess`, after the existing guards, derive the stored port from the connection's real endpoint and enrich the entry:
+
+```go
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return
+	}
+	// Prefer the endpoint the connection actually dialed (mTLS port when the
+	// ladder stepped to port+1) over originalAddr's port — otherwise a
+	// default-device connect (plaintext :50051 in originalAddr) would clobber
+	// discovery's advertised mTLS port in the cache on every command.
+	if _, connPortStr, splitErr := net.SplitHostPort(conn.Addr); splitErr == nil {
+		if connPort, convErr := strconv.Atoi(connPortStr); convErr == nil {
+			port = connPort
+		}
+	}
+	// (the existing deviceCacheLoadFn load + guards stay exactly as they are
+	// between the port derivation above and the entry literal below)
+	entry := discoverycache.Entry{
+		Hostname: cacheHostnameForStorage(host),
+		IP:       conn.Host,
+		Port:     port,
+		MTLS:     conn.IsMTLS,
+	}
+	if org, ok := conn.ObservedServerOrg(); ok {
+		entry.OrgID = org
+	}
+```
+
+(`MTLS: false` on a plaintext connect is a zero value, so Upsert's non-zero-wins merge keeps a previously-true flag — matching today's semantics for that field; the port fix is the behavioral change.)
+
+- [ ] **Step 4: Run the suites**
+
+Run: `go test ./go/internal/cli/commands/ ./go/internal/cli/grpcclient/ -count=1`
+Expected: all PASS (existing `cacheConnectSuccess` tests construct `AgentConnection` literals without `Addr` — their fallback path keeps them green; update any that now assert the old clobbering behavior, noting it in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/grpcclient/ go/internal/cli/commands/
+git commit -m "fix(cli): connect write-back stores the actually-dialed endpoint + MTLS/org
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Connect-flow integration tests
+
+**Files:**
+- Test: `go/internal/cli/commands/helpers_lkg_test.go` (new)
+
+**Interfaces:**
+- Consumes: seams `deviceCacheLoadFn`, `dialAgentLKGFn`, `dialAgentLadderFn`, `osLookupHostFn`, `lanBrowseFn` (all existing or added in Tasks 1-3) and `connectWithAutoTLSDiagnostics` itself.
+
+- [ ] **Step 1: Write the tests**
+
+```go
+package commands
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// seedLKGCache installs a deviceCacheLoadFn serving one entry, stale by
+// stalenessFactor×TTL (0 = fresh).
+func seedLKGCache(t *testing.T, e discoverycache.Entry, stale time.Duration) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "devices.json")
+	c, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	now := time.Now().Add(-stale)
+	c.Upsert(e, now)
+	if err := c.Flush(now); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	orig := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
+	t.Cleanup(func() { deviceCacheLoadFn = orig })
+}
+
+func TestConnectFastPathStaleEntryZeroResolution(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2,
+	}, 3*discoverycache.TTL) // well past the display TTL
+
+	resolverCalls := 0
+	origLookup, origBrowse := osLookupHostFn, lanBrowseFn
+	osLookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		resolverCalls++
+		return nil, errors.New("resolver must not run on an LKG hit")
+	}
+	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
+		resolverCalls++
+		return nil, errors.New("browse must not run on an LKG hit")
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		if e.IP != "10.0.0.9" || e.Port != 50052 {
+			t.Errorf("LKG got entry %s:%d, want 10.0.0.9:50052", e.IP, e.Port)
+		}
+		return want, nil, true
+	}
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		t.Errorf("general ladder ran despite LKG success (addr %s)", addr)
+		return nil, nil, errors.New("unreachable")
+	}
+	t.Cleanup(func() {
+		osLookupHostFn, lanBrowseFn = origLookup, origBrowse
+		dialAgentLKGFn, dialAgentLadderFn = origLKG, origLadder
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "orin.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want the LKG connection", conn, err)
+	}
+	if resolverCalls != 0 {
+		t.Errorf("resolver invoked %d times on a stale-entry LKG hit, want 0 (any-age fast path)", resolverCalls)
+	}
+}
+
+func TestConnectFastPathLKGFailureFallsThroughToLadder(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "orin.local", IP: "10.0.0.9", Port: 50052, MTLS: true,
+	}, 0)
+
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		return nil, nil, false // dead IP: pre-check failed
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	var ladderAddr string
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = addr
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() {
+		dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach
+	})
+
+	conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "orin.local:50051")
+	if err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection after LKG fall-through", conn, err)
+	}
+	if ladderAddr != "10.0.0.9:50051" {
+		t.Errorf("ladder addr = %q, want cached-IP fallback 10.0.0.9:50051", ladderAddr)
+	}
+}
+
+func TestConnectFastPathNonMTLSEntrySkipsLKG(t *testing.T) {
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
+	}, 0)
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, bool) {
+		t.Error("LKG ran for a non-mTLS entry")
+		return nil, nil, false
+	}
+	want := &grpcclient.AgentConnection{IsMTLS: true}
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
+		return want, nil, nil
+	}
+	origReach := cacheFastPathReachableFn
+	cacheFastPathReachableFn = func(ctx context.Context, conn *grpcclient.AgentConnection, err error) bool { return true }
+	t.Cleanup(func() { dialAgentLKGFn, dialAgentLadderFn, cacheFastPathReachableFn = origLKG, origLadder, origReach })
+
+	if conn, _, err := connectWithAutoTLSDiagnostics(context.Background(), "pi.local:50051"); err != nil || conn != want {
+		t.Fatalf("connect = (%v, %v), want ladder connection", conn, err)
+	}
+}
+```
+
+Adjust seam names to the actual ones if they differ (`osLookupHostFn`/`lanBrowseFn` exist on the base branch in `helpers.go` — verify signatures before writing).
+
+- [ ] **Step 2: Run**
+
+Run: `go test ./go/internal/cli/commands/ -run 'TestConnectFastPath' -count=5 -v`
+Expected: all PASS, no flakes.
+
+- [ ] **Step 3: Full suite + commit**
+
+Run: `go test ./go/internal/cli/commands/ -count=1`
+
+```bash
+git add go/internal/cli/commands/helpers_lkg_test.go
+git commit -m "test(cli): LKG connect-flow integration coverage
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full verification, push, stacked draft PR
+
+- [ ] **Step 1: gofmt + build + suites**
+
+```bash
+gofmt -l .
+go build ./go/...
+go test ./go/internal/cli/commands/ ./go/internal/shared/discoverycache/ ./go/internal/cli/grpcclient/ -count=1
+```
+Expected: gofmt empty; build clean; all green. Report (don't broadly fix) any failure not caused by this branch's files.
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin ed/lkg-connect-cache
+gh pr create --draft --base ed/instant-mdns-discovery --title "Last-known-good connect: any-age cache, bounded dead-IP cost, mTLS-port + org-cert first" --body "$(cat <<'EOF'
+## Summary
+Delta over #1616's device-cache connect fast path, closing its four remaining gaps:
+
+- **Any-age lookup** for connects (`Entries()` + most-recent-wins): the 1h TTL stays a display bound; the first command after a quiet morning no longer pays ~1.3s of mDNS resolution.
+- **Bounded dead-IP cost**: a 1s TCP pre-check (`lkgTCPConnectTimeout`) before the direct dial — previously a dead cached IP could burn up to ~17s of ladder probes before the stale retry.
+- **mTLS-port-first + org-cert-first direct dial** (`dialAgentLKG`): skips the plaintext-port ladder step and, for multi-org users, the ~1-2s-per-wrong-cert device-side handshakes (`rotateCertsForOrg`).
+- **Endpoint-faithful write-back**: `cacheConnectSuccess` now stores the actually-dialed port + `MTLS` + observed `OrgID` (new `AgentConnection.Addr`), fixing the base's clobbering of discovery's advertised mTLS port with 50051.
+
+Trust unchanged: the cache is routing only — same certs, verifiers, pins; every failure falls through to the existing resolution + ladder + stale-retry flow. Composes with #1612's session resumption once both merge (same address ⇒ same ticket).
+
+Spec: `specs/2026-08-08-lkg-connect-cache-design.md`
+
+## Verification
+- [x] Unit + connect-flow integration tests (any-age zero-resolution, dead-IP fall-through, non-mTLS skip, rotation, write-back fidelity)
+- [ ] On-device: with a >1h-old cache entry, `wendy device info --device <name>.local` skips resolution; dead-IP fallback ≤1s + normal retry
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Update project memory** with the PR number and the on-device gate.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 any-age → Task 1; §2 direct dial/rotation/TCP bound/debug lines → Tasks 2-3; §3 write-back fidelity → Task 4; §4 trust (no changes — enforced by reusing the ladder verbatim); §5/§6 → Task 5 tests + Task 6's PR gate.
+- **Seam inventory relied on:** existing on base — `deviceCacheLoadFn`, `dialAgentLadderFn`, `cacheFastPathReachableFn`, `osLookupHostFn`, `lanBrowseFn`; added here — `dialAgentLadderWithCertsFn`, `dialAgentLKGFn`, `tcpDialTimeoutFn`, `loadAllCLICertsFn`. Implementers must verify each existing seam's exact name/signature in `helpers.go` before use.
+- **Known accepted behavior:** after an LKG failure the fromCache ladder may re-attempt the same mTLS endpoint once (redundant handshake in failure paths only); plaintext-downgrade during LKG closes the connection and falls through.


### PR DESCRIPTION
## Summary
Delta over #1616's device-cache connect fast path, closing its four remaining gaps:

- **Any-age lookup** for connects (`Entries()` + most-recent-wins): the 1h TTL stays a display bound; the first command after a quiet morning no longer pays ~1.3s of mDNS resolution.
- **Bounded dead-IP cost**: a 1s TCP pre-check (`lkgTCPConnectTimeout`) gates every cache-derived dial, not just the direct dial — a dead cached IP never enters the cached-IP ladder at all; it falls straight through to fresh resolution instead (previously a dead cached IP could burn up to ~17s of ladder probes first). A live-but-failed-handshake cached IP still gets the full cached-IP ladder + stale-retry diagnostics, unchanged.
- **mTLS-port-first + org-cert-first direct dial** (`dialAgentLKG`): skips the plaintext-port ladder step and, for multi-org users, the ~1-2s-per-wrong-cert device-side handshakes (`rotateCertsForOrg`).
- **Endpoint-faithful write-back**: `cacheConnectSuccess` now stores the actually-dialed port + `MTLS` + observed `OrgID` (new `AgentConnection.Addr`), fixing the base's clobbering of discovery's advertised mTLS port with 50051.

Trust unchanged: the cache is routing only — same certs, verifiers, pins; every failure falls through to the existing resolution + ladder + stale-retry flow. Composes with #1612's session resumption once both merge (same address ⇒ same ticket).

Spec: `specs/2026-08-08-lkg-connect-cache-design.md`

## Verification
- [x] Unit + connect-flow integration tests (any-age zero-resolution, dead-IP fall-through to fresh resolution vs. live-but-failed fall-through to the cached-IP ladder, LKG-ineligible dead/live TCP pre-check, rotation, write-back fidelity)
- [x] On-device — **verified 2026-08-08** on a live LAN (Jetson Orin Nano, macOS CLI): 2h-stale cache entry → LKG direct dial, **241–491ms** mTLS phase with zero resolution (vs ~1.5s resolution-dominated baseline); poisoned dead-IP entry → `tcp pre-check failed` at 1s, fresh resolution, connect at **2.3s total** (vs ~17s unbounded pre-fix), cache self-healed to the live IP on success. Note for follow-ups: background version-probe sweeps under cancelled contexts log `lkg …: direct dial failed: <nil>` — harmless but the line should name the plaintext-downgrade/ctx-cancel cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

