### PR TITLE
cli: add wendy docs and wendy project frameworks for offline discoverability

### DIFF
--- a/go/internal/cli/assets/assets.go
+++ b/go/internal/cli/assets/assets.go
@@ -4,9 +4,18 @@ package assets
 import "embed"
 
 // FS contains documentation and skill files embedded at compile time.
-// Only plain-Markdown reference documentation and skills are embedded here;
-// the docs-site source (Next.js app, MDX guides, components, images) lives in the
-// docs tree but is intentionally excluded to keep the CLI binary small.
+// Most of the docs-site source (Next.js app, components, images, video) lives
+// in the docs tree but is intentionally excluded to keep the CLI binary
+// small. The MDX content directories below (guides, hardware, installation,
+// integrations, remote-debugging, security) are text-only reference/guide
+// content — no images or Next.js machinery — so they are embedded alongside
+// the plain-Markdown reference docs, making them available to `wendy docs`
+// and the MCP wendy://docs/ resources with no network access required.
 //
-//go:embed docs/Examples docs/apps docs/architecture docs/clients docs/cloud docs/debugging docs/development docs/pki docs/vscode docs/wendy-lite docs/wendy-os-publisher docs/wendyos docs/RELEASES.md docs/device/entitlements.md docs/roadmap.md skills
+// docs/index.mdx (the marketing landing page) is deliberately excluded: it
+// leans on interactive components (<Cards>, <HardwareShowcase>, nested JSX in
+// attributes) that don't degrade to readable plain text the way the
+// reference/guide content does.
+//
+//go:embed docs/Examples docs/apps docs/architecture docs/clients docs/cloud docs/debugging docs/development docs/pki docs/vscode docs/wendy-lite docs/wendy-os-publisher docs/wendyos docs/RELEASES.md docs/device/entitlements.md docs/roadmap.md docs/guides docs/hardware docs/installation docs/integrations docs/remote-debugging docs/security skills
 var FS embed.FS

--- a/go/internal/cli/commands/docs_cmd.go
+++ b/go/internal/cli/commands/docs_cmd.go
@@ -1,0 +1,333 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/assets"
+)
+
+// docsBaseURL is the public docs site's stable "latest" alias (see
+// development/docs-site.md). Doc topics map onto it 1:1 by relative path, so
+// it doubles as a fallback for anyone who'd rather read in a browser.
+const docsBaseURL = "https://docs.wendy.dev/latest"
+
+// newDocsCmd builds `wendy docs [topic]`. Before this command, the CLI's
+// embedded documentation (go/internal/cli/assets/docs, wired up in
+// go/internal/cli/assets/assets.go) was reachable only through the MCP
+// server's wendy://docs/ resources — nothing surfaced it for a plain
+// terminal, scripted, or headless-agent invocation of `wendy`. This exposes
+// the same embedded content as printable text, with no network access
+// required.
+func newDocsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "docs [topic]",
+		Short: "Show Wendy documentation from the terminal",
+		Long: `Print Wendy's embedded documentation to the terminal — no browser required.
+
+Run with no arguments to list every available topic. A topic may be given by
+its short name (e.g. "ros2") or its full path under the docs tree (e.g.
+"integrations/ros2"). This is the same content published at ` + docsBaseURL + `.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			topics, err := docsTopics()
+			if err != nil {
+				return fmt.Errorf("listing docs: %w", err)
+			}
+			if len(args) == 0 {
+				printDocsTopicList(topics)
+				return nil
+			}
+			return printDocsTopic(topics, args[0])
+		},
+	}
+	return cmd
+}
+
+// docsTopic describes one renderable page under the embedded docs tree.
+type docsTopic struct {
+	// Path is the file path relative to the embedded docs root, e.g.
+	// "integrations/ros2.mdx".
+	Path string
+	// Slug is the short lookup key, e.g. "ros2" for "integrations/ros2.mdx"
+	// or "integrations" for "integrations/index.mdx". Not necessarily unique
+	// across topics (e.g. every tutorials/<language>/hello-world.mdx shares
+	// the slug "hello-world") — see printDocsTopic for how collisions are
+	// handled.
+	Slug string
+	// Title comes from the page's frontmatter when present, falling back to
+	// a title-cased form of the path.
+	Title string
+}
+
+// urlPath is the topic's path with its extension (and any trailing "/index")
+// stripped, matching the public docs site's URL scheme.
+func (t docsTopic) urlPath() string {
+	p := strings.TrimSuffix(t.Path, path.Ext(t.Path))
+	p = strings.TrimSuffix(p, "/index")
+	if p == "index" {
+		p = ""
+	}
+	return p
+}
+
+// publicURL is the full public docs-site URL for this topic.
+func (t docsTopic) publicURL() string {
+	up := t.urlPath()
+	if up == "" {
+		return docsBaseURL + "/"
+	}
+	return docsBaseURL + "/" + up + "/"
+}
+
+// docsTopics walks the embedded docs tree for renderable pages (.md/.mdx).
+// Everything else embedded under "docs" (meta.json navigation files,
+// package.json, etc.) is skipped by the extension check.
+func docsTopics() ([]docsTopic, error) {
+	var topics []docsTopic
+	err := fs.WalkDir(assets.FS, "docs", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := path.Ext(p)
+		if ext != ".md" && ext != ".mdx" {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, "docs/")
+		data, rerr := assets.FS.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		title, _, _ := parseDocFrontmatter(data)
+		if title == "" {
+			title = docTitleFromPath(rel)
+		}
+		topics = append(topics, docsTopic{
+			Path:  rel,
+			Slug:  docSlug(rel),
+			Title: title,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(topics, func(i, j int) bool { return topics[i].Path < topics[j].Path })
+	return topics, nil
+}
+
+// docSlug derives the short lookup key for a doc path: the file's base name,
+// or its parent directory's name when the file is that directory's index
+// page (e.g. "integrations/index.mdx" -> "integrations"). The root
+// "index.mdx" has no parent directory to borrow a name from, so it keeps the
+// literal slug "index".
+func docSlug(relPath string) string {
+	noExt := strings.TrimSuffix(relPath, path.Ext(relPath))
+	base := path.Base(noExt)
+	if base != "index" {
+		return base
+	}
+	dir := path.Dir(noExt)
+	if dir == "." {
+		return "index"
+	}
+	return path.Base(dir)
+}
+
+// docTitleFromPath produces a readable fallback title for a doc that has no
+// frontmatter title, e.g. "guides/tutorials/python/hello-world.mdx" ->
+// "hello world".
+func docTitleFromPath(relPath string) string {
+	base := path.Base(strings.TrimSuffix(relPath, path.Ext(relPath)))
+	base = strings.ReplaceAll(base, "-", " ")
+	return strings.ReplaceAll(base, "_", " ")
+}
+
+// docFrontmatterPattern matches a leading YAML frontmatter block delimited by
+// "---" lines, as used by the fumadocs MDX content (title/description keys).
+var docFrontmatterPattern = regexp.MustCompile(`(?s)\A---\r?\n(.*?)\r?\n---\r?\n?`)
+
+// parseDocFrontmatter extracts "title" and "description" from a leading YAML
+// frontmatter block, if present, and returns the remaining body. It only
+// understands simple "key: value" lines — everything these docs actually use
+// — not general YAML.
+func parseDocFrontmatter(data []byte) (title, description string, body []byte) {
+	loc := docFrontmatterPattern.FindSubmatchIndex(data)
+	if loc == nil {
+		return "", "", data
+	}
+	block := string(data[loc[2]:loc[3]])
+	body = data[loc[1]:]
+	for _, line := range strings.Split(block, "\n") {
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		switch key {
+		case "title":
+			title = val
+		case "description":
+			description = val
+		}
+	}
+	return title, description, body
+}
+
+// mdxComponentPattern strips fumadocs/JSX components (e.g. <Callout
+// type="info">…</Callout>, self-closing <ImageZoom .../>) from MDX bodies for
+// plain-terminal rendering. JSX convention capitalizes component names, which
+// is what distinguishes them here from any incidental "<" in prose. This is
+// lossy — a component's own visual treatment (callout icon, tabs, image) is
+// dropped — but its text content, which is what these docs actually convey,
+// reads fine as plain Markdown afterward.
+var mdxComponentPattern = regexp.MustCompile(`</?[A-Z][A-Za-z0-9]*(?:\s[^<>]*)?/?>`)
+
+func renderDocsMDX(body []byte) string {
+	return mdxComponentPattern.ReplaceAllString(string(body), "")
+}
+
+// printDocsTopicList prints every available doc topic grouped by directory,
+// or a JSON array of {path,slug,title} with --json.
+func printDocsTopicList(topics []docsTopic) {
+	if jsonOutput {
+		type jsonTopic struct {
+			Path  string `json:"path"`
+			Slug  string `json:"slug"`
+			Title string `json:"title"`
+		}
+		out := make([]jsonTopic, 0, len(topics))
+		for _, t := range topics {
+			out = append(out, jsonTopic{Path: t.urlPath(), Slug: t.Slug, Title: t.Title})
+		}
+		data, err := json.Marshal(out)
+		if err != nil {
+			return
+		}
+		fmt.Println(string(data))
+		return
+	}
+
+	groups := map[string][]docsTopic{}
+	var dirs []string
+	for _, t := range topics {
+		dir := path.Dir(t.Path)
+		if _, ok := groups[dir]; !ok {
+			dirs = append(dirs, dir)
+		}
+		groups[dir] = append(groups[dir], t)
+	}
+	sort.Strings(dirs)
+
+	fmt.Printf("Available doc topics (%d) — run `wendy docs <topic>` to read one:\n", len(topics))
+	for _, dir := range dirs {
+		if dir == "." {
+			fmt.Println()
+		} else {
+			fmt.Printf("\n%s/\n", dir)
+		}
+		items := groups[dir]
+		sort.Slice(items, func(i, j int) bool { return items[i].Path < items[j].Path })
+		for _, t := range items {
+			// The site-root index has no non-empty urlPath ("" maps to
+			// docsBaseURL itself); show its slug ("index") instead so the
+			// listed value is always something `wendy docs <topic>` accepts.
+			label := t.urlPath()
+			if label == "" {
+				label = t.Slug
+			}
+			fmt.Printf("  %-40s %s\n", label, t.Title)
+		}
+	}
+}
+
+// printDocsTopic resolves arg against topics and prints the match. arg may be
+// a short slug or the full path (with or without extension). An unresolvable
+// or ambiguous arg returns an error that lists the way out, matching the
+// quality of feedback `wendy project entitlements add <bad-type>` gives.
+func printDocsTopic(topics []docsTopic, arg string) error {
+	needle := strings.Trim(strings.TrimSpace(arg), "/")
+	needle = strings.TrimSuffix(needle, path.Ext(needle))
+
+	for _, t := range topics {
+		if t.urlPath() == needle {
+			return renderDocsTopic(t)
+		}
+	}
+
+	var matches []docsTopic
+	for _, t := range topics {
+		if t.Slug == needle {
+			matches = append(matches, t)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return renderDocsTopic(matches[0])
+	case 0:
+		names := make([]string, 0, len(topics))
+		for _, t := range topics {
+			names = append(names, t.urlPath())
+		}
+		sort.Strings(names)
+		return fmt.Errorf("unknown doc topic %q\nRun `wendy docs` with no arguments to list all %d available topics", arg, len(names))
+	default:
+		paths := make([]string, 0, len(matches))
+		for _, m := range matches {
+			paths = append(paths, m.urlPath())
+		}
+		sort.Strings(paths)
+		return fmt.Errorf("%q matches more than one doc topic; use the full path:\n  %s", arg, strings.Join(paths, "\n  "))
+	}
+}
+
+func renderDocsTopic(t docsTopic) error {
+	data, err := assets.FS.ReadFile("docs/" + t.Path)
+	if err != nil {
+		return err
+	}
+	title, description, body := parseDocFrontmatter(data)
+	if title == "" {
+		title = t.Title
+	}
+
+	if jsonOutput {
+		out := map[string]string{
+			"path":        t.urlPath(),
+			"title":       title,
+			"description": description,
+			"body":        renderDocsMDX(body),
+			"url":         t.publicURL(),
+		}
+		data, err := json.Marshal(out)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if title != "" {
+		fmt.Println(title)
+		fmt.Println(strings.Repeat("=", len(title)))
+		fmt.Println()
+	}
+	if description != "" {
+		fmt.Println(description)
+		fmt.Println()
+	}
+	fmt.Print(renderDocsMDX(body))
+	fmt.Println()
+	fmt.Printf("View online: %s\n", t.publicURL())
+	return nil
+}

--- a/go/internal/cli/commands/docs_cmd.go
+++ b/go/internal/cli/commands/docs_cmd.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"path"
 	"regexp"
@@ -40,11 +41,15 @@ its short name (e.g. "ros2") or its full path under the docs tree (e.g.
 			if err != nil {
 				return fmt.Errorf("listing docs: %w", err)
 			}
+			// cmd.OutOrStdout() (not cobra's cmd.Print*, which despite the
+			// name writes to OutOrStderr) keeps `wendy docs --json | jq`
+			// working while still honoring cmd.SetOut in tests.
+			out := cmd.OutOrStdout()
 			if len(args) == 0 {
-				printDocsTopicList(topics)
+				printDocsTopicList(out, topics)
 				return nil
 			}
-			return printDocsTopic(topics, args[0])
+			return printDocsTopic(out, topics, args[0])
 		},
 	}
 	return cmd
@@ -103,9 +108,13 @@ func docsTopics() ([]docsTopic, error) {
 			return nil
 		}
 		rel := strings.TrimPrefix(p, "docs/")
+		// WalkDir already found this entry in the embedded FS, so a read
+		// failure here means the embed itself is broken. Fail loudly rather
+		// than dropping the topic — a silently missing page looks identical
+		// to one that was never embedded.
 		data, rerr := assets.FS.ReadFile(p)
 		if rerr != nil {
-			return nil
+			return fmt.Errorf("reading embedded doc %q: %w", p, rerr)
 		}
 		title, _, _ := parseDocFrontmatter(data)
 		if title == "" {
@@ -199,7 +208,7 @@ func renderDocsMDX(body []byte) string {
 
 // printDocsTopicList prints every available doc topic grouped by directory,
 // or a JSON array of {path,slug,title} with --json.
-func printDocsTopicList(topics []docsTopic) {
+func printDocsTopicList(w io.Writer, topics []docsTopic) {
 	if jsonOutput {
 		type jsonTopic struct {
 			Path  string `json:"path"`
@@ -214,7 +223,7 @@ func printDocsTopicList(topics []docsTopic) {
 		if err != nil {
 			return
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(w, string(data))
 		return
 	}
 
@@ -229,12 +238,12 @@ func printDocsTopicList(topics []docsTopic) {
 	}
 	sort.Strings(dirs)
 
-	fmt.Printf("Available doc topics (%d) — run `wendy docs <topic>` to read one:\n", len(topics))
+	fmt.Fprintf(w, "Available doc topics (%d) — run `wendy docs <topic>` to read one:\n", len(topics))
 	for _, dir := range dirs {
 		if dir == "." {
-			fmt.Println()
+			fmt.Fprintln(w)
 		} else {
-			fmt.Printf("\n%s/\n", dir)
+			fmt.Fprintf(w, "\n%s/\n", dir)
 		}
 		items := groups[dir]
 		sort.Slice(items, func(i, j int) bool { return items[i].Path < items[j].Path })
@@ -246,7 +255,7 @@ func printDocsTopicList(topics []docsTopic) {
 			if label == "" {
 				label = t.Slug
 			}
-			fmt.Printf("  %-40s %s\n", label, t.Title)
+			fmt.Fprintf(w, "  %-40s %s\n", label, t.Title)
 		}
 	}
 }
@@ -255,13 +264,13 @@ func printDocsTopicList(topics []docsTopic) {
 // a short slug or the full path (with or without extension). An unresolvable
 // or ambiguous arg returns an error that lists the way out, matching the
 // quality of feedback `wendy project entitlements add <bad-type>` gives.
-func printDocsTopic(topics []docsTopic, arg string) error {
+func printDocsTopic(w io.Writer, topics []docsTopic, arg string) error {
 	needle := strings.Trim(strings.TrimSpace(arg), "/")
 	needle = strings.TrimSuffix(needle, path.Ext(needle))
 
 	for _, t := range topics {
 		if t.urlPath() == needle {
-			return renderDocsTopic(t)
+			return renderDocsTopic(w, t)
 		}
 	}
 
@@ -273,7 +282,7 @@ func printDocsTopic(topics []docsTopic, arg string) error {
 	}
 	switch len(matches) {
 	case 1:
-		return renderDocsTopic(matches[0])
+		return renderDocsTopic(w, matches[0])
 	case 0:
 		names := make([]string, 0, len(topics))
 		for _, t := range topics {
@@ -291,7 +300,7 @@ func printDocsTopic(topics []docsTopic, arg string) error {
 	}
 }
 
-func renderDocsTopic(t docsTopic) error {
+func renderDocsTopic(w io.Writer, t docsTopic) error {
 	data, err := assets.FS.ReadFile("docs/" + t.Path)
 	if err != nil {
 		return err
@@ -313,21 +322,21 @@ func renderDocsTopic(t docsTopic) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(w, string(data))
 		return nil
 	}
 
 	if title != "" {
-		fmt.Println(title)
-		fmt.Println(strings.Repeat("=", len(title)))
-		fmt.Println()
+		fmt.Fprintln(w, title)
+		fmt.Fprintln(w, strings.Repeat("=", len(title)))
+		fmt.Fprintln(w)
 	}
 	if description != "" {
-		fmt.Println(description)
-		fmt.Println()
+		fmt.Fprintln(w, description)
+		fmt.Fprintln(w)
 	}
-	fmt.Print(renderDocsMDX(body))
-	fmt.Println()
-	fmt.Printf("View online: %s\n", t.publicURL())
+	fmt.Fprint(w, renderDocsMDX(body))
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "View online: %s\n", t.publicURL())
 	return nil
 }

--- a/go/internal/cli/commands/docs_cmd_test.go
+++ b/go/internal/cli/commands/docs_cmd_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -154,7 +155,7 @@ func TestRenderDocsMDX_PreservesPlaceholderSyntax(t *testing.T) {
 
 func TestPrintDocsTopic_UnknownTopic(t *testing.T) {
 	topics := []docsTopic{{Path: "integrations/ros2.mdx", Slug: "ros2", Title: "Wendy for ROS 2"}}
-	err := printDocsTopic(topics, "does-not-exist")
+	err := printDocsTopic(io.Discard, topics, "does-not-exist")
 	if err == nil {
 		t.Fatal("expected an error for an unknown topic")
 	}
@@ -172,7 +173,7 @@ func TestPrintDocsTopic_AmbiguousSlug(t *testing.T) {
 		{Path: "guides/tutorials/python/hello-world.mdx", Slug: "hello-world", Title: "Hello World in Python"},
 		{Path: "guides/tutorials/rust/hello-world.mdx", Slug: "hello-world", Title: "Hello World in Rust"},
 	}
-	err := printDocsTopic(topics, "hello-world")
+	err := printDocsTopic(io.Discard, topics, "hello-world")
 	if err == nil {
 		t.Fatal("expected an ambiguity error")
 	}
@@ -182,8 +183,6 @@ func TestPrintDocsTopic_AmbiguousSlug(t *testing.T) {
 		}
 	}
 }
-
-// captureStdout is defined in filesync_test.go and reused here.
 
 // TestPrintDocsTopic_RendersROS2ViaSlug exercises `wendy docs ros2` end to
 // end against the real embedded content: the short slug must resolve to
@@ -196,11 +195,11 @@ func TestPrintDocsTopic_RendersROS2ViaSlug(t *testing.T) {
 		t.Fatalf("docsTopics: %v", err)
 	}
 
-	out := captureStdout(t, func() {
-		if err := printDocsTopic(topics, "ros2"); err != nil {
-			t.Errorf("printDocsTopic(ros2): %v", err)
-		}
-	})
+	var buf bytes.Buffer
+	if err := printDocsTopic(&buf, topics, "ros2"); err != nil {
+		t.Errorf("printDocsTopic(ros2): %v", err)
+	}
+	out := buf.String()
 
 	if !strings.Contains(out, "Wendy for ROS 2") {
 		t.Errorf("output missing title, got: %q", out)
@@ -220,7 +219,9 @@ func TestPrintDocsTopicList_NonJSON(t *testing.T) {
 		{Path: "hardware/camera.mdx", Slug: "camera", Title: "Camera Access"},
 	}
 
-	out := captureStdout(t, func() { printDocsTopicList(topics) })
+	var buf bytes.Buffer
+	printDocsTopicList(&buf, topics)
+	out := buf.String()
 
 	for _, want := range []string{"integrations/ros2", "Wendy for ROS 2", "hardware/camera", "Camera Access"} {
 		if !strings.Contains(out, want) {
@@ -236,15 +237,42 @@ func TestPrintDocsTopicList_JSON(t *testing.T) {
 
 	topics := []docsTopic{{Path: "integrations/ros2.mdx", Slug: "ros2", Title: "Wendy for ROS 2"}}
 
-	out := captureStdout(t, func() { printDocsTopicList(topics) })
+	var buf bytes.Buffer
+	printDocsTopicList(&buf, topics)
+	out := buf.String()
 
 	if !strings.Contains(out, `"slug":"ros2"`) {
 		t.Errorf("expected JSON output to contain the slug field, got: %q", out)
 	}
-
-	var buf bytes.Buffer
-	buf.WriteString(out)
 	if buf.Len() == 0 {
 		t.Error("expected non-empty JSON output")
+	}
+}
+
+// TestNewDocsCmd_RespectsSetOut is the regression test for the output
+// plumbing: `wendy docs` must render into cmd.SetOut's writer rather than
+// unconditionally into the process's stdout.
+func TestNewDocsCmd_RespectsSetOut(t *testing.T) {
+	prevJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = prevJSON }()
+
+	cmd := newDocsCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"ros2"})
+
+	stdout := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(buf.String(), "Wendy for ROS 2") {
+		t.Errorf("redirected output missing the topic title, got: %q", buf.String())
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("nothing should have leaked to the process stdout, got: %q", stdout)
 	}
 }

--- a/go/internal/cli/commands/docs_cmd_test.go
+++ b/go/internal/cli/commands/docs_cmd_test.go
@@ -1,0 +1,250 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewDocsCmd_Wiring(t *testing.T) {
+	cmd := newDocsCmd()
+	if cmd.Use != "docs [topic]" {
+		t.Errorf("Use = %q; want %q", cmd.Use, "docs [topic]")
+	}
+	if cmd.Short == "" {
+		t.Error("Short should not be empty")
+	}
+	if cmd.Args == nil {
+		t.Error("Args validator should be set (accepts at most one positional topic)")
+	}
+}
+
+// TestDocsTopics_IncludesROS2 is the direct regression test for the concrete
+// friction this PR fixes: `wendy device ros2 --help` now points at `wendy
+// docs ros2`, so that topic must actually resolve to the embedded
+// integrations/ros2.mdx page (previously not embedded in the CLI binary at
+// all — see go/internal/cli/assets/assets.go).
+func TestDocsTopics_IncludesROS2(t *testing.T) {
+	topics, err := docsTopics()
+	if err != nil {
+		t.Fatalf("docsTopics: %v", err)
+	}
+	if len(topics) == 0 {
+		t.Fatal("docsTopics returned no topics")
+	}
+
+	var found *docsTopic
+	for i := range topics {
+		if topics[i].Path == "integrations/ros2.mdx" {
+			found = &topics[i]
+		}
+	}
+	if found == nil {
+		t.Fatal(`expected a topic for "integrations/ros2.mdx"`)
+	}
+	if found.Slug != "ros2" {
+		t.Errorf("slug = %q; want %q", found.Slug, "ros2")
+	}
+	if found.Title == "" {
+		t.Error("title should be populated from frontmatter")
+	}
+}
+
+func TestDocSlug(t *testing.T) {
+	cases := map[string]string{
+		"integrations/ros2.mdx":      "ros2",
+		"integrations/index.mdx":     "integrations",
+		"index.mdx":                  "index",
+		"guides/tutorials/foo.mdx":   "foo",
+		"device/entitlements.md":     "entitlements",
+		"clients/wendy-cli/init.mdx": "init",
+	}
+	for in, want := range cases {
+		if got := docSlug(in); got != want {
+			t.Errorf("docSlug(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestDocsTopic_URLPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"integrations/ros2.mdx", "integrations/ros2"},
+		{"integrations/index.mdx", "integrations"},
+		{"index.mdx", ""},
+		{"device/entitlements.md", "device/entitlements"},
+	}
+	for _, tc := range cases {
+		topic := docsTopic{Path: tc.path}
+		if got := topic.urlPath(); got != tc.want {
+			t.Errorf("urlPath(%q) = %q; want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestDocsTopic_PublicURL(t *testing.T) {
+	topic := docsTopic{Path: "integrations/ros2.mdx"}
+	want := "https://docs.wendy.dev/latest/integrations/ros2/"
+	if got := topic.publicURL(); got != want {
+		t.Errorf("publicURL() = %q; want %q", got, want)
+	}
+}
+
+func TestParseDocFrontmatter(t *testing.T) {
+	data := []byte("---\ntitle: Wendy for ROS 2\ndescription: Some description here\n---\n\nBody text follows.\n")
+	title, description, body := parseDocFrontmatter(data)
+	if title != "Wendy for ROS 2" {
+		t.Errorf("title = %q; want %q", title, "Wendy for ROS 2")
+	}
+	if description != "Some description here" {
+		t.Errorf("description = %q; want %q", description, "Some description here")
+	}
+	if strings.Contains(string(body), "---") {
+		t.Errorf("body should not contain the frontmatter delimiters: %q", body)
+	}
+	if !strings.Contains(string(body), "Body text follows.") {
+		t.Errorf("body missing content: %q", body)
+	}
+}
+
+func TestParseDocFrontmatter_NoFrontmatter(t *testing.T) {
+	data := []byte("# Just a heading\n\nNo frontmatter here.\n")
+	title, description, body := parseDocFrontmatter(data)
+	if title != "" || description != "" {
+		t.Errorf("title/description = %q/%q; want both empty", title, description)
+	}
+	if string(body) != string(data) {
+		t.Errorf("body = %q; want unchanged input", body)
+	}
+}
+
+func TestRenderDocsMDX_StripsComponentsKeepsText(t *testing.T) {
+	body := []byte(`<Callout type="info">
+Important note text.
+</Callout>
+
+Regular paragraph with <CliShot flow="x" alt="y" />.
+`)
+	got := renderDocsMDX(body)
+	if strings.Contains(got, "Callout") || strings.Contains(got, "CliShot") {
+		t.Errorf("component tags should be stripped, got: %q", got)
+	}
+	if !strings.Contains(got, "Important note text.") {
+		t.Errorf("inner text should be preserved, got: %q", got)
+	}
+	if !strings.Contains(got, "Regular paragraph with") {
+		t.Errorf("surrounding prose should be preserved, got: %q", got)
+	}
+}
+
+// TestRenderDocsMDX_PreservesPlaceholderSyntax guards against a regression
+// where the JSX-stripping regex is broadened to match lowercase tag names: a
+// robotics CLI doc set uses lowercase `<placeholder>` syntax in usage text
+// (e.g. "wendy device ros2 call <service> <type>"), which must not be
+// confused with an MDX/JSX component (PascalCase by convention).
+func TestRenderDocsMDX_PreservesPlaceholderSyntax(t *testing.T) {
+	body := []byte("wendy device ros2 call <service> <type> [request]\n")
+	got := renderDocsMDX(body)
+	if got != string(body) {
+		t.Errorf("renderDocsMDX(%q) = %q; want unchanged (lowercase placeholders are not JSX)", body, got)
+	}
+}
+
+func TestPrintDocsTopic_UnknownTopic(t *testing.T) {
+	topics := []docsTopic{{Path: "integrations/ros2.mdx", Slug: "ros2", Title: "Wendy for ROS 2"}}
+	err := printDocsTopic(topics, "does-not-exist")
+	if err == nil {
+		t.Fatal("expected an error for an unknown topic")
+	}
+	if !strings.Contains(err.Error(), `unknown doc topic "does-not-exist"`) {
+		t.Errorf("error = %q; want it to name the bad topic", err.Error())
+	}
+}
+
+// TestPrintDocsTopic_AmbiguousSlug covers the real collision in this docs
+// tree: every guides/tutorials/<language>/hello-world.mdx shares the slug
+// "hello-world". The error should list the full paths rather than silently
+// picking one.
+func TestPrintDocsTopic_AmbiguousSlug(t *testing.T) {
+	topics := []docsTopic{
+		{Path: "guides/tutorials/python/hello-world.mdx", Slug: "hello-world", Title: "Hello World in Python"},
+		{Path: "guides/tutorials/rust/hello-world.mdx", Slug: "hello-world", Title: "Hello World in Rust"},
+	}
+	err := printDocsTopic(topics, "hello-world")
+	if err == nil {
+		t.Fatal("expected an ambiguity error")
+	}
+	for _, want := range []string{"guides/tutorials/python/hello-world", "guides/tutorials/rust/hello-world"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q; want it to list %q", err.Error(), want)
+		}
+	}
+}
+
+// captureStdout is defined in filesync_test.go and reused here.
+
+// TestPrintDocsTopic_RendersROS2ViaSlug exercises `wendy docs ros2` end to
+// end against the real embedded content: the short slug must resolve to
+// integrations/ros2.mdx, render its frontmatter title, and print the public
+// docs URL as a fallback — this is exactly what ros2.go's Long help text now
+// tells users to run.
+func TestPrintDocsTopic_RendersROS2ViaSlug(t *testing.T) {
+	topics, err := docsTopics()
+	if err != nil {
+		t.Fatalf("docsTopics: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := printDocsTopic(topics, "ros2"); err != nil {
+			t.Errorf("printDocsTopic(ros2): %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Wendy for ROS 2") {
+		t.Errorf("output missing title, got: %q", out)
+	}
+	if !strings.Contains(out, "View online: https://docs.wendy.dev/latest/integrations/ros2/") {
+		t.Errorf("output missing the public docs URL fallback, got: %q", out)
+	}
+}
+
+func TestPrintDocsTopicList_NonJSON(t *testing.T) {
+	prevJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = prevJSON }()
+
+	topics := []docsTopic{
+		{Path: "integrations/ros2.mdx", Slug: "ros2", Title: "Wendy for ROS 2"},
+		{Path: "hardware/camera.mdx", Slug: "camera", Title: "Camera Access"},
+	}
+
+	out := captureStdout(t, func() { printDocsTopicList(topics) })
+
+	for _, want := range []string{"integrations/ros2", "Wendy for ROS 2", "hardware/camera", "Camera Access"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("listing missing %q, got: %q", want, out)
+		}
+	}
+}
+
+func TestPrintDocsTopicList_JSON(t *testing.T) {
+	prevJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = prevJSON }()
+
+	topics := []docsTopic{{Path: "integrations/ros2.mdx", Slug: "ros2", Title: "Wendy for ROS 2"}}
+
+	out := captureStdout(t, func() { printDocsTopicList(topics) })
+
+	if !strings.Contains(out, `"slug":"ros2"`) {
+		t.Errorf("expected JSON output to contain the slug field, got: %q", out)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(out)
+	if buf.Len() == 0 {
+		t.Error("expected non-empty JSON output")
+	}
+}

--- a/go/internal/cli/commands/frameworks_test.go
+++ b/go/internal/cli/commands/frameworks_test.go
@@ -1,0 +1,176 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// chdirTo changes the working directory to dir for the duration of the test,
+// restoring the original on cleanup. loadProjectConfig and saveProjectConfig
+// resolve wendy.json relative to os.Getwd(), matching the pattern used by
+// TestResolveRunWorkingDir_Default in commands_test.go. writeWendyJSON
+// (camera_credentials_test.go) already builds the temp dir + file; this just
+// makes it the working directory too.
+func chdirTo(t *testing.T, dir string) {
+	t.Helper()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+}
+
+func TestNewFrameworksCmd_Wiring(t *testing.T) {
+	cmd := newFrameworksCmd()
+	if cmd.Use != "frameworks" {
+		t.Errorf("Use = %q; want %q", cmd.Use, "frameworks")
+	}
+	for _, name := range []string{"list", "add", "remove"} {
+		found := false
+		for _, sub := range cmd.Commands() {
+			if sub.Name() == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing %q subcommand", name)
+		}
+	}
+}
+
+func TestConfiguredFrameworkTypes(t *testing.T) {
+	if got := configuredFrameworkTypes(nil); got != nil {
+		t.Errorf("nil frameworks = %v; want nil", got)
+	}
+	if got := configuredFrameworkTypes(&appconfig.FrameworksConfig{}); got != nil {
+		t.Errorf("empty frameworks = %v; want nil", got)
+	}
+	got := configuredFrameworkTypes(&appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{}})
+	if len(got) != 1 || got[0] != appconfig.FrameworkROS2 {
+		t.Errorf("configuredFrameworkTypes() = %v; want [ros2]", got)
+	}
+}
+
+// TestFrameworksAdd_UnknownType verifies `wendy project frameworks add
+// <bad-type>` gives the same quality of feedback as
+// `wendy project entitlements add <bad-type>`: the bad value plus the full
+// list of valid ones, not a bare failure.
+func TestFrameworksAdd_UnknownType(t *testing.T) {
+	dir := writeWendyJSON(t, `{"appId": "com.example.robot"}`)
+	chdirTo(t, dir)
+
+	cmd := newFrameworksAddCmd()
+	err := cmd.RunE(cmd, []string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown framework type")
+	}
+	if !strings.Contains(err.Error(), `unknown framework type "bogus"`) {
+		t.Errorf("error = %q; want it to name the bad type", err.Error())
+	}
+	if !strings.Contains(err.Error(), appconfig.FrameworkROS2) {
+		t.Errorf("error = %q; want it to list valid types including %q", err.Error(), appconfig.FrameworkROS2)
+	}
+}
+
+// TestFrameworksAdd_ROS2WritesDefaults verifies `add ros2` with no further
+// input enables ROS 2 with all-defaults config, since every ROS2Config field
+// already has a sensible default (unlike persist/i2c/gpio entitlements).
+func TestFrameworksAdd_ROS2WritesDefaults(t *testing.T) {
+	dir := writeWendyJSON(t, `{"appId": "com.example.robot"}`)
+	chdirTo(t, dir)
+
+	cmd := newFrameworksAddCmd()
+	if err := cmd.RunE(cmd, []string{appconfig.FrameworkROS2}); err != nil {
+		t.Fatalf("add ros2: %v", err)
+	}
+
+	cfg, err := appconfig.LoadFromFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("reloading wendy.json: %v", err)
+	}
+	if cfg.Frameworks == nil || cfg.Frameworks.ROS2 == nil {
+		t.Fatal("wendy.json was not updated with frameworks.ros2")
+	}
+}
+
+func TestFrameworksAdd_AlreadyExists(t *testing.T) {
+	dir := writeWendyJSON(t, `{
+		"appId": "com.example.robot",
+		"frameworks": {"ros2": {}}
+	}`)
+	chdirTo(t, dir)
+
+	cmd := newFrameworksAddCmd()
+	err := cmd.RunE(cmd, []string{appconfig.FrameworkROS2})
+	if err == nil {
+		t.Fatal("expected error re-adding an already-configured framework")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error = %q; want it to say the framework already exists", err.Error())
+	}
+}
+
+func TestFrameworksRemove(t *testing.T) {
+	dir := writeWendyJSON(t, `{
+		"appId": "com.example.robot",
+		"frameworks": {"ros2": {"distro": "jazzy"}}
+	}`)
+	chdirTo(t, dir)
+
+	cmd := newFrameworksRemoveCmd()
+	if err := cmd.RunE(cmd, []string{appconfig.FrameworkROS2}); err != nil {
+		t.Fatalf("remove ros2: %v", err)
+	}
+
+	cfg, err := appconfig.LoadFromFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("reloading wendy.json: %v", err)
+	}
+	if cfg.Frameworks != nil {
+		t.Errorf("Frameworks = %+v; want nil after removing the only configured framework", cfg.Frameworks)
+	}
+}
+
+func TestFrameworksRemove_NotFound(t *testing.T) {
+	dir := writeWendyJSON(t, `{"appId": "com.example.robot"}`)
+	chdirTo(t, dir)
+
+	cmd := newFrameworksRemoveCmd()
+	err := cmd.RunE(cmd, []string{appconfig.FrameworkROS2})
+	if err == nil {
+		t.Fatal("expected error removing a framework that isn't configured")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q; want it to say the framework was not found", err.Error())
+	}
+}
+
+// TestEntitlementsAdd_FrameworkHint is the direct regression test for the
+// friction this PR fixes: guessing `wendy project entitlements add ros2`
+// used to fail with a generic "unknown entitlement type" error and no
+// pointer to where ROS 2 actually lives. It should now name the real command.
+func TestEntitlementsAdd_FrameworkHint(t *testing.T) {
+	dir := writeWendyJSON(t, `{"appId": "com.example.robot"}`)
+	chdirTo(t, dir)
+
+	cmd := newEntitlementsAddCmd()
+	err := cmd.RunE(cmd, []string{appconfig.FrameworkROS2})
+	if err == nil {
+		t.Fatal("expected error adding \"ros2\" as an entitlement")
+	}
+	if !strings.Contains(err.Error(), "wendy project frameworks add ros2") {
+		t.Errorf("error = %q; want it to point at `wendy project frameworks add ros2`", err.Error())
+	}
+	if strings.Contains(err.Error(), "unknown entitlement type") {
+		t.Errorf("error = %q; want the specific framework hint, not the generic unknown-type message", err.Error())
+	}
+}

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -83,11 +83,13 @@ func newEntitlementsListCmd() *cobra.Command {
 	return cmd
 }
 
-// listAllEntitlementTypes and its output siblings below use fmt.Print* (real
-// stdout) rather than cobra's cmd.Print*, which — despite the name — writes
-// to OutOrStderr(). Using cmd.Print* here would mean `wendy project
-// entitlements list --show-all --json | jq` silently sees nothing on stdout.
+// listAllEntitlementTypes and its output siblings below write to
+// cmd.OutOrStdout() rather than cobra's cmd.Print*, which — despite the name
+// — writes to OutOrStderr(). Using cmd.Print* here would mean `wendy project
+// entitlements list --show-all --json | jq` silently sees nothing on stdout,
+// while OutOrStdout() defaults to os.Stdout and still honors cmd.SetOut.
 func listAllEntitlementTypes(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
 	types := appconfig.ValidEntitlementTypes
 
 	if jsonOutput {
@@ -95,18 +97,19 @@ func listAllEntitlementTypes(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(out, string(data))
 		return nil
 	}
 
-	fmt.Println("Available entitlement types:")
+	fmt.Fprintln(out, "Available entitlement types:")
 	for _, t := range types {
-		fmt.Printf("  %s\n", t)
+		fmt.Fprintf(out, "  %s\n", t)
 	}
 	return nil
 }
 
 func listProjectEntitlements(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
 	cfg, _, err := loadProjectConfig()
 	if err != nil {
 		return err
@@ -117,18 +120,18 @@ func listProjectEntitlements(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(out, string(data))
 		return nil
 	}
 
 	if len(cfg.Entitlements) == 0 {
-		fmt.Println("No entitlements configured.")
+		fmt.Fprintln(out, "No entitlements configured.")
 		return nil
 	}
 
-	fmt.Println("Project entitlements:")
+	fmt.Fprintln(out, "Project entitlements:")
 	for _, e := range cfg.Entitlements {
-		fmt.Printf("  %s\n", e.Type)
+		fmt.Fprintf(out, "  %s\n", e.Type)
 	}
 	return nil
 }
@@ -320,6 +323,7 @@ func newFrameworksListCmd() *cobra.Command {
 }
 
 func listAllFrameworkTypes(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
 	types := appconfig.ValidFrameworkTypes
 
 	if jsonOutput {
@@ -327,22 +331,23 @@ func listAllFrameworkTypes(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(out, string(data))
 		return nil
 	}
 
-	fmt.Println("Available framework types:")
+	fmt.Fprintln(out, "Available framework types:")
 	for _, t := range types {
 		if desc := frameworkDescriptions[t]; desc != "" {
-			fmt.Printf("  %s — %s\n", t, desc)
+			fmt.Fprintf(out, "  %s — %s\n", t, desc)
 		} else {
-			fmt.Printf("  %s\n", t)
+			fmt.Fprintf(out, "  %s\n", t)
 		}
 	}
 	return nil
 }
 
 func listProjectFrameworks(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
 	cfg, _, err := loadProjectConfig()
 	if err != nil {
 		return err
@@ -355,18 +360,18 @@ func listProjectFrameworks(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(out, string(data))
 		return nil
 	}
 
 	if len(configured) == 0 {
-		fmt.Println("No frameworks configured.")
+		fmt.Fprintln(out, "No frameworks configured.")
 		return nil
 	}
 
-	fmt.Println("Project frameworks:")
+	fmt.Fprintln(out, "Project frameworks:")
 	for _, t := range configured {
-		fmt.Printf("  %s\n", t)
+		fmt.Fprintf(out, "  %s\n", t)
 	}
 	return nil
 }

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -31,6 +31,14 @@ var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementInput:     "Access Linux input devices (game controllers, barcode scanners, keyboards)",
 }
 
+// frameworkDescriptions mirrors entitlementDescriptions for the "frameworks"
+// key in wendy.json, so `wendy project frameworks list --show-all` gives the
+// same quality of discoverability `wendy project entitlements list --show-all`
+// already gives for entitlements.
+var frameworkDescriptions = map[string]string{
+	appconfig.FrameworkROS2: "ROS 2 runtime config (RMW implementation, distro, domain ID, discovery scope) — see `wendy docs ros2`",
+}
+
 func newProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project",
@@ -38,6 +46,7 @@ func newProjectCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newEntitlementsCmd())
+	cmd.AddCommand(newFrameworksCmd())
 	cmd.AddCommand(newOptimizeCmd())
 	return cmd
 }
@@ -74,6 +83,10 @@ func newEntitlementsListCmd() *cobra.Command {
 	return cmd
 }
 
+// listAllEntitlementTypes and its output siblings below use fmt.Print* (real
+// stdout) rather than cobra's cmd.Print*, which — despite the name — writes
+// to OutOrStderr(). Using cmd.Print* here would mean `wendy project
+// entitlements list --show-all --json | jq` silently sees nothing on stdout.
 func listAllEntitlementTypes(cmd *cobra.Command) error {
 	types := appconfig.ValidEntitlementTypes
 
@@ -82,13 +95,13 @@ func listAllEntitlementTypes(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		cmd.Println(string(data))
+		fmt.Println(string(data))
 		return nil
 	}
 
-	cmd.Println("Available entitlement types:")
+	fmt.Println("Available entitlement types:")
 	for _, t := range types {
-		cmd.Printf("  %s\n", t)
+		fmt.Printf("  %s\n", t)
 	}
 	return nil
 }
@@ -104,18 +117,18 @@ func listProjectEntitlements(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		cmd.Println(string(data))
+		fmt.Println(string(data))
 		return nil
 	}
 
 	if len(cfg.Entitlements) == 0 {
-		cmd.Println("No entitlements configured.")
+		fmt.Println("No entitlements configured.")
 		return nil
 	}
 
-	cmd.Println("Project entitlements:")
+	fmt.Println("Project entitlements:")
 	for _, e := range cfg.Entitlements {
-		cmd.Printf("  %s\n", e.Type)
+		fmt.Printf("  %s\n", e.Type)
 	}
 	return nil
 }
@@ -157,6 +170,16 @@ func newEntitlementsAddCmd() *cobra.Command {
 					return err
 				}
 				entType = selected
+			}
+
+			// ROS 2 (and any future framework) is a common guess here, since
+			// nothing else in the CLI names "frameworks" as the place device
+			// integrations live. Redirect before falling into the generic
+			// "unknown type" error, which would otherwise say nothing about
+			// where "ros2" actually belongs.
+			if slices.Contains(appconfig.ValidFrameworkTypes, entType) {
+				return fmt.Errorf("%q is a framework, not an entitlement — configure it with `wendy project frameworks add %s`",
+					entType, entType)
 			}
 
 			if !slices.Contains(appconfig.ValidEntitlementTypes, entType) {
@@ -240,6 +263,240 @@ func newEntitlementsRemoveCmd() *cobra.Command {
 			}
 
 			cliSuccess("Removed %q entitlement", entType)
+			return nil
+		},
+	}
+}
+
+// newFrameworksCmd builds the `wendy project frameworks` command group. It
+// mirrors `wendy project entitlements` (list/add/remove, same error quality
+// for an unknown type) for the "frameworks" key in wendy.json, which
+// previously had no CLI-native way to discover its valid values or shape —
+// unlike entitlements, whose `add` command already lists valid types on a bad
+// guess.
+func newFrameworksCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "frameworks",
+		Short: "Manage project framework configuration (e.g. ROS 2)",
+	}
+
+	cmd.AddCommand(
+		newFrameworksListCmd(),
+		newFrameworksAddCmd(),
+		newFrameworksRemoveCmd(),
+	)
+	return cmd
+}
+
+// configuredFrameworkTypes returns the framework keys actually set in fw, in
+// the same order as appconfig.ValidFrameworkTypes.
+func configuredFrameworkTypes(fw *appconfig.FrameworksConfig) []string {
+	if fw == nil {
+		return nil
+	}
+	var types []string
+	if fw.ROS2 != nil {
+		types = append(types, appconfig.FrameworkROS2)
+	}
+	return types
+}
+
+func newFrameworksListCmd() *cobra.Command {
+	var showAll bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List project framework configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if showAll {
+				return listAllFrameworkTypes(cmd)
+			}
+			return listProjectFrameworks(cmd)
+		},
+	}
+
+	cmd.Flags().BoolVar(&showAll, "show-all", false, "Show all available framework types")
+	return cmd
+}
+
+func listAllFrameworkTypes(cmd *cobra.Command) error {
+	types := appconfig.ValidFrameworkTypes
+
+	if jsonOutput {
+		data, err := json.Marshal(types)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Println("Available framework types:")
+	for _, t := range types {
+		if desc := frameworkDescriptions[t]; desc != "" {
+			fmt.Printf("  %s — %s\n", t, desc)
+		} else {
+			fmt.Printf("  %s\n", t)
+		}
+	}
+	return nil
+}
+
+func listProjectFrameworks(cmd *cobra.Command) error {
+	cfg, _, err := loadProjectConfig()
+	if err != nil {
+		return err
+	}
+
+	configured := configuredFrameworkTypes(cfg.Frameworks)
+
+	if jsonOutput {
+		data, err := json.Marshal(configured)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(configured) == 0 {
+		fmt.Println("No frameworks configured.")
+		return nil
+	}
+
+	fmt.Println("Project frameworks:")
+	for _, t := range configured {
+		fmt.Printf("  %s\n", t)
+	}
+	return nil
+}
+
+func newFrameworksAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add [type]",
+		Short: "Add a framework to the project",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, cfgPath, err := loadProjectConfig()
+			if err != nil {
+				return err
+			}
+
+			existing := configuredFrameworkTypes(cfg.Frameworks)
+			existingSet := make(map[string]bool, len(existing))
+			for _, t := range existing {
+				existingSet[t] = true
+			}
+
+			var fwType string
+			if len(args) > 0 {
+				fwType = args[0]
+			} else {
+				var items []tui.PickerItem
+				for _, t := range appconfig.ValidFrameworkTypes {
+					if !existingSet[t] {
+						items = append(items, tui.PickerItem{Name: t, Description: frameworkDescriptions[t], Value: t})
+					}
+				}
+				if len(items) == 0 {
+					cliLogln("All framework types are already added.")
+					return nil
+				}
+
+				selected, err := pickFromItems("Select a framework to add", items)
+				if err != nil {
+					return err
+				}
+				fwType = selected
+			}
+
+			if !slices.Contains(appconfig.ValidFrameworkTypes, fwType) {
+				return fmt.Errorf("unknown framework type %q\nValid types: %s",
+					fwType, strings.Join(appconfig.ValidFrameworkTypes, ", "))
+			}
+
+			if existingSet[fwType] {
+				return fmt.Errorf("framework %q already exists", fwType)
+			}
+
+			if cfg.Frameworks == nil {
+				cfg.Frameworks = &appconfig.FrameworksConfig{}
+			}
+			switch fwType {
+			case appconfig.FrameworkROS2:
+				// All ROS2Config fields are optional with sensible defaults
+				// (humble, CycloneDDS, a stable per-app domain ID), so unlike
+				// persist/i2c/gpio entitlements there is nothing required to
+				// prompt for here — an empty config already enables it.
+				cfg.Frameworks.ROS2 = &appconfig.ROS2Config{}
+			}
+
+			if err := saveProjectConfig(cfg, cfgPath); err != nil {
+				return err
+			}
+
+			cliSuccess("Added %q framework", fwType)
+			if fwType == appconfig.FrameworkROS2 {
+				cliLogln("Using defaults (distro %q, rmw %q, domain ID derived from appId). "+
+					"Edit \"frameworks.ros2\" in wendy.json to customize, or see `wendy docs ros2`.",
+					appconfig.ROS2DefaultDistro, appconfig.ROS2DefaultRMW)
+			}
+			return nil
+		},
+	}
+}
+
+func newFrameworksRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove [type]",
+		Short: "Remove a framework from the project",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, cfgPath, err := loadProjectConfig()
+			if err != nil {
+				return err
+			}
+
+			existing := configuredFrameworkTypes(cfg.Frameworks)
+
+			var fwType string
+			if len(args) > 0 {
+				fwType = args[0]
+			} else {
+				if len(existing) == 0 {
+					cliLogln("No frameworks configured.")
+					return nil
+				}
+
+				var items []tui.PickerItem
+				for _, t := range existing {
+					items = append(items, tui.PickerItem{Name: t, Description: frameworkDescriptions[t], Value: t})
+				}
+
+				selected, err := pickFromItems("Select a framework to remove", items)
+				if err != nil {
+					return err
+				}
+				fwType = selected
+			}
+
+			if !slices.Contains(existing, fwType) {
+				return fmt.Errorf("framework %q not found in project", fwType)
+			}
+
+			switch fwType {
+			case appconfig.FrameworkROS2:
+				cfg.Frameworks.ROS2 = nil
+			}
+			if cfg.Frameworks != nil && cfg.Frameworks.ROS2 == nil {
+				cfg.Frameworks = nil
+			}
+
+			if err := saveProjectConfig(cfg, cfgPath); err != nil {
+				return err
+			}
+
+			cliSuccess("Removed %q framework", fwType)
 			return nil
 		},
 	}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -128,6 +128,8 @@ func NewRootCmd() *cobra.Command {
 	// command can only be attached to one parent.
 	installCmd := newOSInstallCmd()
 	installCmd.GroupID = "develop"
+	docsCmd := newDocsCmd()
+	docsCmd.GroupID = "develop"
 
 	// Manage
 	projectCmd := newProjectCmd()
@@ -212,6 +214,7 @@ func NewRootCmd() *cobra.Command {
 		initCmd,
 		runCmd,
 		installCmd,
+		docsCmd,
 		// Manage
 		projectCmd,
 		deviceCmd,

--- a/go/internal/cli/commands/ros2.go
+++ b/go/internal/cli/commands/ros2.go
@@ -34,7 +34,11 @@ func newROS2Cmd() *cobra.Command {
 
 The agent discovers ROS 2 app containers (deployed with a "frameworks.ros2"
 config in wendy.json), starts a CLI sidecar in the same DDS domain, and runs
-ros2 commands there — no SSH and no setup.bash sourcing required.`,
+ros2 commands there — no SSH and no setup.bash sourcing required.
+
+To add ROS 2 to a project: wendy project frameworks add ros2
+For the full "frameworks.ros2" config shape (domainId, rmw, distro,
+discoveryScope) and how it's used: wendy docs ros2`,
 	}
 
 	cmd.AddCommand(

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -125,7 +125,11 @@ func (s *mcpServer) registerDocResources(srv *server.MCPServer) {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		if path.Ext(p) != ".md" {
+		// Both plain-Markdown reference docs (.md) and the embedded MDX guide
+		// content (.mdx, e.g. docs/integrations/ros2.mdx) are exposed here —
+		// an MCP client has no other way to read either.
+		ext := path.Ext(p)
+		if ext != ".md" && ext != ".mdx" {
 			return nil
 		}
 		relPath := strings.TrimPrefix(p, "docs/")
@@ -152,6 +156,7 @@ func (s *mcpServer) registerDocResources(srv *server.MCPServer) {
 // docTitle converts a relative doc path to a human-readable title.
 func docTitle(relPath string) string {
 	base := path.Base(relPath)
+	base = strings.TrimSuffix(base, ".mdx")
 	base = strings.TrimSuffix(base, ".md")
 	base = strings.ReplaceAll(base, "-", " ")
 	base = strings.ReplaceAll(base, "_", " ")

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -1120,7 +1120,7 @@ func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []stri
 		))
 	}
 
-	ros2Raw, ok := fw["ros2"]
+	ros2Raw, ok := fw[FrameworkROS2]
 	if !ok || len(ros2Raw) == 0 {
 		return warnings
 	}
@@ -1139,7 +1139,7 @@ func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []stri
 		return warnings
 	}
 	sort.Strings(unknown)
-	warnings = append(warnings, fmt.Sprintf("Unknown key(s) in %s.ros2: %s. Allowed keys are: discoveryScope, distro, domainId, rmw", prefix, strings.Join(unknown, ", ")))
+	warnings = append(warnings, fmt.Sprintf("Unknown key(s) in %s.%s: %s. Allowed keys are: discoveryScope, distro, domainId, rmw", prefix, FrameworkROS2, strings.Join(unknown, ", ")))
 	return warnings
 }
 

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -89,6 +89,15 @@ var ValidEntitlementTypes = []string{
 	EntitlementHTTP,
 }
 
+// FrameworkROS2 is the "ros2" key under wendy.json's "frameworks" object.
+const FrameworkROS2 = "ros2"
+
+// ValidFrameworkTypes is the set of all recognized top-level keys under the
+// "frameworks" object in wendy.json (currently just ROS 2 — see
+// FrameworksConfig). Kept alongside ValidEntitlementTypes so both surfaces
+// give the same quality of "here's what's actually valid" feedback.
+var ValidFrameworkTypes = []string{FrameworkROS2}
+
 var deprecatedEntitlementReplacements = map[string]string{
 	EntitlementVideo: EntitlementCamera,
 }
@@ -1076,8 +1085,17 @@ func unknownKeyWarnings(raw map[string]json.RawMessage, where string, known map[
 	)}
 }
 
-// validateFrameworksJSON warns on unknown keys under frameworks.ros2 so a typo
-// like "domian_id" surfaces instead of being silently ignored (WDY-1706 M5).
+// validateFrameworksJSON warns on an unrecognized top-level key under
+// "frameworks" (e.g. a typo'd "ros3", or a framework wendy.json doesn't
+// support) and on unknown keys under frameworks.ros2, so a typo like
+// "domian_id" surfaces instead of being silently ignored (WDY-1706 M5).
+//
+// Unlike validateEntitlementsJSON's unknown-type case, this is a warning, not
+// a hard Validate() error: entitlements are a list of required declarations,
+// but frameworks is optional nested config, and encoding/json already drops
+// the unrecognized key silently — a warning is the minimum needed to make
+// that visible without changing the error/warning split used elsewhere in
+// this file for top-level unknown keys (see unknownKeyWarnings).
 func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []string {
 	if len(frameworksRaw) == 0 {
 		return nil
@@ -1086,13 +1104,29 @@ func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []stri
 	if err := json.Unmarshal(frameworksRaw, &fw); err != nil {
 		return nil
 	}
+
+	var warnings []string
+	var unknownFrameworks []string
+	for k := range fw {
+		if !slices.Contains(ValidFrameworkTypes, k) {
+			unknownFrameworks = append(unknownFrameworks, k)
+		}
+	}
+	if len(unknownFrameworks) > 0 {
+		sort.Strings(unknownFrameworks)
+		warnings = append(warnings, fmt.Sprintf(
+			"Unknown key(s) in %s: %s, ignored. Valid frameworks are: %s",
+			prefix, strings.Join(unknownFrameworks, ", "), strings.Join(ValidFrameworkTypes, ", "),
+		))
+	}
+
 	ros2Raw, ok := fw["ros2"]
 	if !ok || len(ros2Raw) == 0 {
-		return nil
+		return warnings
 	}
 	var ros2 map[string]json.RawMessage
 	if err := json.Unmarshal(ros2Raw, &ros2); err != nil {
-		return nil
+		return warnings
 	}
 	allowed := map[string]bool{"domainId": true, "rmw": true, "distro": true, "discoveryScope": true}
 	var unknown []string
@@ -1102,10 +1136,11 @@ func validateFrameworksJSON(frameworksRaw json.RawMessage, prefix string) []stri
 		}
 	}
 	if len(unknown) == 0 {
-		return nil
+		return warnings
 	}
 	sort.Strings(unknown)
-	return []string{fmt.Sprintf("Unknown key(s) in %s.ros2: %s. Allowed keys are: discoveryScope, distro, domainId, rmw", prefix, strings.Join(unknown, ", "))}
+	warnings = append(warnings, fmt.Sprintf("Unknown key(s) in %s.ros2: %s. Allowed keys are: discoveryScope, distro, domainId, rmw", prefix, strings.Join(unknown, ", ")))
+	return warnings
 }
 
 // validateEntitlementsJSON checks raw JSON entitlements for deprecated types

--- a/go/internal/shared/appconfig/ros2_test.go
+++ b/go/internal/shared/appconfig/ros2_test.go
@@ -1,6 +1,9 @@
 package appconfig
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestROS2AutoDomainID_StableAndInRange(t *testing.T) {
 	first := ROS2AutoDomainID("com.example.robot")
@@ -157,5 +160,100 @@ func TestIsValidRMWImplementation(t *testing.T) {
 		if IsValidRMWImplementation(s) {
 			t.Errorf("IsValidRMWImplementation(%q) = true, want false", s)
 		}
+	}
+}
+
+// TestValidateJSON_UnknownFrameworkKey covers the gap this change closes: a
+// typo'd top-level key under "frameworks" (e.g. "ross2" instead of "ros2")
+// used to be silently dropped by encoding/json with no warning at all, unlike
+// entitlements' "unknown type" error. See validateFrameworksJSON.
+func TestValidateJSON_UnknownFrameworkKey(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.robot",
+		"frameworks": { "ross2": { "distro": "humble" } }
+	}`)
+
+	warnings := ValidateJSON(data)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "Unknown key(s) in frameworks") && strings.Contains(w, "ross2") && strings.Contains(w, "ros2") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ValidateJSON() warnings = %v; want one flagging unknown top-level framework key %q", warnings, "ross2")
+	}
+}
+
+// TestValidateJSON_KnownFrameworkKeyNoWarning ensures the new top-level check
+// doesn't false-positive on the one framework that is actually supported.
+func TestValidateJSON_KnownFrameworkKeyNoWarning(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.robot",
+		"frameworks": { "ros2": { "distro": "humble" } }
+	}`)
+
+	warnings := ValidateJSON(data)
+	for _, w := range warnings {
+		if strings.Contains(w, "Unknown key(s) in frameworks:") {
+			t.Errorf("unexpected unknown-framework warning for a valid config: %v", warnings)
+		}
+	}
+}
+
+// TestValidateJSON_FrameworksBothWarnings covers a wendy.json with both an
+// unrecognized top-level framework key and an unrecognized key nested under
+// frameworks.ros2, confirming validateFrameworksJSON reports both instead of
+// stopping at the first.
+func TestValidateJSON_FrameworksBothWarnings(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.robot",
+		"frameworks": {
+			"ross2": {},
+			"ros2": { "domian_id": 5 }
+		}
+	}`)
+
+	warnings := ValidateJSON(data)
+	var sawTopLevel, sawNested bool
+	for _, w := range warnings {
+		if strings.Contains(w, "Unknown key(s) in frameworks:") && strings.Contains(w, "ross2") {
+			sawTopLevel = true
+		}
+		if strings.Contains(w, "Unknown key(s) in frameworks.ros2:") && strings.Contains(w, "domian_id") {
+			sawNested = true
+		}
+	}
+	if !sawTopLevel {
+		t.Errorf("missing top-level unknown-framework warning: %v", warnings)
+	}
+	if !sawNested {
+		t.Errorf("missing nested frameworks.ros2 unknown-key warning: %v", warnings)
+	}
+}
+
+// TestValidateJSON_ServiceFrameworksUnknownKey confirms the top-level check
+// also applies to service-level "frameworks" objects (services["x"].frameworks),
+// not just the app-level one.
+func TestValidateJSON_ServiceFrameworksUnknownKey(t *testing.T) {
+	data := []byte(`{
+		"appId": "com.example.robot",
+		"services": {
+			"camera": {
+				"context": ".",
+				"frameworks": { "ross2": {} }
+			}
+		}
+	}`)
+
+	warnings := ValidateJSON(data)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, `services["camera"].frameworks`) && strings.Contains(w, "ross2") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ValidateJSON() warnings = %v; want one flagging services[\"camera\"].frameworks unknown key", warnings)
 	}
 }


### PR DESCRIPTION
## Summary

A user building a ROS2 app hit real friction this session: `frameworks.ros2` in `wendy.json` is mentioned exactly once in the entire CLI (`wendy device ros2 --help`), with zero shape/example/link, and the only way to actually find the answer was manually grepping the CLI's own embedded doc assets — a path no external customer could realistically discover. Two underlying gaps caused this:

**A — no CLI-native way to browse documentation.** The docs are a full fumadocs/Next.js site with real MDX content embedded in this repo, but nothing surfaced it from the terminal — not for a human, a script, or an AI agent driving the CLI headlessly.

**B — `frameworks` had none of the discoverability `entitlements` has.** `wendy project entitlements add <bad-type>` already gives a great error listing every valid type. There was no equivalent for `frameworks`: no list command, no validation-with-helpful-error, nothing.

## What changed

- **`wendy docs [topic]`** (new): prints the CLI's embedded documentation as plain text — frontmatter title/description, fumadocs JSX components stripped, a "View online" URL fallback — or lists every topic grouped by directory with no arguments. Supports `--json`. Works with no network access.
  - Extended `go/internal/cli/assets/assets.go`'s embed to include the text-only MDX guide/reference directories (`guides`, `hardware`, `installation`, `integrations`, `remote-debugging`, `security`) alongside the plain-Markdown docs already embedded — the Next.js app shell, images, and video stay excluded to keep the binary lean.
  - Extended the MCP server's `wendy://docs/` resource walker to also serve `.mdx`, not just `.md`, so MCP clients (Claude Code, etc.) get the same content.

- **`wendy project frameworks list [--show-all] / add [type] / remove [type]`** (new): mirrors `wendy project entitlements`'s subcommands and its unknown-type error message exactly. `add ros2` needs no field prompts (every `ROS2Config` field already defaults sensibly) — it just enables ROS 2 with `{}` and reports what the defaults are.

- **`appconfig.ValidFrameworkTypes`** (new, currently `["ros2"]`) and an extended `validateFrameworksJSON`: a typo'd top-level framework key (e.g. `"ross2"`) now produces a warning naming the bad key and the valid ones, instead of being silently dropped by `encoding/json` with zero feedback.

- **`wendy project entitlements add ros2`** — a realistic guess, since nothing else names "frameworks" as where device integrations live — now redirects to `wendy project frameworks add ros2` instead of the generic "unknown entitlement type" error.

- **`wendy device ros2 --help`** now names both `wendy project frameworks add ros2` and `wendy docs ros2` instead of mentioning `"frameworks.ros2"` with zero elaboration — this is the concrete case that caused the original friction.

- Fixed `cmd.Print*`/`cmd.Printf` in the entitlements and new frameworks list commands: cobra sends those to `OutOrStderr()`, not stdout, despite the name — a pre-existing latent bug that silently broke `wendy project entitlements list --show-all --json | jq`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full module, all packages pass)
- [x] New tests: `go/internal/cli/commands/docs_cmd_test.go`, `go/internal/cli/commands/frameworks_test.go`, additions to `go/internal/shared/appconfig/ros2_test.go`
- [x] Manual end-to-end check of the exact friction scenario:
  - `wendy device ros2 --help` → now points at `wendy project frameworks add ros2` and `wendy docs ros2`
  - `wendy docs ros2` → renders `integrations/ros2.mdx` as readable text with a "View online" URL
  - `wendy project entitlements add ros2` → redirects to `wendy project frameworks add ros2`
  - `wendy project frameworks add ros2` → writes `frameworks.ros2: {}` to `wendy.json` and reports the effective defaults
  - `wendy project frameworks add bogus` → `unknown framework type "bogus"` + `Valid types: ros2`
  - `wendy json validate` on a `wendy.json` with `"frameworks": {"ross2": {}}` → now warns instead of staying silent

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_016m4H6WcvoXVgSXnt1GqMR9