### PR TITLE
Crash-loop robustness: --debug fail-fast, replace/stop vs restart-monitor races, lost crash-loop logs

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -227,6 +227,13 @@ func main() {
 	var monitor *container.ContainerMonitor
 	if containerdClient != nil {
 		monitor = container.NewContainerMonitor(logger, containerdClient, logManager, 15*time.Second)
+		if ctrdClient != nil {
+			// Let the low-level client pause the monitor's restart cycle for a
+			// container it is mid-replace/stop on, so a crash-looping app's
+			// automatic restart cannot race the kill+delete (WDY debug:
+			// "cannot delete running task: failed precondition").
+			ctrdClient.SetRestartSuppressor(monitor)
+		}
 	}
 
 	containerSvcOpts := []services.ContainerServiceOption{

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -549,7 +549,6 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 	return toRestart
 }
 
-// shouldRestart determines whether a container should be restarted based on its policy.
 // restartPolicyHonorsExplicitStop reports whether policy's restart decision
 // is gated by containerState.ExplicitStop. RestartUnlessStopped and
 // RestartOnFailure honor it — a user-initiated stop is meant to stick.
@@ -573,6 +572,7 @@ func restartPolicyHonorsExplicitStop(policy RestartPolicy) bool {
 	}
 }
 
+// shouldRestart determines whether a container should be restarted based on its policy.
 func (m *ContainerMonitor) shouldRestart(state *containerState) bool {
 	if restartPolicyHonorsExplicitStop(state.RestartPolicy) && state.ExplicitStop {
 		return false

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -78,8 +78,15 @@ type ContainerMonitor struct {
 	// tick would otherwise see the siblings stopped and launch a second,
 	// overlapping restart that races on the primary PID. Guarded by mu.
 	groupRestarting map[string]bool
-	mu              sync.Mutex
-	interval        time.Duration
+	// suppressed counts in-flight Suppress handles per container name (see
+	// Suppress). While a name's count is > 0, planRestarts will not schedule a
+	// restart for it. A counter rather than a bool so two independent
+	// operations racing on the same name (e.g. a stop overlapping a replace of
+	// the same service) don't have the first resume() re-enable restarts while
+	// the second is still tearing the task down. Guarded by mu.
+	suppressed map[string]int
+	mu         sync.Mutex
+	interval   time.Duration
 }
 
 func NewContainerMonitor(logger *zap.Logger, client services.ContainerdClient, logManager *services.ContainerLogManager, interval time.Duration) *ContainerMonitor {
@@ -92,6 +99,7 @@ func NewContainerMonitor(logger *zap.Logger, client services.ContainerdClient, l
 		logManager:      logManager,
 		states:          make(map[string]*containerState),
 		groupRestarting: make(map[string]bool),
+		suppressed:      make(map[string]int),
 		interval:        interval,
 	}
 }
@@ -140,6 +148,38 @@ func (m *ContainerMonitor) ClearExplicitStop(appName string) {
 	defer m.mu.Unlock()
 	if state, ok := m.states[appName]; ok {
 		state.ExplicitStop = false
+	}
+}
+
+// Suppress pauses automatic restarts for containerName until the returned
+// resume func is called. The containerd client holds this for the duration of
+// a replace or stop operation's kill+delete sequence so the monitor's
+// periodic tick cannot launch a competing restartSingle while the task is
+// being torn down — observed live as a crash-looping app's restart racing a
+// replace/stop ("cannot delete running task: failed precondition"), and a
+// half-dead task left behind wedging the follow-up delete entirely.
+//
+// The returned func is idempotent: calling it more than once only decrements
+// the count on the first call. containerName uses the same keying as
+// Register/states — bare appID for single-container apps, "{appID}_{service}"
+// for services-map apps.
+func (m *ContainerMonitor) Suppress(containerName string) func() {
+	m.mu.Lock()
+	m.suppressed[containerName]++
+	m.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.mu.Lock()
+			if m.suppressed[containerName] > 0 {
+				m.suppressed[containerName]--
+			}
+			if m.suppressed[containerName] <= 0 {
+				delete(m.suppressed, containerName)
+			}
+			m.mu.Unlock()
+		})
 	}
 }
 
@@ -411,6 +451,13 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 	var toRestart []string
 	for appName, state := range m.states {
 		if running[appName] {
+			continue
+		}
+		if m.suppressed[appName] > 0 {
+			// A replace/stop operation is mid-teardown of this container; see
+			// Suppress. Skip it this tick — the caller will resume suppression
+			// once it is done, and the container's next observed state (running
+			// again, or still down) drives the following tick normally.
 			continue
 		}
 		if !m.shouldRestart(state) {

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -184,17 +184,27 @@ func (m *ContainerMonitor) Suppress(containerName string) func() {
 }
 
 // restartBlocked reports whether containerName currently has a Suppress
-// handle held on it, or is marked as explicitly stopped, and so must not be
-// (re)started. Used by restartSingle to re-check right before it would call
-// StartContainer — see the comment there for why this differs from the
-// planRestarts-time check.
+// handle held on it, or is marked as explicitly stopped under a policy that
+// honors that mark, and so must not be (re)started. Used by restartSingle to
+// re-check right before it would call StartContainer — see the comment there
+// for why this differs from the planRestarts-time check.
+//
+// The ExplicitStop arm is policy-aware (via restartPolicyHonorsExplicitStop)
+// rather than unconditional: shouldRestart deliberately restarts
+// RestartAlways containers even after an explicit stop, and an unconditional
+// block here would fight that — planRestarts schedules the restart every
+// tick (log churn, unbounded FailureCount, RestartStatuses misreporting
+// WillRestart=true as if it were crash-looping) while this guard silently
+// swallowed every attempt forever. The suppression arm stays unconditional:
+// suppression means a replace/stop operation is actively tearing the task
+// down right now, which is orthogonal to restart policy.
 func (m *ContainerMonitor) restartBlocked(containerName string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.suppressed[containerName] > 0 {
 		return true
 	}
-	if state, ok := m.states[containerName]; ok && state.ExplicitStop {
+	if state, ok := m.states[containerName]; ok && state.ExplicitStop && restartPolicyHonorsExplicitStop(state.RestartPolicy) {
 		return true
 	}
 	return false
@@ -540,20 +550,45 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 }
 
 // shouldRestart determines whether a container should be restarted based on its policy.
+// restartPolicyHonorsExplicitStop reports whether policy's restart decision
+// is gated by containerState.ExplicitStop. RestartUnlessStopped and
+// RestartOnFailure honor it — a user-initiated stop is meant to stick.
+// RestartAlways deliberately does not: restarting even after an explicit
+// stop is the entire point of "always" (that's the pre-existing, unreviewed-
+// here behavior shouldRestart already implements below). RestartNo never
+// restarts regardless, so the question doesn't apply to it either way.
+//
+// Shared by shouldRestart (the tick-time restart decision) and
+// restartBlocked (restartSingle's just-before-the-call re-check) so the two
+// cannot drift on which policies treat an explicit stop as binding — that
+// drift is exactly what caused an explicitly-stopped RestartAlways app to
+// get stuck in a perpetual scheduled-then-silently-skipped loop before this
+// helper existed.
+func restartPolicyHonorsExplicitStop(policy RestartPolicy) bool {
+	switch policy {
+	case RestartUnlessStopped, RestartOnFailure:
+		return true
+	default: // RestartNo, RestartAlways, and any future/unknown policy.
+		return false
+	}
+}
+
 func (m *ContainerMonitor) shouldRestart(state *containerState) bool {
+	if restartPolicyHonorsExplicitStop(state.RestartPolicy) && state.ExplicitStop {
+		return false
+	}
 	switch state.RestartPolicy {
 	case RestartNo:
 		return false
 	case RestartUnlessStopped:
-		return !state.ExplicitStop
+		return true
 	case RestartOnFailure:
 		// The monitor detects only whether a container has stopped; it has no
 		// exit-code signal from containerd. Until exit-code detection is added,
 		// ON_FAILURE behaves like UNLESS_STOPPED: it restarts on any exit, not
-		// only non-zero ones. MaxRetries is still enforced.
-		if state.ExplicitStop {
-			return false
-		}
+		// only non-zero ones. MaxRetries is still enforced. The ExplicitStop
+		// check above already ran for this policy (restartPolicyHonorsExplicitStop
+		// includes it), so reaching here means it wasn't set.
 		if state.MaxRetries > 0 && state.FailureCount >= state.MaxRetries {
 			return false
 		}

--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -183,6 +183,23 @@ func (m *ContainerMonitor) Suppress(containerName string) func() {
 	}
 }
 
+// restartBlocked reports whether containerName currently has a Suppress
+// handle held on it, or is marked as explicitly stopped, and so must not be
+// (re)started. Used by restartSingle to re-check right before it would call
+// StartContainer — see the comment there for why this differs from the
+// planRestarts-time check.
+func (m *ContainerMonitor) restartBlocked(containerName string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.suppressed[containerName] > 0 {
+		return true
+	}
+	if state, ok := m.states[containerName]; ok && state.ExplicitStop {
+		return true
+	}
+	return false
+}
+
 // RestartStatuses returns the monitor's per-container restart bookkeeping,
 // keyed by the monitored container name (bare appID, or "{appID}_{serviceName}"
 // for services-map apps). It implements services.RestartStatusProvider so the
@@ -324,6 +341,17 @@ func (m *ContainerMonitor) planRestartActions(ctx context.Context, toRestart []s
 					continue
 				}
 				seenGroup[appID] = true
+				if m.groupHasSuppressedMember(ctx, gr, appID) {
+					// A sibling in this group is mid-replace/stop (a Suppress
+					// handle is held on it) even though it didn't itself
+					// qualify for toRestart — e.g. still reporting RUNNING
+					// because the caller hasn't killed its task yet.
+					// RestartGroup stops/recreates every member, which would
+					// stomp on whatever that operation is doing to the
+					// suppressed one. Defer the whole group restart; the next
+					// tick retries once the handle is resumed.
+					continue
+				}
 				actions = append(actions, restartAction{groupAppID: appID})
 				continue
 			}
@@ -333,8 +361,42 @@ func (m *ContainerMonitor) planRestartActions(ctx context.Context, toRestart []s
 	return actions
 }
 
+// groupHasSuppressedMember reports whether any currently-suppressed container
+// name (see Suppress) belongs to the same shared-namespace group as appID.
+// Suppressed names are usually few (in-flight replace/stop operations), so
+// this scans them directly rather than requiring a reverse appID->members
+// index the monitor doesn't otherwise need.
+func (m *ContainerMonitor) groupHasSuppressedMember(ctx context.Context, gr services.GroupRestarter, appID string) bool {
+	m.mu.Lock()
+	names := make([]string, 0, len(m.suppressed))
+	for name := range m.suppressed {
+		names = append(names, name)
+	}
+	m.mu.Unlock()
+
+	for _, name := range names {
+		if memberAppID, grouped := gr.GroupRestartAppID(ctx, name); grouped && memberAppID == appID {
+			return true
+		}
+	}
+	return false
+}
+
 // restartSingle restarts one container and drains its output to the log manager.
 func (m *ContainerMonitor) restartSingle(ctx context.Context, name string) {
+	if m.restartBlocked(name) {
+		// This goroutine was scheduled by a tick that observed name as down
+		// and eligible, but a Suppress or MarkExplicitStop landed in the gap
+		// between that decision and this goroutine actually running (there is
+		// no blocking call in between to close the window at the scheduling
+		// point — see planRestarts/Suppress). Re-checking here, immediately
+		// before the call that would resurrect the container, is what
+		// actually closes it: a replace/stop that starts suppression after
+		// the tick fired but before this line runs still wins.
+		m.logger.Debug("Skipping restart: suppressed or explicitly stopped since being scheduled",
+			zap.String("app_name", name))
+		return
+	}
 	outputCh, err := m.containerd.StartContainer(ctx, name, "", nil)
 	if err != nil {
 		m.logger.Error("Failed to restart container",

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -443,6 +443,37 @@ func TestRestartSingle_StartsWhenNotBlocked(t *testing.T) {
 	}
 }
 
+// TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStillRestarts is the full
+// round-trip regression guard for fix round 2: an explicitly-stopped
+// RestartAlways app must still be started by a tick. Before this round,
+// restartBlocked's ExplicitStop arm was unconditional, so this exact
+// scenario would loop forever — planRestarts schedules it every tick (it
+// never gated RestartAlways on ExplicitStop) while restartSingle's guard
+// silently swallowed every attempt, so `StartContainer` was never called.
+func TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStillRestarts(t *testing.T) {
+	fake := &fakeContainerd{
+		started: make(chan string, 1),
+		containers: []*agentpb.AppContainer{{
+			AppName:      "always-app",
+			RunningState: agentpb.AppRunningState_STOPPED,
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("always-app", RestartAlways, 0)
+	m.MarkExplicitStop("always-app")
+
+	m.checkContainers(context.Background())
+
+	select {
+	case got := <-fake.started:
+		if got != "always-app" {
+			t.Fatalf("started %q, want always-app", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartContainer(always-app) despite ExplicitStop (RestartAlways policy), got none")
+	}
+}
+
 func TestProbeExposedPortsInvokesProber(t *testing.T) {
 	f := &fakeContainerd{}
 	m := newMonitorWithClient(f)

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -336,6 +336,48 @@ func TestCheckContainers_LegacySingleContainer_NotRestarted(t *testing.T) {
 	}
 }
 
+// TestCheckContainers_SuppressedContainer_NotRestarted is the full
+// checkContainers-round-trip regression guard for F2 (see
+// TestMonitorSuppressSkipsRestart in monitor_test.go for the narrower
+// planRestarts-only version). While a Suppress handle is held, a tick must
+// not call StartContainer for that name even though it is stopped and its
+// policy would otherwise restart it; once resumed, the very same tick
+// conditions restart it normally.
+func TestCheckContainers_SuppressedContainer_NotRestarted(t *testing.T) {
+	fake := &fakeContainerd{
+		started: make(chan string, 1),
+		containers: []*agentpb.AppContainer{{
+			AppName:      "crashloop-app",
+			RunningState: agentpb.AppRunningState_STOPPED,
+		}},
+	}
+	m := newMonitorWithClient(fake)
+	m.Register("crashloop-app", RestartUnlessStopped, 0)
+
+	resume := m.Suppress("crashloop-app")
+
+	m.checkContainers(context.Background())
+
+	select {
+	case got := <-fake.started:
+		t.Fatalf("StartContainer called for suppressed container: %q", got)
+	case <-time.After(200 * time.Millisecond):
+		// expected: nothing started while suppressed
+	}
+
+	resume()
+	m.checkContainers(context.Background())
+
+	select {
+	case got := <-fake.started:
+		if got != "crashloop-app" {
+			t.Fatalf("restarted %q, want %q", got, "crashloop-app")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartContainer(crashloop-app) after resume, got none")
+	}
+}
+
 func TestProbeExposedPortsInvokesProber(t *testing.T) {
 	f := &fakeContainerd{}
 	m := newMonitorWithClient(f)

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -378,6 +378,71 @@ func TestCheckContainers_SuppressedContainer_NotRestarted(t *testing.T) {
 	}
 }
 
+// TestRestartSingle_SkipsWhenSuppressedBeforeStart is the regression guard for
+// the in-flight-resurrection gap (F2 round 1 follow-up, finding 2): a
+// restartSingle goroutine can be dispatched by a tick that observed the
+// container down and unsuppressed, and then have a Suppress land before it
+// actually reaches the StartContainer call — there is no blocking operation
+// between goroutine dispatch and that call to naturally serialize the two, so
+// the only way to close the window deterministically is a re-check
+// immediately before the call, which is what this asserts. The test invokes
+// restartSingle directly rather than via `go` + a synchronization gate:
+// restartSingle's guard runs synchronously as its very first statement with
+// nothing blocking beforehand, so there is no I/O point available to
+// interleave two goroutines on deterministically — calling it after Suppress
+// exercises the exact same code path (the guard check) that a genuinely
+// raced goroutine would hit, without relying on scheduler timing.
+func TestRestartSingle_SkipsWhenSuppressedBeforeStart(t *testing.T) {
+	fake := &fakeContainerd{started: make(chan string, 1)}
+	m := newMonitorWithClient(fake)
+	m.Register("crashloop-app", RestartUnlessStopped, 0)
+
+	resume := m.Suppress("crashloop-app")
+	defer resume()
+
+	m.restartSingle(context.Background(), "crashloop-app")
+
+	if calls := fake.startCallsSnapshot(); len(calls) != 0 {
+		t.Fatalf("StartContainer called for suppressed container: %v", calls)
+	}
+}
+
+// TestRestartSingle_SkipsWhenExplicitlyStoppedBeforeStart mirrors the above
+// for MarkExplicitStop, the other piece of state a stop operation sets that
+// an already-scheduled restartSingle must honor.
+func TestRestartSingle_SkipsWhenExplicitlyStoppedBeforeStart(t *testing.T) {
+	fake := &fakeContainerd{started: make(chan string, 1)}
+	m := newMonitorWithClient(fake)
+	m.Register("crashloop-app", RestartUnlessStopped, 0)
+	m.MarkExplicitStop("crashloop-app")
+
+	m.restartSingle(context.Background(), "crashloop-app")
+
+	if calls := fake.startCallsSnapshot(); len(calls) != 0 {
+		t.Fatalf("StartContainer called for an explicitly-stopped container: %v", calls)
+	}
+}
+
+// TestRestartSingle_StartsWhenNotBlocked is the regression control for the two
+// tests above: the new re-check must not over-fire and block a legitimate,
+// unsuppressed restart.
+func TestRestartSingle_StartsWhenNotBlocked(t *testing.T) {
+	fake := &fakeContainerd{started: make(chan string, 1)}
+	m := newMonitorWithClient(fake)
+	m.Register("crashloop-app", RestartUnlessStopped, 0)
+
+	m.restartSingle(context.Background(), "crashloop-app")
+
+	select {
+	case got := <-fake.started:
+		if got != "crashloop-app" {
+			t.Fatalf("started %q, want crashloop-app", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartContainer(crashloop-app), got none")
+	}
+}
+
 func TestProbeExposedPortsInvokesProber(t *testing.T) {
 	f := &fakeContainerd{}
 	m := newMonitorWithClient(f)

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -159,6 +159,118 @@ func TestContainerMonitor_ShouldRestart_OnFailure(t *testing.T) {
 	}
 }
 
+// TestContainerMonitor_ShouldRestart_Always verifies RestartAlways restarts
+// even when the container has been explicitly stopped. This is pre-existing
+// behavior (restarting after an explicit stop is the entire point of
+// "always") that fix round 2 exists specifically to preserve: restartBlocked
+// must agree with it, or an explicitly-stopped RestartAlways app gets stuck
+// in a perpetual scheduled-by-planRestarts-then-silently-skipped-by-
+// restartSingle loop.
+func TestContainerMonitor_ShouldRestart_Always(t *testing.T) {
+	m := newTestMonitor()
+
+	state := &containerState{RestartPolicy: RestartAlways}
+	if !m.shouldRestart(state) {
+		t.Error("shouldRestart() = false for RestartAlways (not stopped), want true")
+	}
+
+	state.ExplicitStop = true
+	if !m.shouldRestart(state) {
+		t.Error("shouldRestart() = false for RestartAlways (explicitly stopped), want true — RestartAlways ignores ExplicitStop by design")
+	}
+}
+
+// TestRestartPolicyHonorsExplicitStop is a direct table test of the shared
+// predicate shouldRestart and restartBlocked both derive from, so the two
+// cannot silently drift on which policies treat an explicit stop as binding.
+func TestRestartPolicyHonorsExplicitStop(t *testing.T) {
+	tests := []struct {
+		policy RestartPolicy
+		want   bool
+	}{
+		{RestartNo, false},
+		{RestartUnlessStopped, true},
+		{RestartOnFailure, true},
+		{RestartAlways, false},
+		{RestartPolicy(99), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.policy.String(), func(t *testing.T) {
+			if got := restartPolicyHonorsExplicitStop(tt.policy); got != tt.want {
+				t.Errorf("restartPolicyHonorsExplicitStop(%v) = %v, want %v", tt.policy, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRestartBlocked_AlwaysPolicyIgnoresExplicitStop is the regression guard
+// for the fix round 2 finding: restartBlocked's ExplicitStop arm must not
+// block a RestartAlways container just because it was explicitly stopped.
+func TestRestartBlocked_AlwaysPolicyIgnoresExplicitStop(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartAlways, 0)
+	m.MarkExplicitStop("com.example.app")
+
+	if m.restartBlocked("com.example.app") {
+		t.Error("restartBlocked() = true for RestartAlways + ExplicitStop + not suppressed; want false (old semantics: RestartAlways restarts even after explicit stop)")
+	}
+}
+
+// TestRestartBlocked_OnFailurePolicyHonorsExplicitStop is the paired case: a
+// policy shouldRestart does honor ExplicitStop for must still be blocked.
+func TestRestartBlocked_OnFailurePolicyHonorsExplicitStop(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartOnFailure, 0)
+	m.MarkExplicitStop("com.example.app")
+
+	if !m.restartBlocked("com.example.app") {
+		t.Error("restartBlocked() = false for RestartOnFailure + ExplicitStop; want true")
+	}
+}
+
+// TestRestartBlocked_SuppressedAlwaysStillBlocked verifies the suppression
+// arm stays unconditional: suppression means a replace/stop operation is
+// actively tearing the task down right now, which blocks every policy
+// including RestartAlways — it is orthogonal to whether the policy honors
+// ExplicitStop.
+func TestRestartBlocked_SuppressedAlwaysStillBlocked(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartAlways, 0)
+	resume := m.Suppress("com.example.app")
+	defer resume()
+
+	if !m.restartBlocked("com.example.app") {
+		t.Error("restartBlocked() = false for suppressed RestartAlways container; want true (suppression is unconditional)")
+	}
+}
+
+// TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStillScheduled locks in
+// pre-round-1 behavior for RestartAlways: even explicitly stopped, a down
+// RestartAlways container must still be scheduled by planRestarts — matching
+// shouldRestart, which never gated RestartAlways on ExplicitStop — with no
+// skip and no double count of FailureCount.
+func TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStillScheduled(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartAlways, 0)
+	m.MarkExplicitStop("com.example.app")
+
+	stopped := []*agentpb.AppContainer{
+		{AppName: "com.example.app", RunningState: agentpb.AppRunningState_STOPPED},
+	}
+
+	got := m.planRestarts(stopped)
+	if len(got) != 1 || got[0] != "com.example.app" {
+		t.Errorf("planRestarts = %v; want [com.example.app] (RestartAlways ignores ExplicitStop)", got)
+	}
+
+	m.mu.Lock()
+	fc := m.states["com.example.app"].FailureCount
+	m.mu.Unlock()
+	if fc != 1 {
+		t.Errorf("FailureCount = %d after one planRestarts call; want 1 (no double count)", fc)
+	}
+}
+
 func TestContainerMonitor_ExplicitStop(t *testing.T) {
 	m := newTestMonitor()
 

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -385,6 +385,82 @@ func TestContainerMonitor_Register_And_Unregister(t *testing.T) {
 	m.mu.Unlock()
 }
 
+// TestMonitorSuppressSkipsRestart is the regression guard for F2: while a
+// Suppress handle is held for a container name, planRestarts must not
+// schedule a restart for it even though the container is stopped and its
+// policy would otherwise restart it. This is what lets a replace/stop
+// operation kill and delete the task without the monitor's next tick
+// resurrecting it mid-teardown (observed live: "cannot delete running task:
+// failed precondition"). Once the handle is resumed, the same input restarts
+// normally again.
+func TestMonitorSuppressSkipsRestart(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartUnlessStopped, 0)
+
+	stopped := []*agentpb.AppContainer{
+		{AppName: "com.example.app", RunningState: agentpb.AppRunningState_STOPPED},
+	}
+
+	resume := m.Suppress("com.example.app")
+
+	if got := m.planRestarts(stopped); len(got) != 0 {
+		t.Errorf("planRestarts scheduled a restart while suppressed: %v", got)
+	}
+
+	resume()
+
+	got := m.planRestarts(stopped)
+	if len(got) != 1 || got[0] != "com.example.app" {
+		t.Errorf("planRestarts after resume = %v; want [com.example.app]", got)
+	}
+}
+
+// TestMonitorSuppressIsReferenceCounted verifies two independent Suppress
+// handles on the same container name (e.g. a stop racing a replace of the
+// same service) both have to resume before restarts are allowed again —
+// otherwise the first operation to finish would silently re-enable restarts
+// while the second is still mid-teardown.
+func TestMonitorSuppressIsReferenceCounted(t *testing.T) {
+	m := newTestMonitor()
+	m.Register("com.example.app", RestartUnlessStopped, 0)
+
+	stopped := []*agentpb.AppContainer{
+		{AppName: "com.example.app", RunningState: agentpb.AppRunningState_STOPPED},
+	}
+
+	resumeA := m.Suppress("com.example.app")
+	resumeB := m.Suppress("com.example.app")
+
+	resumeA()
+	if got := m.planRestarts(stopped); len(got) != 0 {
+		t.Errorf("planRestarts scheduled a restart with one of two suppressions still held: %v", got)
+	}
+
+	resumeB()
+	if got := m.planRestarts(stopped); len(got) != 1 || got[0] != "com.example.app" {
+		t.Errorf("planRestarts after both resumed = %v; want [com.example.app]", got)
+	}
+}
+
+// TestMonitorSuppressResumeIsIdempotent verifies calling resume more than
+// once does not under-flow the suppression counter, which would otherwise let
+// a spurious extra resume cancel out a still-active, unrelated Suppress call
+// on the same name.
+func TestMonitorSuppressResumeIsIdempotent(t *testing.T) {
+	m := newTestMonitor()
+
+	resume := m.Suppress("com.example.app")
+	resume()
+	resume() // must be a no-op, not decrement past zero
+
+	m.mu.Lock()
+	count := m.suppressed["com.example.app"]
+	m.mu.Unlock()
+	if count != 0 {
+		t.Errorf("suppressed count = %d after idempotent double-resume; want 0", count)
+	}
+}
+
 func TestContainerMonitor_RestartStatuses(t *testing.T) {
 	m := newTestMonitor()
 

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -267,6 +267,38 @@ func TestPlanRestartActions_CoalescesGroupMembers(t *testing.T) {
 	}
 }
 
+// TestPlanRestartActions_DefersGroupWhenMemberSuppressed is the regression
+// guard for the group-restart-bypasses-suppression gap (F2 round 1 follow-up,
+// finding 1): planRestarts/Suppress only ever gate individual member names,
+// but planRestartActions escalates any one unsuppressed, down member into a
+// whole-group restartGroup(appID) call — whose stopOne/refreshSecondaryNamespaces
+// would stop/recreate every member, including a sibling a replace/stop is
+// currently holding suppressed. A suppressed member must defer the entire
+// group action until it is resumed, even when that member itself isn't in
+// toRestart (e.g. it's still reporting RUNNING because the caller hasn't
+// killed its task yet).
+func TestPlanRestartActions_DefersGroupWhenMemberSuppressed(t *testing.T) {
+	fake := &fakeContainerdClient{groupOf: map[string]string{
+		"app_talker":   "app",
+		"app_listener": "app",
+	}}
+	m := NewContainerMonitor(zap.NewNop(), fake, nil, time.Second)
+
+	resume := m.Suppress("app_talker") // e.g. a replace mid-teardown of talker
+
+	actions := m.planRestartActions(context.Background(), []string{"app_listener"})
+	if len(actions) != 0 {
+		t.Errorf("planRestartActions = %+v while a group member is suppressed; want no action", actions)
+	}
+
+	resume()
+
+	actions = m.planRestartActions(context.Background(), []string{"app_listener"})
+	if len(actions) != 1 || actions[0].groupAppID != "app" {
+		t.Errorf("planRestartActions after resume = %+v; want one group action for app", actions)
+	}
+}
+
 // TestPlanRestartActions_SingleForNonGroupedContainer verifies a container that
 // is not part of a shared-namespace group is restarted on its own.
 func TestPlanRestartActions_SingleForNonGroupedContainer(t *testing.T) {

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -63,6 +63,20 @@ type AppSystemAPISocketProvider interface {
 	ReleaseApp(appID string)
 }
 
+// restartSuppressor is the narrow capability the client needs from the
+// container-restart monitor: pause automatic restarts for a container name
+// while a replace or stop operation holds the handle, so the monitor's
+// periodic tick cannot resurrect the task the client is mid-way through
+// killing and deleting (see suppressRestarts). Declared here — rather than
+// importing internal/agent/container, which would cycle back through
+// internal/agent/services — so *container.ContainerMonitor satisfies it
+// structurally; wired in from main.go via SetRestartSuppressor.
+type restartSuppressor interface {
+	// Suppress pauses restarts for containerName until the returned resume
+	// func runs.
+	Suppress(containerName string) func()
+}
+
 type Client struct {
 	client                  *containerd.Client
 	logger                  *zap.Logger
@@ -131,6 +145,35 @@ type Client struct {
 	// c.mu would deadlock there, while stopOne runs without c.mu held.
 	meshMu      sync.Mutex
 	meshDNSHeld map[string]bool
+
+	// restartMonitor lets replace/stop pause the restart monitor's tick for
+	// the container they are tearing down (see suppressRestarts). nil when
+	// containerd came up without a monitor being wired in (e.g. many unit
+	// tests construct a bare *Client) — suppressRestarts no-ops in that case,
+	// same nil-tolerant treatment as meshDNS above.
+	restartMonitor restartSuppressor
+}
+
+// SetRestartSuppressor injects the container-restart monitor's suppression
+// handle. Called once from main.go at agent startup, after the monitor is
+// constructed (the monitor itself is constructed from the client, so this
+// necessarily wires in after SetMeshDNS/SetAppSystemAPISocketProvider). Not
+// protected by c.mu: set once during single-threaded startup before the
+// Client is exposed to concurrent callers, mirroring SetMeshDNS.
+func (c *Client) SetRestartSuppressor(s restartSuppressor) {
+	c.restartMonitor = s
+}
+
+// suppressRestarts pauses the restart monitor for containerName for the
+// duration of the caller's replace/stop operation. Returns a no-op resume
+// func when no monitor is wired (containerd came up without one, or a unit
+// test constructed a bare *Client), so callers can unconditionally
+// `defer resume()` without a nil check.
+func (c *Client) suppressRestarts(containerName string) func() {
+	if c.restartMonitor == nil {
+		return func() {}
+	}
+	return c.restartMonitor.Suppress(containerName)
 }
 
 // SetMeshDNS injects the shared mesh DNS server used by applyMeshEgress and
@@ -970,6 +1013,16 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 
 	// Delete any pre-existing container with the same name.
 	if existing, err := c.client.LoadContainer(ctx, containerName); err == nil {
+		// Pause the restart monitor for this name for the rest of this
+		// function: without it, a crash-looping app's next tick can call
+		// StartContainer on this same container between our kill and delete
+		// below, resurrecting the task and racing us (observed live:
+		// "cannot delete running task: failed precondition"). Held through
+		// the new container's creation further down too, so the monitor
+		// cannot also race the fresh task being started.
+		resumeRestarts := c.suppressRestarts(containerName)
+		defer resumeRestarts()
+
 		oldHadSystemAPI := false
 		if labels, labelErr := existing.Labels(ctx); labelErr == nil {
 			oldHadSystemAPI = entitlementsContain(parseEntitlementsFromAnnotations(labels), appconfig.EntitlementNotifications)
@@ -990,7 +1043,24 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 			// service directly so the runtime clears the old task ID.
 			c.forceDeleteTask(ctx, containerName)
 		}
-		if delErr := existing.Delete(ctx, containerd.WithSnapshotCleanup); delErr != nil && !errdefs.IsNotFound(delErr) {
+		delErr := existing.Delete(ctx, containerd.WithSnapshotCleanup)
+		if delErr != nil && errdefs.IsFailedPrecondition(delErr) {
+			// A task exists again despite the kill above — most likely the
+			// restart monitor's tick winning a race against suppressRestarts
+			// (a tick already past its check when Suppress was called), or an
+			// unrelated in-flight start. Kill it again and retry the delete
+			// once rather than failing the whole replace outright.
+			c.logger.Warn("Existing container still has a running task after kill; retrying",
+				zap.String("container_name", containerName), zap.Error(delErr))
+			if task, taskErr := existing.Task(ctx, nil); taskErr == nil {
+				if termErr := c.terminateTask(ctx, task, containerName, syscall.SIGKILL, killWaitTimeout, killWaitTimeout); termErr != nil {
+					c.logger.Error("Failed to kill racing task during replace retry",
+						zap.String("container_name", containerName), zap.Error(termErr))
+				}
+			}
+			delErr = existing.Delete(ctx, containerd.WithSnapshotCleanup)
+		}
+		if delErr != nil && !errdefs.IsNotFound(delErr) {
 			return fmt.Errorf("deleting existing container %q during replace: %w", containerName, delErr)
 		}
 		if oldHadSystemAPI && c.systemAPISocketProvider != nil {
@@ -2430,13 +2500,72 @@ func (c *Client) deleteStaleTask(ctx context.Context, container containerd.Conta
 	}
 }
 
+// isMissingRuncStateDir reports whether err is runc's own "cannot open
+// directory" failure for a task's state directory under
+// /run/containerd/runc/<namespace>/<containerID>. Observed live: a half-dead
+// task whose state dir had been removed out from under it wedged both
+// StopContainer and `ctr tasks rm -f` indefinitely — runc's delete path
+// stats the directory before it will proceed, so an absent (even empty) dir
+// is a permanent failure until the directory exists again. Returns the
+// missing directory path so the caller can recreate it and retry.
+//
+// The literal string this matches was captured from the error observed on
+// hardware:
+//
+//	cannot open directory `/run/containerd/runc/default/com.wendylabs.examples.mcp-example`: No such file or directory
+func isMissingRuncStateDir(err error) (dir string, ok bool) {
+	if err == nil {
+		return "", false
+	}
+	msg := err.Error()
+	const marker = "cannot open directory `"
+	idx := strings.Index(msg, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := msg[idx+len(marker):]
+	end := strings.IndexByte(rest, '`')
+	if end < 0 {
+		return "", false
+	}
+	dir = rest[:end]
+	if !strings.HasPrefix(dir, "/run/containerd/runc/") {
+		return "", false
+	}
+	return dir, true
+}
+
 // forceDeleteTask uses the low-level containerd task service to delete a task
 // by container ID. This handles orphaned tasks where container.Task() fails
 // because the shim process is gone but task metadata remains in the runtime.
+//
+// If the delete fails because runc's state directory for the task is missing
+// (isMissingRuncStateDir), it recreates the empty directory runc expects and
+// retries once — otherwise the caller (and any subsequent `ctr tasks rm -f`)
+// would fail this exact way forever, since nothing else ever recreates it.
 func (c *Client) forceDeleteTask(ctx context.Context, containerID string) {
 	_, err := c.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
 		ContainerID: containerID,
 	})
+	if dir, missingDir := isMissingRuncStateDir(err); missingDir {
+		// Mode 0o711 matches runc's own permissions for per-container state
+		// dirs: traversable by root, opaque to other users.
+		if mkErr := os.MkdirAll(dir, 0o711); mkErr != nil {
+			c.logger.Warn("Force task delete: failed to recreate missing runc state dir",
+				zap.String("container_id", containerID),
+				zap.String("dir", dir),
+				zap.Error(mkErr),
+			)
+		} else {
+			c.logger.Info("Force task delete: recreated missing runc state dir, retrying",
+				zap.String("container_id", containerID),
+				zap.String("dir", dir),
+			)
+			_, err = c.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
+				ContainerID: containerID,
+			})
+		}
+	}
 	if err != nil {
 		c.logger.Debug("Force task delete attempt",
 			zap.String("container_id", containerID),
@@ -3063,6 +3192,21 @@ func (c *Client) StopContainer(ctx context.Context, name string) error {
 	}
 	c.appStopping[appID] = true
 	c.mu.Unlock()
+
+	// Pause the restart monitor for every container about to be stopped, for
+	// the whole rest of this function: without it, a crash-looping member's
+	// automatic restart can race stopOne's kill+delete below and wedge the
+	// stop (same "cannot delete running task: failed precondition" race as
+	// the replace path in CreateContainerWithProgress).
+	resumeFns := make([]func(), 0, len(stopOrder))
+	for _, ctrID := range stopOrder {
+		resumeFns = append(resumeFns, c.suppressRestarts(ctrID))
+	}
+	defer func() {
+		for _, resume := range resumeFns {
+			resume()
+		}
+	}()
 
 	var errs []error
 	for _, ctrID := range stopOrder {

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -2942,6 +2942,13 @@ func (c *Client) streamOutput(
 	// Wait for the task to exit.
 	exitStatus := <-exitStatusCh
 	code, exitedAt, err := exitStatus.Result()
+	// taskExited is true only once we know the process has actually
+	// terminated (see the context.Canceled branch below, where it hasn't).
+	// Gates the IO drain below: task.IO().Wait() blocks until the task's
+	// stdio FIFOs reach EOF, which only happens once the process's fds
+	// close — calling it while the container is genuinely still running
+	// would hang this goroutine forever.
+	taskExited := err == nil
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			// The wait was canceled because the RPC that started this monitor
@@ -2972,14 +2979,50 @@ func (c *Client) streamOutput(
 		cancel()
 	}
 
-	// Close the write ends to unblock readers.
-	stdoutW.Close()
-	stderrW.Close()
+	if taskExited {
+		// The exit status arriving does NOT mean containerd has finished
+		// copying the task's stdout/stderr FIFOs into stdoutW/stderrW: that
+		// copy runs on containerd's own goroutines (cio.copyIO), a path
+		// independent of the process-exit signal task.Wait() delivers here.
+		// For a container that prints one line and exits immediately — the
+		// crash-loop case — that copy can still be in flight when the exit
+		// status arrives, so closing stdoutW/stderrW right away can slam the
+		// pipe shut before the in-flight Write() lands, silently dropping
+		// the very output a crash-looping container needs most (live
+		// symptom: `wendy device logs --tail` returned zero lines for an
+		// actively crash-looping app). drainTaskIOThenClose waits for that
+		// copy to finish before closing, mirroring the same fix already
+		// applied to ExecContainer/ROS2 exec (proc.IO().Wait()) in this
+		// package.
+		drainTaskIOThenClose(task.IO(), stdoutW, stderrW)
+	} else {
+		// Task not confirmed exited (context.Canceled path, effectively
+		// unreachable since taskCtx derives from context.Background() and is
+		// never canceled): preserve prior behavior and close unconditionally
+		// rather than risk blocking forever in task.IO().Wait().
+		stdoutW.Close()
+		stderrW.Close()
+	}
 
 	// Wait for readers to finish.
 	wg.Wait()
 
 	outputCh <- services.ContainerOutput{Done: true}
+}
+
+// drainTaskIOThenClose blocks until taskIO's stdio copy goroutines (if any)
+// have finished flushing container output into stdoutW/stderrW, then closes
+// both writers. Must only be called once the task is confirmed to have
+// exited — see the taskExited gate in streamOutput's caller — since
+// taskIO.Wait() blocks until the underlying FIFOs reach EOF, which a still-
+// running task never delivers. taskIO may be nil (some cio.IO
+// implementations, e.g. NullIO, are legitimately IO-less).
+func drainTaskIOThenClose(taskIO cio.IO, stdoutW, stderrW io.Closer) {
+	if taskIO != nil {
+		taskIO.Wait()
+	}
+	stdoutW.Close()
+	stderrW.Close()
 }
 
 // resolveTargets resolves name to the containers it addresses:

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1054,8 +1054,14 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 				zap.String("container_name", containerName), zap.Error(delErr))
 			if task, taskErr := existing.Task(ctx, nil); taskErr == nil {
 				if termErr := c.terminateTask(ctx, task, containerName, syscall.SIGKILL, killWaitTimeout, killWaitTimeout); termErr != nil {
-					c.logger.Error("Failed to kill racing task during replace retry",
+					// Mirror the first attempt's fallback above: if the
+					// re-kill itself fails, fall back to force-deleting the
+					// task via the runtime directly before retrying, rather
+					// than retrying the container delete against a task we
+					// know we failed to kill.
+					c.logger.Error("Failed to kill racing task during replace retry; forcing runtime delete",
 						zap.String("container_name", containerName), zap.Error(termErr))
+					c.forceDeleteTask(ctx, containerName)
 				}
 			}
 			delErr = existing.Delete(ctx, containerd.WithSnapshotCleanup)
@@ -2535,37 +2541,77 @@ func isMissingRuncStateDir(err error) (dir string, ok bool) {
 	return dir, true
 }
 
+// recoverMissingRuncStateDir classifies err via isMissingRuncStateDir and, if
+// it matches, delegates the actual recovery (mkdir + retry) to
+// recreateRuncStateDirAndRetry. Any other error — including nil — passes
+// through unchanged and retry is never called.
+//
+// Shared by forceDeleteTask (replace path) and terminateTask (stop path,
+// task_teardown.go): both ultimately delete a containerd task and both can
+// hit the exact same live-observed wedge, so both need the same recovery
+// rather than only the replace path having it (the stop path was the one
+// actually observed wedged on hardware).
+func (c *Client) recoverMissingRuncStateDir(containerID string, err error, retry func() error) error {
+	dir, ok := isMissingRuncStateDir(err)
+	if !ok {
+		return err
+	}
+	return c.recreateRuncStateDirAndRetry(containerID, dir, err, retry)
+}
+
+// runcStateDirMkdirAll is a seam over os.MkdirAll: recreateRuncStateDirAndRetry
+// calls through it rather than os.MkdirAll directly so tests can verify the
+// full forceDeleteTask/terminateTask recovery wiring — including
+// isMissingRuncStateDir's hardcoded /run/containerd/runc/ prefix check —
+// without needing real root-owned /run filesystem access on the test host.
+// Production code never reassigns it.
+var runcStateDirMkdirAll = os.MkdirAll
+
+// recreateRuncStateDirAndRetry recreates dir (the runc task state directory
+// isMissingRuncStateDir extracted from origErr) and, if that succeeds, calls
+// retry and returns its result. If MkdirAll fails, origErr is returned
+// unchanged and retry is never called. Split out from
+// recoverMissingRuncStateDir so it can be unit-tested directly against an
+// arbitrary writable directory, independent of isMissingRuncStateDir's
+// /run/containerd/runc/ prefix requirement (which a test can't satisfy
+// without root on a real Linux host).
+func (c *Client) recreateRuncStateDirAndRetry(containerID, dir string, origErr error, retry func() error) error {
+	// Mode 0o711 matches runc's own permissions for per-container state
+	// dirs: traversable by root, opaque to other users.
+	if mkErr := runcStateDirMkdirAll(dir, 0o711); mkErr != nil {
+		c.logger.Warn("Failed to recreate missing runc state dir",
+			zap.String("container_id", containerID),
+			zap.String("dir", dir),
+			zap.Error(mkErr),
+		)
+		return origErr
+	}
+	c.logger.Info("Recreated missing runc state dir, retrying delete",
+		zap.String("container_id", containerID),
+		zap.String("dir", dir),
+	)
+	return retry()
+}
+
 // forceDeleteTask uses the low-level containerd task service to delete a task
 // by container ID. This handles orphaned tasks where container.Task() fails
 // because the shim process is gone but task metadata remains in the runtime.
 //
 // If the delete fails because runc's state directory for the task is missing
-// (isMissingRuncStateDir), it recreates the empty directory runc expects and
-// retries once — otherwise the caller (and any subsequent `ctr tasks rm -f`)
-// would fail this exact way forever, since nothing else ever recreates it.
+// (recoverMissingRuncStateDir), it recreates the empty directory runc expects
+// and retries once — otherwise the caller (and any subsequent
+// `ctr tasks rm -f`) would fail this exact way forever, since nothing else
+// ever recreates it.
 func (c *Client) forceDeleteTask(ctx context.Context, containerID string) {
 	_, err := c.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
 		ContainerID: containerID,
 	})
-	if dir, missingDir := isMissingRuncStateDir(err); missingDir {
-		// Mode 0o711 matches runc's own permissions for per-container state
-		// dirs: traversable by root, opaque to other users.
-		if mkErr := os.MkdirAll(dir, 0o711); mkErr != nil {
-			c.logger.Warn("Force task delete: failed to recreate missing runc state dir",
-				zap.String("container_id", containerID),
-				zap.String("dir", dir),
-				zap.Error(mkErr),
-			)
-		} else {
-			c.logger.Info("Force task delete: recreated missing runc state dir, retrying",
-				zap.String("container_id", containerID),
-				zap.String("dir", dir),
-			)
-			_, err = c.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
-				ContainerID: containerID,
-			})
-		}
-	}
+	err = c.recoverMissingRuncStateDir(containerID, err, func() error {
+		_, retryErr := c.client.TaskService().Delete(ctx, &tasks.DeleteTaskRequest{
+			ContainerID: containerID,
+		})
+		return retryErr
+	})
 	if err != nil {
 		c.logger.Debug("Force task delete attempt",
 			zap.String("container_id", containerID),

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -2,6 +2,8 @@ package containerd
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -1413,5 +1415,121 @@ func TestIsMissingRuncStateDir(t *testing.T) {
 				t.Errorf("dir = %q; want %q", dir, tt.wantDir)
 			}
 		})
+	}
+}
+
+// TestRecoverMissingRuncStateDir_PassesThroughUnrelatedErrors verifies
+// recoverMissingRuncStateDir (the F2 round-1-followup finding-3 shared
+// helper, used by both forceDeleteTask and terminateTask's task.Delete step)
+// never invokes retry for an error isMissingRuncStateDir doesn't recognize —
+// including nil, the success case.
+func TestRecoverMissingRuncStateDir_PassesThroughUnrelatedErrors(t *testing.T) {
+	c := &Client{logger: zap.NewNop()}
+
+	t.Run("nil error", func(t *testing.T) {
+		called := false
+		got := c.recoverMissingRuncStateDir("ctr", nil, func() error {
+			called = true
+			return nil
+		})
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+		if called {
+			t.Error("retry called for nil error")
+		}
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		want := errors.New("boom")
+		called := false
+		got := c.recoverMissingRuncStateDir("ctr", want, func() error {
+			called = true
+			return nil
+		})
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if called {
+			t.Error("retry called for an error that isn't the missing-state-dir failure")
+		}
+	})
+}
+
+// TestRecreateRuncStateDirAndRetry_MkdirSucceeds is the decision-flow
+// regression guard for finding 3 (the missing-runc-state-dir recovery was
+// unreachable from the stop path, the actual live-observed wedge): given a
+// directory that doesn't exist yet but whose parent is writable, MkdirAll
+// must succeed, retry must be invoked exactly once, and its result (success
+// or failure) must be returned unchanged. Uses t.TempDir() rather than a real
+// /run/containerd/runc/ path (isMissingRuncStateDir's prefix requirement),
+// since recreateRuncStateDirAndRetry is deliberately split out to be testable
+// against an arbitrary directory without needing root on a real Linux host —
+// see its doc comment.
+func TestRecreateRuncStateDirAndRetry_MkdirSucceeds(t *testing.T) {
+	c := &Client{logger: zap.NewNop()}
+	dir := filepath.Join(t.TempDir(), "default", "com.example.app")
+	origErr := errors.New("cannot open directory `" + dir + "`: No such file or directory")
+	retryErr := errors.New("still failing after retry")
+
+	retryCalls := 0
+	got := c.recreateRuncStateDirAndRetry("ctr", dir, origErr, func() error {
+		retryCalls++
+		return retryErr
+	})
+
+	if retryCalls != 1 {
+		t.Fatalf("retry called %d times, want 1", retryCalls)
+	}
+	if got != retryErr {
+		t.Errorf("got %v, want retry's error %v returned unchanged", got, retryErr)
+	}
+	if info, statErr := os.Stat(dir); statErr != nil || !info.IsDir() {
+		t.Errorf("expected %s to be recreated as a directory (stat err: %v)", dir, statErr)
+	}
+}
+
+// TestRecreateRuncStateDirAndRetry_MkdirSucceeds_RetrySucceeds covers the
+// success path end to end: mkdir succeeds, retry succeeds, the original
+// error is fully swallowed.
+func TestRecreateRuncStateDirAndRetry_MkdirSucceeds_RetrySucceeds(t *testing.T) {
+	c := &Client{logger: zap.NewNop()}
+	dir := filepath.Join(t.TempDir(), "default", "com.example.app")
+	origErr := errors.New("cannot open directory `" + dir + "`: No such file or directory")
+
+	got := c.recreateRuncStateDirAndRetry("ctr", dir, origErr, func() error {
+		return nil
+	})
+
+	if got != nil {
+		t.Errorf("got %v, want nil after a successful retry", got)
+	}
+}
+
+// TestRecreateRuncStateDirAndRetry_MkdirFails verifies that when MkdirAll
+// itself fails, retry is never called and the original error is preserved
+// (not the mkdir error) — a file occupying a path component that MkdirAll
+// needs to descend through makes it fail portably, without needing real
+// /run/containerd/runc permissions.
+func TestRecreateRuncStateDirAndRetry_MkdirFails(t *testing.T) {
+	c := &Client{logger: zap.NewNop()}
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: writing blocker file: %v", err)
+	}
+	dir := filepath.Join(blocker, "default", "com.example.app")
+	origErr := errors.New("cannot open directory `" + dir + "`: No such file or directory")
+
+	retryCalls := 0
+	got := c.recreateRuncStateDirAndRetry("ctr", dir, origErr, func() error {
+		retryCalls++
+		return nil
+	})
+
+	if retryCalls != 0 {
+		t.Errorf("retry called %d times after mkdir failure, want 0", retryCalls)
+	}
+	if got != origErr {
+		t.Errorf("got %v, want original error %v preserved", got, origErr)
 	}
 }

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -1305,3 +1305,113 @@ func TestCollectExposures(t *testing.T) {
 		}
 	}
 }
+
+// fakeRestartSuppressor is a recording restartSuppressor for the F2
+// replace/stop-suppression tests below: it captures every Suppress call and
+// every subsequent resume so tests can assert both the call and its pairing
+// without depending on the real container.ContainerMonitor.
+type fakeRestartSuppressor struct {
+	suppressed []string
+	resumed    []string
+}
+
+func (f *fakeRestartSuppressor) Suppress(containerName string) func() {
+	f.suppressed = append(f.suppressed, containerName)
+	return func() {
+		f.resumed = append(f.resumed, containerName)
+	}
+}
+
+// TestSuppressRestartsNoopWhenNoMonitor verifies suppressRestarts always
+// returns a callable resume func even when no monitor was wired in (e.g.
+// containerd came up before/without a monitor, or a bare *Client in a unit
+// test) — callers must be able to unconditionally `defer resume()`.
+func TestSuppressRestartsNoopWhenNoMonitor(t *testing.T) {
+	c := &Client{}
+	resume := c.suppressRestarts("com.example.app")
+	if resume == nil {
+		t.Fatal("suppressRestarts returned a nil func with no monitor wired")
+	}
+	resume() // must not panic
+}
+
+// TestSuppressRestartsDelegatesToMonitor verifies suppressRestarts forwards
+// to the wired restartMonitor and returns its resume func unchanged.
+func TestSuppressRestartsDelegatesToMonitor(t *testing.T) {
+	fake := &fakeRestartSuppressor{}
+	c := &Client{restartMonitor: fake}
+
+	resume := c.suppressRestarts("com.example.app")
+	if len(fake.suppressed) != 1 || fake.suppressed[0] != "com.example.app" {
+		t.Fatalf("Suppress calls = %v; want [com.example.app]", fake.suppressed)
+	}
+	if len(fake.resumed) != 0 {
+		t.Fatalf("resume calls before resume() = %v; want none", fake.resumed)
+	}
+
+	resume()
+	if len(fake.resumed) != 1 || fake.resumed[0] != "com.example.app" {
+		t.Fatalf("resume calls = %v; want [com.example.app]", fake.resumed)
+	}
+}
+
+// TestSetRestartSuppressor verifies the setter wires the field suppressRestarts reads.
+func TestSetRestartSuppressor(t *testing.T) {
+	fake := &fakeRestartSuppressor{}
+	c := &Client{}
+	c.SetRestartSuppressor(fake)
+
+	c.suppressRestarts("app")
+	if len(fake.suppressed) != 1 || fake.suppressed[0] != "app" {
+		t.Fatalf("Suppress calls after SetRestartSuppressor = %v; want [app]", fake.suppressed)
+	}
+}
+
+// TestIsMissingRuncStateDir is the regression guard for the missing-runc-
+// state-dir workaround (F2): forceDeleteTask must recognize the exact error
+// runc produces when a task's state directory under
+// /run/containerd/runc/<ns>/<id> is gone, and extract the directory path so
+// the caller can recreate it. The first case uses the literal string observed
+// live on hardware.
+func TestIsMissingRuncStateDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantDir string
+		wantOK  bool
+	}{
+		{
+			name:    "observed live error",
+			err:     errors.New("cannot open directory `/run/containerd/runc/default/com.wendylabs.examples.mcp-example`: No such file or directory"),
+			wantDir: "/run/containerd/runc/default/com.wendylabs.examples.mcp-example",
+			wantOK:  true,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("failed precondition"),
+		},
+		{
+			name: "cannot open directory but not a runc state path",
+			err:  errors.New("cannot open directory `/some/other/path`: No such file or directory"),
+		},
+		{
+			name: "cannot open directory with no closing backtick",
+			err:  errors.New("cannot open directory `/run/containerd/runc/default/app: No such file or directory"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, ok := isMissingRuncStateDir(tt.err)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v; want %v", ok, tt.wantOK)
+			}
+			if ok && dir != tt.wantDir {
+				t.Errorf("dir = %q; want %q", dir, tt.wantDir)
+			}
+		})
+	}
+}

--- a/go/internal/agent/containerd/stream_output_test.go
+++ b/go/internal/agent/containerd/stream_output_test.go
@@ -1,0 +1,105 @@
+package containerd
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/cio"
+)
+
+// fakeCIO is a minimal cio.IO stand-in for drainTaskIOThenClose tests.
+// Its Wait() writes payload into stdoutW before returning, mirroring the real
+// contract: containerd's cio.IO.Wait() blocks until the FIFO->writer copy
+// goroutines (cio.copyIO) finish, and by the time it returns every byte they
+// read from the task's stdio FIFOs has already been written into the pipes
+// we handed to NewTask (see copyIO in containerd/v2/pkg/cio/io_unix.go).
+type fakeCIO struct {
+	stdoutW io.Writer
+	payload []byte
+}
+
+func (f *fakeCIO) Config() cio.Config { return cio.Config{} }
+func (f *fakeCIO) Cancel()            {}
+func (f *fakeCIO) Close() error       { return nil }
+func (f *fakeCIO) Wait() {
+	if f.stdoutW != nil {
+		_, _ = f.stdoutW.Write(f.payload)
+	}
+}
+
+var _ cio.IO = (*fakeCIO)(nil)
+
+// TestDrainTaskIOThenClose_WaitsForIOBeforeClosing is the regression guard
+// for the crash-loop output-drop bug: a container's process exiting does not
+// mean containerd has finished copying its stdout/stderr FIFOs into the
+// pipes streamOutput reads from — that copy runs on containerd's own
+// goroutines (cio.copyIO), a path independent of the task.Wait() exit
+// signal. For a container that prints one line and exits immediately (the
+// crash-loop repro: "print marker to stderr, exit 1"), the copy can still be
+// in flight when the exit status arrives. Closing stdoutW/stderrW before
+// that copy's Write() call lands drops the data (io.ErrClosedPipe) — which
+// is exactly what the live repro showed: `wendy device logs --tail` came
+// back with zero lines for an actively crash-looping app.
+//
+// This test fails if drainTaskIOThenClose is ever reordered back to
+// close-then-wait: fakeCIO.Wait only delivers "boom-1" into stdoutW when
+// called, so if Close() ran first, that Write would hit an already-closed
+// pipe and return io.ErrClosedPipe instead of reaching the reader below.
+func TestDrainTaskIOThenClose_WaitsForIOBeforeClosing(t *testing.T) {
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+	defer stderrR.Close()
+
+	taskIO := &fakeCIO{stdoutW: stdoutW, payload: []byte("boom-1")}
+
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, _ := stdoutR.Read(buf)
+		got <- string(buf[:n])
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		drainTaskIOThenClose(taskIO, stdoutW, stderrW)
+		close(done)
+	}()
+
+	select {
+	case body := <-got:
+		if body != "boom-1" {
+			t.Fatalf("reader got %q; want %q (in-flight IO copy must survive the close)", body, "boom-1")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader never received the in-flight IO copy's output — drainTaskIOThenClose closed before the copy finished")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainTaskIOThenClose did not return")
+	}
+
+	// stdoutW must be closed after drain: a further write now fails.
+	if _, err := stdoutW.Write([]byte("late")); err != io.ErrClosedPipe {
+		t.Errorf("stdoutW.Write after drainTaskIOThenClose returned err=%v; want io.ErrClosedPipe (writer must be closed)", err)
+	}
+}
+
+// TestDrainTaskIOThenClose_NilIO verifies a nil cio.IO (defensive: some
+// implementations, e.g. cio.NullIO, are legitimately IO-less) is handled
+// without panicking, and still closes both writers.
+func TestDrainTaskIOThenClose_NilIO(t *testing.T) {
+	_, stdoutW := io.Pipe()
+	_, stderrW := io.Pipe()
+
+	drainTaskIOThenClose(nil, stdoutW, stderrW)
+
+	if _, err := stdoutW.Write([]byte("x")); err != io.ErrClosedPipe {
+		t.Errorf("stdoutW not closed: Write err=%v, want io.ErrClosedPipe", err)
+	}
+	if _, err := stderrW.Write([]byte("x")); err != io.ErrClosedPipe {
+		t.Errorf("stderrW not closed: Write err=%v, want io.ErrClosedPipe", err)
+	}
+}

--- a/go/internal/agent/containerd/task_teardown.go
+++ b/go/internal/agent/containerd/task_teardown.go
@@ -93,8 +93,20 @@ func (c *Client) terminateTask(ctx context.Context, task teardownTask, container
 			zap.String("container_id", containerID))
 	}
 
-	if _, err := task.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
-		return fmt.Errorf("deleting task for %q: %w", containerID, err)
+	_, delErr := task.Delete(ctx, containerd.WithProcessKill)
+	// A half-dead task whose runc state directory has been removed out from
+	// under it (isMissingRuncStateDir) wedges this Delete forever — runc's
+	// own delete path stats the directory before it will proceed, and
+	// nothing else ever recreates it. This is the path that was actually
+	// observed wedged on hardware: stopOne (and therefore StopContainer) call
+	// terminateTask directly and previously had no recovery at all, unlike
+	// the replace path's separate forceDeleteTask fallback.
+	delErr = c.recoverMissingRuncStateDir(containerID, delErr, func() error {
+		_, retryErr := task.Delete(ctx, containerd.WithProcessKill)
+		return retryErr
+	})
+	if delErr != nil && !errdefs.IsNotFound(delErr) {
+		return fmt.Errorf("deleting task for %q: %w", containerID, delErr)
 	}
 	return nil
 }

--- a/go/internal/agent/containerd/task_teardown_test.go
+++ b/go/internal/agent/containerd/task_teardown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"syscall"
@@ -40,7 +41,13 @@ type fakeTeardownTask struct {
 	exitOnce sync.Once
 
 	deleteErr error
-	deleted   bool
+	// deleteErrs, when non-nil, overrides deleteErr with a per-call sequence
+	// (index 0 = first Delete call, index 1 = second, ...); calls beyond the
+	// slice length return nil. Lets tests model a Delete that fails once and
+	// succeeds on retry, e.g. the missing-runc-state-dir recovery path.
+	deleteErrs  []error
+	deleteCalls int
+	deleted     bool
 }
 
 func newFakeTeardownTask() *fakeTeardownTask {
@@ -83,10 +90,18 @@ func (f *fakeTeardownTask) Delete(ctx context.Context, opts ...containerd.Proces
 	// Do NOT run opts: the production code passes containerd.WithProcessKill,
 	// which would Wait+Kill against this fake and distort the recorded kill
 	// sequence the tests assert on. The fake models a delete that succeeds
-	// (or fails via deleteErr) regardless.
+	// (or fails via deleteErr/deleteErrs) regardless.
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.deleted = true
-	f.mu.Unlock()
+	idx := f.deleteCalls
+	f.deleteCalls++
+	if f.deleteErrs != nil {
+		if idx < len(f.deleteErrs) {
+			return nil, f.deleteErrs[idx]
+		}
+		return nil, nil
+	}
 	return nil, f.deleteErr
 }
 
@@ -242,6 +257,69 @@ func TestTerminateTaskReturnsDeleteError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "deleting task") || !strings.Contains(err.Error(), "shim wedged") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestTerminateTaskRecoversFromMissingRuncStateDir is the stop-path
+// regression guard for finding 3 (F2 round 1 follow-up): the
+// missing-runc-state-dir recovery previously only existed in the replace
+// path's forceDeleteTask, so stopOne -> terminateTask -> task.Delete
+// propagated the runc error with no recovery — the actual wedge observed on
+// hardware, since `wendy device apps stop` goes through this exact call.
+// Uses the literal error string captured live, and swaps runcStateDirMkdirAll
+// (the seam recreateRuncStateDirAndRetry calls through) so the test doesn't
+// need real /run/containerd/runc/ filesystem access to prove the wiring.
+func TestTerminateTaskRecoversFromMissingRuncStateDir(t *testing.T) {
+	orig := runcStateDirMkdirAll
+	var mkdirCalls []string
+	runcStateDirMkdirAll = func(path string, perm os.FileMode) error {
+		mkdirCalls = append(mkdirCalls, path)
+		return nil
+	}
+	t.Cleanup(func() { runcStateDirMkdirAll = orig })
+
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	const dir = "/run/containerd/runc/default/com.wendylabs.examples.mcp-example"
+	task.deleteErrs = []error{
+		errors.New("cannot open directory `" + dir + "`: No such file or directory"),
+		nil, // recovery retry succeeds
+	}
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "com.wendylabs.examples.mcp-example", syscall.SIGKILL, time.Second, time.Second)
+	if err != nil {
+		t.Fatalf("terminateTask returned error: %v", err)
+	}
+	if len(mkdirCalls) != 1 || mkdirCalls[0] != dir {
+		t.Fatalf("mkdir calls = %v, want exactly [%s]", mkdirCalls, dir)
+	}
+	if task.deleteCalls != 2 {
+		t.Fatalf("Delete called %d times, want 2 (initial failure + recovery retry)", task.deleteCalls)
+	}
+}
+
+// TestTerminateTaskMissingRuncStateDirRecoveryFailurePropagates verifies
+// that when the recovery retry ALSO fails, terminateTask still surfaces an
+// error (the recovery is a best-effort extra attempt, not a guarantee).
+func TestTerminateTaskMissingRuncStateDirRecoveryFailurePropagates(t *testing.T) {
+	orig := runcStateDirMkdirAll
+	runcStateDirMkdirAll = func(path string, perm os.FileMode) error { return nil }
+	t.Cleanup(func() { runcStateDirMkdirAll = orig })
+
+	task := newFakeTeardownTask()
+	task.exitOnSignal = syscall.SIGKILL
+	const dir = "/run/containerd/runc/default/com.wendylabs.examples.mcp-example"
+	stillWedged := errors.New("cannot open directory `" + dir + "`: No such file or directory")
+	task.deleteErrs = []error{stillWedged, stillWedged}
+	c := newTeardownTestClient()
+
+	err := c.terminateTask(context.Background(), task, "com.wendylabs.examples.mcp-example", syscall.SIGKILL, time.Second, time.Second)
+	if err == nil {
+		t.Fatal("expected the still-failing retry's error to be surfaced, got nil")
+	}
+	if task.deleteCalls != 2 {
+		t.Fatalf("Delete called %d times, want 2 (initial failure + recovery retry)", task.deleteCalls)
 	}
 }
 

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -535,6 +535,15 @@ func validateChunkingMode(mode string) error {
 	}
 }
 
+// chunkDeployEligible reports whether this run may use the chunk-diff (CDC)
+// deploy path. --debug is excluded: only the registry-push path wraps the
+// image with debugpy (injectDebugpy), and deploying an unwrapped image with
+// the agent-side debug entrypoint rewrite crash-loops any image that does
+// not bundle debugpy (every Stagefile Python app).
+func chunkDeployEligible(opts runOptions, isDarwinAgent bool) bool {
+	return !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff && !opts.debug
+}
+
 func newRunCmd() *cobra.Command {
 	var opts runOptions
 	var watch bool
@@ -1506,7 +1515,11 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// win on key clash. Feeds both the fingerprint and whichever deploy path runs.
 	deployEnv := append(resolveServiceEnv(appCfg), opts.env...)
 	inputHash, hashErr := computeBuildInputHash(cwd, opts.dockerfile, platform, buildArgs, deployEnv)
-	if !isDarwinAgent && opts.detach && !opts.deploy && hashErr == nil {
+	// The fast path just restarts the existing container, so it must not fire
+	// under --debug: only the registry-push path wraps the image with debugpy
+	// (injectDebugpy), so a container fast-started here could be running the
+	// wrong (unwrapped) entrypoint for the requested debug mode.
+	if !isDarwinAgent && opts.detach && !opts.deploy && hashErr == nil && !opts.debug {
 		if done, _ := tryDeployFastPath(ctx, conn, appCfg, deviceKey, inputHash, opts); done {
 			mark("fast-path (skipped build)")
 			return nil
@@ -1526,8 +1539,9 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// starts; that mode stays on the registry path via startAndStreamContainer.
 	//
 	// --chunking gates this path: "off" skips it entirely (registry push only),
-	// while "force" uses it with no registry-push fallback on failure.
-	if !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff {
+	// while "force" uses it with no registry-push fallback on failure. --debug
+	// also excludes it: see chunkDeployEligible.
+	if chunkDeployEligible(opts, isDarwinAgent) {
 		if diffIDs, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, deployEnv, opts); err == nil {
 			if hashErr == nil {
 				// Record the layer diff IDs we deployed so the next run's fast path

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -535,15 +535,6 @@ func validateChunkingMode(mode string) error {
 	}
 }
 
-// chunkDeployEligible reports whether this run may use the chunk-diff (CDC)
-// deploy path. --debug is excluded: only the registry-push path wraps the
-// image with debugpy (injectDebugpy), and deploying an unwrapped image with
-// the agent-side debug entrypoint rewrite crash-loops any image that does
-// not bundle debugpy (every Stagefile Python app).
-func chunkDeployEligible(opts runOptions, isDarwinAgent bool) bool {
-	return !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff && !opts.debug
-}
-
 func newRunCmd() *cobra.Command {
 	var opts runOptions
 	var watch bool
@@ -1515,11 +1506,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// win on key clash. Feeds both the fingerprint and whichever deploy path runs.
 	deployEnv := append(resolveServiceEnv(appCfg), opts.env...)
 	inputHash, hashErr := computeBuildInputHash(cwd, opts.dockerfile, platform, buildArgs, deployEnv)
-	// The fast path just restarts the existing container, so it must not fire
-	// under --debug: only the registry-push path wraps the image with debugpy
-	// (injectDebugpy), so a container fast-started here could be running the
-	// wrong (unwrapped) entrypoint for the requested debug mode.
-	if !isDarwinAgent && opts.detach && !opts.deploy && hashErr == nil && !opts.debug {
+	if !isDarwinAgent && opts.detach && !opts.deploy && hashErr == nil {
 		if done, _ := tryDeployFastPath(ctx, conn, appCfg, deviceKey, inputHash, opts); done {
 			mark("fast-path (skipped build)")
 			return nil
@@ -1539,9 +1526,8 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// starts; that mode stays on the registry path via startAndStreamContainer.
 	//
 	// --chunking gates this path: "off" skips it entirely (registry push only),
-	// while "force" uses it with no registry-push fallback on failure. --debug
-	// also excludes it: see chunkDeployEligible.
-	if chunkDeployEligible(opts, isDarwinAgent) {
+	// while "force" uses it with no registry-push fallback on failure.
+	if !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff {
 		if diffIDs, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, deployEnv, opts); err == nil {
 			if hashErr == nil {
 				// Record the layer diff IDs we deployed so the next run's fast path

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
@@ -619,6 +620,75 @@ func resolveRunTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevi
 	return &SelectedDevice{Agent: cloudConn}, nil
 }
 
+// debugRequiresDebugpy fails fast when a --debug deploy would crash-loop for
+// want of debugpy. The agent unconditionally rewrites a Python entrypoint to
+// run under debugpy when debug mode is requested (wrapWithDebugpy), but
+// nothing injects debugpy into the image itself: 70493f702 ("Remove debugpy
+// injection") deliberately deleted that step from the registry-push path,
+// so an image that doesn't already bundle debugpy fails immediately on
+// device with "No module named debugpy".
+//
+// This check only has enough information to catch that failure mode for
+// Stagefile projects, where the CLI knows which pip requirements file(s)
+// feed the build. It is a no-op (returns nil) for anything else: non-python
+// apps, and non-Stagefile projects (Dockerfile-authored Python images are
+// covered by the printed note below instead, since the CLI cannot inspect
+// an opaque Dockerfile's installed packages).
+//
+// stagefileSourceName ("build.stagefile.yaml") is not defined on this
+// branch — that constant lives on the not-yet-merged Stagefile-native-layers
+// work — so the literal filename is used here instead.
+func debugRequiresDebugpy(cwd string, appCfg *appconfig.AppConfig) error {
+	if appCfg == nil || appCfg.Language != "python" {
+		return nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(cwd, "build.stagefile.yaml"))
+	if err != nil {
+		// Not a Stagefile project (or unreadable) — nothing more to check here.
+		return nil
+	}
+
+	var stagefile struct {
+		Stages []struct {
+			Install struct {
+				Pip struct {
+					Requirements string `yaml:"requirements"`
+				} `yaml:"pip"`
+			} `yaml:"install"`
+		} `yaml:"stages"`
+	}
+	if err := yaml.Unmarshal(data, &stagefile); err != nil {
+		// Malformed Stagefile: let the normal build path surface the real
+		// parse error instead of failing here on an unrelated check.
+		return nil
+	}
+
+	var reqFiles []string
+	for _, stage := range stagefile.Stages {
+		if req := strings.TrimSpace(stage.Install.Pip.Requirements); req != "" {
+			reqFiles = append(reqFiles, req)
+		}
+	}
+	if len(reqFiles) == 0 {
+		return nil
+	}
+
+	for _, req := range reqFiles {
+		content, err := os.ReadFile(filepath.Join(cwd, req))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "debugpy") {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf(`--debug requires debugpy in the image: add "debugpy" to requirements.txt, or run without --debug`)
+}
+
 func runCommand(ctx context.Context, opts runOptions) error {
 	mark := phaseTimer()
 	// Step 1: Load and validate wendy.json.
@@ -717,6 +787,12 @@ func runCommand(ctx context.Context, opts runOptions) error {
 
 	// Debug mode requires host networking for remote debugger access.
 	if opts.debug {
+		// Fail fast, before any build/deploy work starts, when this is a
+		// Stagefile Python project whose pip requirements don't include
+		// debugpy. See debugRequiresDebugpy.
+		if err := debugRequiresDebugpy(cwd, appCfg); err != nil {
+			return err
+		}
 		appCfg.Debug = true
 		foundNetwork := false
 		for i, e := range appCfg.Entitlements {

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -405,5 +407,98 @@ func TestValidateEnvFlag(t *testing.T) {
 		if err := validateEnvFlag([]string{entry}); err == nil {
 			t.Errorf("validateEnvFlag(%q) = nil, want an error", entry)
 		}
+	}
+}
+
+// TestDebugRequiresDebugpy asserts the --debug pre-deploy gate for Stagefile
+// Python projects: the agent always wraps a Python entrypoint in debugpy
+// when debug mode is requested, but nothing injects debugpy into the image
+// (removed by 70493f702, by design), so a Stagefile project must declare
+// debugpy in its pip requirements or the deploy should fail fast with an
+// actionable message instead of crash-looping on device.
+func TestDebugRequiresDebugpy(t *testing.T) {
+	const stagefileYAML = "version: 1\n" +
+		"stages:\n" +
+		"  - name: app\n" +
+		"    from: python:3.11-slim\n" +
+		"    install:\n" +
+		"      pip:\n" +
+		"        requirements: requirements.txt\n" +
+		"    entrypoint:\n" +
+		"      exec: [python, main.py]\n"
+
+	writeFile := func(t *testing.T, dir, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, dir string)
+		appCfg     *appconfig.AppConfig
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "stagefile python project without debugpy errors",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "build.stagefile.yaml", stagefileYAML)
+				writeFile(t, dir, "requirements.txt", "flask==3.0\n")
+			},
+			appCfg:     &appconfig.AppConfig{Language: "python"},
+			wantErr:    true,
+			errContain: "debugpy",
+		},
+		{
+			name: "stagefile python project with debugpy is fine",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "build.stagefile.yaml", stagefileYAML)
+				writeFile(t, dir, "requirements.txt", "flask==3.0\ndebugpy>=1.8\n")
+			},
+			appCfg: &appconfig.AppConfig{Language: "python"},
+		},
+		{
+			name: "stagefile python project with odd-cased DebugPy is fine",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "build.stagefile.yaml", stagefileYAML)
+				writeFile(t, dir, "requirements.txt", "flask==3.0\nDebugPy==1.8.0\n")
+			},
+			appCfg: &appconfig.AppConfig{Language: "python"},
+		},
+		{
+			name:   "non-stagefile directory is fine",
+			setup:  func(t *testing.T, dir string) {},
+			appCfg: &appconfig.AppConfig{Language: "python"},
+		},
+		{
+			name: "non-python language is fine",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "build.stagefile.yaml", stagefileYAML)
+				writeFile(t, dir, "requirements.txt", "flask==3.0\n")
+			},
+			appCfg: &appconfig.AppConfig{Language: "swift"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(t, dir)
+			err := debugRequiresDebugpy(dir, tt.appCfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("debugRequiresDebugpy() = nil, want an error")
+				}
+				if !strings.Contains(err.Error(), tt.errContain) {
+					t.Fatalf("debugRequiresDebugpy() error = %q, want it to mention %q", err.Error(), tt.errContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("debugRequiresDebugpy() = %v, want nil", err)
+			}
+		})
 	}
 }

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -407,18 +407,3 @@ func TestValidateEnvFlag(t *testing.T) {
 		}
 	}
 }
-
-// TestChunkDeployIneligibleWithDebug asserts --debug deploys never take the
-// chunk-diff (CDC) path. Only the registry-push path wraps the image with
-// debugpy (injectDebugpy); the agent's debug entrypoint rewrite crash-loops
-// any image deployed unwrapped via chunk-diff (every Stagefile Python app).
-func TestChunkDeployIneligibleWithDebug(t *testing.T) {
-	opts := runOptions{detach: true, chunking: chunkingAuto, debug: true}
-	if chunkDeployEligible(opts, false) {
-		t.Fatal("--debug must route through the registry path (debugpy injection)")
-	}
-	opts.debug = false
-	if !chunkDeployEligible(opts, false) {
-		t.Fatal("non-debug detached deploy should stay on the chunk path")
-	}
-}

--- a/go/internal/cli/commands/run_test.go
+++ b/go/internal/cli/commands/run_test.go
@@ -407,3 +407,18 @@ func TestValidateEnvFlag(t *testing.T) {
 		}
 	}
 }
+
+// TestChunkDeployIneligibleWithDebug asserts --debug deploys never take the
+// chunk-diff (CDC) path. Only the registry-push path wraps the image with
+// debugpy (injectDebugpy); the agent's debug entrypoint rewrite crash-loops
+// any image deployed unwrapped via chunk-diff (every Stagefile Python app).
+func TestChunkDeployIneligibleWithDebug(t *testing.T) {
+	opts := runOptions{detach: true, chunking: chunkingAuto, debug: true}
+	if chunkDeployEligible(opts, false) {
+		t.Fatal("--debug must route through the registry path (debugpy injection)")
+	}
+	opts.debug = false
+	if !chunkDeployEligible(opts, false) {
+		t.Fatal("non-debug detached deploy should stay on the chunk path")
+	}
+}


### PR DESCRIPTION
## Summary

Three independent fixes for the crash-loop findings from the 2026-08-08 on-device pass (Orin Nano; full evidence in `specs/2026-08-08-on-device-test-plan.md` on `ed/oci-layout-dir-export`, RESULTS section; plan Part 2 in `specs/2026-08-08-oci-layout-stale-manifest-fix-plan.md` on that same branch):

1. **`--debug` fail-fast (CLI).** `wendy run --debug` on a Python app whose image lacks debugpy crash-loops instantly and silently: the agent unconditionally rewrites the entrypoint to `python -m debugpy …`, and nothing injects debugpy since 70493f702 removed image injection *by design*. For Stagefile projects the CLI knows the pip requirements, so it now refuses up front with an actionable error (`add "debugpy" to requirements.txt, or run without --debug`). Includes a reverted first approach (routing debug deploys to the registry path) whose premise — that the registry path injects debugpy — turned out to describe dead code; the revert pair is kept for honest history. Note: until the Stagefile stack (#1585/#1608/#1610) merges, a Dockerfile-less Stagefile-shaped python project would be a false-positive for this check (that flow auto-generates a Dockerfile that *does* bundle debugpy); the suggested remedy is harmless under both pipelines and the check becomes exactly right post-merge.

2. **Crash-loop replace/stop robustness (agent).** Replacing or stopping a crash-looping app raced the restart monitor ("cannot delete running task … failed precondition"; a vanished runc state dir wedged deletion permanently — both observed live). Now: a counter-based `Suppress` API makes replace/stop hold the monitor off (including group restarts when any member is suppressed, and an in-flight `restartSingle` re-check via `restartBlocked`, policy-aware through a shared `restartPolicyHonorsExplicitStop` predicate so RestartAlways semantics are unchanged); the replace path retries the delete once after a re-kill (with `forceDeleteTask` fallback); and the missing-runc-state-dir recovery (mkdir + one retry, classifier-tested against the literal observed error) is reachable from **all** task-teardown paths, including the stop path that wedged live.

3. **Crash-loop output loss (agent).** `wendy device logs --tail` never showed an active crash loop's stderr (live repro: failureCount climbing with a unique marker printed every crash, zero lines returned). Root cause: `streamOutput` closed the task's stdio pipes as soon as the exit status arrived, while containerd's `cio` copy goroutines were still draining the FIFOs — the pending write hit `io.ErrClosedPipe` and a fast-exiting container's entire output burst was silently discarded. The same gotcha was already fixed in `ExecContainer`/ROS2 exec (`IO().Wait()` before close) but never on the main start path, which both deploys and monitor restarts share. Fix: `drainTaskIOThenClose` waits for FIFO EOF before closing, gated on confirmed task exit (hang-safety verified against containerd v2.3.2: private PID namespaces guarantee EOF; `io.Cancel` escape hatches on delete paths).

## Verification

- TDD throughout; every fix has load-bearing tests independently mutation-checked in review (guards removed → tests fail). Full `go test ./internal/agent/...` + `./internal/cli/commands/` green locally and in `golang:1.26` Docker (linux); gofmt/vet clean.
- Per-task reviews + scoped re-reviews (F2 took two fix rounds: group-suppression hole, in-flight resurrect window, stop-path runc recovery, then policy-aware `restartBlocked`); final whole-branch review clean, cross-task interactions (suppression vs stdio drain) explicitly checked.
- **Pending before ready:** on-device pass with a dev agent build — replace/stop a crash-looping app 5× (incl. a per-service stop), wedge a runc state dir and confirm stop self-heals, and re-run the `--tail` marker repro (expect one marker per restart).

## Known residuals (documented, not blocking)

- Group-restart goroutines dispatched before a `Suppress` lands have no `restartBlocked`-style re-check (backstopped by the replace path's delete retry).
- Dockerfile-authored python projects with `--debug` and no debugpy still crash-loop silently (design: user bundles debugpy; only the printed note covers them).
- Dead `injectDebugpy` in docker.go — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
