### PR TITLE
fix(cli): surface ROS 2 frameworks in wendy init, fix headless template picks

### DIFF
--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -87,6 +87,51 @@ If `brewfile` is omitted and a `Brewfile.wendy` exists at the project root, `wen
 
 Array of capabilities the app requires. See [Entitlements](#entitlements-1) below.
 
+### `frameworks`
+
+Framework-level configuration, separate from `entitlements`. Where an entitlement grants access to a device capability, `frameworks` configures how a framework the app is built on is wired up on the device. ROS 2 is the only framework today.
+
+```json
+{
+  "frameworks": {
+    "ros2": {
+      "domainId": 42,
+      "rmw": "cyclonedds",
+      "distro": "humble",
+      "discoveryScope": "host"
+    }
+  }
+}
+```
+
+Every field is optional — `"frameworks": { "ros2": {} }` is a valid way to say "this is a ROS 2 app, use the defaults". The presence of `frameworks.ros2` is what marks a container as a ROS 2 app: the agent labels it, joins it to the right DDS domain, and starts the CLI sidecar that backs [`wendy device ros2`](/docs/integrations/ros2).
+
+#### `frameworks.ros2`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `domainId` | integer (0–232) | derived from `appId` | `ROS_DOMAIN_ID` for the app. Omit it to get a stable value hashed from the app ID, which keeps the domain constant across restarts without colliding with unrelated apps. |
+| `rmw` | string | `cyclonedds` | RMW middleware implementation. Accepts short names (`cyclonedds`, `fastrtps`/`fastdds`, `connextdds`, `gurumdds`) or full identifiers (`rmw_cyclonedds_cpp`, `rmw_fastrtps_cpp`, `rmw_connextdds`, `rmw_gurumdds_cpp`). |
+| `distro` | string | `humble` | ROS 2 distribution the app targets, e.g. `humble`, `iron`, `jazzy`. Lowercase letters and digits, starting with a letter. Selects the matching CLI sidecar image. Only the shape is enforced, not a fixed list, so a new ROS 2 release is usable before Wendy ships explicit support for it. |
+| `discoveryScope` | string | `app` | `app` restricts DDS discovery to the app group's own network namespace (`ROS_LOCALHOST_ONLY=1`), so unrelated apps and robots do not discover each other. `host` lets discovery use the device's host network — pair it with `{ "type": "network", "mode": "host" }`. |
+
+An out-of-range `domainId`, an unsupported `rmw`, a malformed `distro`, or an unknown `discoveryScope` is rejected when the config is parsed, rather than silently starting a container with no domain or middleware isolation.
+
+For multi-service apps, declare `frameworks` per service under `services.<name>.frameworks` to give a service its own ROS 2 settings. A service without its own `frameworks` inherits the top-level one, so a stack of talker/listener services shares a domain by default.
+
+```json
+{
+  "appId": "robot",
+  "frameworks": { "ros2": { "rmw": "cyclonedds" } },
+  "services": {
+    "talker":   { "context": "./talker" },
+    "bridge":   { "context": "./bridge", "frameworks": { "ros2": { "discoveryScope": "host" } } }
+  }
+}
+```
+
+Use [`wendy init --framework ros2`](../clients/wendy-cli/commands/init.md#frameworks) to scaffold this block, or add it by hand — `wendy run` picks it up on the next deploy. See [Wendy for ROS 2](/docs/integrations/ros2) for inspecting and debugging the running system.
+
 ### `readiness`
 
 Configures how the CLI determines when the app is ready after starting.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
@@ -1,0 +1,256 @@
+# `wendy init`
+
+Creates a new Wendy project: a [`wendy.json`](../../../apps/wendy.json.md), scaffolded source files, and optionally an AI assistant session.
+
+Run it with no arguments for an interactive wizard, or pass flags to script it end to end. Every prompt has a matching flag, so any wizard answer can be supplied up front.
+
+## Usage
+
+```sh
+# Interactive wizard
+wendy init
+
+# Create ./my-app and scaffold into it
+wendy init my-app
+
+# Fully non-interactive
+wendy init \
+  --app-id my-app \
+  --target wendyos \
+  --language swift \
+  --no-extra-entitlements \
+  --assistant skip
+```
+
+An `[app-id]` argument (or `--app-id`) always creates a new subdirectory of that name. With neither, the wizard offers to scaffold into the current directory instead.
+
+## What it produces
+
+1. Picks the **target**, so template and language choices can be filtered to what that target supports.
+2. Picks a **template** (`--template`), or continues with the plain wizard.
+3. Picks the **language**.
+4. Collects **entitlements** — the capabilities the app needs. See [Entitlements](../../../apps/wendy.json.md#entitlements-1).
+5. Collects **framework** configuration — currently ROS 2. See [Frameworks](#frameworks).
+6. Writes `wendy.json` and scaffolds the project files.
+7. Optionally launches an AI assistant (`--assistant`).
+
+## Targets
+
+| `--target` | `platform` written to `wendy.json` | Languages |
+|---|---|---|
+| `wendyos` | `linux` | `swift`, `python` |
+| `darwin` (aliases: `mac`, `macos`) | `darwin` | `swift` only |
+| `wendy-lite` | `wendy-lite` | `swift` only |
+
+Templates may offer additional languages (for example `rust`, `node`, or `cpp`) on a `wendyos` target; the plain wizard writes `swift` or `python`.
+
+## Flags
+
+### Project flags
+
+| Flag | Description |
+|---|---|
+| `--app-id <id>` | Application ID written to `wendy.json`. Creates a subdirectory of that name. |
+| `--target <name>` | Target platform: `wendyos`, `darwin`, or `wendy-lite`. Required when running non-interactively. |
+| `--language <name>` | Project language. `swift` or `python` for the plain wizard; templates may offer more. |
+| `--git-init <yes\|no>` | Initialize a git repo in the project directory. |
+
+### Template flags
+
+| Flag | Description |
+|---|---|
+| `--template [<name>]` | Scaffold from a template. Passing it **without** a value opens a picker filtered by target. |
+| `--branch <name>` | Branch of the templates repo to read templates from. |
+| `--var KEY=VALUE` | Override a template variable. Repeatable. |
+
+### Entitlement flags
+
+| Flag | Description |
+|---|---|
+| `--entitlement <name>` | Entitlement to enable. Repeatable or comma-separated. |
+| `--all-entitlements` | Enable every entitlement. Requires the field flags below for `gpio`, `i2c`, and `persist`. |
+| `--no-extra-entitlements` | Skip the entitlement prompts and write only the default `network` entitlement. |
+| `--gpio-pins 17,27,22` | Pins for the `gpio` entitlement. |
+| `--i2c-device /dev/i2c-1` | Device path for the `i2c` entitlement. |
+| `--persist-name <id>` | Storage namespace for the `persist` entitlement. |
+| `--persist-path /data` | Mount path for the `persist` entitlement. |
+
+Passing any entitlement flag suppresses the interactive entitlement prompts entirely — the flags become the complete answer.
+
+### Framework flags
+
+| Flag | Description |
+|---|---|
+| `--framework <name>` | Framework to enable under `wendy.json`'s top-level `frameworks` key. Repeatable or comma-separated. Currently accepts `ros2`. |
+| `--ros2-domain-id <n>` | ROS 2 domain ID, `0`–`232`. Default: derived as a stable hash of the app ID. |
+| `--ros2-rmw <impl>` | ROS 2 middleware: `cyclonedds` (default), `fastrtps`, `connextdds`, or `gurumdds`. |
+| `--ros2-distro <name>` | ROS 2 distribution, e.g. `humble` (default) or `jazzy`. Lowercase letters and digits, starting with a letter. |
+| `--ros2-discovery-scope <scope>` | `app` (default, isolated to this app's containers) or `host` (discoverable across the device's host network). |
+
+See [Frameworks](#frameworks) below.
+
+### AI assistant flags
+
+| Flag | Description |
+|---|---|
+| `--assistant <claude\|codex\|skip>` | Launch an assistant in the new project after scaffolding. `claude` and `codex` must be on `PATH`. |
+| `--install-claude-skills` | Install the Wendy Claude skills before launching Claude. Requires `--assistant=claude`. |
+
+## Frameworks
+
+`wendy.json` has a top-level [`frameworks`](../../../apps/wendy.json.md#frameworks) key, separate from `entitlements`, for framework-level configuration. ROS 2 is the only framework today.
+
+`wendy init` fills it in three ways:
+
+**Flags.** Pass `--framework ros2`, or any `--ros2-*` flag on its own (which implies `--framework ros2`):
+
+```sh
+wendy init \
+  --app-id go2-network-bridge \
+  --target wendyos \
+  --language swift \
+  --framework ros2 \
+  --ros2-rmw cyclonedds \
+  --ros2-discovery-scope host \
+  --assistant skip
+```
+
+This writes:
+
+```json
+{
+  "frameworks": {
+    "ros2": {
+      "rmw": "cyclonedds",
+      "discoveryScope": "host"
+    }
+  }
+}
+```
+
+Values are validated against the same rules `wendy.json` itself enforces, so a typo fails immediately at `init` rather than surfacing later from `wendy run` or `wendy device ros2`.
+
+**Interactively.** On a `wendyos` target, when no entitlement flags and no framework flags were passed, the wizard asks whether the app uses ROS 2 and then walks through middleware, discovery scope, and domain ID. The distro is left at its default; edit `frameworks.ros2.distro` in `wendy.json` to change it.
+
+**By hand.** Add the `frameworks` key to `wendy.json` yourself at any point; `wendy run` picks it up on the next deploy.
+
+Frameworks are WendyOS-only. `--framework ros2` with `--target darwin` or `--target wendy-lite` is rejected — neither target runs the ROS 2 container image.
+
+### With `--template`
+
+Entitlement and framework flags are merged into the template's own `wendy.json` after it is scaffolded, and in both cases **the template's configuration wins where it is more specific**:
+
+- `--entitlement` values already covered by the template are skipped; the rest are appended.
+- `--framework`/`--ros2-*` are written only if the template does not already configure `frameworks`. A template that ships its own `frameworks` block keeps it, and the flags are dropped. A `frameworks` key that configures nothing (`null`, `{}`, or an object whose members are all `null`) does not count as configured, so the flags still apply.
+
+`wendy init` reports what it merged in its summary (`Frameworks added from flags: ros2`).
+
+## Non-interactive and headless use
+
+`wendy init` detects whether a real terminal is attached. In CI, in scripts, and under AI agents there is none, so the interactive pickers are skipped rather than failing on a TTY that cannot be opened. Instead the CLI prints the choices as plain text and exits with an error naming the flag to pass:
+
+- **No `--target`** — prints the available targets, then errors with `--target is required when running non-interactively`.
+- **Bare `--template` with no value** — prints the templates available for the selected target, then errors with `--template requires a value when running non-interactively`. If the target has no templates at all, it errors with `no templates available for <target>` instead.
+- **No app ID** — errors with `an app ID is required when running non-interactively`; pass `--app-id` or the `[app-id]` argument.
+
+So discovering the valid values is a matter of running the command and reading the list:
+
+```sh
+$ wendy init
+Available targets:
+  WendyOS - Full Linux-based edge device (Jetson, Raspberry Pi, ...)
+  macOS - Native macOS app deployed to Wendy Agent for Mac
+  Wendy Lite - Microcontroller running WASM (ESP32)
+Error: --target is required when running non-interactively (valid: wendyos, darwin, wendy-lite)
+
+$ wendy init --app-id my-app --target wendyos --template
+Available templates for wendyos:
+  simple-api - Minimal HTTP API
+  fullstack - Web UI plus API
+Error: --template requires a value when running non-interactively; pass --template=<name> using one of the templates listed above
+```
+
+For a fully scripted run, supply every choice as a flag. `--no-extra-entitlements` and `--assistant skip` are what suppress the remaining prompts:
+
+```sh
+wendy init \
+  --app-id my-app \
+  --target wendyos \
+  --language swift \
+  --no-extra-entitlements \
+  --assistant skip
+```
+
+## Examples
+
+```sh
+# Scaffold from a template, picking the language interactively
+wendy init --template simple-api
+
+# Non-interactive template scaffold with a variable override
+wendy init --app-id my-api --template simple-api --language rust --var PORT=8080
+
+# A template from a branch of the templates repo
+wendy init --template simple-api --branch feature/new-template
+
+# WendyOS Python app with persistent storage
+wendy init \
+  --app-id demo-app \
+  --target wendyos \
+  --language python \
+  --entitlement gpu,usb,persist \
+  --persist-name demo-data \
+  --persist-path /data \
+  --assistant skip
+
+# WendyOS app with GPIO and I2C
+wendy init \
+  --app-id edge-sensors \
+  --target wendyos \
+  --language swift \
+  --entitlement gpio,i2c \
+  --gpio-pins 17,27,22 \
+  --i2c-device /dev/i2c-1 \
+  --assistant skip
+
+# Wendy Lite always uses Swift
+wendy init \
+  --app-id lite-app \
+  --target wendy-lite \
+  --no-extra-entitlements \
+  --assistant skip
+
+# Native macOS app for Wendy Agent for Mac
+wendy init \
+  --app-id mac-llm \
+  --target darwin \
+  --language swift \
+  --template mac-llm \
+  --assistant skip
+
+# ROS 2 app on a shared host DDS domain
+wendy init \
+  --app-id go2-network-bridge \
+  --target wendyos \
+  --language swift \
+  --framework ros2 \
+  --ros2-rmw cyclonedds \
+  --ros2-discovery-scope host \
+  --assistant skip
+
+# Start Claude in the new project with the Wendy skills installed
+wendy init \
+  --app-id ai-app \
+  --target wendyos \
+  --language python \
+  --entitlement gpu,audio \
+  --assistant claude \
+  --install-claude-skills
+```
+
+## Related
+
+- [`wendy.json`](../../../apps/wendy.json.md) — every field `wendy init` can write.
+- [`wendy project entitlements add`](project/entitlements/add.md) — add entitlements after init.
+- [Wendy for ROS 2](/docs/integrations/ros2) — inspect and debug the ROS 2 app you just scaffolded.
+- [`wendy run`](run.md) — build and deploy the new project to a device.

--- a/go/internal/cli/assets/docs/integrations/ros2.mdx
+++ b/go/internal/cli/assets/docs/integrations/ros2.mdx
@@ -33,6 +33,32 @@ runs apps across multiple RMW implementations (for example CycloneDDS and Fast
 DDS), results are tagged with the RMW they came from, such as `[cyclonedds]`.
 </Callout>
 
+## Scaffold a ROS 2 app
+
+`wendy init` writes the `frameworks.ros2` block for you. Pass `--framework ros2`,
+plus any of the `--ros2-*` flags to override the defaults:
+
+```bash
+wendy init \
+  --app-id my-ros2-app \
+  --target wendyos \
+  --language swift \
+  --framework ros2 \
+  --ros2-rmw cyclonedds \
+  --ros2-discovery-scope host \
+  --assistant skip
+```
+
+Any `--ros2-*` flag on its own implies `--framework ros2`, and values are
+validated up front, so a mistyped RMW or distro fails at `init` rather than at
+deploy time. Run `wendy init` interactively on a WendyOS target and it asks
+whether the app uses ROS 2, then walks through middleware, discovery scope, and
+domain ID.
+
+Existing projects need no scaffolding — add the `frameworks.ros2` key to
+`wendy.json` by hand and `wendy run` picks it up on the next deploy. See
+[`wendy.json`](/docs/apps/wendy.json#frameworks) for every field.
+
 ## Prerequisites
 
 - A ROS 2 app running on the device. See

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -505,7 +505,13 @@ func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
 // exist at all.
 func resolveBareTemplatePick(target string, meta *repoMeta) (string, error) {
 	if !isInteractiveTerminal() {
-		printPickerItemsPlainText("Available templates for "+target, templateItemsForTarget(target, meta))
+		// Report "no templates" the same way the picker path does rather than
+		// printing an empty list and then blaming the missing --template value.
+		items := templateItemsForTarget(target, meta)
+		if len(items) == 0 {
+			return "", fmt.Errorf("no templates available for %s", target)
+		}
+		printPickerItemsPlainText("Available templates for "+target, items)
 		return "", fmt.Errorf("--template requires a value when running non-interactively; pass --template=<name> using one of the templates listed above")
 	}
 	return pickTemplateNameForTarget(target, meta)
@@ -1027,6 +1033,13 @@ func resolveInitTarget(opts initOptions) (string, error) {
 // discoverability follow-up).
 func printPickerItemsPlainText(title string, items []tui.PickerItem) {
 	cliLogln("%s:", title)
+	if len(items) == 0 {
+		// Defensive: callers are expected to handle "nothing to choose from"
+		// with a specific error, but a bare title with no list under it reads
+		// as a rendering bug.
+		cliLogln("  (none)")
+		return
+	}
 	for _, item := range items {
 		if item.Description != "" {
 			cliLogln("  %s - %s", item.Name, item.Description)
@@ -1522,7 +1535,7 @@ func mergeTemplateFrameworks(cfgPath string, requested *appconfig.FrameworksConf
 		return false, fmt.Errorf("parsing scaffolded wendy.json: %w", err)
 	}
 
-	if existing, ok := raw["frameworks"]; ok && len(existing) > 0 && string(existing) != "null" {
+	if existing, ok := raw["frameworks"]; ok && templateFrameworksAreSet(existing) {
 		return false, nil
 	}
 
@@ -1541,6 +1554,31 @@ func mergeTemplateFrameworks(cfgPath string, requested *appconfig.FrameworksConf
 		return false, fmt.Errorf("writing scaffolded wendy.json: %w", err)
 	}
 	return true, nil
+}
+
+// templateFrameworksAreSet reports whether a template's "frameworks" value
+// actually configures a framework. `null`, `{}`, and an object whose every
+// member is null (e.g. `{"ros2": null}`) configure nothing, so they must not
+// suppress the caller's --framework/--ros2-* flags — "the template's more
+// specific config wins" only applies when the template is in fact more
+// specific. A non-object (malformed or a scalar) counts as set: it is not
+// this function's job to silently overwrite something it cannot interpret.
+func templateFrameworksAreSet(existing json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(existing))
+	if trimmed == "" || trimmed == "null" {
+		return false
+	}
+
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(existing, &members); err != nil {
+		return true
+	}
+	for _, member := range members {
+		if strings.TrimSpace(string(member)) != "null" {
+			return true
+		}
+	}
+	return false
 }
 
 // templateEntitlementCovers reports whether the template's entitlements

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -84,18 +85,28 @@ type initOptions struct {
 	persistPath         string
 	assistant           string
 	installClaudeSkills bool
+	frameworks          []string
+	ros2DomainID        int
+	ros2RMW             string
+	ros2Distro          string
+	ros2DiscoveryScope  string
 
-	appIDSet        bool
-	targetSet       bool
-	languageSet     bool
-	templateSet     bool
-	gitInitSet      bool
-	entitlementsSet bool
-	gpioPinsSet     bool
-	i2cDeviceSet    bool
-	persistNameSet  bool
-	persistPathSet  bool
-	assistantSet    bool
+	appIDSet              bool
+	targetSet             bool
+	languageSet           bool
+	templateSet           bool
+	gitInitSet            bool
+	entitlementsSet       bool
+	gpioPinsSet           bool
+	i2cDeviceSet          bool
+	persistNameSet        bool
+	persistPathSet        bool
+	assistantSet          bool
+	frameworksSet         bool
+	ros2DomainIDSet       bool
+	ros2RMWSet            bool
+	ros2DistroSet         bool
+	ros2DiscoveryScopeSet bool
 }
 
 // Questions for WendyOS devices.
@@ -118,7 +129,11 @@ func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [app-id]",
 		Short: "Initialize a new Wendy project",
-		Long:  "Interactively create a new Wendy project with scaffolding, entitlements, and optional AI assistant setup.",
+		Long: "Interactively create a new Wendy project with scaffolding, entitlements, and optional AI assistant setup.\n\n" +
+			"wendy.json also supports a separate, top-level \"frameworks\" key for framework-level config " +
+			"(currently ROS 2: domain ID, RMW middleware, discovery scope). Enable it with --framework " +
+			"(see the ROS 2 example below), through the interactive prompt on a WendyOS target, or by hand-editing " +
+			"\"frameworks\" in wendy.json afterwards.",
 		Example: `  # Interactive wizard
   wendy init
 
@@ -185,7 +200,17 @@ func newInitCmd() *cobra.Command {
     --language python \
     --entitlement gpu,audio \
     --assistant claude \
-    --install-claude-skills`,
+    --install-claude-skills
+
+  # ROS 2 app: enable the "frameworks" key with the ros2 framework
+  wendy init \
+    --app-id go2-network-bridge \
+    --target wendyos \
+    --language swift \
+    --framework ros2 \
+    --ros2-rmw cyclonedds \
+    --ros2-discovery-scope host \
+    --assistant skip`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.appIDSet = cmd.Flags().Changed("app-id")
@@ -199,6 +224,11 @@ func newInitCmd() *cobra.Command {
 			opts.persistNameSet = cmd.Flags().Changed("persist-name")
 			opts.persistPathSet = cmd.Flags().Changed("persist-path")
 			opts.assistantSet = cmd.Flags().Changed("assistant")
+			opts.frameworksSet = cmd.Flags().Changed("framework")
+			opts.ros2DomainIDSet = cmd.Flags().Changed("ros2-domain-id")
+			opts.ros2RMWSet = cmd.Flags().Changed("ros2-rmw")
+			opts.ros2DistroSet = cmd.Flags().Changed("ros2-distro")
+			opts.ros2DiscoveryScopeSet = cmd.Flags().Changed("ros2-discovery-scope")
 
 			err := runInitWizard(args, opts)
 			if errors.Is(err, tui.ErrCancelled) {
@@ -224,6 +254,11 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.persistPath, "persist-path", "", "Mount path for the persist entitlement (e.g. /data)")
 	cmd.Flags().StringVar(&opts.assistant, "assistant", "", "AI assistant to launch after init: claude, codex, or skip")
 	cmd.Flags().BoolVar(&opts.installClaudeSkills, "install-claude-skills", false, "Install Wendy Claude skills before launching Claude")
+	cmd.Flags().StringSliceVar(&opts.frameworks, "framework", nil, "App framework to enable in wendy.json's top-level \"frameworks\" key (repeatable or comma-separated; currently: ros2)")
+	cmd.Flags().IntVar(&opts.ros2DomainID, "ros2-domain-id", -1, fmt.Sprintf("ROS 2 domain ID, %d-%d (default: derived from the app ID)", appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax))
+	cmd.Flags().StringVar(&opts.ros2RMW, "ros2-rmw", "", "ROS 2 middleware implementation: cyclonedds (default), fastrtps, connextdds, or gurumdds")
+	cmd.Flags().StringVar(&opts.ros2Distro, "ros2-distro", "", fmt.Sprintf("ROS 2 distribution (default: %s)", appconfig.ROS2DefaultDistro))
+	cmd.Flags().StringVar(&opts.ros2DiscoveryScope, "ros2-discovery-scope", "", fmt.Sprintf("ROS 2 discovery scope: %s (default, isolated) or %s (shared with the device's host network)", appconfig.ROS2DiscoveryScopeApp, appconfig.ROS2DiscoveryScopeHost))
 
 	// Allow bare `--template` (no value) by rewriting os.Args before cobra
 	// parses flags. When --template appears as the last arg or is followed by
@@ -305,6 +340,15 @@ func runInitWizard(args []string, opts initOptions) error {
 		return err
 	}
 
+	// Step 3b: Framework support (currently ROS 2), via --framework/--ros2-*
+	// flags or, on a WendyOS target with no entitlement flags, an interactive
+	// prompt. wendy.json's top-level "frameworks" key otherwise has no
+	// discovery path from `wendy init` (WDY frameworks discoverability).
+	frameworks, err := resolveInitFrameworks(target, opts)
+	if err != nil {
+		return err
+	}
+
 	// Step 4: Generate wendy.json.
 	// WendyOS is Linux, so the WendyOS target writes the plain "linux"
 	// platform. wendy-lite and darwin need distinct values.
@@ -322,6 +366,7 @@ func runInitWizard(args []string, opts initOptions) error {
 		Platform:     platform,
 		Language:     language,
 		Entitlements: entitlements,
+		Frameworks:   frameworks,
 	}
 
 	if language == langPython {
@@ -339,6 +384,9 @@ func runInitWizard(args []string, opts initOptions) error {
 	}
 
 	cliSuccess("\nCreated wendy.json for %s", appID)
+	if frameworks != nil && frameworks.ROS2 != nil {
+		cliLogln("  Framework: ros2 (edit the \"frameworks\" key in wendy.json to change domain ID, RMW, or discovery scope)")
+	}
 
 	// Step 5: Scaffold project files.
 	if err := scaffoldProject(cwd, appID, target, language); err != nil {
@@ -368,7 +416,7 @@ func resolveInitTemplateForTarget(target string, opts initOptions) (string, *rep
 
 		if tmpl == "_pick" {
 			// Bare --template (no value): show interactive picker filtered by target.
-			name, err := pickTemplateNameForTarget(target, meta)
+			name, err := resolveBareTemplatePick(target, meta)
 			return name, meta, err
 		}
 
@@ -421,9 +469,10 @@ func templateTargetMatch(t repoMetaTemplate, target string) bool {
 	return false
 }
 
-// pickTemplateNameForTarget shows a picker with templates available for the given target.
-func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
-	fmt.Println()
+// templateItemsForTarget builds the picker items for the templates available
+// for target, shared by the interactive picker and its non-interactive
+// plain-text fallback.
+func templateItemsForTarget(target string, meta *repoMeta) []tui.PickerItem {
 	var items []tui.PickerItem
 	for _, t := range meta.Templates {
 		if templateTargetMatch(t, target) {
@@ -434,10 +483,32 @@ func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
 			})
 		}
 	}
+	return items
+}
+
+// pickTemplateNameForTarget shows a picker with templates available for the given target.
+func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
+	fmt.Println()
+	items := templateItemsForTarget(target, meta)
 	if len(items) == 0 {
 		return "", fmt.Errorf("no templates available for %s", target)
 	}
 	return pickFromItems("Choose a template", items)
+}
+
+// resolveBareTemplatePick handles a bare `--template` (rewritten to the
+// "_pick" sentinel by rewriteBareTemplateFlag): it shows the interactive
+// picker filtered by target, or — with no TTY attached — prints the same
+// list as plain text instead of failing on the picker's TTY open. Without
+// this, a headless caller (script, CI, or an AI agent) hit
+// "picker: could not open a new TTY" with no way to discover what templates
+// exist at all.
+func resolveBareTemplatePick(target string, meta *repoMeta) (string, error) {
+	if !isInteractiveTerminal() {
+		printPickerItemsPlainText("Available templates for "+target, templateItemsForTarget(target, meta))
+		return "", fmt.Errorf("--template requires a value when running non-interactively; pass --template=<name> using one of the templates listed above")
+	}
+	return pickTemplateNameForTarget(target, meta)
 }
 
 // pickTemplateOrSkipForTarget shows templates for the given target plus a "No template" option.
@@ -650,6 +721,12 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	// Resolve --framework/--ros2-* flags up front for the same reason.
+	requestedFrameworks, err := templateFrameworksFromFlags(target, opts)
+	if err != nil {
+		return err
+	}
+
 	// Parse --var overrides.
 	varOverrides, err := parseVarFlags(opts.vars)
 	if err != nil {
@@ -696,12 +773,20 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	addedFrameworks, err := mergeTemplateFrameworks(filepath.Join(destDir, "wendy.json"), requestedFrameworks)
+	if err != nil {
+		return err
+	}
+
 	cliSuccess("\nScaffolded %s project from template %q", language, tmpl)
 	cliLogln("  Directory: %s", tui.Path(destDir+"/"))
 	for _, v := range manifest.Variables {
 		if val, ok := vals[v.Name]; ok {
 			cliLogln("  %s: %v", v.Name, val)
 		}
+	}
+	if addedFrameworks {
+		cliLogln("  Frameworks added from flags: ros2")
 	}
 	if len(addedEntitlements) > 0 {
 		cliLogln("  Entitlements added from flags: %s", strings.Join(addedEntitlements, ", "))
@@ -908,6 +993,15 @@ func resolveInitAppID(cwd string, args []string, opts initOptions) (string, erro
 	return "", nil
 }
 
+// initTargetItems is the shared source of truth for the target picker (TTY)
+// and its non-interactive plain-text fallback (see resolveInitTarget), so the
+// two can never drift out of sync.
+var initTargetItems = []tui.PickerItem{
+	{Name: "WendyOS", Description: "Full Linux-based edge device (Jetson, Raspberry Pi, ...)", Value: targetWendyOS, SortKey: "0"},
+	{Name: "macOS", Description: "Native macOS app deployed to Wendy Agent for Mac", Value: targetDarwin, SortKey: "1"},
+	{Name: "Wendy Lite", Description: "Microcontroller running WASM (ESP32)", Value: targetWendyLite, SortKey: "2"},
+}
+
 func resolveInitTarget(opts initOptions) (string, error) {
 	if opts.targetSet {
 		target := normalizeInitTarget(opts.target)
@@ -917,12 +1011,29 @@ func resolveInitTarget(opts initOptions) (string, error) {
 		return target, nil
 	}
 
+	if !isInteractiveTerminal() {
+		printPickerItemsPlainText("Available targets", initTargetItems)
+		return "", fmt.Errorf("--target is required when running non-interactively (valid: %s, %s, %s)", targetWendyOS, targetDarwin, targetWendyLite)
+	}
+
 	fmt.Println()
-	return pickFromItems("What is your target device?", []tui.PickerItem{
-		{Name: "WendyOS", Description: "Full Linux-based edge device (Jetson, Raspberry Pi, ...)", Value: targetWendyOS, SortKey: "0"},
-		{Name: "macOS", Description: "Native macOS app deployed to Wendy Agent for Mac", Value: targetDarwin, SortKey: "1"},
-		{Name: "Wendy Lite", Description: "Microcontroller running WASM (ESP32)", Value: targetWendyLite, SortKey: "2"},
-	})
+	return pickFromItems("What is your target device?", initTargetItems)
+}
+
+// printPickerItemsPlainText renders picker items as a plain-text list. Used
+// as the non-interactive fallback for choices that would otherwise require a
+// Bubble Tea picker, which fails ungracefully ("could not open a new TTY")
+// when stdin/stdout are not real terminals (WDY frameworks/template
+// discoverability follow-up).
+func printPickerItemsPlainText(title string, items []tui.PickerItem) {
+	cliLogln("%s:", title)
+	for _, item := range items {
+		if item.Description != "" {
+			cliLogln("  %s - %s", item.Name, item.Description)
+		} else {
+			cliLogln("  %s", item.Name)
+		}
+	}
 }
 
 func resolveInitLanguage(target string, opts initOptions) (string, error) {
@@ -948,6 +1059,25 @@ func resolveInitEntitlements(target, language string, opts initOptions) ([]appco
 
 	fmt.Println()
 	return askEntitlementQuestions(target, language)
+}
+
+// resolveInitFrameworks determines the "frameworks" config (currently just
+// ROS 2) for the non-template flow: explicit --framework/--ros2-* flags win;
+// otherwise, on a WendyOS target with no entitlement flags either (i.e. the
+// caller is answering questions interactively, not scripting the whole
+// setup), ask. wendy-lite and darwin targets don't run the ROS 2 container
+// image, so frameworks are WendyOS-only.
+func resolveInitFrameworks(target string, opts initOptions) (*appconfig.FrameworksConfig, error) {
+	if initFrameworksProvided(opts) {
+		return buildInitFrameworksFromFlags(target, opts)
+	}
+
+	if initEntitlementsProvided(opts) || target != targetWendyOS {
+		return nil, nil
+	}
+
+	fmt.Println()
+	return askFrameworkQuestions()
 }
 
 func resolveInitAssistant(appID, target, language string, entitlements []appconfig.Entitlement, opts initOptions) error {
@@ -1027,6 +1157,160 @@ var askEntitlementQuestions = func(target, language string) ([]appconfig.Entitle
 	}
 
 	return entitlements, nil
+}
+
+// ros2RMWPickerItems lists the RMW implementations offered by the interactive
+// ROS 2 setup prompt. Values are the short aliases appconfig.ROS2Config
+// accepts (see ResolvedRMW) alongside their full identifiers.
+var ros2RMWPickerItems = []tui.PickerItem{
+	{Name: "CycloneDDS", Description: "Default; lightweight and widely used", Value: "cyclonedds", SortKey: "0"},
+	{Name: "Fast DDS", Description: "eProsima's RMW, ROS 2's historical default", Value: "fastrtps", SortKey: "1"},
+	{Name: "Connext DDS", Description: "RTI's commercial-grade RMW", Value: "connextdds", SortKey: "2"},
+	{Name: "GurumDDS", Description: "Gurum Networks RMW", Value: "gurumdds", SortKey: "3"},
+}
+
+// askFrameworkQuestions interactively offers ROS 2 support for a WendyOS
+// app (WDY frameworks discoverability: `wendy init` gave no hint that a
+// separate top-level "frameworks" key exists in wendy.json). Domain ID and
+// discovery scope are surfaced; the distro is left at its default and can be
+// changed by hand afterwards.
+var askFrameworkQuestions = func() (*appconfig.FrameworksConfig, error) {
+	wantROS2, err := tui.Confirm("Does your app use ROS 2 (Robot Operating System)?")
+	if err != nil {
+		return nil, err
+	}
+	if !wantROS2 {
+		return nil, nil
+	}
+
+	rmw, err := pickFromItems("Which ROS 2 middleware (RMW) implementation?", ros2RMWPickerItems)
+	if err != nil {
+		return nil, err
+	}
+
+	scope, err := pickFromItems("ROS 2 discovery scope?", []tui.PickerItem{
+		{Name: "App-local (default)", Description: "Isolated to this app's own containers", Value: appconfig.ROS2DiscoveryScopeApp, SortKey: "0"},
+		{Name: "Host network", Description: "Discoverable across the device's host network", Value: appconfig.ROS2DiscoveryScopeHost, SortKey: "1"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	domainIDInput, err := tui.PromptText(
+		"ROS 2 domain ID",
+		fmt.Sprintf("%d-%d, leave empty to auto-derive from the app ID", appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax),
+		func(v string) error {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				return nil
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("must be a number")
+			}
+			if n < appconfig.ROS2DomainIDMin || n > appconfig.ROS2DomainIDMax {
+				return fmt.Errorf("must be between %d and %d", appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ros2 := &appconfig.ROS2Config{RMW: rmw, DiscoveryScope: scope}
+	if domainIDInput = strings.TrimSpace(domainIDInput); domainIDInput != "" {
+		domainID, err := strconv.Atoi(domainIDInput)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ROS 2 domain ID %q: %w", domainIDInput, err)
+		}
+		ros2.DomainID = &domainID
+	}
+
+	cliLogln("ROS 2 distro left at the default (%q) — edit \"frameworks.ros2.distro\" in wendy.json to change it.", appconfig.ROS2DefaultDistro)
+
+	return &appconfig.FrameworksConfig{ROS2: ros2}, nil
+}
+
+// initFrameworksProvided reports whether the user supplied any
+// --framework/--ros2-* flag, mirroring initEntitlementsProvided.
+func initFrameworksProvided(opts initOptions) bool {
+	return opts.frameworksSet || opts.ros2DomainIDSet || opts.ros2RMWSet || opts.ros2DistroSet || opts.ros2DiscoveryScopeSet
+}
+
+// buildInitFrameworksFromFlags resolves --framework/--ros2-* into a
+// FrameworksConfig, or nil when no framework was requested. Field values are
+// validated with the same rules appconfig.AppConfig.Validate enforces on
+// wendy.json (see validateROS2Config), so a typo fails fast here with a
+// --flag-specific message instead of surfacing later from `wendy run` or
+// `wendy device ros2`.
+func buildInitFrameworksFromFlags(target string, opts initOptions) (*appconfig.FrameworksConfig, error) {
+	ros2Requested := opts.ros2DomainIDSet || opts.ros2RMWSet || opts.ros2DistroSet || opts.ros2DiscoveryScopeSet
+
+	if opts.frameworksSet {
+		var unknown []string
+		requestedROS2 := false
+		for _, raw := range opts.frameworks {
+			name := normalizeInitChoice(raw)
+			if name == "" {
+				continue
+			}
+			if name == "ros2" {
+				requestedROS2 = true
+				continue
+			}
+			unknown = append(unknown, name)
+		}
+		if len(unknown) > 0 {
+			return nil, fmt.Errorf("invalid framework %q (valid: ros2)", strings.Join(unknown, ", "))
+		}
+		if !requestedROS2 && !ros2Requested {
+			return nil, fmt.Errorf("--framework requires at least one valid framework")
+		}
+		ros2Requested = ros2Requested || requestedROS2
+	}
+
+	if !ros2Requested {
+		return nil, nil
+	}
+
+	if target == targetWendyLite || target == targetDarwin {
+		return nil, fmt.Errorf("%s does not support the ros2 framework", target)
+	}
+
+	ros2 := &appconfig.ROS2Config{}
+
+	if opts.ros2DomainIDSet {
+		if opts.ros2DomainID < appconfig.ROS2DomainIDMin || opts.ros2DomainID > appconfig.ROS2DomainIDMax {
+			return nil, fmt.Errorf("--ros2-domain-id must be between %d and %d, got %d", appconfig.ROS2DomainIDMin, appconfig.ROS2DomainIDMax, opts.ros2DomainID)
+		}
+		domainID := opts.ros2DomainID
+		ros2.DomainID = &domainID
+	}
+
+	if opts.ros2RMWSet {
+		ros2.RMW = strings.TrimSpace(opts.ros2RMW)
+		if ros2.ResolvedRMW() == "" {
+			return nil, fmt.Errorf("invalid --ros2-rmw %q (valid: cyclonedds, fastrtps, connextdds, gurumdds)", opts.ros2RMW)
+		}
+	}
+
+	if opts.ros2DistroSet {
+		distro := strings.TrimSpace(opts.ros2Distro)
+		if !appconfig.ROS2DistroPattern.MatchString(strings.ToLower(distro)) {
+			return nil, fmt.Errorf("invalid --ros2-distro %q (lowercase letters and digits, starting with a letter — e.g. %q)", opts.ros2Distro, appconfig.ROS2DefaultDistro)
+		}
+		ros2.Distro = distro
+	}
+
+	if opts.ros2DiscoveryScopeSet {
+		ros2.DiscoveryScope = strings.TrimSpace(opts.ros2DiscoveryScope)
+		if ros2.ResolvedDiscoveryScope() == "" {
+			return nil, fmt.Errorf("invalid --ros2-discovery-scope %q (valid: %s, %s)", opts.ros2DiscoveryScope, appconfig.ROS2DiscoveryScopeApp, appconfig.ROS2DiscoveryScopeHost)
+		}
+	}
+
+	return &appconfig.FrameworksConfig{ROS2: ros2}, nil
 }
 
 func initEntitlementsProvided(opts initOptions) bool {
@@ -1206,6 +1490,57 @@ func mergeTemplateEntitlements(cfgPath string, requested []appconfig.Entitlement
 		return nil, fmt.Errorf("writing scaffolded wendy.json: %w", err)
 	}
 	return added, nil
+}
+
+// templateFrameworksFromFlags resolves --framework/--ros2-* flags for the
+// template flow, mirroring templateEntitlementsFromFlags.
+func templateFrameworksFromFlags(target string, opts initOptions) (*appconfig.FrameworksConfig, error) {
+	if !initFrameworksProvided(opts) {
+		return nil, nil
+	}
+	return buildInitFrameworksFromFlags(target, opts)
+}
+
+// mergeTemplateFrameworks writes requested into the scaffolded wendy.json's
+// top-level "frameworks" key, reporting whether it made a change. Unlike
+// mergeTemplateEntitlements (a list, deduplicated entry by entry),
+// "frameworks" is a single nested object: if the template already sets one,
+// it wins outright and requested is dropped, matching the "template's more
+// specific config wins" rule mergeTemplateEntitlements documents.
+func mergeTemplateFrameworks(cfgPath string, requested *appconfig.FrameworksConfig) (bool, error) {
+	if requested == nil {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return false, fmt.Errorf("reading scaffolded wendy.json to merge framework flags: %w", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parsing scaffolded wendy.json: %w", err)
+	}
+
+	if existing, ok := raw["frameworks"]; ok && len(existing) > 0 && string(existing) != "null" {
+		return false, nil
+	}
+
+	frameworksRaw, err := json.Marshal(requested)
+	if err != nil {
+		return false, fmt.Errorf("marshaling frameworks: %w", err)
+	}
+	raw["frameworks"] = frameworksRaw
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshaling scaffolded wendy.json: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(cfgPath, out, 0o644); err != nil {
+		return false, fmt.Errorf("writing scaffolded wendy.json: %w", err)
+	}
+	return true, nil
 }
 
 // templateEntitlementCovers reports whether the template's entitlements

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -27,6 +27,11 @@ func TestNewInitCmd_Flags(t *testing.T) {
 		"persist-path",
 		"assistant",
 		"install-claude-skills",
+		"framework",
+		"ros2-domain-id",
+		"ros2-rmw",
+		"ros2-distro",
+		"ros2-discovery-scope",
 	}
 
 	for _, name := range expectedFlags {
@@ -55,6 +60,10 @@ func TestInitCommand_HelpIncludesExamples(t *testing.T) {
 		"--no-extra-entitlements",
 		"--assistant claude",
 		"--install-claude-skills",
+		// WDY frameworks discoverability: `wendy init --help` must at least
+		// mention that a "frameworks" key exists and how to reach it.
+		"frameworks",
+		"--framework ros2",
 	}
 	for _, want := range expected {
 		if !strings.Contains(output, want) {
@@ -651,6 +660,12 @@ func TestInitCommand_NoExtraEntitlementsFalseStillPrompts(t *testing.T) {
 	}
 	t.Cleanup(func() { askEntitlementQuestions = origAsk })
 
+	// Also replace the (equally interactive) ROS 2 framework prompt this test
+	// doesn't care about, so it doesn't try to open a real TTY.
+	origAskFrameworks := askFrameworkQuestions
+	askFrameworkQuestions = func() (*appconfig.FrameworksConfig, error) { return nil, nil }
+	t.Cleanup(func() { askFrameworkQuestions = origAskFrameworks })
+
 	cmd := newInitCmd()
 	cmd.SetArgs([]string{
 		"--app-id", "demo-app",
@@ -1048,5 +1063,455 @@ func TestTemplateEntitlementsFromFlags_DarwinRejectsEntitlementFlags(t *testing.
 	})
 	if err == nil {
 		t.Fatal("expected darwin + --entitlement to fail")
+	}
+}
+
+// ── Problem B: `wendy init --template` (and the target picker upstream of
+// it) must degrade to a plain-text list instead of crashing on TTY open when
+// no TTY is attached. ────────────────────────────────────────────────────
+
+func TestResolveInitTarget_NonInteractiveWithoutFlagFails(t *testing.T) {
+	orig := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = orig })
+
+	_, err := resolveInitTarget(initOptions{})
+	if err == nil {
+		t.Fatal("expected non-interactive target resolution without --target to fail")
+	}
+	if !strings.Contains(err.Error(), "--target is required") {
+		t.Fatalf("error = %q, want mention of --target", err)
+	}
+}
+
+func TestResolveInitTarget_NonInteractiveWithFlagSucceeds(t *testing.T) {
+	orig := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = orig })
+
+	target, err := resolveInitTarget(initOptions{target: "wendyos", targetSet: true})
+	if err != nil {
+		t.Fatalf("resolveInitTarget: %v", err)
+	}
+	if target != targetWendyOS {
+		t.Fatalf("target = %q, want %q", target, targetWendyOS)
+	}
+}
+
+// The WDY-init-template-tty repro: `wendy init --template` with no TTY must
+// print the available templates instead of crashing with
+// "picker: could not open a new TTY".
+func TestResolveBareTemplatePick_NonInteractivePrintsListAndErrors(t *testing.T) {
+	orig := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = orig })
+
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{
+			{Name: "simple-api", Description: "Minimal HTTP API"},
+			{Name: "mac-llm", Description: "macOS-only template", Targets: []string{targetDarwin}},
+		},
+	}
+
+	_, err := resolveBareTemplatePick(targetWendyOS, meta)
+	if err == nil {
+		t.Fatal("expected non-interactive bare --template to fail")
+	}
+	if !strings.Contains(err.Error(), "--template requires a value") {
+		t.Fatalf("error = %q, want mention of --template", err)
+	}
+}
+
+func TestTemplateItemsForTarget_FiltersByTarget(t *testing.T) {
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{
+			{Name: "simple-api", Description: "Minimal HTTP API"},
+			{Name: "mac-llm", Description: "macOS-only template", Targets: []string{targetDarwin}},
+		},
+	}
+
+	items := templateItemsForTarget(targetWendyOS, meta)
+	if len(items) != 1 || items[0].Value.(string) != "simple-api" {
+		t.Fatalf("templateItemsForTarget(wendyos) = %+v, want only simple-api", items)
+	}
+
+	items = templateItemsForTarget(targetDarwin, meta)
+	if len(items) != 1 || items[0].Value.(string) != "mac-llm" {
+		t.Fatalf("templateItemsForTarget(darwin) = %+v, want only mac-llm", items)
+	}
+}
+
+// ── Problem A: `frameworks`/ROS 2 support must be discoverable from
+// `wendy init` via --framework/--ros2-* flags or an interactive prompt. ────
+
+func TestBuildInitFrameworksFromFlags_NoFlagsIsNoOp(t *testing.T) {
+	frameworks, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{})
+	if err != nil {
+		t.Fatalf("buildInitFrameworksFromFlags: %v", err)
+	}
+	if frameworks != nil {
+		t.Fatalf("frameworks = %+v, want nil", frameworks)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_FrameworkROS2CreatesDefaultConfig(t *testing.T) {
+	frameworks, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		frameworksSet: true,
+		frameworks:    []string{"ros2"},
+	})
+	if err != nil {
+		t.Fatalf("buildInitFrameworksFromFlags: %v", err)
+	}
+	if frameworks == nil || frameworks.ROS2 == nil {
+		t.Fatalf("frameworks = %+v, want a ros2 config", frameworks)
+	}
+	if frameworks.ROS2.DomainID != nil || frameworks.ROS2.RMW != "" || frameworks.ROS2.Distro != "" || frameworks.ROS2.DiscoveryScope != "" {
+		t.Fatalf("ros2 config = %+v, want all fields left at their zero value (defaults apply)", frameworks.ROS2)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsUnknownFramework(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		frameworksSet: true,
+		frameworks:    []string{"ros1"},
+	})
+	if err == nil {
+		t.Fatal("expected unknown framework to fail")
+	}
+	if !strings.Contains(err.Error(), `"ros1"`) {
+		t.Fatalf("error = %q, want mention of ros1", err)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_EmptyFrameworkFlagFails(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		frameworksSet: true,
+		frameworks:    []string{"", "  "},
+	})
+	if err == nil {
+		t.Fatal("expected --framework with no valid entries to fail")
+	}
+}
+
+// Ros2-specific flags imply the ros2 framework even without --framework ros2,
+// mirroring how --gpio-pins implies the gpio entitlement.
+func TestBuildInitFrameworksFromFlags_ROS2FlagsImplyFramework(t *testing.T) {
+	domainID := 42
+	frameworks, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		ros2DomainIDSet:       true,
+		ros2DomainID:          domainID,
+		ros2RMWSet:            true,
+		ros2RMW:               "fastrtps",
+		ros2DistroSet:         true,
+		ros2Distro:            "jazzy",
+		ros2DiscoveryScopeSet: true,
+		ros2DiscoveryScope:    "host",
+	})
+	if err != nil {
+		t.Fatalf("buildInitFrameworksFromFlags: %v", err)
+	}
+	if frameworks == nil || frameworks.ROS2 == nil {
+		t.Fatal("expected ros2-specific flags to produce a ros2 config")
+	}
+	ros2 := frameworks.ROS2
+	if ros2.DomainID == nil || *ros2.DomainID != domainID {
+		t.Fatalf("DomainID = %v, want %d", ros2.DomainID, domainID)
+	}
+	if ros2.RMW != "fastrtps" {
+		t.Fatalf("RMW = %q, want fastrtps", ros2.RMW)
+	}
+	if ros2.Distro != "jazzy" {
+		t.Fatalf("Distro = %q, want jazzy", ros2.Distro)
+	}
+	if ros2.DiscoveryScope != "host" {
+		t.Fatalf("DiscoveryScope = %q, want host", ros2.DiscoveryScope)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsOutOfRangeDomainID(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		ros2DomainIDSet: true,
+		ros2DomainID:    9999,
+	})
+	if err == nil {
+		t.Fatal("expected out-of-range --ros2-domain-id to fail")
+	}
+	if !strings.Contains(err.Error(), "--ros2-domain-id") {
+		t.Fatalf("error = %q, want mention of --ros2-domain-id", err)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsInvalidRMW(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		ros2RMWSet: true,
+		ros2RMW:    "not-a-real-rmw",
+	})
+	if err == nil {
+		t.Fatal("expected invalid --ros2-rmw to fail")
+	}
+	if !strings.Contains(err.Error(), "--ros2-rmw") {
+		t.Fatalf("error = %q, want mention of --ros2-rmw", err)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsInvalidDistro(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		ros2DistroSet: true,
+		ros2Distro:    "Not_Valid!",
+	})
+	if err == nil {
+		t.Fatal("expected invalid --ros2-distro to fail")
+	}
+	if !strings.Contains(err.Error(), "--ros2-distro") {
+		t.Fatalf("error = %q, want mention of --ros2-distro", err)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsInvalidDiscoveryScope(t *testing.T) {
+	_, err := buildInitFrameworksFromFlags(targetWendyOS, initOptions{
+		ros2DiscoveryScopeSet: true,
+		ros2DiscoveryScope:    "everywhere",
+	})
+	if err == nil {
+		t.Fatal("expected invalid --ros2-discovery-scope to fail")
+	}
+	if !strings.Contains(err.Error(), "--ros2-discovery-scope") {
+		t.Fatalf("error = %q, want mention of --ros2-discovery-scope", err)
+	}
+}
+
+func TestBuildInitFrameworksFromFlags_RejectsUnsupportedTargets(t *testing.T) {
+	for _, target := range []string{targetWendyLite, targetDarwin} {
+		t.Run(target, func(t *testing.T) {
+			_, err := buildInitFrameworksFromFlags(target, initOptions{
+				frameworksSet: true,
+				frameworks:    []string{"ros2"},
+			})
+			if err == nil {
+				t.Fatalf("expected %s + ros2 framework to fail", target)
+			}
+		})
+	}
+}
+
+func TestResolveInitFrameworks_SkipsInteractivePromptWhenEntitlementFlagsProvided(t *testing.T) {
+	// If askFrameworkQuestions were invoked here, it would try to open a real
+	// TTY (it isn't stubbed in this test) and fail; a nil, nil result proves
+	// resolveInitFrameworks took the flag-driven no-op path instead.
+	frameworks, err := resolveInitFrameworks(targetWendyOS, initOptions{noExtraEntitlements: true})
+	if err != nil {
+		t.Fatalf("resolveInitFrameworks: %v", err)
+	}
+	if frameworks != nil {
+		t.Fatalf("frameworks = %+v, want nil", frameworks)
+	}
+}
+
+func TestResolveInitFrameworks_SkipsInteractivePromptForUnsupportedTargets(t *testing.T) {
+	for _, target := range []string{targetWendyLite, targetDarwin} {
+		t.Run(target, func(t *testing.T) {
+			frameworks, err := resolveInitFrameworks(target, initOptions{})
+			if err != nil {
+				t.Fatalf("resolveInitFrameworks: %v", err)
+			}
+			if frameworks != nil {
+				t.Fatalf("frameworks = %+v, want nil", frameworks)
+			}
+		})
+	}
+}
+
+func TestResolveInitFrameworks_UsesFlagsWhenProvided(t *testing.T) {
+	frameworks, err := resolveInitFrameworks(targetWendyOS, initOptions{
+		frameworksSet: true,
+		frameworks:    []string{"ros2"},
+	})
+	if err != nil {
+		t.Fatalf("resolveInitFrameworks: %v", err)
+	}
+	if frameworks == nil || frameworks.ROS2 == nil {
+		t.Fatal("expected --framework ros2 to produce a ros2 config")
+	}
+}
+
+func TestTemplateFrameworksFromFlags_NoFlagsIsNoOp(t *testing.T) {
+	frameworks, err := templateFrameworksFromFlags(targetWendyOS, initOptions{})
+	if err != nil {
+		t.Fatalf("templateFrameworksFromFlags: %v", err)
+	}
+	if frameworks != nil {
+		t.Fatalf("frameworks = %+v, want nil", frameworks)
+	}
+}
+
+func TestMergeTemplateFrameworks_AddsROS2ToTemplateConfig(t *testing.T) {
+	cfgPath := writeTemplateWendyJSON(t, `{
+  "appId": "ros2-app",
+  "version": "0.1.0",
+  "platform": "linux",
+  "language": "swift",
+  "entitlements": [{"type": "network"}]
+}`)
+
+	requested, err := templateFrameworksFromFlags(targetWendyOS, initOptions{
+		frameworksSet: true,
+		frameworks:    []string{"ros2"},
+	})
+	if err != nil {
+		t.Fatalf("templateFrameworksFromFlags: %v", err)
+	}
+
+	added, err := mergeTemplateFrameworks(cfgPath, requested)
+	if err != nil {
+		t.Fatalf("mergeTemplateFrameworks: %v", err)
+	}
+	if !added {
+		t.Fatal("expected mergeTemplateFrameworks to report a change")
+	}
+
+	cfg, err := appconfig.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	if cfg.Frameworks == nil || cfg.Frameworks.ROS2 == nil {
+		t.Fatalf("Frameworks = %+v, want a ros2 config", cfg.Frameworks)
+	}
+}
+
+func TestMergeTemplateFrameworks_NoFlagsIsNoOp(t *testing.T) {
+	added, err := mergeTemplateFrameworks(filepath.Join(t.TempDir(), "missing", "wendy.json"), nil)
+	if err != nil {
+		t.Fatalf("mergeTemplateFrameworks: %v", err)
+	}
+	if added {
+		t.Fatal("expected no-op when nothing was requested")
+	}
+}
+
+// The template's own "frameworks" config wins over --framework/--ros2-*
+// flags, mirroring how a template's more specific entitlement config wins in
+// mergeTemplateEntitlements.
+func TestMergeTemplateFrameworks_TemplateConfigWins(t *testing.T) {
+	content := `{
+  "appId": "ros2-app",
+  "frameworks": {"ros2": {"distro": "iron"}},
+  "entitlements": [{"type": "network"}]
+}`
+	cfgPath := writeTemplateWendyJSON(t, content)
+
+	domainID := 5
+	requested := &appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{DomainID: &domainID}}
+	added, err := mergeTemplateFrameworks(cfgPath, requested)
+	if err != nil {
+		t.Fatalf("mergeTemplateFrameworks: %v", err)
+	}
+	if added {
+		t.Fatal("expected template's existing frameworks config to win")
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != content {
+		t.Fatalf("wendy.json was rewritten:\n%s", data)
+	}
+}
+
+func TestMergeTemplateFrameworks_MissingConfigFails(t *testing.T) {
+	_, err := mergeTemplateFrameworks(
+		filepath.Join(t.TempDir(), "wendy.json"),
+		&appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{}},
+	)
+	if err == nil {
+		t.Fatal("expected merge into a missing wendy.json to fail")
+	}
+}
+
+// End-to-end: --framework ros2 plus --ros2-* flags on a non-template `wendy
+// init` must produce a wendy.json with a populated "frameworks" key — the
+// concrete, scriptable path around the discoverability gap in Problem A.
+func TestInitCommand_FrameworkFlagsCreateROS2Config(t *testing.T) {
+	tempDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{
+		"--app-id", "go2-network-bridge",
+		"--target", "wendyos",
+		"--language", "swift",
+		"--no-extra-entitlements",
+		"--framework", "ros2",
+		"--ros2-rmw", "fastrtps",
+		"--ros2-discovery-scope", "host",
+		"--ros2-domain-id", "17",
+		"--assistant", "skip",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	cfg, err := appconfig.LoadFromFile(filepath.Join(tempDir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+
+	if cfg.Frameworks == nil || cfg.Frameworks.ROS2 == nil {
+		t.Fatalf("Frameworks = %+v, want a ros2 config", cfg.Frameworks)
+	}
+	ros2 := cfg.Frameworks.ROS2
+	if ros2.RMW != "fastrtps" {
+		t.Fatalf("RMW = %q, want fastrtps", ros2.RMW)
+	}
+	if ros2.DiscoveryScope != "host" {
+		t.Fatalf("DiscoveryScope = %q, want host", ros2.DiscoveryScope)
+	}
+	if ros2.DomainID == nil || *ros2.DomainID != 17 {
+		t.Fatalf("DomainID = %v, want 17", ros2.DomainID)
+	}
+}
+
+func TestInitCommand_NoFrameworkFlagsLeavesFrameworksNil(t *testing.T) {
+	tempDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{
+		"--app-id", "plain-app",
+		"--target", "wendyos",
+		"--language", "swift",
+		"--no-extra-entitlements",
+		"--assistant", "skip",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	cfg, err := appconfig.LoadFromFile(filepath.Join(tempDir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	if cfg.Frameworks != nil {
+		t.Fatalf("Frameworks = %+v, want nil when no --framework flags were passed", cfg.Frameworks)
 	}
 }

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1122,6 +1122,29 @@ func TestResolveBareTemplatePick_NonInteractivePrintsListAndErrors(t *testing.T)
 	}
 }
 
+func TestResolveBareTemplatePick_NonInteractiveWithNoTemplatesReportsNoTemplates(t *testing.T) {
+	orig := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = orig })
+
+	// Only a darwin template exists, so the wendyos list is empty. The error
+	// must name the real problem instead of blaming the missing --template
+	// value and printing an empty list.
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{
+			{Name: "mac-llm", Description: "macOS-only template", Targets: []string{targetDarwin}},
+		},
+	}
+
+	_, err := resolveBareTemplatePick(targetWendyOS, meta)
+	if err == nil {
+		t.Fatal("expected non-interactive bare --template with no templates to fail")
+	}
+	if !strings.Contains(err.Error(), "no templates available for "+targetWendyOS) {
+		t.Fatalf("error = %q, want %q", err, "no templates available for "+targetWendyOS)
+	}
+}
+
 func TestTemplateItemsForTarget_FiltersByTarget(t *testing.T) {
 	meta := &repoMeta{
 		Templates: []repoMetaTemplate{
@@ -1407,6 +1430,68 @@ func TestMergeTemplateFrameworks_TemplateConfigWins(t *testing.T) {
 	}
 	if added {
 		t.Fatal("expected template's existing frameworks config to win")
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != content {
+		t.Fatalf("wendy.json was rewritten:\n%s", data)
+	}
+}
+
+func TestMergeTemplateFrameworks_EmptyTemplateObjectDoesNotWin(t *testing.T) {
+	// A template that writes "frameworks": {} (or a null member) configures
+	// nothing, so it must not silently swallow --framework/--ros2-* flags.
+	for name, content := range map[string]string{
+		"emptyObject": `{"appId": "ros2-app", "frameworks": {}}`,
+		"nullMember":  `{"appId": "ros2-app", "frameworks": {"ros2": null}}`,
+		"nullValue":   `{"appId": "ros2-app", "frameworks": null}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfgPath := writeTemplateWendyJSON(t, content)
+
+			domainID := 5
+			requested := &appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{DomainID: &domainID}}
+			added, err := mergeTemplateFrameworks(cfgPath, requested)
+			if err != nil {
+				t.Fatalf("mergeTemplateFrameworks: %v", err)
+			}
+			if !added {
+				t.Fatal("expected requested frameworks to be merged into an unset template frameworks key")
+			}
+
+			data, err := os.ReadFile(cfgPath)
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			var cfg appconfig.AppConfig
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if cfg.Frameworks == nil || cfg.Frameworks.ROS2 == nil || cfg.Frameworks.ROS2.DomainID == nil {
+				t.Fatalf("frameworks.ros2.domainId missing:\n%s", data)
+			}
+			if *cfg.Frameworks.ROS2.DomainID != domainID {
+				t.Fatalf("domainId = %d, want %d", *cfg.Frameworks.ROS2.DomainID, domainID)
+			}
+		})
+	}
+}
+
+func TestMergeTemplateFrameworks_MalformedFrameworksValueLeavesFileUntouched(t *testing.T) {
+	// A scalar under "frameworks" is not something this merge can interpret,
+	// so it is left alone rather than silently overwritten.
+	content := `{"appId": "ros2-app", "frameworks": "ros2"}`
+	cfgPath := writeTemplateWendyJSON(t, content)
+
+	added, err := mergeTemplateFrameworks(cfgPath, &appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{}})
+	if err != nil {
+		t.Fatalf("mergeTemplateFrameworks: %v", err)
+	}
+	if added {
+		t.Fatal("expected an uninterpretable frameworks value to be left untouched")
 	}
 
 	data, err := os.ReadFile(cfgPath)


### PR DESCRIPTION
## Summary

Two pieces of `wendy init` friction hit while scaffolding a ROS2 app for WendyOS:

- **Problem A — `frameworks` was undiscoverable.** `wendy.json` supports a separate, top-level `frameworks` key (used for ROS 2: domain ID, RMW middleware, discovery scope), but nothing in `wendy init`'s scaffold, its `--help` flags, or the generated `wendy.json` hinted it exists. Someone scaffolding a fresh ROS 2 app had no way to discover the feature short of already knowing to look for it.
- **Problem B — `wendy init --template` crashed with no TTY.** Running `wendy init --template` with no value in a non-interactive/headless context (script, CI, an AI agent) failed with `picker: could not open a new TTY: open /dev/tty: device not configured` instead of listing the available templates as plain text.

## Changes

- Added `--framework` (mirrors the existing `--entitlement` flag; currently accepts `ros2`) plus `--ros2-domain-id`, `--ros2-rmw`, `--ros2-distro`, and `--ros2-discovery-scope` to `wendy init`, wired into both the plain wizard flow and the `--template` flow (merged into the scaffolded `wendy.json` the same way `--entitlement` flags are).
- Added an interactive "Does your app use ROS 2?" prompt (RMW + discovery-scope pickers, domain-ID text prompt) on WendyOS targets when the user isn't already answering everything via flags.
- Mentioned `frameworks`/ROS 2 in `wendy init --help`'s `Long` description and added a worked `--framework ros2` example.
- Fixed `resolveInitTarget` (the target-device picker) and the bare `--template` picker to check `isInteractiveTerminal()` (the same detection the picker itself uses to produce the TTY error) and print their choices as plain text plus an actionable "pass --target/--template=<name>" error instead of crashing when no TTY is attached. Root-caused with a debug build: `wendy init --template` alone hits the *target* picker first, so both had to be fixed for the reported command to actually stop crashing.

## Test plan

- [x] `go test ./go/...` — full module, all green
- [x] `go vet ./go/...` — clean
- [x] `gofmt -l` — clean
- [x] New unit tests for `buildInitFrameworksFromFlags`, `resolveInitFrameworks`, `templateFrameworksFromFlags`/`mergeTemplateFrameworks`, `resolveInitTarget` (non-interactive), and `resolveBareTemplatePick` (non-interactive), following this repo's existing `isInteractiveTerminalFn`-stubbing convention
- [x] End-to-end `wendy init` tests asserting the scaffolded `wendy.json`'s `frameworks.ros2` fields
- [x] Manually reproduced both original bugs against a built binary and confirmed they're fixed:
  - `wendy init --app-id go2-network-bridge --target wendyos --language swift --no-extra-entitlements --framework ros2 --ros2-rmw cyclonedds --ros2-discovery-scope host --assistant skip --git-init no` now writes a `frameworks.ros2` block
  - `wendy init --template < /dev/null` no longer crashes; prints available targets/templates and an actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m4H6WcvoXVgSXnt1GqMR9