### PR TITLE
fix(ros2): source setup.sh, not setup.bash, under /bin/sh

### DIFF
--- a/go/internal/agent/containerd/ros2.go
+++ b/go/internal/agent/containerd/ros2.go
@@ -498,11 +498,25 @@ func ros2ShellArgs(distro, script string, extra []string) []string {
 	return args
 }
 
+// ros2SetupScript is the ROS environment script to dot-source for a distro.
+//
+// It must be setup.sh, not setup.bash. The sidecar runs commands under /bin/sh
+// (a slim app image may ship no bash), and on Ubuntu-based ROS images /bin/sh
+// is dash. ament's setup.bash resolves its own location via ${BASH_SOURCE[0]}
+// and declares AMENT_SHELL=bash, so dash aborts on it — and because the sourcing
+// is silenced, the only visible symptom was `command -v ros2` failing, which the
+// probe then reported as "the image does not include the ros2 CLI" for images
+// that plainly do. ament generates setup.sh alongside it for exactly this case:
+// it avoids BASH_SOURCE and bakes the install prefix in at generation time.
+func ros2SetupScript(distro string) string {
+	return fmt.Sprintf("/opt/ros/%s/setup.sh", distro)
+}
+
 // ros2SourceAndExec is the shell script the sidecar runs for a `ros2` invocation:
 // source the ROS environment, then exec the CLI with the caller's arguments kept
 // out of shell interpretation via "$@" (SOC2-CC6, ISO27001-A.8, NIST-SI-10).
 func ros2SourceAndExec(distro string) string {
-	return fmt.Sprintf(". /opt/ros/%s/setup.bash >/dev/null 2>&1 && exec ros2 \"$@\"", distro)
+	return fmt.Sprintf(". %s >/dev/null 2>&1 && exec ros2 \"$@\"", ros2SetupScript(distro))
 }
 
 // sidecarHasROS2CLI reports whether the running sidecar task can find the ros2
@@ -518,7 +532,7 @@ func (c *Client) sidecarHasROS2CLI(ctx context.Context, container containerd.Con
 	pspec := spec.Process
 	pspec.Terminal = false
 	pspec.Args = ros2ShellArgs(distro,
-		fmt.Sprintf(". /opt/ros/%s/setup.bash >/dev/null 2>&1; command -v ros2 >/dev/null 2>&1", distro),
+		fmt.Sprintf(". %s >/dev/null 2>&1; command -v ros2 >/dev/null 2>&1", ros2SetupScript(distro)),
 		nil)
 	execID := fmt.Sprintf("ros2-probe-%d", ros2ExecCounter.Add(1))
 	proc, err := task.Exec(ctx, execID, pspec, cio.NullIO)

--- a/go/internal/agent/containerd/ros2_shell_test.go
+++ b/go/internal/agent/containerd/ros2_shell_test.go
@@ -27,8 +27,8 @@ func TestROS2SourceAndExec_UsesPOSIXSourceBuiltin(t *testing.T) {
 	if strings.Contains(script, "source ") {
 		t.Errorf("`source` is a bashism; use `.` so the script runs under /bin/sh: %q", script)
 	}
-	if !strings.HasPrefix(script, ". /opt/ros/humble/setup.bash") {
-		t.Errorf("script should dot-source the distro's setup.bash, got %q", script)
+	if !strings.HasPrefix(script, ". /opt/ros/humble/setup.sh") {
+		t.Errorf("script should dot-source the distro's setup.sh, got %q", script)
 	}
 	if !strings.Contains(script, `exec ros2 "$@"`) {
 		t.Errorf(`script must keep caller args out of shell interpretation via "$@", got %q`, script)
@@ -87,9 +87,38 @@ func TestROS2ShellArgs_EmptyExtraStillGetsArgvZero(t *testing.T) {
 func TestROS2SourceAndExecUsesTheGivenDistro(t *testing.T) {
 	for _, distro := range []string{"humble", "jazzy", "iron"} {
 		script := ros2SourceAndExec(distro)
-		if !strings.Contains(script, "/opt/ros/"+distro+"/setup.bash") {
+		if !strings.Contains(script, "/opt/ros/"+distro+"/setup.sh") {
 			t.Errorf("distro %q not reflected in the script: %q", distro, script)
 		}
+	}
+}
+
+// Dot-sourcing setup.bash under /bin/sh is the bug this guards. ament's
+// setup.bash resolves its own path via ${BASH_SOURCE[0]} and sets
+// AMENT_SHELL=bash, so dash aborts on it. Because both call sites silence the
+// sourcing with >/dev/null 2>&1, the failure surfaced only as `command -v ros2`
+// returning non-zero — which the sidecar reported as the app image lacking the
+// ros2 CLI, for images that shipped it. setup.sh is ament's POSIX variant and
+// bakes its prefix in at generation time.
+func TestROS2SetupScript_IsThePOSIXVariantNotBash(t *testing.T) {
+	for _, distro := range []string{"humble", "jazzy", "iron"} {
+		got := ros2SetupScript(distro)
+		if strings.HasSuffix(got, ".bash") {
+			t.Errorf("ros2SetupScript(%q) = %q; setup.bash cannot be sourced by dash", distro, got)
+		}
+		if want := "/opt/ros/" + distro + "/setup.sh"; got != want {
+			t.Errorf("ros2SetupScript(%q) = %q, want %q", distro, got, want)
+		}
+	}
+}
+
+// Both the probe and the exec path must agree on the script, or the probe can
+// pass while real commands fail (or the reverse).
+func TestROS2SetupScript_ProbeAndExecAgree(t *testing.T) {
+	script := ros2SourceAndExec("humble")
+	if !strings.Contains(script, ros2SetupScript("humble")) {
+		t.Errorf("exec path %q does not use ros2SetupScript(%q) = %q",
+			script, "humble", ros2SetupScript("humble"))
 	}
 }
 


### PR DESCRIPTION
Found while debugging something else; unrelated to that work, so it's on its own branch off `main`.

## The bug

`wendy device ros2` cannot inspect any CycloneDDS app on an Ubuntu-based ROS image. It reports:

```
ROS 2 app image "..." runs rmw_cyclonedds_cpp but does not include the ros2 CLI,
so `wendy device ros2` cannot inspect it; install the CLI in the app image
```

…for images that ship it. Observed on a Go2 against two unrelated images, including one built `FROM ros:humble` whose `CMD` is literally `ros2 launch`. A probe container confirmed `ros2` lives at `/opt/ros/humble/bin/ros2` in the very image the agent rejected.

## Cause

The sidecar runs commands as `/bin/sh -c '. /opt/ros/<distro>/setup.bash …'` so that a slim app image without bash still works (`ros2_shell_test.go:8-13`). But on Ubuntu-based ROS images `/bin/sh` is dash, and ament's `setup.bash` resolves its own location via `${BASH_SOURCE[0]}` and declares `AMENT_SHELL=bash` — dash aborts on it.

Both call sites silence the sourcing with `>/dev/null 2>&1`, so the only visible symptom is `command -v ros2` returning non-zero, which `sidecarHasROS2CLI` reports as a missing CLI.

The earlier bash→sh change also swapped `source` for `.`, which made the *builtin* POSIX but did nothing about the *file being sourced*. That traded "slim images without bash fail" for "every standard ROS image fails".

## Fix

Source `setup.sh` instead. ament generates it alongside `setup.bash` for exactly this case: it avoids `BASH_SOURCE` and bakes the install prefix in at generation time via `@CMAKE_INSTALL_PREFIX@`, so it works under dash.

Two tests added, including one asserting the probe and exec paths can't drift apart — they must agree or the probe can pass while real commands fail.

## Tests

`go test ./go/internal/agent/containerd` passes.

**Unit-tested only.** Confirming end to end needs a patched agent on a device with a CycloneDDS ROS 2 app, which I have not done. The diagnosis is well-evidenced (dash cannot source `setup.bash`; `ros2` demonstrably present in a rejected image) but the fix itself is unverified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)