### PR TITLE
fix(examples): route VoiceAssistant audio through PipeWire

### DIFF
--- a/Examples/VoiceAssistant/Dockerfile
+++ b/Examples/VoiceAssistant/Dockerfile
@@ -1,9 +1,14 @@
 # syntax=docker/dockerfile:1.6
 FROM python:3.11-slim
 
+# pipewire-bin (pw-record/pw-play) reaches the host's session graph — the only
+# route to Bluetooth audio; pulseaudio-utils (pactl) drives its volume.
+# alsa-utils stays as the fallback for hosts that only expose /dev/snd.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     alsa-utils \
     ca-certificates \
+    pipewire-bin \
+    pulseaudio-utils \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Examples/VoiceAssistant/README.md
+++ b/Examples/VoiceAssistant/README.md
@@ -8,15 +8,22 @@ detection, and 24 kHz mono PCM16 audio in both directions.
 Interruption/barge-in is enabled by default: speak over the assistant and it
 stops immediately, truncating the unheard part of its reply. The assistant can
 also control its own speaker volume — say "set the volume to 30 percent" or
-"turn it up a bit" and it adjusts the ALSA mixer through Realtime function
+"turn it up a bit" and it adjusts the output volume through Realtime function
 tools. It can answer questions that need live data too: weather anywhere via
 the free Open-Meteo API, and anything else current (news, scores, prices)
 via OpenAI web search.
 
+Audio goes through PipeWire whenever the host exposes a session socket (any
+WendyOS build with the PipeWire audio stack). That is what makes Bluetooth
+speakers and microphones reachable — raw ALSA cannot see them. On hosts
+without a PipeWire session the app falls back to the previous
+`arecord`/`aplay` ALSA path automatically.
+
 ## Hardware
 
 - A WendyOS device — Raspberry Pi 3, 4, and 5 are all supported
-- A microphone and speaker visible to ALSA (a USB speakerphone covers both)
+- A microphone and speaker: a USB speakerphone covers both, or a connected
+  Bluetooth speaker/speakerphone on a PipeWire-enabled WendyOS
 - Internet access from the device
 
 Keep the mic away from the speaker for the cleanest turn detection. The mic
@@ -38,11 +45,12 @@ ALSA card *numbers* can change across boots as USB devices enumerate, so
 prefer the stable name form `plughw:CARD=<name>,DEV=<n>` — the app's
 auto-detection (below) does this for you.
 
-## 1. Pick the ALSA devices (optional)
+## 1. Pick the audio devices (optional)
 
-By default the app auto-detects the first USB sound card for both capture and
-playback and falls back to the ALSA `default` device. If that is what you want,
-skip this step.
+By default the app uses the host's default source and sink (PipeWire mode —
+WirePlumber routes these, and a connected Bluetooth speaker set as default
+"just works"), or auto-detects the first USB sound card (ALSA fallback mode).
+If that is what you want, skip this step.
 
 To choose devices yourself, list them:
 
@@ -53,13 +61,18 @@ wendy device audio list --device <hostname>.local
 and export the identifiers before deploying:
 
 ```sh
+# PipeWire mode: a node name (stable) or numeric id from `audio list`
+export AUDIO_INPUT_DEVICE='bluez_input.00_7F_1D_51_A9_6E'
+export AUDIO_OUTPUT_DEVICE='bluez_output.00_7F_1D_51_A9_6E.1'
+
+# ALSA fallback mode: an ALSA PCM name
 export AUDIO_INPUT_DEVICE='plughw:CARD=Device,DEV=0'
 export AUDIO_OUTPUT_DEVICE='plughw:CARD=Device,DEV=0'  # or an HDMI card
 ```
 
-Use `plughw` rather than `hw` so ALSA can convert a device's native sample
-rate to the API's 24 kHz PCM stream when necessary. You can validate the
-microphone before deploying with `wendy device audio monitor`.
+In ALSA mode use `plughw` rather than `hw` so ALSA can convert a device's
+native sample rate to the API's 24 kHz PCM stream when necessary. You can
+validate the microphone before deploying with `wendy device audio monitor`.
 
 ## 2. Supply the API key and deploy
 
@@ -88,7 +101,8 @@ otherwise be silent or very quiet. Set it to `off` to leave the mixer alone.
 
 While the assistant is running, just ask it: "set the volume to 30 percent",
 "turn it up", "how loud are you?". These are Realtime function tools backed by
-`amixer` inside the container.
+`pactl` on the default sink (PipeWire mode) or `amixer` (ALSA fallback) inside
+the container.
 
 You can also drive volume manually with the interactive TUI on the host:
 

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -435,7 +435,7 @@ class PulseMixer:
                 continue
             match = cls._PERCENT.search(line)
             if match:
-                return int(match.group(1))
+                return min(int(match.group(1)), 100)
         return None
 
     async def _pactl(self, *args: str) -> str:

--- a/Examples/VoiceAssistant/app.py
+++ b/Examples/VoiceAssistant/app.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Low-latency ALSA bridge for OpenAI's Realtime speech-to-speech API."""
+"""Low-latency audio bridge for OpenAI's Realtime speech-to-speech API.
+
+Audio goes through PipeWire (pw-record/pw-play) whenever the host exposes a
+session socket — the only route that reaches Bluetooth devices — and falls
+back to raw ALSA (arecord/aplay) on hosts that only provide /dev/snd."""
 
 from __future__ import annotations
 
@@ -9,6 +13,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import time
 import urllib.error
 import urllib.request
@@ -211,6 +216,40 @@ def card_from_device(device: str) -> str | None:
     return digits if digits.isdigit() else None
 
 
+def pipewire_socket() -> str | None:
+    """Path of the PipeWire session socket, or None when no session is exposed.
+
+    The wendy-agent audio entitlement mounts the host's user-session socket
+    into the container and sets PIPEWIRE_RUNTIME_DIR; XDG_RUNTIME_DIR covers
+    running uncontainerized on a desktop."""
+    for env in ("PIPEWIRE_RUNTIME_DIR", "XDG_RUNTIME_DIR"):
+        runtime_dir = (os.getenv(env) or "").strip()
+        if not runtime_dir:
+            continue
+        path = os.path.join(runtime_dir, "pipewire-0")
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def select_audio_backend(which: Any = shutil.which) -> str:
+    """Prefer PipeWire whenever the host exposes a session socket: it is the
+    only route to Bluetooth audio, and raw ALSA on such a host would race
+    WirePlumber for the very devices PipeWire has already claimed."""
+    socket_path = pipewire_socket()
+    if socket_path is None:
+        return "alsa"
+    if which("pw-record") is None or which("pw-play") is None:
+        LOG.error(
+            "PipeWire socket %s is mounted but pw-record/pw-play are missing — "
+            "this image was built without pipewire-bin; falling back to raw "
+            "ALSA, which cannot reach Bluetooth audio",
+            socket_path,
+        )
+        return "alsa"
+    return "pipewire"
+
+
 @dataclass(frozen=True)
 class Config:
     api_key: str
@@ -375,57 +414,88 @@ class AlsaMixer:
         return await self.set_volume(current + delta)
 
 
-class AlsaAudio:
-    """Owns one arecord process and one aplay process."""
+class PulseMixer:
+    """Playback volume control for the PipeWire backend, via `pactl` over the
+    PULSE_SERVER socket the audio entitlement provides. Targets the default
+    sink — the node WirePlumber routes playback to, which is the Bluetooth
+    speaker once one is connected and default. Duck-types AlsaMixer."""
 
-    def __init__(self, config: Config, input_device: str, output_device: str) -> None:
+    SINK = "@DEFAULT_SINK@"
+    _PERCENT = re.compile(r"(\d{1,3})%")
+
+    def __init__(self, run: Any = None) -> None:
+        # apply_startup_volume logs .card; the sink alias is the honest name.
+        self.card = self.SINK
+        self._run = run or (lambda *args: _run_command("pactl", *args))
+
+    @classmethod
+    def parse_volume(cls, output: str) -> int | None:
+        for line in output.splitlines():
+            if "Volume:" not in line:
+                continue
+            match = cls._PERCENT.search(line)
+            if match:
+                return int(match.group(1))
+        return None
+
+    async def _pactl(self, *args: str) -> str:
+        returncode, output = await self._run(*args)
+        if returncode != 0:
+            raise RuntimeError(f"pactl {' '.join(args)} failed: {output.strip()}")
+        return output
+
+    async def get_volume(self) -> int:
+        volume = self.parse_volume(await self._pactl("get-sink-volume", self.SINK))
+        if volume is None:
+            raise RuntimeError("pactl reported no volume for the default sink")
+        return volume
+
+    async def set_volume(self, percent: int) -> int:
+        percent = max(0, min(100, percent))
+        await self._pactl("set-sink-volume", self.SINK, f"{percent}%")
+        await self._pactl("set-sink-mute", self.SINK, "0")
+        # Re-read so callers see what the server actually applied.
+        return await self.get_volume()
+
+    async def adjust_volume(self, direction: str, step: int = 10) -> int:
+        current = await self.get_volume()
+        delta = step if direction == "up" else -step
+        return await self.set_volume(current + delta)
+
+
+class PcmBridge:
+    """Owns one capture process and one playback process bridging raw PCM16.
+
+    Subclasses supply the command lines; the lifecycle — startup, barge-in
+    playback restart, teardown, and error surfacing — is shared."""
+
+    def __init__(
+        self, config: Config, input_device: str | None, output_device: str | None
+    ) -> None:
         self.config = config
         self.input_device = input_device
         self.output_device = output_device
         self.capture: asyncio.subprocess.Process | None = None
         self.playback: asyncio.subprocess.Process | None = None
 
-    async def __aenter__(self) -> "AlsaAudio":
-        common = [
-            "-q",
-            "-D",
-            self.input_device,
-            "-t",
-            "raw",
-            "-f",
-            "S16_LE",
-            "-c",
-            "1",
-            "-r",
-            str(self.config.sample_rate),
-        ]
+    def capture_command(self) -> list[str]:
+        raise NotImplementedError
+
+    def playback_command(self) -> list[str]:
+        raise NotImplementedError
+
+    async def __aenter__(self) -> "PcmBridge":
         self.capture = await asyncio.create_subprocess_exec(
-            "arecord",
-            *common,
+            *self.capture_command(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-
         await self._start_playback()
         return self
 
     async def _start_playback(self) -> None:
-        playback_args = [
-            "-q",
-            "-D",
-            self.output_device,
-            "-t",
-            "raw",
-            "-f",
-            "S16_LE",
-            "-c",
-            "1",
-            "-r",
-            str(self.config.sample_rate),
-        ]
         self.playback = await asyncio.create_subprocess_exec(
-            "aplay",
-            *playback_args,
+            *self.playback_command(),
             stdin=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -462,7 +532,9 @@ class AlsaAudio:
             # PCM16 messages must contain complete samples.
             return chunk[: len(chunk) - (len(chunk) % BYTES_PER_SAMPLE)]
         error = await self._stderr(self.capture)
-        raise RuntimeError(f"microphone capture stopped: {error or 'arecord exited'}")
+        raise RuntimeError(
+            f"microphone capture stopped: {error or self.capture_command()[0] + ' exited'}"
+        )
 
     async def write(self, audio: bytes) -> None:
         assert self.playback is not None and self.playback.stdin is not None
@@ -478,6 +550,61 @@ class AlsaAudio:
         if process.stderr is None:
             return ""
         return (await process.stderr.read()).decode(errors="replace").strip()
+
+
+class AlsaAudio(PcmBridge):
+    """arecord/aplay bridge for hosts that expose only /dev/snd."""
+
+    def _common_args(self, device: str | None) -> list[str]:
+        return [
+            "-q",
+            "-D",
+            device or "default",
+            "-t",
+            "raw",
+            "-f",
+            "S16_LE",
+            "-c",
+            "1",
+            "-r",
+            str(self.config.sample_rate),
+        ]
+
+    def capture_command(self) -> list[str]:
+        return ["arecord", *self._common_args(self.input_device)]
+
+    def playback_command(self) -> list[str]:
+        return ["aplay", *self._common_args(self.output_device)]
+
+
+class PipewireAudio(PcmBridge):
+    """pw-record/pw-play bridge over the session socket the audio entitlement
+    mounts. Targets default to WirePlumber's default source/sink — which is
+    how Bluetooth devices are reached; an explicit AUDIO_*_DEVICE names a
+    PipeWire node (object serial or node.name) instead of an ALSA PCM.
+
+    The flag set matches the agent's own capture invocation
+    (audio_service.go startCapture): raw s16 mono on stdio."""
+
+    def _common_args(self, device: str | None) -> list[str]:
+        args = [
+            "--rate",
+            str(self.config.sample_rate),
+            "--channels",
+            "1",
+            "--format",
+            "s16",
+            "--raw",
+        ]
+        if device:
+            args += ["--target", device]
+        return args + ["-"]
+
+    def capture_command(self) -> list[str]:
+        return ["pw-record", *self._common_args(self.input_device)]
+
+    def playback_command(self) -> list[str]:
+        return ["pw-play", *self._common_args(self.output_device)]
 
 
 class VoiceAssistant:
@@ -675,35 +802,51 @@ class VoiceAssistant:
             "OpenAI-Safety-Identifier": "wendy-voice-assistant-demo",
         }
 
-        # Devices can enumerate late or renumber across reconnects, so resolve
-        # them at the start of every session rather than once at startup.
-        input_device = self.config.input_device or await detect_device("arecord")
-        output_device = self.config.output_device or await detect_device("aplay")
-
-        card = card_from_device(output_device)
-        if card is None and self.config.output_device:
-            # An explicit but unparsable device (e.g. "default" via asound.conf):
-            # bind the mixer to whatever playback card auto-detection can name.
-            # Note this card may differ from the one actually playing.
-            card = card_from_device(await detect_device("aplay"))
-        if card is None:
-            self.mixer = None
-            LOG.warning(
-                "No ALSA card resolved from %s; volume control disabled", output_device
-            )
+        backend = select_audio_backend()
+        if backend == "pipewire":
+            # WirePlumber routes the default source/sink, so no card scan:
+            # empty devices mean "default", explicit ones name PipeWire nodes.
+            input_device = self.config.input_device
+            output_device = self.config.output_device
+            if shutil.which("pactl"):
+                self.mixer = PulseMixer()
+                await self.apply_startup_volume(self.mixer)
+            else:
+                self.mixer = None
+                LOG.warning("pactl not found; volume control disabled")
+            bridge: PcmBridge = PipewireAudio(self.config, input_device, output_device)
         else:
-            self.mixer = AlsaMixer(card)
-            await self.apply_startup_volume(self.mixer)
+            # Devices can enumerate late or renumber across reconnects, so resolve
+            # them at the start of every session rather than once at startup.
+            input_device = self.config.input_device or await detect_device("arecord")
+            output_device = self.config.output_device or await detect_device("aplay")
+
+            card = card_from_device(output_device)
+            if card is None and self.config.output_device:
+                # An explicit but unparsable device (e.g. "default" via asound.conf):
+                # bind the mixer to whatever playback card auto-detection can name.
+                # Note this card may differ from the one actually playing.
+                card = card_from_device(await detect_device("aplay"))
+            if card is None:
+                self.mixer = None
+                LOG.warning(
+                    "No ALSA card resolved from %s; volume control disabled", output_device
+                )
+            else:
+                self.mixer = AlsaMixer(card)
+                await self.apply_startup_volume(self.mixer)
+            bridge = AlsaAudio(self.config, input_device, output_device)
 
         LOG.info(
-            "Opening Realtime session (%s); mic=%s%s speaker=%s%s",
+            "Opening Realtime session (%s) via %s; mic=%s%s speaker=%s%s",
             self.config.model,
-            input_device,
+            backend,
+            input_device or "default",
             "" if self.config.input_device else " (auto)",
-            output_device,
+            output_device or "default",
             "" if self.config.output_device else " (auto)",
         )
-        async with AlsaAudio(self.config, input_device, output_device) as audio:
+        async with bridge as audio:
             async with connect(
                 url,
                 additional_headers=headers,
@@ -718,7 +861,7 @@ class VoiceAssistant:
                     self.receive_events(websocket, audio),
                 )
 
-    async def send_microphone(self, websocket: Any, audio: AlsaAudio) -> None:
+    async def send_microphone(self, websocket: Any, audio: PcmBridge) -> None:
         while True:
             chunk = await audio.read()
             if not chunk:
@@ -734,13 +877,13 @@ class VoiceAssistant:
                 )
             )
 
-    async def receive_events(self, websocket: Any, audio: AlsaAudio) -> None:
+    async def receive_events(self, websocket: Any, audio: PcmBridge) -> None:
         async for message in websocket:
             event = json.loads(message)
             await self.handle_event(event, audio, websocket)
 
     async def handle_event(
-        self, event: dict[str, Any], audio: AlsaAudio, websocket: Any | None = None
+        self, event: dict[str, Any], audio: PcmBridge, websocket: Any | None = None
     ) -> None:
         event_type = event.get("type", "")
 
@@ -781,7 +924,8 @@ class VoiceAssistant:
             chunk = base64.b64decode(event["delta"])
             self.assistant_speaking.set()
             # Track when the final queued sample should reach the speaker. This
-            # prevents opening the microphone while ALSA still has buffered audio.
+            # prevents opening the microphone while the audio server still has
+            # buffered audio.
             now = time.monotonic()
             if not self.playback_started_at:
                 self.playback_started_at = now
@@ -983,7 +1127,7 @@ class VoiceAssistant:
             return
         await websocket.send(json.dumps({"type": "response.create"}))
 
-    async def interrupt_response(self, websocket: Any | None, audio: AlsaAudio) -> None:
+    async def interrupt_response(self, websocket: Any | None, audio: PcmBridge) -> None:
         now = time.monotonic()
         played_seconds = min(
             self.playback_audio_seconds,

--- a/Examples/VoiceAssistant/tests/test_app.py
+++ b/Examples/VoiceAssistant/tests/test_app.py
@@ -9,10 +9,13 @@ import app
 from app import (
     AlsaMixer,
     Config,
+    PipewireAudio,
+    PulseMixer,
     VoiceAssistant,
     card_from_device,
     describe_weather_code,
     extract_output_text,
+    select_audio_backend,
     strip_citations,
     parse_alsa_cards,
     pick_alsa_device,
@@ -459,6 +462,136 @@ class AlsaMixerTests(unittest.IsolatedAsyncioTestCase):
         mixer = AlsaMixer("9", run=runner)
         with self.assertRaises(RuntimeError):
             await mixer.set_volume(50)
+
+
+PACTL_GET_SINK_VOLUME_60 = """\
+Volume: front-left: 39322 /  60% / -13.31 dB,   front-right: 39322 /  60% / -13.31 dB
+        balance 0.00
+"""
+
+
+class FakePactl:
+    """Injectable runner mimicking `pactl <subcommand> <args...>`."""
+
+    def __init__(self, responses):
+        self.responses = responses  # subcommand -> callable(args) or (rc, out)
+        self.calls = []
+
+    async def __call__(self, *args):
+        self.calls.append(args)
+        response = self.responses[args[0]]
+        if callable(response):
+            return response(args)
+        return response
+
+
+class BackendSelectionTests(unittest.TestCase):
+    def test_without_a_pipewire_socket_alsa_is_used(self):
+        with patch.dict(
+            os.environ, {"PIPEWIRE_RUNTIME_DIR": "", "XDG_RUNTIME_DIR": ""}
+        ):
+            self.assertEqual(select_audio_backend(which=lambda _: "/usr/bin/x"), "alsa")
+
+    def test_mounted_socket_with_tools_selects_pipewire(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as runtime_dir:
+            open(os.path.join(runtime_dir, "pipewire-0"), "w").close()
+            with patch.dict(os.environ, {"PIPEWIRE_RUNTIME_DIR": runtime_dir}):
+                self.assertEqual(
+                    select_audio_backend(which=lambda _: "/usr/bin/x"), "pipewire"
+                )
+
+    def test_mounted_socket_without_pw_tools_falls_back_to_alsa(self):
+        # The HelloAudio failure mode: entitlement mounted the socket but the
+        # image was built without pipewire-bin. Must not crash-loop on ENOENT.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as runtime_dir:
+            open(os.path.join(runtime_dir, "pipewire-0"), "w").close()
+            with patch.dict(os.environ, {"PIPEWIRE_RUNTIME_DIR": runtime_dir}):
+                self.assertEqual(select_audio_backend(which=lambda _: None), "alsa")
+
+    def test_env_set_but_socket_missing_falls_back_to_alsa(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as runtime_dir:
+            with patch.dict(
+                os.environ,
+                {"PIPEWIRE_RUNTIME_DIR": runtime_dir, "XDG_RUNTIME_DIR": ""},
+            ):
+                self.assertEqual(
+                    select_audio_backend(which=lambda _: "/usr/bin/x"), "alsa"
+                )
+
+
+class PipewireAudioTests(unittest.TestCase):
+    def test_default_targets_use_wireplumber_routing(self):
+        bridge = PipewireAudio(Config(api_key="k"), None, None)
+        self.assertEqual(
+            bridge.capture_command(),
+            [
+                "pw-record",
+                "--rate", "24000",
+                "--channels", "1",
+                "--format", "s16",
+                "--raw",
+                "-",
+            ],
+        )
+        self.assertEqual(bridge.playback_command()[0], "pw-play")
+        self.assertNotIn("--target", bridge.playback_command())
+
+    def test_explicit_devices_become_pipewire_targets(self):
+        bridge = PipewireAudio(
+            Config(api_key="k"), "bluez_input.00_7F_1D_51_A9_6E", "bluez_output.speaker"
+        )
+        capture = bridge.capture_command()
+        playback = bridge.playback_command()
+        self.assertIn("bluez_input.00_7F_1D_51_A9_6E", capture)
+        self.assertEqual(capture[capture.index("--target") + 1], "bluez_input.00_7F_1D_51_A9_6E")
+        self.assertEqual(playback[playback.index("--target") + 1], "bluez_output.speaker")
+        # Raw streams on stdio, matching the agent's own pw-record invocation.
+        self.assertEqual(capture[-1], "-")
+        self.assertIn("--raw", playback)
+
+
+class PulseMixerTests(unittest.IsolatedAsyncioTestCase):
+    def test_parse_volume_reads_the_first_percentage(self):
+        self.assertEqual(PulseMixer.parse_volume(PACTL_GET_SINK_VOLUME_60), 60)
+        self.assertIsNone(PulseMixer.parse_volume("balance 0.00"))
+        self.assertIsNone(PulseMixer.parse_volume(""))
+
+    async def test_set_volume_clamps_unmutes_and_rereads(self):
+        runner = FakePactl(
+            {
+                "get-sink-volume": (0, PACTL_GET_SINK_VOLUME_60),
+                "set-sink-volume": (0, ""),
+                "set-sink-mute": (0, ""),
+            }
+        )
+        mixer = PulseMixer(run=runner)
+        self.assertEqual(await mixer.set_volume(150), 60)
+        self.assertIn(("set-sink-volume", "@DEFAULT_SINK@", "100%"), runner.calls)
+        self.assertIn(("set-sink-mute", "@DEFAULT_SINK@", "0"), runner.calls)
+
+    async def test_adjust_volume_steps_from_current(self):
+        runner = FakePactl(
+            {
+                "get-sink-volume": (0, PACTL_GET_SINK_VOLUME_60),
+                "set-sink-volume": (0, ""),
+                "set-sink-mute": (0, ""),
+            }
+        )
+        mixer = PulseMixer(run=runner)
+        await mixer.adjust_volume("down", step=25)
+        self.assertIn(("set-sink-volume", "@DEFAULT_SINK@", "35%"), runner.calls)
+
+    async def test_pactl_failure_raises_runtime_error(self):
+        runner = FakePactl({"get-sink-volume": (1, "Connection refused")})
+        mixer = PulseMixer(run=runner)
+        with self.assertRaises(RuntimeError):
+            await mixer.get_volume()
 
 
 class FakeMixer:

--- a/Examples/VoiceAssistant/wendy.json
+++ b/Examples/VoiceAssistant/wendy.json
@@ -1,6 +1,6 @@
 {
   "appId": "sh.wendy.examples.voiceassistant",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "platform": "linux",
   "entitlements": [
     {


### PR DESCRIPTION
## Summary

VoiceAssistant drove audio exclusively through raw ALSA (`arecord`/`aplay` bridge, `amixer` volume, `arecord -l` card scanning). On WendyOS builds carrying the PipeWire audio stack (#1594) that path errors at run time: raw ALSA cannot reach Bluetooth endpoints and races WirePlumber for the cards it has already claimed.

- **Backend selection**: PipeWire whenever the audio entitlement mounts a session socket (`PIPEWIRE_RUNTIME_DIR`, with `XDG_RUNTIME_DIR` for desktop dev); raw ALSA otherwise — hosts that only hand the container `/dev/snd` behave exactly as before.
- **Audio bridge**: `pw-record`/`pw-play --rate … --channels 1 --format s16 --raw -`, mirroring the agent's own `startCapture` invocation from #1594. The process-lifecycle code (barge-in restart, teardown, stderr surfacing) is shared in a `PcmBridge` base; `AlsaAudio` and `PipewireAudio` only supply argv.
- **Volume tools**: `pactl` on `@DEFAULT_SINK@` over the entitlement's `PULSE_SERVER` socket in PipeWire mode (set/adjust/get + startup normalization); `amixer` unchanged in fallback mode.
- **Device env semantics**: `AUDIO_INPUT_DEVICE`/`AUDIO_OUTPUT_DEVICE` name PipeWire nodes (node.name or object serial) in PipeWire mode; unset means WirePlumber's default route, which is how a connected Bluetooth speaker works with zero configuration.
- **Stale-image guard**: a mounted socket with no `pw-record`/`pw-play` in the image (the HelloAudio #1602 failure mode) logs an explicit error and falls back instead of crash-looping on ENOENT.
- Dockerfile adds `pipewire-bin` + `pulseaudio-utils` (python:3.11-slim now ships libpipewire 1.4.2, verified in a container — `--raw`/`--target`/stdio all present).

## Testing

- `python -m unittest discover -s tests`: 72 tests green (9 new: backend selection incl. missing-tools fallback, pw argv construction, pactl volume parsing/clamping/unmute).
- `docker build` of the example image + verified `pw-record`/`pw-play`/`pactl`/`arecord`/`aplay` all present and `import app` clean inside it.
- On-device verify pending: needs a WendyOS image carrying WendyOS-Builder#213/#217 (none published yet — the 2026-08-07 main image build failed on the agent GNU_HASH QA regression) plus agent ≥ 2026.08.08-084214, then a paired Bluetooth speaker end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)