### PR TITLE
Stagefile: scope cache mounts, and measure what sharing=locked costs

### DIFF
--- a/go/internal/stagefile/codegen/cachescope_test.go
+++ b/go/internal/stagefile/codegen/cachescope_test.go
@@ -1,0 +1,118 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// gen compiles one stage at a target platform and returns the Dockerfile.
+func gen(t *testing.T, platform string, s spec.Stage) string {
+	t.Helper()
+	out, err := Generate(&spec.File{Version: 1, Stages: []spec.Stage{s}},
+		map[string]string{s.From: "sha256:abc123"}, nil, platform)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	return out
+}
+
+// mountIDs returns every id= value in out, in order.
+func mountIDs(t *testing.T, out string) []string {
+	t.Helper()
+	var ids []string
+	rest := out
+	for {
+		_, after, found := strings.Cut(rest, "id=")
+		if !found {
+			return ids
+		}
+		id, tail, _ := strings.Cut(after, ",")
+		ids = append(ids, id)
+		rest = tail
+	}
+}
+
+func pipStage(platform string, groups ...spec.PipInstall) spec.Stage {
+	return spec.Stage{Name: "app", From: "python:3.12-slim",
+		Install: &spec.Install{Pip: groups}}
+}
+
+// Without an id BuildKit scopes a cache mount by its target path alone, so
+// every pip install in every concurrently-built service queues on one
+// sharing=locked mount — including installs that could not share a single
+// cached wheel because they pull from different indexes.
+func TestPipCacheMountIsScoped(t *testing.T) {
+	out := gen(t, "linux/arm64", pipStage("linux/arm64", spec.PipInstall{Packages: []string{"flask"}}))
+	ids := mountIDs(t, out)
+	if len(ids) != 1 || ids[0] == "" {
+		t.Fatalf("pip mount carries no id:\n%s", out)
+	}
+}
+
+// Two groups pulling from different indexes cache different wheels, so making
+// them contend buys nothing. This is exactly the CUDA case: a Jetson-index
+// install and a PyPI install in the same stage.
+func TestPipCacheIDSeparatesIndexes(t *testing.T) {
+	out := gen(t, "linux/arm64", pipStage("linux/arm64",
+		spec.PipInstall{Packages: []string{"torch"}, Index: "https://pypi.jetson-ai-lab.io/jp6/cu126/"},
+		spec.PipInstall{Packages: []string{"nvidia-cudnn-cu12"}},
+	))
+	ids := mountIDs(t, out)
+	if len(ids) != 2 {
+		t.Fatalf("want 2 pip mount ids, got %v:\n%s", ids, out)
+	}
+	if ids[0] == ids[1] {
+		t.Fatalf("groups with different indexes share cache id %q, so they serialize for nothing", ids[0])
+	}
+}
+
+// extraIndex changes which wheels can land in the cache, so it belongs in the
+// scope too.
+func TestPipCacheIDSeparatesExtraIndexes(t *testing.T) {
+	a := mountIDs(t, gen(t, "linux/arm64", pipStage("linux/arm64",
+		spec.PipInstall{Packages: []string{"x"}, ExtraIndex: []string{"https://a.example/simple"}})))
+	b := mountIDs(t, gen(t, "linux/arm64", pipStage("linux/arm64",
+		spec.PipInstall{Packages: []string{"x"}, ExtraIndex: []string{"https://b.example/simple"}})))
+	if a[0] == b[0] {
+		t.Fatalf("different extraIndex sets share cache id %q", a[0])
+	}
+}
+
+// Wheels are platform-specific, so an arm64 and an amd64 build store disjoint
+// content. Serializing them is pure loss.
+func TestPipCacheIDSeparatesPlatforms(t *testing.T) {
+	arm := mountIDs(t, gen(t, "linux/arm64", pipStage("", spec.PipInstall{Packages: []string{"flask"}})))
+	amd := mountIDs(t, gen(t, "linux/amd64", pipStage("", spec.PipInstall{Packages: []string{"flask"}})))
+	if arm[0] == amd[0] {
+		t.Fatalf("arm64 and amd64 pip installs share cache id %q", arm[0])
+	}
+}
+
+// The point of keeping sharing=locked is that builds which CAN share a wheel
+// still do. Same index, same platform — different packages — must land on one
+// mount, so the second build gets the first one's downloads.
+func TestPipCacheIDSharesWhenContentCanBeShared(t *testing.T) {
+	a := mountIDs(t, gen(t, "linux/arm64", pipStage("", spec.PipInstall{Packages: []string{"flask"}})))
+	b := mountIDs(t, gen(t, "linux/arm64", pipStage("", spec.PipInstall{Packages: []string{"django"}})))
+	if a[0] != b[0] {
+		t.Fatalf("same index and platform must share a pip cache: %q vs %q", a[0], b[0])
+	}
+	if !strings.Contains(gen(t, "linux/arm64", pipStage("", spec.PipInstall{Packages: []string{"flask"}})), "sharing=locked") {
+		t.Fatal("pip mount must stay sharing=locked; scoping narrows contention, it does not remove the lock")
+	}
+}
+
+// uv resolves wheels the same way pip does and has the same platform split.
+func TestUvCacheIDSeparatesPlatforms(t *testing.T) {
+	s := spec.Stage{Name: "app", From: "python:3.12-slim", Install: &spec.Install{Uv: &spec.UvInstall{}}}
+	arm := mountIDs(t, gen(t, "linux/arm64", s))
+	amd := mountIDs(t, gen(t, "linux/amd64", s))
+	if len(arm) != 1 || len(amd) != 1 {
+		t.Fatalf("uv mount carries no id: %v / %v", arm, amd)
+	}
+	if arm[0] == amd[0] {
+		t.Fatalf("arm64 and amd64 uv syncs share cache id %q", arm[0])
+	}
+}

--- a/go/internal/stagefile/codegen/codegen.go
+++ b/go/internal/stagefile/codegen/codegen.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -76,13 +77,13 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 				lines = append(lines, cmakeInstallLines(s.Install.CMake, stagePlatform)...)
 			}
 			for i := range s.Install.Pip {
-				lines = append(lines, pipInstallLines(&s.Install.Pip[i])...)
+				lines = append(lines, pipInstallLines(&s.Install.Pip[i], stagePlatform)...)
 			}
 			if s.Install.Npm != nil {
 				lines = append(lines, npmInstallLines(s.Install.Npm)...)
 			}
 			if s.Install.Uv != nil {
-				lines = append(lines, uvInstallLines(s.Install.Uv)...)
+				lines = append(lines, uvInstallLines(s.Install.Uv, stagePlatform)...)
 			}
 		}
 
@@ -244,6 +245,34 @@ func cacheRunID(id, dir, cmd string) string {
 	return fmt.Sprintf("RUN --mount=%s,target=%s %s", mount, dir, cmd)
 }
 
+// scopedCacheID hashes the parts that decide whether two builds can share a
+// cache into an opaque BuildKit mount id. Callers pass every input that changes
+// what lands in the cache and nothing else: too narrow a scope makes builds
+// contend for no benefit, too wide a scope makes them miss each other's work.
+func scopedCacheID(kind string, parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		io.WriteString(h, p)
+		h.Write([]byte{0})
+	}
+	return "stagefile-" + kind + "-" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// pipCacheID scopes pip's wheel cache to the index set it can download from and
+// the platform whose wheels it stores.
+//
+// Both matter because the mount stays sharing=locked: without an id, BuildKit
+// scopes by target path, so every pip install in every concurrently-built
+// service queues on ONE lock — including installs that could never share a
+// wheel because they pull from different indexes or build for different
+// architectures. Scoping removes that false contention while keeping the real
+// sharing: same index, same platform still means one mount, so the second build
+// gets the first one's downloads instead of re-fetching them.
+func pipCacheID(p *spec.PipInstall, platform string) string {
+	parts := append([]string{platform, p.Index}, p.ExtraIndex...)
+	return scopedCacheID("pip", parts...)
+}
+
 // cmakeCacheID scopes a cmake build tree to the project and the architecture
 // it is compiled for, and deliberately to nothing else. Commit is excluded so
 // bumping a pin recompiles only what changed — the reason the cache exists.
@@ -252,8 +281,7 @@ func cacheRunID(id, dir, cmd string) string {
 // platform is the one input it cannot detect, because the compiler sits at the
 // same path in either rootfs.
 func cmakeCacheID(repository, platform string) string {
-	sum := sha256.Sum256([]byte(repository + "\x00" + platform))
-	return "stagefile-cmake-" + hex.EncodeToString(sum[:])[:16]
+	return scopedCacheID("cmake", repository, platform)
 }
 
 // aptRepositoryLines emits the declared extra apt sources: ca-certificates
@@ -376,7 +404,7 @@ func cmakeInstallLines(installs []spec.CMakeInstall, platform string) []string {
 	return lines
 }
 
-func pipInstallLines(p *spec.PipInstall) []string {
+func pipInstallLines(p *spec.PipInstall, platform string) []string {
 	var lines []string
 	if p.Requirements != "" {
 		lines = append(lines, fmt.Sprintf("COPY %s %s", p.Requirements, p.Requirements))
@@ -397,7 +425,7 @@ func pipInstallLines(p *spec.PipInstall) []string {
 	for _, pkg := range p.Packages {
 		parts = append(parts, shellQuote(pkg))
 	}
-	lines = append(lines, cacheRun("/root/.cache/pip", strings.Join(parts, " ")))
+	lines = append(lines, cacheRunID(pipCacheID(p, platform), "/root/.cache/pip", strings.Join(parts, " ")))
 	return lines
 }
 
@@ -430,7 +458,7 @@ func npmInstallLines(n *spec.NpmInstall) []string {
 	}
 }
 
-func uvInstallLines(u *spec.UvInstall) []string {
+func uvInstallLines(u *spec.UvInstall, platform string) []string {
 	parts := []string{"uv", "sync", "--frozen"}
 	if !u.Dev {
 		parts = append(parts, "--no-dev")
@@ -440,7 +468,7 @@ func uvInstallLines(u *spec.UvInstall) []string {
 	}
 	return []string{
 		"COPY " + strings.Join(spec.UvLocalFiles, " ") + " ./",
-		cacheRun("/root/.cache/uv", strings.Join(parts, " ")),
+		cacheRunID(scopedCacheID("uv", platform), "/root/.cache/uv", strings.Join(parts, " ")),
 	}
 }
 

--- a/go/internal/stagefile/codegen/codegen_newfields_test.go
+++ b/go/internal/stagefile/codegen/codegen_newfields_test.go
@@ -80,7 +80,7 @@ func TestGeneratePipIndexFlags(t *testing.T) {
 			},
 		}}},
 	}, nil)
-	want := "RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install --index-url 'https://pypi.jetson-ai-lab.io/jp6/cu126' --extra-index-url 'https://pypi.org/simple' 'torch'"
+	want := "RUN --mount=type=cache,sharing=locked,id=stagefile-pip-8982dbbb6e87f5f3,target=/root/.cache/pip pip install --index-url 'https://pypi.jetson-ai-lab.io/jp6/cu126' --extra-index-url 'https://pypi.org/simple' 'torch'"
 	if !strings.Contains(out, want) {
 		t.Fatalf("missing %q in:\n%s", want, out)
 	}
@@ -110,7 +110,7 @@ func TestGenerateUvSync(t *testing.T) {
 	}, nil)
 	for _, want := range []string{
 		"COPY pyproject.toml uv.lock ./",
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/uv uv sync --frozen --no-dev --extra 'proxy'",
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-uv-6e340b9cffb37a98,target=/root/.cache/uv uv sync --frozen --no-dev --extra 'proxy'",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)

--- a/go/internal/stagefile/codegen/codegen_test.go
+++ b/go/internal/stagefile/codegen/codegen_test.go
@@ -178,7 +178,7 @@ func TestGeneratePipInstallFromRequirements(t *testing.T) {
 	}
 	want := "FROM python:3.12-slim@sha256:abc123 AS app\n" +
 		"COPY requirements.txt requirements.txt\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
@@ -201,7 +201,7 @@ func TestGeneratePipInstallCopyPrecedesExplicitCopy(t *testing.T) {
 	}
 	want := "FROM python:3.12-slim@sha256:abc123 AS app\n" +
 		"COPY requirements.txt requirements.txt\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
 		"COPY app.py app.py\n" +
 		"USER 65532\n"
 	if out != want {
@@ -222,7 +222,7 @@ func TestGeneratePipInstallFromPackages(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM python:3.12-slim@sha256:abc123 AS app\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install 'flask' 'gunicorn'\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install 'flask' 'gunicorn'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
@@ -473,7 +473,7 @@ func TestGeneratePipInstallQuotesVersionSpecifiers(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM python:3.12-slim@sha256:abc123 AS app\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install 'flask>=2.0,<3.0'\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install 'flask>=2.0,<3.0'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)

--- a/go/internal/stagefile/codegen/golden_test.go
+++ b/go/internal/stagefile/codegen/golden_test.go
@@ -32,7 +32,7 @@ func TestGenerateGoldenExampleFixture(t *testing.T) {
 		"RUN apt-get update && apt-get install -y --no-install-recommends 'build-essential' \\\n" +
 		"    && rm -rf /var/lib/apt/lists/*\n" +
 		"COPY requirements.txt requirements.txt\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
 		"\n" +
 		"FROM python:3.12-slim@sha256:abc123 AS app\n" +
 		"COPY --from=deps /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages\n" +

--- a/scripts/bench-cache-mount-contention.sh
+++ b/scripts/bench-cache-mount-contention.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Measures what BuildKit cache-mount scoping actually costs and buys.
+#
+# Wendy builds up to four service images concurrently. Every generated pip
+# install shares one `sharing=locked` cache mount, so those four builds queue
+# on one lock. This harness answers two questions with numbers instead of
+# argument:
+#
+#   1. How much wall clock does that lock cost when the services have NOTHING
+#      to share (disjoint dependency sets)?
+#   2. How much does it save when they have EVERYTHING to share (identical
+#      dependency sets)?
+#
+# Variants, all emitting otherwise-identical Dockerfiles:
+#   one-lock     sharing=locked, no id      — one mount for every service
+#   per-service  sharing=locked, unique id  — upper bound on what scoping buys
+#   shared-mode  sharing=shared, no id      — BuildKit's behaviour with no mode
+#
+# Usage: scripts/bench-cache-mount-contention.sh [services] [trials]
+set -uo pipefail
+
+SERVICES=${1:-4}
+TRIALS=${2:-1}
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Disjoint: four sizeable wheels with no shared dependency, so a shared lock
+# buys nothing and only serializes. Shared: the same package everywhere, so the
+# lock is what lets three builds reuse one download.
+# Overridable so the same harness can be run with large wheels, where the
+# sharing a lock buys (one download, three reuses) should matter most.
+read -r -a DISJOINT <<< "${BENCH_DISJOINT:-numpy pillow lxml cryptography}"
+read -r -a SHARED   <<< "${BENCH_SHARED:-numpy numpy numpy numpy}"
+
+emit() { # emit <dir> <variant> <index> <package>
+  local dir=$1 variant=$2 i=$3 pkg=$4 mount
+  case $variant in
+    one-lock)    mount="type=cache,sharing=locked,target=/root/.cache/pip" ;;
+    per-service) mount="type=cache,sharing=locked,id=bench-$i,target=/root/.cache/pip" ;;
+    shared-mode) mount="type=cache,sharing=shared,target=/root/.cache/pip" ;;
+  esac
+  mkdir -p "$dir/s$i"
+  cat > "$dir/s$i/Dockerfile" <<EOF
+FROM python:3.12-slim
+RUN --mount=$mount pip install '$pkg'
+EOF
+}
+
+reset_mounts() {
+  docker buildx prune --force --filter type=exec.cachemount >/dev/null 2>&1 || true
+}
+
+run_variant() { # run_variant <variant> <scenario> -> seconds
+  local variant=$1 scenario=$2 dir="$WORK/$variant-$scenario" i pkgs
+  if [ "$scenario" = disjoint ]; then pkgs=("${DISJOINT[@]}"); else pkgs=("${SHARED[@]}"); fi
+  for ((i = 0; i < SERVICES; i++)); do
+    emit "$dir" "$variant" "$i" "${pkgs[$((i % ${#pkgs[@]}))]}"
+  done
+  reset_mounts
+  local start end pids=()
+  start=$(date +%s)
+  for ((i = 0; i < SERVICES; i++)); do
+    docker buildx build --builder wendy --no-cache --output type=cacheonly \
+      "$dir/s$i" >"$dir/s$i.log" 2>&1 &
+    pids+=($!)
+  done
+  local failed=0
+  for p in "${pids[@]}"; do wait "$p" || failed=1; done
+  end=$(date +%s)
+  if [ "$failed" -ne 0 ]; then
+    echo "FAILED (see $dir/*.log)" >&2
+    grep -h -m2 -iE 'error|ERROR' "$dir"/s*.log >&2 || true
+    echo "-1"
+    return
+  fi
+  echo $((end - start))
+}
+
+printf '%d concurrent services, %d trial(s), builder=wendy\n\n' "$SERVICES" "$TRIALS"
+printf '%-14s %-12s %s\n' VARIANT SCENARIO 'WALL SECONDS'
+for scenario in disjoint shared; do
+  for variant in one-lock per-service shared-mode; do
+    for ((t = 0; t < TRIALS; t++)); do
+      printf '%-14s %-12s %s\n' "$variant" "$scenario" "$(run_variant "$variant" "$scenario")"
+    done
+  done
+done

--- a/specs/2026-08-08-cache-mount-contention-benchmark.md
+++ b/specs/2026-08-08-cache-mount-contention-benchmark.md
@@ -1,0 +1,89 @@
+# What `sharing=locked` on generated cache mounts actually costs
+
+**Status:** measurement, with one recommendation the numbers do not fully settle.
+**Harness:** `scripts/bench-cache-mount-contention.sh` (reproducible; needs buildx).
+
+## Why
+
+PR #1607 added `sharing=locked` to every generated cache mount, reasoning that
+BuildKit's default (`shared`) lets concurrent builds use one cache dir at once,
+and that while package managers survive it, the waiting then happens invisibly
+*inside the tool* rather than in the build graph. That is a legibility argument,
+and it was never measured. Wendy builds up to four services concurrently, and
+without an `id` BuildKit scopes a cache mount by target path — so one lock
+covered every pip install in every concurrent service.
+
+## Method
+
+Four concurrent `docker buildx build --no-cache --output type=cacheonly`, each a
+one-line pip install, cache mounts pruned between trials. Three variants emitting
+otherwise-identical Dockerfiles:
+
+| variant | mount |
+|---|---|
+| `one-lock` | `sharing=locked`, no id — today's behaviour |
+| `per-service` | `sharing=locked`, unique id — upper bound on what scoping can buy |
+| `shared-mode` | `sharing=shared`, no id — BuildKit's default |
+
+Two scenarios: **disjoint** dependency sets (nothing to share, so the lock is
+pure serialization) and **shared** (identical sets, the case the lock exists for).
+
+## Results
+
+Wall seconds, macOS/OrbStack, buildkit v0.31.2, linux/arm64.
+
+| scenario | `one-lock` | `per-service` | `shared-mode` |
+|---|---|---|---|
+| disjoint, small wheels (numpy / pillow / lxml / cryptography) | 11, 13, 14, 16 | 5, 5, 5, 6 | 4, 4, 4, 6 |
+| shared, small wheels (numpy ×4) | 5, 5, 5, 5 | 5, 5, 6, 6 | 4, 4, 5, 5 |
+| shared, large wheel (torch ×4, ~900 MB) | 93 | 78 | — |
+
+Two findings, and the second is the surprising one:
+
+1. **The shared lock costs ~2.7× when services have nothing to share.** 13.5s
+   median vs 5s. Variance is tight across four trials; this is not noise.
+2. **It buys nothing measurable when they do.** Identical dependency sets came
+   out level on small wheels, and on a ~900 MB torch wheel `one-lock` was
+   *slower* (93s vs 78s) than four independent downloads. Four concurrent
+   downloads beat one download plus three cache reuses on this link.
+
+`shared-mode` was fastest or tied in every cell measured.
+
+## What this says about the scoping change in this branch
+
+Honestly: less than the change's first commit message claimed, and that message
+was corrected.
+
+Scoping pip to `(platform, index, extraIndex)` removes contention only between
+builds that differ on one of those axes. The common case — four compose services,
+one platform, plain PyPI — lands on the *same* id and behaves exactly like
+`one-lock`. The measured 2.7× is recovered by `per-service`, which this does not
+reach. So the change is strictly-better-or-neutral and correct in direction, but
+it is not the fix for the contention the benchmark found.
+
+An earlier justification for it was also simply wrong: two pip groups in one
+stage compile to two sequential `RUN` lines, so they can never contend on a
+mount. The contention is across concurrently-built *services*, not within a stage.
+
+## Recommendation, and what it depends on
+
+The data points at either dropping to `sharing=shared` for pip, or scoping the
+id per build context. Both reverse a deliberate, documented decision, so neither
+is taken here.
+
+The open question is safety, not speed: #1607 asserts pip locks its cache
+internally. If that holds, `shared` is simply better and the numbers agree. If it
+does not, `shared` risks cache corruption under exactly the four-way concurrency
+Wendy defaults to, and per-build-context ids are the safe way to get the same
+win. That question should be answered from pip's behaviour, not from this table.
+
+## Caveats
+
+- One machine, one network. The sharing benefit of a lock is bandwidth-bound, so
+  a slow or metered link would shift result 2 — though not result 1.
+- A medium-wheel disjoint run (`scipy onnxruntime pillow lxml`) hit 523s under
+  `one-lock` and is **excluded**: onnxruntime and lxml build from source on
+  arm64, so it measures compilation, not lock contention.
+- `--output type=cacheonly` measures build, not export or push. Real service
+  builds also push through the device-registry tunnel, which is throttled
+  separately (WDY-1690).


### PR DESCRIPTION
Stacked on #1633 (which is stacked on #1621). Retarget as those land.

Two commits: a scoping change, and the benchmark that shows the scoping change is only a partial fix. The benchmark is the more useful half.

## The measurement

#1607 put `sharing=locked` on every generated cache mount, on a legibility argument — it moves waiting out of pip's internals and into the build graph where BuildKit reports it. Reasonable, and never measured. Without an `id`, BuildKit scopes a cache mount by target path, so **one lock covered every pip install in every one of the four concurrently-built services**.

Four concurrent `buildx build --no-cache`, mounts pruned between trials, variants differing only in the mount line:

| scenario | `one-lock` (today) | `per-service` id | `sharing=shared` |
|---|---|---|---|
| disjoint deps, small wheels | 11, 13, 14, 16 | 5, 5, 5, 6 | 4, 4, 4, 6 |
| shared deps, small wheels | 5, 5, 5, 5 | 5, 5, 6, 6 | 4, 4, 5, 5 |
| shared deps, torch ×4 (~900 MB) | 93 | 78 | — |

1. **The shared lock costs ~2.7×** when services have nothing to share. Tight variance over four trials.
2. **It buys nothing measurable when they do** — level on small wheels, and *slower* on a 900 MB torch wheel (93s vs 78s), because four concurrent downloads beat one download plus three reuses on this link.

`sharing=shared` was fastest or tied in every cell.

## The scoping change, and what it doesn't do

pip is scoped to `(platform, index, extraIndex)` and uv to `(platform)` — every input that changes what can land in the cache, and nothing else. Same index and platform still share a mount, so real reuse is preserved.

**This does not recover the 2.7×.** Four compose services on one platform against plain PyPI land on the same id and behave exactly as before. It only helps builds that differ by index or architecture. It is strictly-better-or-neutral and correct in direction, but the benchmark is what says where the win actually is.

I also corrected a wrong justification from my first draft of that commit: two pip groups in one stage compile to two *sequential* `RUN` lines, so they can never contend on a mount. The contention is across concurrently-built services, not within a stage.

## What I deliberately did not do

Dropping to `sharing=shared`, or scoping per build context. Both reverse #1607's documented decision, and the deciding question is safety rather than speed: #1607 asserts pip locks its cache internally. If that holds, `shared` is simply better and these numbers agree. If it doesn't, `shared` risks corruption under exactly the four-way concurrency we default to, and per-build-context ids are the safe way to the same win. That's your call, not a benchmark's.

## Caveats

- One machine, one network. The sharing benefit is bandwidth-bound, so a slow link could change finding 2 — not finding 1. The harness is parameterised by package set so it can be rerun there.
- A medium-wheel disjoint run hit 523s under `one-lock` and is **excluded** from the table: onnxruntime and lxml build from source on arm64, so it measures compilation, not contention.
- `--output type=cacheonly` measures build only, not the push through the device-registry tunnel (throttled separately, WDY-1690).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjGP3gYMArxPQ3muDSbE4U
