### PR TITLE
perf(cli): cut a warm `wendy run --detach` from ~1.57s to ~300ms

### DIFF
--- a/go/internal/cli/commands/certorder.go
+++ b/go/internal/cli/commands/certorder.go
@@ -1,0 +1,158 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// The mTLS dial path probes every CLI certificate against a device until one
+// is accepted (see connectResolvedAgent). The probe order is the order the
+// certs happen to load in, so an operator holding certificates for several
+// organisations pays a full, doomed TLS handshake plus a GetAgentVersion probe
+// for every org that isn't the device's — on every single command. Measured
+// against a device on the second of two orgs, that wasted attempt was roughly
+// half of a ~250ms connect, and TLS session resumption cannot recover it: a
+// rejected first attempt is a fresh handshake by definition.
+//
+// Remembering which organisation last worked for a host and probing that one
+// first removes the waste. The memo is a pure optimisation with no security
+// weight: it only reorders candidates, never adds one, and a stale or wrong
+// entry costs exactly what today's behaviour costs, because the remaining
+// certs are still probed in their original order behind it.
+
+// certOrderMemo maps a device host to the organisation ID of the certificate
+// that last completed a probe against it.
+type certOrderMemo struct {
+	Hosts map[string]int `json:"hosts"`
+}
+
+// certOrderMu serialises the read-modify-write of the memo file so two
+// concurrent commands can't clobber each other's entries.
+var certOrderMu sync.Mutex
+
+// certOrderCacheDir resolves the base cache directory. Indirected through a
+// variable so tests can redirect the memo instead of writing to the developer's
+// real cache (os.UserCacheDir ignores XDG_CACHE_HOME on macOS).
+var certOrderCacheDir = os.UserCacheDir
+
+func certOrderPath() (string, error) {
+	cacheDir, err := certOrderCacheDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(cacheDir, "wendy")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "certorder.json"), nil
+}
+
+func loadCertOrderMemo() certOrderMemo {
+	memo := certOrderMemo{Hosts: map[string]int{}}
+	path, err := certOrderPath()
+	if err != nil {
+		return memo
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return memo
+	}
+	// A corrupt memo is indistinguishable from no memo for our purposes: both
+	// mean "no hint", and the probe loop behaves exactly as it did before.
+	var parsed certOrderMemo
+	if err := json.Unmarshal(data, &parsed); err != nil || parsed.Hosts == nil {
+		return memo
+	}
+	return parsed
+}
+
+// preferredCertOrg returns the organisation ID that last authenticated against
+// host, if one is remembered.
+func preferredCertOrg(host string) (int, bool) {
+	if host == "" {
+		return 0, false
+	}
+	certOrderMu.Lock()
+	defer certOrderMu.Unlock()
+	org, ok := loadCertOrderMemo().Hosts[host]
+	return org, ok
+}
+
+// rememberCertOrg records that org authenticated against host. Best-effort:
+// the memo is a cache, so a write failure only costs the next command the
+// wasted probe it would have paid anyway.
+func rememberCertOrg(host string, org int) {
+	if host == "" {
+		return
+	}
+	certOrderMu.Lock()
+	defer certOrderMu.Unlock()
+
+	memo := loadCertOrderMemo()
+	if existing, ok := memo.Hosts[host]; ok && existing == org {
+		// Already correct — skip the write so the common (warm) path doesn't
+		// touch the disk on every command.
+		return
+	}
+	memo.Hosts[host] = org
+
+	path, err := certOrderPath()
+	if err != nil {
+		return
+	}
+	data, err := json.Marshal(memo)
+	if err != nil {
+		return
+	}
+	// Write via a temp file + rename so a crash mid-write can't leave a
+	// truncated memo behind.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".certorder-*.json")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+	}
+}
+
+// orderCertsByOrg returns certs with those belonging to org moved to the
+// front, preserving the relative order within both groups.
+//
+// Returns the input untouched when there is no hint or nothing matches, so the
+// caller's probe order is unchanged in exactly the cases where the memo has
+// nothing useful to say. The slice is copied rather than sorted in place: the
+// caller's slice comes from loadAllCLICerts and is indexed elsewhere.
+func orderCertsByOrg(certs []config.CertificateInfo, org int, have bool) []config.CertificateInfo {
+	if !have || len(certs) < 2 {
+		return certs
+	}
+	ordered := make([]config.CertificateInfo, 0, len(certs))
+	for _, c := range certs {
+		if c.OrganizationID == org {
+			ordered = append(ordered, c)
+		}
+	}
+	if len(ordered) == 0 || len(ordered) == len(certs) {
+		return certs
+	}
+	for _, c := range certs {
+		if c.OrganizationID != org {
+			ordered = append(ordered, c)
+		}
+	}
+	return ordered
+}

--- a/go/internal/cli/commands/certorder_test.go
+++ b/go/internal/cli/commands/certorder_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func certsForOrgs(orgs ...int) []config.CertificateInfo {
+	certs := make([]config.CertificateInfo, 0, len(orgs))
+	for _, o := range orgs {
+		certs = append(certs, config.CertificateInfo{OrganizationID: o})
+	}
+	return certs
+}
+
+func orgsOf(certs []config.CertificateInfo) []int {
+	orgs := make([]int, 0, len(certs))
+	for _, c := range certs {
+		orgs = append(orgs, c.OrganizationID)
+	}
+	return orgs
+}
+
+func equalOrgs(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestOrderCertsByOrg(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []int
+		org  int
+		have bool
+		want []int
+	}{
+		{
+			// The case this exists for: device is on the second org, so the
+			// default order wastes a full handshake on org 2 every command.
+			name: "moves the remembered org to the front",
+			in:   []int{2, 9}, org: 9, have: true,
+			want: []int{9, 2},
+		},
+		{
+			name: "keeps relative order of the remaining certs",
+			in:   []int{2, 5, 9, 7}, org: 9, have: true,
+			want: []int{9, 2, 5, 7},
+		},
+		{
+			name: "keeps relative order among certs sharing the remembered org",
+			in:   []int{2, 9, 9, 5}, org: 9, have: true,
+			want: []int{9, 9, 2, 5},
+		},
+		{
+			// A stale memo must cost nothing beyond today's behaviour.
+			name: "unknown org leaves the order untouched",
+			in:   []int{2, 9}, org: 42, have: true,
+			want: []int{2, 9},
+		},
+		{
+			name: "no memo leaves the order untouched",
+			in:   []int{2, 9}, org: 0, have: false,
+			want: []int{2, 9},
+		},
+		{
+			name: "single cert is returned untouched",
+			in:   []int{9}, org: 9, have: true,
+			want: []int{9},
+		},
+		{
+			name: "all certs sharing the org leaves the order untouched",
+			in:   []int{9, 9}, org: 9, have: true,
+			want: []int{9, 9},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := certsForOrgs(tc.in...)
+			got := orderCertsByOrg(in, tc.org, tc.have)
+			if !equalOrgs(orgsOf(got), tc.want) {
+				t.Errorf("orderCertsByOrg(%v, %d, %v) = %v, want %v", tc.in, tc.org, tc.have, orgsOf(got), tc.want)
+			}
+			// Reordering must never drop or invent a candidate: the dial loop
+			// still has to be able to reach every cert the user holds.
+			if len(got) != len(tc.in) {
+				t.Errorf("orderCertsByOrg returned %d certs, want %d", len(got), len(tc.in))
+			}
+			// The caller's slice is indexed elsewhere, so it must not be
+			// reordered in place.
+			if !equalOrgs(orgsOf(in), tc.in) {
+				t.Errorf("orderCertsByOrg mutated its input: got %v, want %v", orgsOf(in), tc.in)
+			}
+		})
+	}
+}
+
+// withTempCertOrderCache redirects the memo at its resolver so the test never
+// touches the developer's real cache directory on any platform.
+func withTempCertOrderCache(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	prev := certOrderCacheDir
+	certOrderCacheDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { certOrderCacheDir = prev })
+}
+
+func TestCertOrgMemoRoundTrip(t *testing.T) {
+	withTempCertOrderCache(t)
+
+	if _, ok := preferredCertOrg("example-roundtrip.local"); ok {
+		t.Fatal("preferredCertOrg reported a hit against an empty cache")
+	}
+
+	rememberCertOrg("example-roundtrip.local", 9)
+	got, ok := preferredCertOrg("example-roundtrip.local")
+	if !ok || got != 9 {
+		t.Fatalf("preferredCertOrg after remember = (%d, %v), want (9, true)", got, ok)
+	}
+
+	// A later successful connect on a different org must replace the entry,
+	// not accumulate — otherwise a device that moves orgs stays slow forever.
+	rememberCertOrg("example-roundtrip.local", 2)
+	got, ok = preferredCertOrg("example-roundtrip.local")
+	if !ok || got != 2 {
+		t.Fatalf("preferredCertOrg after re-remember = (%d, %v), want (2, true)", got, ok)
+	}
+}
+
+// TestCertOrgMemoSurvivesCorruptFile pins the fallback: a corrupt memo must
+// read as "no hint" so the dial loop behaves exactly as it did before, rather
+// than erroring out a connection over a cache file.
+func TestCertOrgMemoSurvivesCorruptFile(t *testing.T) {
+	withTempCertOrderCache(t)
+
+	path, err := certOrderPath()
+	if err != nil {
+		t.Fatalf("certOrderPath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("writing corrupt memo: %v", err)
+	}
+	if _, ok := preferredCertOrg("example-corrupt.local"); ok {
+		t.Error("preferredCertOrg reported a hit from a corrupt memo")
+	}
+	// A corrupt file must not wedge future writes either.
+	rememberCertOrg("example-corrupt.local", 9)
+	if got, ok := preferredCertOrg("example-corrupt.local"); !ok || got != 9 {
+		t.Errorf("preferredCertOrg after recovery = (%d, %v), want (9, true)", got, ok)
+	}
+}
+
+func TestPreferredCertOrgEmptyHost(t *testing.T) {
+	withTempCertOrderCache(t)
+	if _, ok := preferredCertOrg(""); ok {
+		t.Error("preferredCertOrg(\"\") reported a hit; an empty host must never match")
+	}
+	// Must not panic or write a bogus entry.
+	rememberCertOrg("", 9)
+}

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -361,7 +361,6 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 	return true, nil
 }
 
-
 // containerExitDetail returns a short human summary of why appID's container
 // stopped (e.g. "container crashed (exit 1)"), or "" if it's running, the cause
 // wasn't recorded, or the lookup fails. Best-effort — it exists only to enrich

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -337,7 +337,10 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 		// The container is untouched, so the agent-side (in-container) hook can't
 		// be re-run, but fire the host-side postStart hook so `wendy run` behaves
 		// the same whether or not it took the fast path (e.g. re-opening the URL).
-		runPostStartHostHook(ctx, conn, appCfg)
+		// No host-side postStart hook: the fast path only ever runs detached
+		// (see the opts.detach gate on tryDeployFastPath's caller), and
+		// detached deploys don't block on readiness — see
+		// runPostStartIfReady's doc comment.
 		return true, nil
 	}
 
@@ -353,20 +356,11 @@ func tryDeployFastPath(ctx context.Context, conn *grpcclient.AgentConnection, ap
 		return false, nil
 	}
 	cliLogln("No changes detected; started existing %s.", containerDisplayName(appCfg))
-	runPostStartHostHook(ctx, conn, appCfg)
+	// No host-side postStart hook here either — see runPostStartIfReady's doc
+	// comment for why detached deploys skip it.
 	return true, nil
 }
 
-// runPostStartHostHook mirrors the normal detached deploy path's host-side
-// postStart handling: wait for readiness, then announce the reachable URL and
-// fire the host hook fire-and-forget on a background context so it outlives
-// the CLI process. A failed readiness probe skips both (see
-// runPostStartIfReady). The agent-side (in-container) hook is attached
-// separately to the StartContainer RPC's context, so it only runs when the
-// fast path actually (re)starts the container.
-func runPostStartHostHook(ctx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) {
-	runPostStartIfReady(ctx, context.Background(), conn, appCfg)
-}
 
 // containerExitDetail returns a short human summary of why appID's container
 // stopped (e.g. "container crashed (exit 1)"), or "" if it's running, the cause

--- a/go/internal/cli/commands/deployfastpath_hooks_test.go
+++ b/go/internal/cli/commands/deployfastpath_hooks_test.go
@@ -127,9 +127,23 @@ func waitForFile(t *testing.T, path string, timeout time.Duration) {
 	t.Fatalf("host-side postStart hook did not run: %s was never created", path)
 }
 
-// TestTryDeployFastPath_StoppedRunsPostStartHooks verifies the fast path fires
-// BOTH postStart hooks when it starts a stopped-but-unchanged app: the agent-side
-// (in-container) hook via StartContainer metadata, and the host-side hook.
+// requireFileAbsent asserts path is still missing after grace. The host-side
+// hook was historically fire-and-forget, so a bare Stat right after the call
+// could pass simply by racing it; waiting out a grace period keeps the
+// assertion meaningful.
+func requireFileAbsent(t *testing.T, path string, grace time.Duration) {
+	t.Helper()
+	time.Sleep(grace)
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("host-side postStart hook ran but should not have: %s exists", path)
+	}
+}
+
+// TestTryDeployFastPath_StoppedRunsPostStartHooks verifies which postStart
+// hook the fast path fires when it starts a stopped-but-unchanged app: the
+// agent-side (in-container) hook via StartContainer metadata runs, and the
+// host-side hook does NOT. The fast path only ever runs detached, and detached
+// deploys skip the readiness probe the host hook is gated on.
 func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
 	isolateFingerprintCache(t)
 
@@ -176,9 +190,12 @@ func TestTryDeployFastPath_StoppedRunsPostStartHooks(t *testing.T) {
 		t.Fatalf("agent postStart hook metadata = %#v, want [%q]", got, agentHook)
 	}
 
-	// Host-side CLI postStart hook must fire (fire-and-forget → poll briefly).
+	// Host-side CLI postStart hook must NOT fire: the fast path only runs
+	// detached, and detached deploys no longer block on the readiness probe
+	// that gates the host hook (see runPostStartIfReady's doc comment). The
+	// agent-side hook asserted above is what still runs.
 	if runtime.GOOS != "windows" {
-		waitForFile(t, sentinel, 3*time.Second)
+		requireFileAbsent(t, sentinel, 300*time.Millisecond)
 	}
 }
 
@@ -215,10 +232,11 @@ func TestStreamRunContainer_AttachedFiresHostPostStartHook(t *testing.T) {
 	}
 }
 
-// TestTryDeployFastPath_RunningFiresHostPostStartHook verifies that when the app
-// is already running and unchanged, the fast path still fires the host-side
-// postStart hook (so `wendy run` behaves the same regardless of the fast path)
-// without restarting the container.
+// TestTryDeployFastPath_RunningFiresHostPostStartHook verifies that when the
+// app is already running and unchanged, the fast path neither restarts the
+// container nor fires the host-side postStart hook. The hook is gated on a
+// readiness probe that costs the app's full boot time, which detached runs —
+// the only kind the fast path serves — must not pay.
 func TestTryDeployFastPath_RunningFiresHostPostStartHook(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("host-side hook uses `touch`, unavailable on Windows")
@@ -254,5 +272,8 @@ func TestTryDeployFastPath_RunningFiresHostPostStartHook(t *testing.T) {
 	if fake.startCalls != 0 {
 		t.Fatalf("StartContainer should not be called for an already-running app, got %d calls", fake.startCalls)
 	}
-	waitForFile(t, sentinel, 3*time.Second)
+	// Detached deploys no longer run the host-side postStart hook — it is
+	// gated on a readiness probe that costs the app's whole boot time, which
+	// --detach and --watch must not pay (see runPostStartIfReady).
+	requireFileAbsent(t, sentinel, 300*time.Millisecond)
 }

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1270,6 +1270,13 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 	if len(allCerts) > 0 {
 		pins := openPinStore()
 		host, portStr, _ := net.SplitHostPort(plaintextAddr)
+		// Probe the organisation that last authenticated against this host
+		// first. With certs for several orgs loaded, the default order makes
+		// every command pay a doomed handshake per non-matching org (see
+		// certorder.go). Purely a reordering — the remaining certs still follow
+		// in their original order, so a stale hint costs nothing extra.
+		preferredOrg, havePreferredOrg := preferredCertOrg(host)
+		allCerts = orderCertsByOrg(allCerts, preferredOrg, havePreferredOrg)
 		if port, err := strconv.Atoi(portStr); err == nil {
 			// Try the given port first (covers explicit tunnel ports that already
 			// point at the mTLS port), then fall back to port+1 (the normal case
@@ -1310,6 +1317,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 					_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 					cancel()
 					if probeErr == nil {
+						rememberCertOrg(host, allCerts[i].OrganizationID)
 						return conn, nil, nil
 					}
 					recordMTLSErr(mtlsAddr, probeErr)
@@ -2464,7 +2472,10 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, excludeBl
 		return nil, fmt.Errorf("device picker: %w", err)
 	}
 
-	pm := finalModel.(tui.PickerModel)
+	pm, ok := finalModel.(tui.PickerModel)
+	if !ok {
+		return nil, fmt.Errorf("device picker returned unexpected model %T", finalModel)
+	}
 	if pm.Cancelled() {
 		return nil, ErrUserCancelled
 	}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/analytics"
-	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/env"
@@ -44,9 +43,11 @@ func NewRootCmd() *cobra.Command {
 				jsonOutput = true
 			}
 
+			// Provider availability is probed lazily on first use (see
+			// providers.ensureAvailable) rather than here: the probes shell out
+			// to `docker`/`container` and most commands never consult a
+			// provider at all.
 			premark := phaseTimer()
-			providers.Initialize(cmd.Context())
-			premark("  prerun: providers.Initialize")
 
 			cfg, err := config.Load()
 			if err != nil {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1967,8 +1967,11 @@ func synthesizedOpenURLHook(appCfg *appconfig.AppConfig) *appconfig.HooksConfig 
 // context.Background() so the hook outlives the CLI. Returns the hook's cmd
 // for the caller to reap, nil when no CLI hook ran.
 func runPostStartIfReady(ctx, hookCtx context.Context, conn *grpcclient.AgentConnection, appCfg *appconfig.AppConfig) *exec.Cmd {
+	rp := phaseTimer()
 	readiness := effectiveReadiness(appCfg)
-	if err := waitForReadiness(ctx, readiness, conn.Host); err != nil {
+	err := waitForReadiness(ctx, readiness, conn.Host)
+	rp("  ↳ runcontainer: readiness wait")
+	if err != nil {
 		if ctx.Err() == nil {
 			warnReadiness(ctx, conn, appCfg.AppID, err)
 			if appCfg.Hooks != nil && appCfg.Hooks.PostStart != nil &&
@@ -1995,7 +1998,9 @@ func runPostStartIfReady(ctx, hookCtx context.Context, conn *grpcclient.AgentCon
 		clone.Hooks = hooks
 		effectiveCfg = &clone
 	}
-	return startPostStartHook(hookCtx, effectiveCfg, hookHost, appCfg.ServiceName)
+	cmd := startPostStartHook(hookCtx, effectiveCfg, hookHost, appCfg.ServiceName)
+	rp("  ↳ runcontainer: announce + postStart hook")
+	return cmd
 }
 
 // startPostStartHook fires the postStart hook actions for appCfg. serviceName
@@ -2093,6 +2098,11 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 	// when the stream ends (matching startAndStreamContainer's runCtx handling).
 	// Cleanup runs in a defer so the hook is killed and reaped on every exit
 	// path, including stream errors.
+	// Splits the runcontainer phase into its device-side and host-side halves:
+	// everything up to Started is the agent creating and starting the
+	// container, everything after is the CLI waiting on the app and firing
+	// hooks. They have completely different causes when one is slow.
+	rc := phaseTimer()
 	hookCtx, hookCancel := context.WithCancel(ctx)
 	var postStartCmd *exec.Cmd
 	defer func() {
@@ -2111,6 +2121,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 			return fmt.Errorf("receiving container output: %w", err)
 		}
 		if resp.GetStarted() != nil {
+			rc("  ↳ runcontainer: device create+start")
 			if opts.deploy {
 				cliLogln("Container %s created (not started).", containerDisplayName(appCfg))
 				return nil

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -565,7 +565,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.builder, "builder", "", "Image builder to force for Dockerfile/Containerfile builds: docker, apple-container, or buildkit")
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Enable debug logging")
 	cmd.Flags().BoolVar(&opts.deploy, "deploy", false, "Create container but do not start it")
-	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container but do not stream logs")
+	cmd.Flags().BoolVar(&opts.detach, "detach", false, "Start container and return without streaming logs, waiting for readiness, or opening the app URL")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Automatically accept all interactive prompts")
 	cmd.Flags().BoolVar(&opts.restartUnlessStopped, "restart-unless-stopped", false, "Restart unless manually stopped")
 	cmd.Flags().BoolVar(&opts.restartOnFailure, "restart-on-failure", false, "Restart on failure")
@@ -1723,9 +1723,8 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 			return fmt.Errorf("waiting for container start: %w", err)
 		}
 		cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
-		// Announce + fire-and-forget post-start hook (outlives the CLI process),
-		// but only if the app passes readiness.
-		runPostStartIfReady(ctx, context.Background(), conn, appCfg)
+		// Detached returns as soon as the container is started — see
+		// runPostStartIfReady's doc comment.
 		return nil
 	}
 
@@ -1963,6 +1962,23 @@ func synthesizedOpenURLHook(appCfg *appconfig.AppConfig) *appconfig.HooksConfig 
 // probe reported a success that never happened — "App reachable at ..." and a
 // browser tab pointed at a container that had already exited.
 //
+// ATTACHED RUNS ONLY. Detached deploys (--detach, and --watch, which sets
+// opts.detach) never call this. The readiness probe waits out the app's own
+// boot — measured at ~500-660ms for a trivial Python app, several times the
+// CLI's entire remaining overhead — which an attached run can afford because
+// it stays to stream logs anyway, but a detached run cannot: its whole point
+// is to return once the container is started, and --watch paid that wait on
+// every single redeploy.
+//
+// The host-side hook goes with it rather than being fired early, because it
+// is only meaningful once the app is listening: an app declaring an `http`
+// entitlement gets an openURL hook synthesized automatically (see
+// synthesizedOpenURLHook), so firing it without the gate would open a browser
+// at a port nothing is bound to yet — and in watch mode, one per redeploy.
+//
+// The agent-side (in-container) hook is unaffected: it rides on the
+// RunContainer/StartContainer RPC context and still runs on the device.
+//
 // hookCtx bounds the hook's CLI child process; detached callers pass
 // context.Background() so the hook outlives the CLI. Returns the hook's cmd
 // for the caller to reap, nil when no CLI hook ran.
@@ -2128,11 +2144,10 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 			}
 			if opts.detach {
 				// Mirror startAndStreamContainer's detach branch: the container
-				// is started; wait for readiness, fire the host post-start hook,
-				// then return without tailing logs. The container keeps running
-				// independently of this (now-abandoned) output stream.
+				// is started, so return without tailing logs or waiting on
+				// readiness (see runPostStartIfReady's doc comment). The container keeps
+				// running independently of this (now-abandoned) output stream.
 				cliLogln("Application %s running in detached mode.", containerDisplayName(appCfg))
-				runPostStartIfReady(ctx, context.Background(), conn, appCfg)
 				return nil
 			}
 			// Attached: mirror startAndStreamContainer's attached branch — wait

--- a/go/internal/cli/providers/registry.go
+++ b/go/internal/cli/providers/registry.go
@@ -2,12 +2,15 @@ package providers
 
 import (
 	"context"
+	"strings"
 	"sync"
+	"time"
 )
 
 var (
 	allProviders       []DeviceProvider
 	availableProviders []DeviceProvider
+	availableOnce      sync.Once
 	mu                 sync.RWMutex
 )
 
@@ -20,21 +23,58 @@ func init() {
 	}
 }
 
-// Initialize probes each registered provider and filters to those that are
-// currently available. Call this once at CLI startup.
-func Initialize(ctx context.Context) {
-	mu.Lock()
-	defer mu.Unlock()
+// availabilityProbeTimeout bounds the whole availability sweep. The probes are
+// `--version` calls that normally answer in well under a second; the cap is
+// here so a wedged container runtime can't hang every CLI command that needs
+// the provider list.
+const availabilityProbeTimeout = 5 * time.Second
 
-	availableProviders = nil
-	for _, p := range allProviders {
-		if p.IsAvailable(ctx) {
-			availableProviders = append(availableProviders, p)
+// ensureAvailable probes each registered provider exactly once, concurrently,
+// and caches the providers that reported themselves available.
+//
+// The probe is lazy and parallel because it is neither free nor always needed:
+// two of the four providers shell out (`docker --version`, `container
+// --version`), ~88ms each on a warm macOS box. Running them sequentially at
+// CLI startup put ~175ms in front of EVERY command — including the common
+// `wendy run` against a device hostname, which never consults a provider at
+// all. Probing on first use keeps that cost off commands that don't need it,
+// and probing concurrently makes the sweep cost the slowest single probe
+// rather than their sum.
+func ensureAvailable() {
+	availableOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), availabilityProbeTimeout)
+		defer cancel()
+
+		// Index-addressed so each goroutine owns its own slot and no lock is
+		// needed during the sweep. Compacting in index order afterwards
+		// preserves allProviders' registration order, which callers such as the
+		// device picker rely on for stable output.
+		probed := make([]DeviceProvider, len(allProviders))
+		var wg sync.WaitGroup
+		for i, p := range allProviders {
+			wg.Go(func() {
+				if p.IsAvailable(ctx) {
+					probed[i] = p
+				}
+			})
 		}
-	}
+		wg.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+		availableProviders = nil
+		for _, p := range probed {
+			if p != nil {
+				availableProviders = append(availableProviders, p)
+			}
+		}
+	})
 }
 
+// AvailableProviders returns the providers whose toolchain is present on this
+// machine, probing them on first call.
 func AvailableProviders() []DeviceProvider {
+	ensureAvailable()
 	mu.RLock()
 	defer mu.RUnlock()
 	return availableProviders
@@ -42,14 +82,35 @@ func AvailableProviders() []DeviceProvider {
 
 // AllProviders returns all registered providers regardless of toolchain availability.
 // Use this for device discovery where you want to find devices even if you can't
-// build for them.
+// build for them. This is static registration data, so it never triggers a probe.
 func AllProviders() []DeviceProvider {
 	mu.RLock()
 	defer mu.RUnlock()
 	return allProviders
 }
 
+// isNetworkAddressKey reports whether key is a network address rather than a
+// possible provider key.
+//
+// Every built-in provider key is a short dotless token ("docker",
+// "apple-container", "local", "wendy-lite"), so a key carrying a "." or a
+// leading "[" is an address — a ".local" mDNS name, a hostname, an IPv4
+// literal, or a bracketed IPv6 — and can never match one. This mirrors the
+// same short-circuit resolveTargetInner applies before its findDeviceByID
+// provider sweep.
+func isNetworkAddressKey(key string) bool {
+	return strings.Contains(key, ".") || strings.HasPrefix(key, "[")
+}
+
+// ProviderForKey returns the available provider registered under key, or nil.
 func ProviderForKey(key string) DeviceProvider {
+	// Rejecting addresses before ensureAvailable keeps `wendy run` against a
+	// device hostname — the common case — from paying for the provider probes
+	// at all.
+	if isNetworkAddressKey(key) {
+		return nil
+	}
+	ensureAvailable()
 	mu.RLock()
 	defer mu.RUnlock()
 	for _, p := range availableProviders {

--- a/go/internal/cli/providers/registry_test.go
+++ b/go/internal/cli/providers/registry_test.go
@@ -1,0 +1,70 @@
+package providers
+
+import "testing"
+
+// TestIsNetworkAddressKey pins the predicate that keeps `wendy run` against a
+// device hostname from paying for the provider availability probes. Both
+// directions matter: a real provider key must still reach the registry lookup,
+// and every address shape the device flag accepts must short-circuit.
+func TestIsNetworkAddressKey(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want bool
+	}{
+		// Real provider keys — must NOT be treated as addresses, or the
+		// providers would become unreachable via --device.
+		{ProviderKeyDocker, false},
+		{ProviderKeyAppleContainer, false},
+		{ProviderKeyLocal, false},
+		{"wendy-lite", false},
+		{"", false},
+
+		// Address shapes the device flag accepts.
+		{"spark-3011.local", true},
+		{"spark-3011.local:50051", true},
+		{"192.168.0.24", true},
+		{"192.168.0.24:50051", true},
+		{"[fe80::1]", true},
+		{"[fe80::1]:50051", true},
+	} {
+		if got := isNetworkAddressKey(tc.key); got != tc.want {
+			t.Errorf("isNetworkAddressKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestProviderForKeyRejectsNetworkAddresses covers the same short-circuit at
+// the exported boundary: an address never resolves to a provider, regardless
+// of which providers happen to be available on the machine running the test.
+func TestProviderForKeyRejectsNetworkAddresses(t *testing.T) {
+	for _, key := range []string{"spark-3011.local", "192.168.0.24:50051", "[fe80::1]"} {
+		if p := ProviderForKey(key); p != nil {
+			t.Errorf("ProviderForKey(%q) = %v, want nil", key, p.Key())
+		}
+	}
+}
+
+// TestAllProvidersNeedsNoProbe asserts the static registration list is served
+// without consulting availability — AllProviders is used by discovery paths
+// that want every provider even when its toolchain is missing, so making it
+// probe would reintroduce the startup cost this file exists to avoid.
+func TestAllProvidersNeedsNoProbe(t *testing.T) {
+	got := AllProviders()
+	if len(got) != len(allProviders) {
+		t.Fatalf("AllProviders() returned %d providers, want %d", len(got), len(allProviders))
+	}
+}
+
+// TestAvailableProvidersIsStable checks the lazy probe is idempotent: repeated
+// calls must return the same set rather than re-probing and appending.
+func TestAvailableProvidersIsStable(t *testing.T) {
+	first := AvailableProviders()
+	second := AvailableProviders()
+	if len(first) != len(second) {
+		t.Fatalf("AvailableProviders() returned %d then %d providers; probe is not idempotent", len(first), len(second))
+	}
+	// LocalProvider always reports available, so the probe must find at least it.
+	if len(first) == 0 {
+		t.Fatal("AvailableProviders() returned nothing; LocalProvider is unconditionally available")
+	}
+}


### PR DESCRIPTION
Four independent CLI latency fixes found by profiling `wendy run --detach` against a Spark (linux/arm64) with `WENDY_TIMING=1`. Each commit stands alone and can be dropped without affecting the others.

cc @EBro912 — the measurements here lean heavily on your #1610 native-layer path; details at the bottom.

## Measured effect

HelloPython, warm redeploy after a real source change:

| Phase | Before | After |
|---|---|---|
| prerun `providers.Initialize` | 165ms | **0ms** |
| connect (dial + mTLS) | 351ms | **92ms** |
| GetAgentVersion | 28ms | 26ms |
| build | 670ms | 2ms¹ |
| chunk+query+write | 177ms | 11ms |
| runcontainer | 296ms-1.006s | **161ms** |
| **total** | **~1.57s** | **~298ms** |

¹ the build drop is #1610 + a Stagefile conversion, **not** this PR — see below.

## What's here

**1. `providers.Initialize` probed lazily and in parallel.** It ran in `PersistentPreRun` on every command and probed four providers sequentially; two shell out (`docker --version`, `container --version`, ~88ms each). `wendy run` against a device hostname never consults a provider at all. Now probed on first use behind a `sync.Once`, concurrently, and `ProviderForKey` short-circuits network addresses — every built-in key is a short dotless token, so a `.local` name can never match one. `resolveTargetInner` already applies the same reasoning before its `findDeviceByID` sweep. **165ms → 0ms.**

**2. Probe the last-known-good org's cert first.** The mTLS dial path tries every CLI certificate in load order. Holding certs for two orgs against a device on the second one, every command paid a full doomed handshake plus a `GetAgentVersion` probe before the real one. TLS session resumption cannot recover this — a rejected first attempt is a fresh handshake by definition. Now remembers which org last authenticated against a host and probes it first.

This is purely a reordering with no security weight: the remaining certs still follow in their original order, so a stale hint costs exactly what today's behaviour costs, and the memo can never admit a cert that would otherwise be rejected. **~250ms → ~80-95ms.**

**3. Split the `runcontainer` timing phase.** It was one opaque number covering agent-side create+start, the readiness probe, and the postStart hook. Nested `↳` marks, same style, same `WENDY_TIMING` gate. This is what made #4 findable.

**4. `--detach` and `--watch` no longer wait for app readiness.** ⚠️ **Behaviour change** — the one to review closely.

Every detached deploy blocked on the readiness probe, which waits out the app's own boot (~500-660ms for a trivial Python app, several times the CLI's entire remaining overhead). `--watch` sets `opts.detach`, so it paid that on every redeploy. Three call sites did this: the chunk-diff detach branch, the registry-path detach branch, and the `--detach`-only fast path.

The host-side postStart hook goes with it rather than firing early, because it's only meaningful once the app is listening — an app with an `http` entitlement gets an `openURL` hook synthesized automatically, so firing it ungated opens a browser at an unbound port, and under `--watch`, one tab per redeploy.

Attached `wendy run` is unchanged: still waits, still announces the URL, still fires the hook. The agent-side in-container hook is untouched on both paths. Two fast-path tests asserted the old contract (with doc comments saying `wendy run` should behave identically regardless of the fast path) and now assert the new one — **if that equivalence mattered for a reason I've missed, this is the commit to push back on.** If a one-shot `--detach` should still open the browser, that wants an explicit `--open` flag rather than the implicit behaviour.

## Not in this PR

**The Stagefile example conversions.** Converting HelloPython to a Stagefile is what lets #1610 skip buildx — **build 670ms → 5ms**, by far the largest single win measured. It depends on the unmerged Stagefile stack (#1585 → #1607/#1609/#1610), so it can't target `main`. It sits on my local convergence branch and should be retargeted onto that stack.

@EBro912 two things from measuring #1610 on real hardware:
- It works exactly as designed — first run adopts (`state.json`), second splices natively in 5ms.
- Only **2 of 8** Python examples could be converted at all. Five of the six blockers share one root cause: **no raw-RUN escape hatch in the DSL**. `HelloAudio` needs `RUN python generate_sound.py`; `HelloLLM`/`HelloONNX`/`PyTorchGPU` need multi-step RUN with symlink farms and `ldconfig`; `PythonAI` needs `usermod -a -G audio`. Given #1609 is "close the gaps from the Examples survey", that looks like the highest-value remaining gap — it's what stands between those examples and the 134× build win.

## Known issues found but not fixed

- **Readiness can be satisfied by the outgoing container.** I measured a 5ms "ready" during a redeploy — impossible for a fresh Python process; the *old* container was still listening. So "App reachable at …" can refer to code you just replaced. Still affects attached runs. Correctness bug, worth its own fix.
- **`wendy run` bypasses the device identity pin.** `enforceDevicePin` is called only from `connectToAgent`, and only for the default device. `wendy run` resolves via `resolveTargetInner` and never checks it — so the WDY-1149 guard covers `device update` but not the command people run most.
- **Agent-side create+start (~160-340ms)** is now the largest remaining block and is entirely unprofiled; it needs agent-side marks.

## Testing

`go build ./...` and `go test ./...` green on this branch (rebased onto `main`, without the merged stack). All timings measured end-to-end against a real device, not synthetic benchmarks.