### PR TITLE
cli: enforce device identity against mDNS/dial spoofing, not just chain+org

### DIFF
--- a/go/internal/cli/assets/docs/pki/README.md
+++ b/go/internal/cli/assets/docs/pki/README.md
@@ -42,27 +42,65 @@ The CLI verifies device server certificates on all mTLS connections (BLE, LAN gR
 
 2. **Organization matching** — The server certificate's Wendy org ID is extracted and compared against the CLI's expected org ID. If the device belongs to a different organization than the CLI session, the connection is rejected with an `OrgMismatchError`. For BLE connections, the CLI automatically retries with a matching certificate from another org if one is available.
 
-3. **SPKI pinning (BLE)** — On first BLE connection to a device, its SPKI fingerprint is pinned in `~/.config/wendy/known_devices.json`. Subsequent connections verify the device presents the same fingerprint. If the fingerprint differs, a warning is printed to stderr (potential MITM or legitimate rotation).
+3. **Exact device identity (`ServerVerifyOpts.ExpectedIdentity`)** — When the caller has pinned a specific asset (see "Device identity pinning" below), the verifier additionally requires the peer's leaf certificate to carry an `asset` Wendy identity whose org and entity id match exactly. Unlike organization matching there is no grace mode here: a certificate with no Wendy identity at all is a mismatch, not a legacy device to tolerate, because the caller asked for a *specific* device and got something that cannot prove it is that device. This check runs inside `tls.Config.VerifyConnection`, not `VerifyPeerCertificate` — a resumed TLS 1.3 handshake skips `VerifyPeerCertificate` but not `VerifyConnection`, so pinning implemented in the wrong hook would silently stop firing on session resumption.
+
+4. **SPKI pinning** — On first mTLS connection to a device — over BLE, LAN gRPC, or the cloud tunnel — its SPKI (Subject Public Key Info) fingerprint is pinned in `~/.config/wendy/known_devices.json`, keyed by the certificate's Wendy asset identity. A later connection presenting a different key while the *previously pinned* certificate is still within its validity window is hard-refused (a `PinMismatchError` aborts the handshake): a renewal replaces an expiring certificate, it does not race one that is still live, so an unexplained key change during that window is treated as a MITM signal, not a warning. Once the pinned certificate has expired, a new key is ordinary rotation — accepted silently, and the pin is updated to the new fingerprint.
 
 ## Device identity pinning (default device)
 
-On the first successful connection to your default device, the CLI records that hostname's identity in `~/.wendy/config.json` under `devicePins`: the **organisation**, the **cloud host** that issued its certificate, and the **asset id** from the device certificate's `urn:wendy:org:<org>:asset:<assetID>` URI SAN. Every later connection to that hostname is checked against the pin.
+On the first successful connection to a hostname, the CLI records that hostname's identity in `~/.wendy/config.json` under `devicePins`: the **organisation**, the **cloud host** that issued its certificate, and the **asset id** from the device certificate's `urn:wendy:org:<org>:asset:<assetID>` URI SAN. Every later connection to that hostname is checked against the pin — this is what feeds `ServerVerifyOpts.ExpectedIdentity` above, so a wrong device is rejected during the TLS handshake itself, not after.
 
 The pin is deliberately not a certificate fingerprint — a device legitimately rotates and re-enrolls certificates, and that must not look like an attack. What trips it is a change of *who* is answering:
 
 | Observed | Result |
 | --- | --- |
 | Same org + cloud + asset (renewed or re-enrolled cert) | Connects normally |
-| Different org or cloud host | Refused; prompts to trust and re-pin |
-| Same org + cloud, **different asset id** | Refused; the hostname now resolves to a different machine, or the device was wiped and re-enrolled as a new asset |
-| **No mTLS identity at all**, on a hostname that was pinned | Refused; an enrolled device does not drop its certificate on its own — it has been reflashed or factory reset, or another machine has taken its name |
+| Different org or cloud host | Refused, no prompt |
+| Same org + cloud, **different asset id** | Refused, no prompt — the hostname now resolves to a different machine, or the device was wiped and re-enrolled as a new asset |
+| **No mTLS identity at all**, on a hostname that was pinned | Refused, no prompt — an enrolled device does not drop its certificate on its own; it has been reflashed or factory reset, or another machine has taken its name |
 | No mTLS identity, hostname never pinned | Connects normally (ordinary out-of-the-box device) |
 
-The asset id is read only from a certificate that passed chain and org verification, so an impostor cannot assert its way past the pin.
+The asset id is read only from a certificate that passed chain and org verification, so an impostor cannot assert its way past the pin. On the dial ladder, a wrong-device rejection aborts the whole ladder immediately — no further certificate or port is tried — and a hostname that carries any pin at all is never offered the unauthenticated plaintext rung, regardless of what its (attacker-controlled) mDNS TXT records claim about it.
 
-In an interactive terminal each refusal offers a prompt to accept the new identity. Under `--json` or a non-TTY the connection is refused outright. To re-pin deliberately, run `wendy device set-default <hostname>` — naming the device explicitly clears its pin so the next connection records a fresh one.
+**Every refusal above reads identically** whether the CLI is running interactively, under `--json`, or non-interactively — there is deliberately no "trust this identity anyway?" prompt. A MITM warning that can be dismissed gets dismissed, and the person who could actually distinguish a legitimate replacement from an attack is rarely the one staring at a prompt mid-command. The one way past a refusal is a separate, deliberate act:
 
-Pins that predate asset pinning carry no asset id; the first connection whose org and cloud still match backfills it silently. Agents whose certificates carry no asset identity are never treated as swapped devices.
+```sh
+wendy device unpin <hostname>
+```
+
+This clears the local pin only — it never dials the device, so it works even when the device is offline, wiped, or gone. The next successful connection to that hostname records a fresh pin from scratch. Naming a device explicitly with `wendy device set-default <hostname>` has the same clearing effect, since typing the hostname is itself the user asserting "I mean that device."
+
+## Pin sources and precedence
+
+A pin's `source` field records how the CLI learned it:
+
+| Source | Written by | Trust basis |
+| --- | --- | --- |
+| `lan` | An ordinary connection to the device (the default) | Only a certificate presented on the local network |
+| `cloud` | The org's asset roster, fetched over an authenticated cloud session (e.g. `wendy cloud discover` seeds a pin for every named asset the roster returns) | The org's cloud vouching for the (name, org, asset) binding |
+
+Pins written before sources were tracked carry an empty `source` and are treated as `lan`.
+
+A `cloud` write is authoritative and overwrites whatever was pinned for that name, `lan`-sourced or not — that is how cloud-known devices get their trust-on-first-use window closed before the CLI ever meets them on the network (see below). The reverse never holds: a LAN sighting cannot upgrade or override a `cloud` pin, and specifically:
+
+- A `lan`-sourced pin that predates asset ids (no asset recorded) is backfilled with the observed asset id on the first connection whose org and cloud still match — org and cloud already vouch for the connection, so this is a one-time upgrade, not a challenge. A `cloud`-sourced pin with no asset id is **not** backfilled this way: the cloud already spoke for this name, and a LAN sighting is not evidence to the contrary, so it is treated as a plain match instead.
+- An asset-less `cloud` pin is never displaced by a `lan` pin in a way that would erase an existing exact-identity constraint on that name — cloud authority decides *which* binding to believe, and applying it is worthless if the result is a name constrained to no asset at all.
+
+Agents whose certificates carry no asset identity at all are never treated as swapped devices: an empty *observed* asset id can never produce a mismatch on its own, regardless of source.
+
+## Multi-key pin lookup
+
+One device can answer to more than one name, and different surfaces record its pin under different ones: an ordinary connection records under the mDNS hostname actually dialed, cloud seeding records under the asset's roster name, and a mesh dial names the device by its mesh name. Resolving "does this dial have a pin" therefore checks, in order:
+
+1. The name the caller dialed (`--device` value, saved default, or the device picker's name).
+2. The mesh name from the discovery-cache entry whose hostname matches (1), if the cache has one.
+3. That entry's display name.
+
+Consulting an alias can only ever *find* a pin, never discard one: an attacker-chosen alias can at most impose a stricter constraint that the real device still satisfies, never a way to bypass one. The trust decision itself always rests on the certificate, never on which name resolved the lookup.
+
+## Cloud pin seeding
+
+A hostname the CLI has never connected to has no pin, so its first connection is trust-on-first-use — the one moment this scheme cannot, by construction, distinguish the real device from an impostor answering first. Seeding pins from the cloud closes that window for every device the org's cloud already knows about: whenever the CLI fetches the org's asset roster over an authenticated session, each named asset is recorded as a `cloud`-sourced pin (org, asset id) before the CLI has ever reached it on the network. An impostor answering an mDNS query for that name is then rejected on the very first LAN connection attempt, not just the second.
 
 ## CA key rollover
 

--- a/go/internal/cli/assets/docs/pki/README.md
+++ b/go/internal/cli/assets/docs/pki/README.md
@@ -66,9 +66,14 @@ The asset id is read only from a certificate that passed chain and org verificat
 
 ```sh
 wendy device unpin <hostname>
+wendy device unpin urn:wendy:org:<org>:asset:<id>
 ```
 
 This clears the local pin only — it never dials the device, so it works even when the device is offline, wiped, or gone. The next successful connection to that hostname records a fresh pin from scratch. Naming a device explicitly with `wendy device set-default <hostname>` has the same clearing effect, since typing the hostname is itself the user asserting "I mean that device."
+
+Both forms are accepted because the two stores are keyed differently. The identity-change refusals above name a hostname, and the hostname form clears it. The **SPKI** refusal (point 4 above) can only name the certificate identity URN, because that is what `known_devices.json` is keyed by and there is often no hostname to offer: `wendy device list` and the device picker dial the device's IP, and an agent that never advertises `orgid` in its mDNS records leaves nothing locally that maps a name to an asset. Copy the URN out of the refusal and pass it back — it clears the SPKI entry and any `devicePins` entry naming the same asset.
+
+Unpinning by hostname also clears pins filed under the device's *other* names (the cloud roster's asset name, its mesh name), because one device is legitimately pinned under several — but only when those pins name the same organisation and asset. Those alternate names come from mDNS, which is unauthenticated, so a pin naming a *different* asset is a different device's pin and is left alone. Whatever is cleared is printed, one line per entry, so an unpin never removes trust state silently.
 
 ## Pin sources and precedence
 

--- a/go/internal/cli/assets/docs/wendyos/networking/mdns.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/mdns.md
@@ -116,7 +116,9 @@ The wendy-agent Go code (`internal/shared/discovery/`) uses `_wendyos._udp` as t
 
 **CLI-side note:** The shipped CLI binary is built with `CGO_ENABLED=0`, so it cannot use nss-mdns to resolve `.local` names. Instead, it performs its own mDNS browse for `.local` hostnames when connecting. Set `WENDY_MDNS_DEBUG=1` to log browse failures, or `WENDY_MDNS_TIMEOUT` (1s–30s) to adjust the timeout.
 
-Both the primary `avahi-browse` path and the `hashicorp/mdns` fallback path parse all TXT records into a key→value map, including the `tls` record. A device that advertises `tls=true` has `IsMTLS` set to `true` and is contacted on the mTLS port (50052). The fallback path also resolves `wendyosdevice` and `displayname` TXT records, matching the behaviour of the primary path.
+Both the primary `avahi-browse` path and the `hashicorp/mdns` fallback path parse all TXT records into a key→value map, including the `tls` record.
+
+TXT records are **unauthenticated**: they are advertised by whatever host answers on the network, and anyone who can reach the multicast segment can advertise `_wendyos._udp` with any TXT values it likes. They are used for **routing and display only**, never for trust. A device that advertises `tls=true` has `IsMTLS` set to `true`, which tells the CLI to dial the mTLS port (50052) instead of the plaintext one — that arithmetic is real and still applies — but it is not what decides whether the CLI trusts the host it ends up talking to. Trust is established afterward, from the certificate that host presents during the TLS handshake, checked against the identity pin recorded for the name being dialed (see the "Device identity pinning" section of `pki/README.md`). A spoofed TXT record can get a connection attempt redirected to the wrong port on the wrong host; it cannot get that host trusted — the certificate check and pin still have to pass. The fallback path also resolves `wendyosdevice` and `displayname` TXT records, matching the behaviour of the primary path.
 
 IPv6 link-local addresses returned by mDNS are annotated with the zone ID (`%<ifname>`) so that the caller can use them directly in `net.Dial()` calls.
 

--- a/go/internal/cli/commands/cloud_discover.go
+++ b/go/internal/cli/commands/cloud_discover.go
@@ -136,6 +136,14 @@ func (m cloudDiscoverModel) scanCmd() tea.Cmd {
 	onlineOnly := !m.all
 	return func() tea.Msg {
 		assets, err := fetchCloudAssetsFiltered(ctx, auth, onlineOnly)
+		if err == nil {
+			// This refreshes every cloudDiscoverRefreshInterval (10s) while the
+			// TUI is open, so this reseeds on every tick — wasteful, but
+			// best-effort and cheap enough (one config read + conditional
+			// write) not to special-case out of the picker's one true asset
+			// roster fetch.
+			seedPinsFromAssetsBestEffort(auth, assets)
+		}
 		return cloudScanMsg{assets: assets, err: err}
 	}
 }
@@ -503,6 +511,7 @@ func cloudDiscoverJSON(ctx context.Context, auth *config.AuthConfig, all bool) e
 	if err != nil {
 		return err
 	}
+	seedPinsFromAssetsBestEffort(auth, assets)
 	infos := make([]discoverDeviceInfo, 0, len(assets))
 	for _, a := range assets {
 		infos = append(infos, cloudDeviceInfoFromAsset(a, nil))

--- a/go/internal/cli/commands/cloud_pin_seed.go
+++ b/go/internal/cli/commands/cloud_pin_seed.go
@@ -16,8 +16,17 @@ import (
 // CLI ever meets it on the network.
 //
 // An asset with no name has no key to pin under and is skipped rather than
-// filed under "". config.Save is only called when at least one pin actually
-// changed, so a roster of unnamed assets (or an empty roster) never touches
+// filed under "". An asset with no usable id is skipped for the mirror-image
+// reason: it would be pinned as AssetID "0", a non-empty asset constraint no
+// certificate can ever present, and because the pin is cloud-sourced
+// EvaluateDevicePin would then take its pin.AssetID != assetID branch and
+// hard-fail every future dial to that name, with no adoption path out. A
+// missing id is missing information, and the honest encoding of that is no pin
+// at all — which leaves trust-on-first-use, not a permanent refusal.
+//
+// Skipping is per-asset: one unusable entry never costs the rest of the roster
+// its pins. config.Save is only called when at least one pin actually changed,
+// so a roster of entirely unusable assets (or an empty roster) never touches
 // disk.
 func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC string) error {
 	cfg, err := loadConfigForPinFn()
@@ -27,7 +36,7 @@ func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC strin
 	changed := false
 	for _, a := range assets {
 		name := a.GetName()
-		if name == "" {
+		if name == "" || a.GetId() <= 0 {
 			continue
 		}
 		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, strconv.Itoa(int(a.GetId())), config.PinSourceCloud)

--- a/go/internal/cli/commands/cloud_pin_seed.go
+++ b/go/internal/cli/commands/cloud_pin_seed.go
@@ -39,7 +39,21 @@ func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC strin
 		if name == "" || a.GetId() <= 0 {
 			continue
 		}
-		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, strconv.Itoa(int(a.GetId())), config.PinSourceCloud)
+		want := config.DevicePin{
+			OrgID:     orgID,
+			CloudGRPC: cloudGRPC,
+			AssetID:   strconv.Itoa(int(a.GetId())),
+			Source:    config.PinSourceCloud,
+		}
+		// Only a pin whose stored value would actually differ counts as a
+		// change. Setting the flag for every valid asset made "changed" mean "the
+		// roster was non-empty", so the steady state — a roster already fully
+		// seeded — rewrote config.json on every pass, which for the TUI's 10s
+		// refresh is a disk write every 10 seconds that alters nothing.
+		if existing, ok := cfg.DevicePinFor(name); ok && existing == want {
+			continue
+		}
+		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, want.AssetID, config.PinSourceCloud)
 		changed = true
 	}
 	if !changed {

--- a/go/internal/cli/commands/cloud_pin_seed.go
+++ b/go/internal/cli/commands/cloud_pin_seed.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// seedPinsFromCloudAssets records the org's asset roster as cloud-sourced pins.
+// The cloud spoke over an authenticated session, so this is authority, not a
+// sighting: it overwrites whatever a LAN observation recorded, and closes the
+// trust-on-first-use window for every device the cloud knows about before the
+// CLI ever meets it on the network.
+//
+// An asset with no name has no key to pin under and is skipped rather than
+// filed under "". config.Save is only called when at least one pin actually
+// changed, so a roster of unnamed assets (or an empty roster) never touches
+// disk.
+func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC string) error {
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for _, a := range assets {
+		name := a.GetName()
+		if name == "" {
+			continue
+		}
+		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, strconv.Itoa(int(a.GetId())), config.PinSourceCloud)
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return config.Save(cfg)
+}
+
+// seedPinsFromAssetsBestEffort seeds pins from a verified cloud asset roster,
+// deriving the org and cloud host from the auth session that fetched it.
+//
+// Best-effort by design: this runs after a caller's own fetchCloudAssetsFiltered
+// call has already succeeded, so a seeding failure (e.g. an unwritable config
+// file) must never fail the command the user actually ran — 'wendy cloud
+// discover' must still list devices even if pins cannot be written. Errors are
+// therefore swallowed and only surfaced via WENDY_TLS_DEBUG.
+func seedPinsFromAssetsBestEffort(auth *config.AuthConfig, assets []*cloudpb.Asset) {
+	if auth == nil || len(auth.Certificates) == 0 {
+		return
+	}
+	orgID := auth.Certificates[0].OrganizationID
+	if err := seedPinsFromCloudAssets(assets, orgID, auth.CloudGRPC); err != nil {
+		debugPinSeed("seeding cloud pins for org %d failed: %v", orgID, err)
+	}
+}
+
+// debugPinSeed logs only when WENDY_TLS_DEBUG is set, matching the CLI's other
+// mTLS/pin diagnostics (see debugClock in device_clock.go).
+func debugPinSeed(format string, args ...any) {
+	if os.Getenv("WENDY_TLS_DEBUG") != "" {
+		fmt.Fprintf(os.Stderr, "[pin-seed] "+format+"\n", args...)
+	}
+}

--- a/go/internal/cli/commands/cloud_pin_seed_test.go
+++ b/go/internal/cli/commands/cloud_pin_seed_test.go
@@ -154,6 +154,67 @@ func TestSeedPinsFromCloudAssets(t *testing.T) {
 		}
 	})
 
+	// The steady state. `wendy cloud discover`'s TUI re-fetches the roster every
+	// 10 seconds, and a roster that has already been seeded describes pins that
+	// are byte-for-byte what is on disk. Marking "changed" for every valid asset
+	// made the flag mean "the roster was non-empty", so that steady state wrote
+	// config.json every 10 seconds to store exactly what it already held.
+	t.Run("does not rewrite config when every pin already matches", func(t *testing.T) {
+		cfg := &config.Config{DevicePins: map[string]config.DevicePin{
+			"calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceCloud},
+			"bold-fern":   {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "43", Source: config.PinSourceCloud},
+		}}
+		stubLoadConfigForPin(t, cfg)
+
+		// Same sentinel as the subtests above: a HOME that cannot hold ~/.wendy,
+		// so an attempted config.Save fails loudly. Every asset below is already
+		// pinned exactly as the roster describes, so Save must never run.
+		unwritableHome := t.TempDir() + "-not-a-directory"
+		if err := os.WriteFile(unwritableHome, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("writing sentinel file: %v", err)
+		}
+		t.Setenv("HOME", unwritableHome)
+		t.Setenv("USERPROFILE", unwritableHome)
+
+		assets := []*cloudpb.Asset{
+			{Id: 42, Name: "calm-zinnia"},
+			{Id: 43, Name: "bold-fern"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v (config.Save should never have been attempted for an unchanged roster)", err)
+		}
+	})
+
+	// The other half: suppression must be scoped to pins that genuinely match.
+	// One drifted asset in an otherwise-unchanged roster still has to be written.
+	t.Run("writes when a single asset in an otherwise unchanged roster drifts", func(t *testing.T) {
+		cfg := &config.Config{DevicePins: map[string]config.DevicePin{
+			"calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceCloud},
+			"bold-fern":   {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "99", Source: config.PinSourceCloud},
+		}}
+		stubLoadConfigForPin(t, cfg)
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		assets := []*cloudpb.Asset{
+			{Id: 42, Name: "calm-zinnia"},
+			{Id: 43, Name: "bold-fern"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v", err)
+		}
+
+		onDisk, err := config.Load()
+		if err != nil {
+			t.Fatalf("config.Load: %v", err)
+		}
+		pin, ok := onDisk.DevicePinFor("bold-fern")
+		if !ok || pin.AssetID != "43" {
+			t.Fatalf("on-disk pin for bold-fern = %+v (ok=%v), want asset 43 persisted — a re-pointed asset must still reach disk", pin, ok)
+		}
+	})
+
 	// A roster is not all-or-nothing: one unusable asset must not cost the
 	// others their pins.
 	t.Run("seeds the usable assets in a mixed roster", func(t *testing.T) {

--- a/go/internal/cli/commands/cloud_pin_seed_test.go
+++ b/go/internal/cli/commands/cloud_pin_seed_test.go
@@ -118,4 +118,69 @@ func TestSeedPinsFromCloudAssets(t *testing.T) {
 			t.Fatal("an unnamed asset was pinned under the empty-string key")
 		}
 	})
+
+	// An asset with no usable id would be pinned as AssetID "0" — a non-empty
+	// asset constraint that no real certificate can ever present. Because the
+	// pin is cloud-sourced, EvaluateDevicePin's pin.AssetID != assetID branch
+	// would then hard-fail every future dial to that name, with no adoption
+	// path out. Skipping mirrors the empty-name guard: no key, no pin.
+	t.Run("skips assets with no id", func(t *testing.T) {
+		cfg := &config.Config{}
+		stubLoadConfigForPin(t, cfg)
+
+		// Same sentinel as the empty-name subtest: a HOME that cannot hold
+		// ~/.wendy, so an attempted config.Save would fail loudly. Every asset
+		// below is skipped, so "changed" must stay false and Save never run.
+		unwritableHome := t.TempDir() + "-not-a-directory"
+		if err := os.WriteFile(unwritableHome, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("writing sentinel file: %v", err)
+		}
+		t.Setenv("HOME", unwritableHome)
+		t.Setenv("USERPROFILE", unwritableHome)
+
+		assets := []*cloudpb.Asset{
+			{Id: 0, Name: "calm-zinnia"},
+			{Id: -1, Name: "bold-fern"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v (config.Save should never have been attempted)", err)
+		}
+
+		if len(cfg.DevicePins) != 0 {
+			t.Fatalf("DevicePins = %+v, want empty — an asset with no id must not be pinned to the unmatchable asset \"0\"", cfg.DevicePins)
+		}
+		if pin, ok := cfg.DevicePinFor("calm-zinnia"); ok {
+			t.Fatalf("pinned %+v for an id-less asset; a cloud-sourced AssetID %q hard-fails every future dial to this name", pin, pin.AssetID)
+		}
+	})
+
+	// A roster is not all-or-nothing: one unusable asset must not cost the
+	// others their pins.
+	t.Run("seeds the usable assets in a mixed roster", func(t *testing.T) {
+		cfg := &config.Config{}
+		stubLoadConfigForPin(t, cfg)
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		assets := []*cloudpb.Asset{
+			{Id: 0, Name: "calm-zinnia"},
+			{Id: 7, Name: ""},
+			{Id: 42, Name: "bold-fern"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v", err)
+		}
+
+		if len(cfg.DevicePins) != 1 {
+			t.Fatalf("DevicePins = %+v, want exactly the one usable asset", cfg.DevicePins)
+		}
+		pin, ok := cfg.DevicePinFor("bold-fern")
+		if !ok {
+			t.Fatal("the usable asset was not pinned; one bad roster entry must not suppress the rest")
+		}
+		if pin.AssetID != "42" || pin.Source != config.PinSourceCloud {
+			t.Fatalf("pin = %+v, want AssetID 42 from a cloud source", pin)
+		}
+	})
 }

--- a/go/internal/cli/commands/cloud_pin_seed_test.go
+++ b/go/internal/cli/commands/cloud_pin_seed_test.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// stubLoadConfigForPin points the loadConfigForPinFn seam at cfg for the
+// duration of a test.
+func stubLoadConfigForPin(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	orig := loadConfigForPinFn
+	loadConfigForPinFn = func() (*config.Config, error) { return cfg, nil }
+	t.Cleanup(func() { loadConfigForPinFn = orig })
+}
+
+// TestSeedPinsFromCloudAssets covers seedPinsFromCloudAssets in isolation via
+// the loadConfigForPinFn seam, so no test here touches the developer's real
+// config file.
+func TestSeedPinsFromCloudAssets(t *testing.T) {
+	t.Run("writes a cloud-sourced pin per asset", func(t *testing.T) {
+		cfg := &config.Config{}
+		stubLoadConfigForPin(t, cfg)
+		// config.Save is not seamed, so it still hits the real filesystem path
+		// derived from HOME; point that at a scratch dir for this test.
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		assets := []*cloudpb.Asset{
+			{Id: 42, Name: "calm-zinnia"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v", err)
+		}
+
+		pin, ok := cfg.DevicePinFor("calm-zinnia")
+		if !ok {
+			t.Fatal("expected a pin for \"calm-zinnia\", found none")
+		}
+		want := config.DevicePin{OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceCloud}
+		if pin != want {
+			t.Fatalf("pin = %+v, want %+v", pin, want)
+		}
+
+		// Must actually have persisted (config.Save called), not just mutated
+		// the in-memory cfg the seam handed back.
+		onDisk, err := config.Load()
+		if err != nil {
+			t.Fatalf("config.Load: %v", err)
+		}
+		if p, ok := onDisk.DevicePinFor("calm-zinnia"); !ok || p != want {
+			t.Fatalf("on-disk pin = %+v (ok=%v), want %+v", p, ok, want)
+		}
+	})
+
+	t.Run("overwrites a conflicting lan pin", func(t *testing.T) {
+		cfg := &config.Config{
+			DevicePins: map[string]config.DevicePin{
+				"calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "99", Source: config.PinSourceLAN},
+			},
+		}
+		stubLoadConfigForPin(t, cfg)
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		assets := []*cloudpb.Asset{
+			{Id: 42, Name: "calm-zinnia"},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v", err)
+		}
+
+		pin, ok := cfg.DevicePinFor("calm-zinnia")
+		if !ok {
+			t.Fatal("expected a pin for \"calm-zinnia\", found none")
+		}
+		if pin.AssetID != "42" {
+			t.Fatalf("AssetID = %q, want %q — the cloud roster must overwrite the conflicting LAN sighting (asset 99)", pin.AssetID, "42")
+		}
+		if pin.Source != config.PinSourceCloud {
+			t.Fatalf("Source = %q, want %q — a cloud-fetched roster is authority, not a sighting, and must win outright", pin.Source, config.PinSourceCloud)
+		}
+	})
+
+	t.Run("skips assets with no name", func(t *testing.T) {
+		cfg := &config.Config{}
+		stubLoadConfigForPin(t, cfg)
+
+		// Point HOME at a path that cannot hold a ~/.wendy directory (a regular
+		// file, not a directory), so that if seedPinsFromCloudAssets called
+		// config.Save it would fail loudly. Every asset below is unnamed, so
+		// "changed" must stay false and Save must never be attempted — proven
+		// by this call succeeding despite the broken HOME.
+		unwritableHome := t.TempDir() + "-not-a-directory"
+		if err := os.WriteFile(unwritableHome, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("writing sentinel file: %v", err)
+		}
+		t.Setenv("HOME", unwritableHome)
+		t.Setenv("USERPROFILE", unwritableHome)
+
+		assets := []*cloudpb.Asset{
+			{Id: 1, Name: ""},
+			{Id: 2, Name: ""},
+		}
+		if err := seedPinsFromCloudAssets(assets, 7, "grpc.a.sh:443"); err != nil {
+			t.Fatalf("seedPinsFromCloudAssets: unexpected error: %v (config.Save should never have been attempted)", err)
+		}
+
+		if len(cfg.DevicePins) != 0 {
+			t.Fatalf("DevicePins = %+v, want empty — an unnamed asset must not be pinned under \"\"", cfg.DevicePins)
+		}
+		if _, ok := cfg.DevicePinFor(""); ok {
+			t.Fatal("an unnamed asset was pinned under the empty-string key")
+		}
+	})
+}

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -374,7 +374,12 @@ func openBrokerTunnel(ctx context.Context, brokerConn *grpc.ClientConn, auth *co
 }
 
 func fetchCloudAssets(ctx context.Context, auth *config.AuthConfig) ([]*cloudpb.Asset, error) {
-	return fetchCloudAssetsFiltered(ctx, auth, true)
+	assets, err := fetchCloudAssetsFiltered(ctx, auth, true)
+	if err != nil {
+		return nil, err
+	}
+	seedPinsFromAssetsBestEffort(auth, assets)
+	return assets, nil
 }
 
 func resolveCloudAsset(assets []*cloudpb.Asset, deviceName string) (*cloudpb.Asset, error) {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -78,6 +78,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceSetDefaultCmd(),
 		newDeviceGetDefaultCmd(),
 		newDeviceUnsetDefaultCmd(),
+		newDeviceUnpinCmd(),
 		newDeviceSetupCmd(),
 		newDeviceEnrollCmd(),
 		newDeviceUnenrollCmd(),

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -578,7 +578,33 @@ func pickDeviceForDefault(ctx context.Context) (string, error) {
 	}
 	defer selected.Close()
 
+	return defaultDeviceNameFor(selected)
+}
+
+// defaultDeviceNameFor is the name a picker selection should be saved as the
+// default device under.
+//
+// PinKey, not Agent.Host, whenever there is one. Agent.Host is the address the
+// picker actually dialled, which on a LAN row is an IP: saving that would make
+// the default device a DHCP lease, and — worse — would file every later
+// connection's pin under the IP while the picker had just pinned the device
+// under its hostname seconds earlier. pinCandidateKeys cannot map an IP back to
+// a hostname row, so the hostname pin would never be consulted again and
+// enforcement would be off for what is probably the most common configuration.
+// It is also the failure pinKeyForAddr's own comment warns about, arriving by a
+// different door.
+//
+// Agent.Host remains the fallback for a selection with no pin key at all
+// (nothing else identifies it) — that is exactly today's behaviour for those,
+// and they are already left unenforced by enforceSelectedDevicePin.
+func defaultDeviceNameFor(selected *SelectedDevice) (string, error) {
+	if selected == nil {
+		return "", fmt.Errorf("no device selected")
+	}
 	if selected.Agent != nil {
+		if selected.PinKey != "" {
+			return selected.PinKey, nil
+		}
 		return selected.Agent.Host, nil
 	}
 	if selected.External != nil {

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -514,11 +514,15 @@ func newDeviceSetDefaultCmd() *cobra.Command {
 
 			// Naming a device here is an explicit assertion that this is the one
 			// the user means, so any pin recorded for it is dropped first: that
-			// makes the connect below a first use, and makes the "re-run
-			// set-default to re-pin" advice in the identity-change refusals real
-			// (otherwise this connect would hit the same refusal and never
-			// re-pin).
-			clearDevicePinForRepin(device)
+			// makes the connect below a first use, and gives a device whose
+			// identity changed a way back (otherwise this connect would hit the
+			// same refusal and never re-pin).
+			//
+			// pinKeyForAddr, not the raw argument: `set-default my-mac.local:50051`
+			// is a legal default, and enforcement keys that host under
+			// "my-mac.local". Clearing "my-mac.local:50051" would drop nothing,
+			// leaving a host:port default with no way out of a refusal at all.
+			clearDevicePinForRepin(pinKeyForAddr(device))
 
 			// WDY-1149: pin the device's (organisation, cloud host, asset)
 			// identity now if it is reachable, so later connections detect a

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -2932,11 +2932,7 @@ func updatedAgentReconnectFunc(ctx context.Context, previous *grpcclient.AgentCo
 		}
 	}
 
-	if addr, _, err := resolveDeviceAddress(); err == nil {
-		hostname := addr
-		if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
-			hostname = host
-		}
+	if addr, hostname, _, err := resolveDeviceAddress(); err == nil {
 		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
 			return connectResolvedAgentWithProvisionedHint(waitCtx, hostname, addr, false, deferProvisionedMTLSCheck(waitCtx, addr))
 		}

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -76,11 +76,17 @@ func enforceDevicePin(hostname string, conn *grpcclient.AgentConnection) error {
 //   - match       → proceed; a renewed or re-enrolled cert for the same
 //     organisation + cloud + asset is expected and never challenged
 //   - legacy pin  → backfill the observed asset id, proceed
-//   - mismatch    → warn in red and interactively ask whether to trust the new
-//     identity; declining, or running non-interactively, aborts the connection
-//   - unprovisioned, but pinned → same challenge: a device we have seen
-//     enrolled answering with no identity at all has been reflashed, factory
-//     reset, or replaced by something squatting its name
+//   - mismatch    → explain what changed and refuse
+//   - unprovisioned, but pinned → same refusal: a device we have seen enrolled
+//     answering with no identity at all has been reflashed, factory reset, or
+//     replaced by something squatting its name
+//
+// The two refusals are unconditional and read identically in interactive, JSON,
+// and non-interactive modes. There is deliberately no "trust this anyway?"
+// prompt: a man-in-the-middle warning that can be dismissed gets dismissed, and
+// the one person who can tell a legitimate replacement from an attack is not
+// the one staring at a prompt mid-command. `wendy device unpin <host>` is the
+// deliberate, separate act that resolves it.
 //
 // A device with no pin that answers unprovisioned is the ordinary
 // out-of-the-box case and passes silently. It is best-effort about local state:
@@ -108,17 +114,7 @@ func enforceDeviceIdentity(hostname string, obs observedDeviceIdentity) error {
 	default: // config.PinMismatch
 		prev, _ := cfg.DevicePinFor(hostname)
 		printIdentityChangeWarning(hostname, prev, obs, cloud)
-
-		if jsonOutput || !isInteractiveTerminal() {
-			return fmt.Errorf("device %q identity changed (organization/cloud/asset); refusing to connect — re-run 'wendy device set-default %s' to re-pin if this is expected", hostname, hostname)
-		}
-		trusted, cErr := tui.ConfirmNoDefaultDanger(fmt.Sprintf("Trust the new identity for %q and re-pin it?", hostname))
-		if cErr != nil || !trusted {
-			return fmt.Errorf("device %q identity change was not trusted; connection aborted", hostname)
-		}
-		cfg.SetDevicePin(hostname, obs.orgID, cloud, obs.assetID)
-		_ = config.Save(cfg)
-		return nil
+		return fmt.Errorf("device %q identity changed (organization/cloud/asset); refusing to connect — if this is expected, run 'wendy device unpin %s'", hostname, hostname)
 	}
 }
 
@@ -142,8 +138,9 @@ func printIdentityChangeWarning(hostname string, prev config.DevicePin, obs obse
 // out-of-the-box flow.
 //
 // This case cannot be folded into EvaluateDevicePin — there is no observed
-// identity to compare — but it is the same trust question: the device that
-// vouched for this hostname is not the one answering now.
+// identity to compare — but it is the same trust question, and it gets the same
+// unconditional answer: the device that vouched for this hostname is not the one
+// answering now, so the connection does not happen.
 func challengeUnprovisionedDevice(cfg *config.Config, hostname string) error {
 	prev, pinned := cfg.DevicePinFor(hostname)
 	if !pinned {
@@ -155,27 +152,17 @@ func challengeUnprovisionedDevice(cfg *config.Config, hostname string) error {
 	fmt.Fprintln(os.Stderr, tui.ErrorMessage("  now:    unprovisioned (no mTLS)"))
 	fmt.Fprintln(os.Stderr, tui.ErrorMessage("An enrolled device does not drop its certificate on its own — it has been reflashed or factory reset, another machine has taken its name or address, or this CLI no longer holds credentials for its organization (try 'wendy auth login'). Anything you run over this connection would be unauthenticated."))
 
-	if jsonOutput || !isInteractiveTerminal() {
-		return fmt.Errorf("device %q was enrolled but is now answering unprovisioned; refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device set-default %s' to accept the change", hostname, hostname)
-	}
-	trusted, cErr := tui.ConfirmNoDefaultDanger(fmt.Sprintf("Continue to %q unauthenticated and forget its pinned identity?", hostname))
-	if cErr != nil || !trusted {
-		return fmt.Errorf("device %q unexpected loss of identity was not trusted; connection aborted", hostname)
-	}
-	// Accepted: there is no identity left to pin, so drop the stale one rather
-	// than re-challenging on every subsequent command.
-	cfg.ClearDevicePin(hostname)
-	_ = config.Save(cfg)
-	return nil
+	return fmt.Errorf("device %q was enrolled but is now answering unprovisioned; refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device unpin %s' if this is expected", hostname, hostname)
 }
 
 // clearDevicePinForRepin drops the stored pin for hostname so the next
 // successful connection records a fresh one. `wendy device set-default <host>`
 // calls it because naming a device on the command line is the user asserting
-// they mean that device — and it is the escape hatch both refusal paths above
-// point at, which would otherwise be a dead end: set-default's own connect
-// would hit the same refusal and never reach the re-pin. Best-effort; a config
-// read/write failure just leaves the old pin in place.
+// they mean that device — without it, set-default's own connect would hit the
+// refusals above and never reach the re-pin. It is the same operation the
+// refusals point at by name (`wendy device unpin <host>`), reached through a
+// different command. Best-effort; a config read/write failure just leaves the
+// old pin in place.
 func clearDevicePinForRepin(hostname string) {
 	cfg, err := config.Load()
 	if err != nil {

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -166,14 +166,20 @@ func challengeUnprovisionedDevice(cfg *config.Config, hostname string) error {
 // it that missed the SPKI store would make that promise false for exactly the
 // refusal that has no other way out. Best-effort; a config read/write failure
 // just leaves the old pin in place.
+//
+// It reports what it cleared on stderr for the same reason unpin does on
+// stdout: set-default deleting trust state is a side effect of a command whose
+// name does not mention pins, and the user is the only one who can notice it
+// touched something they did not mean. Stderr keeps it out of any JSON output.
 func clearDevicePinForRepin(hostname string) {
 	cfg, err := config.Load()
 	if err != nil {
 		return
 	}
-	// The SPKI half is cleared inside clearPinsGoverning whether or not a config
-	// pin existed, so a false return means only "nothing to save".
-	if !clearPinsGoverning(cfg, hostname) {
+	cleared := clearPinsGoverning(cfg, hostname)
+	printClearedPins(os.Stderr, cleared)
+	// The SPKI half flushes itself, so only a config-store clear needs a save.
+	if !clearedAnyConfigPin(cleared) {
 		return
 	}
 	_ = config.Save(cfg)

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -114,7 +114,7 @@ func enforceDeviceIdentity(hostname string, obs observedDeviceIdentity) error {
 	default: // config.PinMismatch
 		prev, _ := cfg.DevicePinFor(hostname)
 		printIdentityChangeWarning(hostname, prev, obs, cloud)
-		return fmt.Errorf("device %q identity changed (organization/cloud/asset); refusing to connect — if this is expected, run 'wendy device unpin %s'", hostname, hostname)
+		return refuseIdentity("device %q identity changed (organization/cloud/asset); refusing to connect — if this is expected, run 'wendy device unpin %s'", hostname, hostname)
 	}
 }
 
@@ -152,26 +152,30 @@ func challengeUnprovisionedDevice(cfg *config.Config, hostname string) error {
 	fmt.Fprintln(os.Stderr, tui.ErrorMessage("  now:    unprovisioned (no mTLS)"))
 	fmt.Fprintln(os.Stderr, tui.ErrorMessage("An enrolled device does not drop its certificate on its own — it has been reflashed or factory reset, another machine has taken its name or address, or this CLI no longer holds credentials for its organization (try 'wendy auth login'). Anything you run over this connection would be unauthenticated."))
 
-	return fmt.Errorf("device %q was enrolled but is now answering unprovisioned; refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device unpin %s' if this is expected", hostname, hostname)
+	return refuseIdentity("device %q was enrolled but is now answering unprovisioned; refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device unpin %s' if this is expected", hostname, hostname)
 }
 
-// clearDevicePinForRepin drops the stored pin for hostname so the next
+// clearDevicePinForRepin drops the stored pins for hostname so the next
 // successful connection records a fresh one. `wendy device set-default <host>`
 // calls it because naming a device on the command line is the user asserting
 // they mean that device — without it, set-default's own connect would hit the
 // refusals above and never reach the re-pin. It is the same operation the
 // refusals point at by name (`wendy device unpin <host>`), reached through a
-// different command. Best-effort; a config read/write failure just leaves the
-// old pin in place.
+// different command, so it goes through the same clearPinsGoverning: pki/README
+// already promises set-default has "the same clearing effect", and a version of
+// it that missed the SPKI store would make that promise false for exactly the
+// refusal that has no other way out. Best-effort; a config read/write failure
+// just leaves the old pin in place.
 func clearDevicePinForRepin(hostname string) {
 	cfg, err := config.Load()
 	if err != nil {
 		return
 	}
-	if _, pinned := cfg.DevicePinFor(hostname); !pinned {
+	// The SPKI half is cleared inside clearPinsGoverning whether or not a config
+	// pin existed, so a false return means only "nothing to save".
+	if !clearPinsGoverning(cfg, hostname) {
 		return
 	}
-	cfg.ClearDevicePin(hostname)
 	_ = config.Save(cfg)
 }
 

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -1,13 +1,19 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
 // TestCloudGRPCForOrg maps the org carried by a verifying mTLS cert back to the
@@ -206,6 +212,184 @@ func TestClearDevicePinForRepin(t *testing.T) {
 	}
 	if _, ok := pins["wendy-orin"]; !ok {
 		t.Error("clearDevicePinForRepin dropped an unrelated device's pin")
+	}
+}
+
+// TestEnforceDeviceIdentityHardFails covers the approved policy change: a
+// mismatch is refused identically in every mode, with no prompt.
+//
+// The arrangement is deliberately the one the old code let through — an
+// interactive TTY, where a user could answer "yes" — because that answer is
+// precisely what an attacker needs. "The human consented" is not evidence about
+// which device answered, so it must not be a way through.
+func TestEnforceDeviceIdentityHardFails(t *testing.T) {
+	// Org 7 asset 43 against a pin for org 7 asset 42: both devices are
+	// legitimately enrolled in the same organisation and cloud, so only the
+	// asset id says the hostname now points at a different machine. It is the
+	// case a user is least able to adjudicate from a one-line prompt.
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	obs := observedDeviceIdentity{mTLS: true, orgID: 7, assetID: "43"}
+
+	origJSON := jsonOutput
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	// Interactive, human output: the mode that used to prompt.
+	stubInteractive(t)
+	jsonOutput = false
+	interactiveErr := enforceDeviceIdentity("wendy-thor.local", obs)
+	if interactiveErr == nil {
+		t.Fatal("interactive mismatch: want a refusal, got nil — a prompt is still deciding this")
+	}
+	if !strings.Contains(interactiveErr.Error(), "wendy device unpin wendy-thor.local") {
+		t.Errorf("refusal %q does not name the command that resolves it", interactiveErr)
+	}
+
+	// A prompt answered "yes" would have re-pinned to asset 43. The original pin
+	// surviving is the observable proof that nothing accepted the new identity —
+	// an assertion on the error alone would also pass if the user had declined a
+	// prompt that still ran.
+	if pin := readPins()["wendy-thor"]; pin.AssetID != "42" {
+		t.Errorf("pin after refusal = %+v, want the original asset 42 intact", pin)
+	}
+
+	// Same input, other two modes. Identical text is the point: a refusal that
+	// reads differently depending on where it is printed invites the reader to
+	// assume the interactive one is negotiable.
+	jsonOutput = true
+	jsonErr := enforceDeviceIdentity("wendy-thor.local", obs)
+	jsonOutput = false
+	stubNonInteractive(t)
+	headlessErr := enforceDeviceIdentity("wendy-thor.local", obs)
+
+	if jsonErr == nil || headlessErr == nil {
+		t.Fatalf("mismatch must be refused in every mode: json=%v, non-interactive=%v", jsonErr, headlessErr)
+	}
+	if jsonErr.Error() != interactiveErr.Error() || headlessErr.Error() != interactiveErr.Error() {
+		t.Errorf("refusal differs by mode:\n  interactive:     %v\n  json:            %v\n  non-interactive: %v", interactiveErr, jsonErr, headlessErr)
+	}
+
+	// The assertions above prove the OUTCOME no longer depends on the mode. This
+	// proves the MECHANISM is gone: with no confirmation prompt anywhere in the
+	// identity path, there is no mode-dependent branch left for one to hide in.
+	// A function seam would only catch a prompt re-added THROUGH the seam; the
+	// likely regression — someone reaching for tui.Confirm* directly, to be
+	// helpful — is what this catches.
+	src, readErr := os.ReadFile("device_pin.go")
+	if readErr != nil {
+		t.Fatalf("reading device_pin.go: %v", readErr)
+	}
+	if strings.Contains(string(src), "tui.Confirm") {
+		t.Error("device_pin.go calls a tui.Confirm* prompt: the identity path must refuse, never ask — a MITM warning that can be dismissed gets dismissed")
+	}
+}
+
+// TestEnforceDeviceIdentityAppliesToNonDefault guards the scope widening: the
+// pin used to be checked only for the saved default device, so `--device
+// <host>` — just as spoofable — went unchecked.
+//
+// It also pins down the correctness trap in that widening. The LKG stub asserts
+// the key the DIAL was constrained by, and the refusal text carries the key the
+// CHECK was made against; asserting both are "wendy-thor.local" is what proves
+// a host cannot be pinned under one key and verified under another, which would
+// disable enforcement while looking like it works.
+func TestEnforceDeviceIdentityAppliesToNonDefault(t *testing.T) {
+	stubNonInteractive(t)
+
+	origFlag := deviceFlag
+	deviceFlag = "wendy-thor.local"
+	t.Cleanup(func() { deviceFlag = origFlag })
+
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 9, CloudGRPC: "grpc.b.sh:443", AssetID: "42"},
+	})
+	// The whole point is that this device is NOT the default: with a default set
+	// the old code would have checked it anyway and the test would prove nothing.
+	if cfg, err := config.Load(); err != nil || cfg.DefaultDevice != "" {
+		t.Fatalf("precondition: no default device may be set (default=%q, err=%v)", cfg.DefaultDevice, err)
+	}
+
+	// Reach the device over the cache fast path so no name resolution or real
+	// dialling happens; the connection it hands back carries a certificate for
+	// org 7, while the pin above says org 9.
+	seedLKGCache(t, discoverycache.Entry{
+		ID: "dev-1", Hostname: "wendy-thor.local", IP: "10.0.0.9", Port: 50052, MTLS: true,
+	}, 0)
+	var dialedPinKey string
+	origLKG := dialAgentLKGFn
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
+		dialedPinKey = pinKey
+		return &grpcclient.AgentConnection{
+			IsMTLS:   true,
+			CertInfo: &config.CertificateInfo{OrganizationID: 7},
+		}, nil, lkgConnected
+	}
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		t.Errorf("general ladder ran despite an LKG hit (addr %s)", target.Addr)
+		return nil, nil, errors.New("unreachable")
+	}
+	origDiscover := discoverLANDevices
+	discoverLANDevices = func(context.Context, time.Duration) ([]models.LANDevice, error) { return nil, nil }
+	t.Cleanup(func() {
+		dialAgentLKGFn, dialAgentLadderFn = origLKG, origLadder
+		discoverLANDevices = origDiscover
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := connectToAgent(ctx, SuppressProvisioningHint(), SuppressUpdateCheck(), NonInteractive())
+	if conn != nil {
+		conn.Close()
+		t.Fatal("connectToAgent returned a connection to a --device host whose certificate contradicts its pin")
+	}
+	if err == nil {
+		t.Fatal("connectToAgent returned no error for a --device host whose certificate contradicts its pin")
+	}
+	if !strings.Contains(err.Error(), `device "wendy-thor.local" identity changed`) ||
+		!strings.Contains(err.Error(), "wendy device unpin wendy-thor.local") {
+		t.Fatalf("err = %v, want the identity refusal naming the device and the unpin escape hatch", err)
+	}
+	if dialedPinKey != "wendy-thor.local" {
+		t.Errorf("dial was constrained by pin key %q, but the check was made against \"wendy-thor.local\"; a host pinned under one key and verified under another is unenforced", dialedPinKey)
+	}
+	if pin := readPins()["wendy-thor"]; pin.OrgID != 9 {
+		t.Errorf("pin after refusal = %+v, want the original org 9 intact", pin)
+	}
+}
+
+// TestPickerPinKeyMatchesDeviceFlagKey is the fourth path's half of the same
+// agreement TestEnforceDeviceIdentityAppliesToNonDefault proves for --device:
+// picking a device from the TUI must file its pin exactly where naming it on
+// the command line looks for it.
+//
+// The DisplayName here is the shape a real WendyOS device advertises — a
+// Title-Cased friendly name from the `displayname` TXT record, built from the
+// device name, while the hostname is "wendyos-" + that name. Keying on it would
+// produce two pins for one device, each path blind to the other's, which reads
+// as enforcement while enforcing nothing.
+func TestPickerPinKeyMatchesDeviceFlagKey(t *testing.T) {
+	lan := &models.LANDevice{DisplayName: "Agx Orin", Hostname: "wendyos-agx-orin.local"}
+
+	origFlag := deviceFlag
+	deviceFlag = "wendyos-agx-orin.local"
+	t.Cleanup(func() { deviceFlag = origFlag })
+	_, flagKey, _, err := resolveDeviceAddress()
+	if err != nil {
+		t.Fatalf("resolveDeviceAddress: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.SetDevicePin(pinKeyForLANDevice(lan), 7, "grpc.a.sh:443", "42")
+	if _, ok := cfg.DevicePinFor(flagKey); !ok {
+		t.Fatalf("a pin recorded for the picked device (key %q) is invisible to --device %q (key %q): pins under %v",
+			pinKeyForLANDevice(lan), deviceFlag, flagKey, cfg.DevicePins)
+	}
+
+	// And the trap itself: the display name must not be what keys the pin.
+	if strings.EqualFold(pinKeyForLANDevice(lan), lan.DisplayName) {
+		t.Errorf("picker pin key = %q, want the hostname %q — the display name is not a transform of the hostname", pinKeyForLANDevice(lan), lan.Hostname)
 	}
 }
 

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -215,6 +215,48 @@ func TestClearDevicePinForRepin(t *testing.T) {
 	}
 }
 
+// TestSetDefaultClearsPinForHostPortDevice covers the escape hatch for the one
+// default shape that used to have none: `wendy device set-default
+// my-host.local:50051`. Enforcement keys that host under "my-host" (pinKeyForAddr
+// strips the port), so passing set-default's raw argument through to
+// clearDevicePinForRepin cleared a key nothing was ever filed under — the pin
+// survived, the connect that follows hit the refusal, and with the interactive
+// "trust it anyway?" prompt now gone there was no other way back.
+func TestSetDefaultClearsPinForHostPortDevice(t *testing.T) {
+	stubNonInteractive(t)
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+		"wendy-orin": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "9"},
+	})
+
+	// set-default connects afterwards to record a fresh pin. Keep that off the
+	// network: nothing resolves, so the dial fails and set-default ignores it
+	// (an offline device is pinned on its next successful connection instead).
+	origLookup, origBrowse, origLadder := osLookupHostFn, lanBrowseFn, dialAgentLadderFn
+	osLookupHostFn = func(context.Context, string) ([]string, error) { return nil, errors.New("no resolver in test") }
+	lanBrowseFn = func(context.Context, time.Duration) ([]models.LANDevice, error) { return nil, nil }
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
+		return nil, nil, errors.New("device offline in test")
+	}
+	t.Cleanup(func() { osLookupHostFn, lanBrowseFn, dialAgentLadderFn = origLookup, origBrowse, origLadder })
+
+	cmd := newDeviceSetDefaultCmd()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd.SetContext(ctx)
+	if err := cmd.RunE(cmd, []string{"wendy-thor.local:50051"}); err != nil {
+		t.Fatalf("set-default with an explicit port: %v", err)
+	}
+
+	pins := readPins()
+	if pin, ok := pins["wendy-thor"]; ok {
+		t.Errorf("pin %+v survived `set-default wendy-thor.local:50051`: the user named the device explicitly and still has no way past its refusal", pin)
+	}
+	if _, ok := pins["wendy-orin"]; !ok {
+		t.Error("set-default dropped an unrelated device's pin")
+	}
+}
+
 // TestEnforceDeviceIdentityHardFails covers the approved policy change: a
 // mismatch is refused identically in every mode, with no prompt.
 //
@@ -276,12 +318,58 @@ func TestEnforceDeviceIdentityHardFails(t *testing.T) {
 	// A function seam would only catch a prompt re-added THROUGH the seam; the
 	// likely regression — someone reaching for tui.Confirm* directly, to be
 	// helpful — is what this catches.
-	src, readErr := os.ReadFile("device_pin.go")
-	if readErr != nil {
-		t.Fatalf("reading device_pin.go: %v", readErr)
+	//
+	// The identity path is located by its function declarations across every
+	// non-test file in the package, not by filename: hardcoding "device_pin.go"
+	// would make this assertion pass while covering nothing the moment the
+	// identity code moves to another file.
+	assertNoPromptInIdentityPath(t)
+}
+
+// assertNoPromptInIdentityPath fails if whichever non-test file in this package
+// declares the identity refusals also reaches for an interactive confirmation,
+// and fails just as loudly if no file declares them at all — an assertion that
+// has quietly stopped scanning anything is worse than no assertion.
+func assertNoPromptInIdentityPath(t *testing.T) {
+	t.Helper()
+
+	// The declarations that mark a file as part of the identity path. Both
+	// refusals live behind these two.
+	decls := []string{"func enforceDeviceIdentity(", "func challengeUnprovisionedDevice("}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package directory: %v", err)
 	}
-	if strings.Contains(string(src), "tui.Confirm") {
-		t.Error("device_pin.go calls a tui.Confirm* prompt: the identity path must refuse, never ask — a MITM warning that can be dismissed gets dismissed")
+	found := make(map[string]string, len(decls))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, readErr := os.ReadFile(name)
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", name, readErr)
+		}
+		text := string(src)
+		var declared []string
+		for _, decl := range decls {
+			if strings.Contains(text, decl) {
+				declared = append(declared, decl)
+				found[decl] = name
+			}
+		}
+		if len(declared) == 0 {
+			continue
+		}
+		if strings.Contains(text, "tui.Confirm") {
+			t.Errorf("%s declares %v and calls a tui.Confirm* prompt: the identity path must refuse, never ask — a MITM warning that can be dismissed gets dismissed", name, declared)
+		}
+	}
+	for _, decl := range decls {
+		if found[decl] == "" {
+			t.Errorf("no non-test file in this package declares %q, so this check is scanning nothing; point it at wherever the identity refusals now live", decl)
+		}
 	}
 }
 
@@ -390,6 +478,144 @@ func TestPickerPinKeyMatchesDeviceFlagKey(t *testing.T) {
 	// And the trap itself: the display name must not be what keys the pin.
 	if strings.EqualFold(pinKeyForLANDevice(lan), lan.DisplayName) {
 		t.Errorf("picker pin key = %q, want the hostname %q — the display name is not a transform of the hostname", pinKeyForLANDevice(lan), lan.Hostname)
+	}
+}
+
+// TestPickerEnforcesPinBeforeAgentUpdate is the picker path's ORDERING, which
+// is a separate question from whether the pin is checked at all.
+//
+// With no default device, `wendy run` goes straight to the picker. If something
+// squats the pinned hostname and answers, every step taken between the connect
+// and the pin check is a step taken against a device the CLI is about to
+// reject — and one of those steps is the agent update check, which prompts
+// "Update the agent now?" and, on a yes, uploads a wendy-agent binary and
+// restarts it. Pushing an executable to an unverified device and only then
+// deciding not to trust it is the wrong order in the way that matters.
+//
+// The named-device path states this invariant in connectToAgent; this asserts
+// the picker path honours it too, by making the update check fail the test if
+// it is reached at all.
+func TestPickerEnforcesPinBeforeAgentUpdate(t *testing.T) {
+	stubNonInteractive(t)
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendyos-agx-orin": {OrgID: 9, CloudGRPC: "grpc.b.sh:443", AssetID: "42"},
+	})
+
+	lan := &models.LANDevice{
+		DisplayName: "Agx Orin",
+		Hostname:    "wendyos-agx-orin.local",
+		IPAddress:   "10.0.0.9",
+		Port:        50051,
+		IsMTLS:      true,
+	}
+
+	// Whoever answers there presents a certificate for org 7; the pin above says
+	// this hostname is an org 9 device. Nothing about the picker row is evidence
+	// either way — mDNS is unauthenticated, so the row is the attacker's claim.
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
+		return &grpcclient.AgentConnection{
+			IsMTLS:   true,
+			CertInfo: &config.CertificateInfo{OrganizationID: 7},
+		}, nil, nil
+	}
+	origUpdate := checkAndOfferUpdateFn
+	checkAndOfferUpdateFn = func(_ context.Context, conn *grpcclient.AgentConnection) (*grpcclient.AgentConnection, error) {
+		t.Error("the agent update check ran on a picker selection whose pin refuses it: that check can upload and restart a wendy-agent binary, so reaching it means the CLI offered to push an executable to a device it had not verified")
+		return conn, nil
+	}
+	t.Cleanup(func() { dialAgentLadderFn, checkAndOfferUpdateFn = origLadder, origUpdate })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// suppressUpdateCheck is false on purpose: the update check is ENABLED here,
+	// so the only thing that can keep it from running is the pin standing in
+	// front of it.
+	picked := &models.DiscoveredDevice{DisplayName: lan.DisplayName, LAN: lan}
+	sel, err := connectPickedLANDevice(ctx, picked, preferredLANAddress(*lan), false)
+	if err == nil {
+		if sel != nil && sel.Agent != nil {
+			sel.Agent.Close()
+		}
+		t.Fatal("picker selection returned a connection to a device whose certificate contradicts its pin")
+	}
+	if sel != nil {
+		t.Errorf("refused selection = %+v, want nil — a refusal must not hand back a usable target", sel)
+	}
+	if !strings.Contains(err.Error(), `device "wendyos-agx-orin.local" identity changed`) ||
+		!strings.Contains(err.Error(), "wendy device unpin wendyos-agx-orin.local") {
+		t.Fatalf("err = %v, want the identity refusal naming the picked device and the unpin escape hatch", err)
+	}
+	if pin := readPins()["wendyos-agx-orin"]; pin.OrgID != 9 {
+		t.Errorf("pin after refusal = %+v, want the original org 9 intact", pin)
+	}
+
+	// A refusal is not "the LAN attempt failed", so it must not slide into the
+	// Bluetooth fallback: that would reach the very device the pin just
+	// rejected, over a second transport, and report success.
+	withBLE := &models.DiscoveredDevice{
+		DisplayName: lan.DisplayName,
+		LAN:         lan,
+		Bluetooth:   &models.BluetoothDevice{DisplayName: "Agx Orin"},
+	}
+	bleSel, bleErr := connectPickedLANDevice(ctx, withBLE, preferredLANAddress(*lan), false)
+	if bleErr == nil || (bleSel != nil && bleSel.Bluetooth != nil) {
+		t.Fatalf("a refused pin fell back to Bluetooth (sel=%+v, err=%v); the BLE fallback is for a device that did not answer, not one that answered as somebody else", bleSel, bleErr)
+	}
+}
+
+// TestPickerRunsUpdateCheckOnceThePinHolds is the other half of the ordering
+// assertion above: the pin gate must not have simply disabled the update check.
+// A device whose pin matches still gets the check, and the connection the check
+// hands back (a restarted agent yields a NEW connection) is the one the caller
+// receives.
+func TestPickerRunsUpdateCheckOnceThePinHolds(t *testing.T) {
+	stubNonInteractive(t)
+	writePinTestConfig(t, map[string]config.DevicePin{
+		"wendyos-agx-orin": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+
+	lan := &models.LANDevice{
+		DisplayName: "Agx Orin",
+		Hostname:    "wendyos-agx-orin.local",
+		IPAddress:   "10.0.0.9",
+		Port:        50051,
+		IsMTLS:      true,
+	}
+
+	origLadder := dialAgentLadderFn
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
+		return &grpcclient.AgentConnection{
+			IsMTLS:   true,
+			CertInfo: &config.CertificateInfo{OrganizationID: 7},
+		}, nil, nil
+	}
+	replacement := &grpcclient.AgentConnection{IsMTLS: true, CertInfo: &config.CertificateInfo{OrganizationID: 7}}
+	updateChecked := false
+	origUpdate := checkAndOfferUpdateFn
+	checkAndOfferUpdateFn = func(context.Context, *grpcclient.AgentConnection) (*grpcclient.AgentConnection, error) {
+		updateChecked = true
+		return replacement, nil
+	}
+	t.Cleanup(func() { dialAgentLadderFn, checkAndOfferUpdateFn = origLadder, origUpdate })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	picked := &models.DiscoveredDevice{DisplayName: lan.DisplayName, LAN: lan}
+	sel, err := connectPickedLANDevice(ctx, picked, preferredLANAddress(*lan), false)
+	if err != nil {
+		t.Fatalf("matching pin: want the selection through, got %v", err)
+	}
+	if !updateChecked {
+		t.Error("the update check never ran for a device whose pin matches: the pin gate must order the check, not remove it")
+	}
+	if sel == nil || sel.Agent != replacement {
+		t.Errorf("selection carries %p, want the connection the update check returned (%p) — an agent that restarts hands back a new connection", sel, replacement)
+	}
+	if sel != nil && sel.PinKey != "wendyos-agx-orin.local" {
+		t.Errorf("PinKey = %q, want the hostname the pin is filed under", sel.PinKey)
 	}
 }
 

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -565,6 +565,149 @@ func TestPickerEnforcesPinBeforeAgentUpdate(t *testing.T) {
 	}
 }
 
+// TestPickerLadderRefusalDoesNotFallBackToBluetooth closes the gap the doc
+// comment on connectPickedLANDevice already claimed was closed.
+//
+// There are two refusals that can reach the picker, and only one of them
+// arrived where the Bluetooth fallback could not see it. The post-connect one
+// (TestPickerEnforcesPinBeforeAgentUpdate) comes back after a successful dial.
+// The dial ladder's own — a wrong-device abort, or a pinned host that offered
+// no authenticated endpoint — comes back as a connect ERROR, and the very next
+// line handed the caller the row's BLE half instead.
+//
+// That is the whole attack: answer the victim's mDNS name over LAN, get
+// rejected, and have the CLI quietly connect to a BLE peer advertising the same
+// name — where attemptBLEConnect sets no ExpectedIdentity and
+// enforceSelectedDevicePin is a no-op for a Bluetooth selection, so nothing
+// checks anything.
+func TestPickerLadderRefusalDoesNotFallBackToBluetooth(t *testing.T) {
+	stubNonInteractive(t)
+	writePinTestConfig(t, map[string]config.DevicePin{
+		"wendyos-agx-orin": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	setPinCache(t)
+
+	lan := &models.LANDevice{
+		DisplayName: "Agx Orin",
+		Hostname:    "wendyos-agx-orin.local",
+		IPAddress:   "10.0.0.9",
+		Port:        50051,
+		IsMTLS:      true,
+	}
+
+	refusals := map[string]error{
+		"wrong device answered": identityRefusal("wendyos-agx-orin.local", &certs.IdentityMismatchError{
+			WantOrg: 7, WantAsset: "42", GotOrg: 7, GotAsset: "43",
+		}),
+		"pinned host offered no authenticated endpoint": pinnedHostWentUnauthenticatedError("wendyos-agx-orin.local"),
+	}
+
+	for name, refusal := range refusals {
+		t.Run(name, func(t *testing.T) {
+			origLadder := dialAgentLadderFn
+			dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
+				return nil, nil, refusal
+			}
+			origUpdate := checkAndOfferUpdateFn
+			checkAndOfferUpdateFn = func(_ context.Context, conn *grpcclient.AgentConnection) (*grpcclient.AgentConnection, error) {
+				t.Error("the agent update check ran despite the dial being refused")
+				return conn, nil
+			}
+			t.Cleanup(func() { dialAgentLadderFn, checkAndOfferUpdateFn = origLadder, origUpdate })
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			withBLE := &models.DiscoveredDevice{
+				DisplayName: lan.DisplayName,
+				LAN:         lan,
+				Bluetooth:   &models.BluetoothDevice{DisplayName: "Agx Orin"},
+			}
+			sel, err := connectPickedLANDevice(ctx, withBLE, preferredLANAddress(*lan), false)
+			if err == nil {
+				t.Fatalf("a refused dial fell through to a usable selection (%+v); the BLE fallback is for a device that did not answer, not one that answered as somebody else", sel)
+			}
+			if sel != nil {
+				t.Errorf("refused selection = %+v, want nil", sel)
+			}
+			if !errors.Is(err, errDeviceIdentityRefused) {
+				t.Errorf("err = %v does not read as an identity refusal; the fallback is decided on the error's type, not its wording", err)
+			}
+		})
+	}
+
+	// The fallback itself must survive: an ordinary connect failure — the device
+	// is off, the port is shut — is exactly what BLE is there for.
+	t.Run("an ordinary connect failure still falls back", func(t *testing.T) {
+		origLadder := dialAgentLadderFn
+		dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
+			return nil, nil, errors.New("dial tcp 10.0.0.9:50051: connect: connection refused")
+		}
+		t.Cleanup(func() { dialAgentLadderFn = origLadder })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ble := &models.BluetoothDevice{DisplayName: "Agx Orin"}
+		withBLE := &models.DiscoveredDevice{DisplayName: lan.DisplayName, LAN: lan, Bluetooth: ble}
+		sel, err := connectPickedLANDevice(ctx, withBLE, preferredLANAddress(*lan), false)
+		if err != nil {
+			t.Fatalf("an unreachable LAN half must still fall back to BLE, got %v", err)
+		}
+		if sel == nil || sel.Bluetooth != ble {
+			t.Fatalf("selection = %+v, want the row's Bluetooth half", sel)
+		}
+	})
+}
+
+// TestDefaultDeviceNameForPrefersPinKey covers what `wendy device set-default`
+// with no argument stores.
+//
+// selected.Agent.Host is the address the picker dialled, which on any LAN row
+// is an IP. Saving that made the default device a DHCP lease — and worse, it
+// keyed every later connection's pin on the IP while the picker had just pinned
+// the device under its HOSTNAME seconds earlier. pinCandidateKeys cannot map an
+// IP back to a hostname row, so that pin was never consulted again and
+// enforcement was silently off for the whole configuration.
+func TestDefaultDeviceNameForPrefersPinKey(t *testing.T) {
+	picked := &SelectedDevice{
+		Agent:  &grpcclient.AgentConnection{Host: "10.0.0.9"},
+		PinKey: "wendyos-agx-orin.local",
+	}
+
+	got, err := defaultDeviceNameFor(picked)
+	if err != nil {
+		t.Fatalf("defaultDeviceNameFor: %v", err)
+	}
+	if got != "wendyos-agx-orin.local" {
+		t.Fatalf("default device name = %q, want the pin key %q — an IP is a DHCP lease, not a device", got, picked.PinKey)
+	}
+
+	// The consequence, stated directly: the pin the picker just wrote has to be
+	// visible to every later connect keyed on the saved default.
+	cfg := &config.Config{}
+	cfg.SetDevicePin(picked.PinKey, 7, "grpc.a.sh:443", "42")
+	if _, ok := cfg.DevicePinFor(pinKeyForAddr(got)); !ok {
+		t.Fatalf("the pin recorded under %q is invisible to a default of %q: every later connect keys on a name no pin was filed under, and enforcement is off",
+			picked.PinKey, got)
+	}
+
+	// A selection with no pin key has nothing else to identify it; the address
+	// stays the fallback, exactly as before.
+	noKey := &SelectedDevice{Agent: &grpcclient.AgentConnection{Host: "10.0.0.9"}}
+	if got, err := defaultDeviceNameFor(noKey); err != nil || got != "10.0.0.9" {
+		t.Fatalf("keyless selection = (%q, %v), want the dialled host as the fallback", got, err)
+	}
+
+	ext := &SelectedDevice{External: &models.ExternalDevice{ProviderKey: "adb"}}
+	if got, err := defaultDeviceNameFor(ext); err != nil || got != "adb" {
+		t.Fatalf("external selection = (%q, %v), want its provider key", got, err)
+	}
+	if _, err := defaultDeviceNameFor(&SelectedDevice{}); err == nil {
+		t.Error("an empty selection must not name a default device")
+	}
+}
+
 // TestPickerRunsUpdateCheckOnceThePinHolds is the other half of the ordering
 // assertion above: the pin gate must not have simply disabled the update check.
 // A device whose pin matches still gets the check, and the connection the check

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"

--- a/go/internal/cli/commands/device_unpin.go
+++ b/go/internal/cli/commands/device_unpin.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
@@ -40,30 +41,7 @@ func newDeviceUnpinCmd() *cobra.Command {
 				return fmt.Errorf("loading config: %w", err)
 			}
 
-			// Read the config pin BEFORE clearing it: it is the only place the
-			// (org, asset) pair needed to compute the SPKI store's key still
-			// lives. Clear first and that information is gone.
-			pin, hadPin := cfg.DevicePinFor(pinKey)
-			cfg.ClearDevicePin(pinKey)
-
-			// A legacy pin (no AssetID) has no derivable SPKI key. That is not a
-			// failure: clear the config pin and succeed, same as any other
-			// unpin.
-			if hadPin && pin.AssetID != "" {
-				// Same config-directory resolution as openPinStore, but that
-				// helper returns certs.PinChecker, which only exposes
-				// CheckAndUpdate — not Remove. Open the concrete store directly.
-				if dir, dirErr := config.ConfigDir(); dirErr == nil {
-					if store, openErr := devicepin.Open(dir); openErr == nil {
-						key := certs.WendyIdentity{
-							OrgID:      int32(pin.OrgID),
-							EntityType: "asset",
-							EntityID:   pin.AssetID,
-						}.IdentityKey()
-						_ = store.Remove(key)
-					}
-				}
-			}
+			clearPinsGoverning(cfg, pinKey)
 
 			if err := config.Save(cfg); err != nil {
 				return fmt.Errorf("saving config: %w", err)
@@ -72,5 +50,101 @@ func newDeviceUnpinCmd() *cobra.Command {
 			fmt.Fprintf(cmd.OutOrStdout(), "Unpinned %q. The next connection to it will record a fresh identity.\n", hostname)
 			return nil
 		},
+	}
+}
+
+// clearPinsGoverning drops every pin that could govern a dial to pinKey — the
+// config pins under each of the device's candidate keys, plus the SPKI entries
+// those pins identify — and reports whether any config pin was actually
+// removed. It mutates cfg; saving is the caller's job.
+//
+// It clears EVERY candidate rather than only the one lookupPin would return,
+// because "unpin" has to terminate. A device pinned under both its mDNS
+// hostname and the cloud roster's asset name would otherwise refuse under one
+// pin, be unpinned, and refuse again under the other — a user watching that
+// happen learns the command does not work. Consulting the same candidate list
+// the dial path uses is what keeps the two in step: whatever a refusal could be
+// caused by is what this clears.
+//
+// SPKI entries are cleared unconditionally, not only when a config pin was
+// found. The two stores are written on different paths — getAgentVersionAtAddress
+// runs the ladder with the SPKI store for every device the mDNS prober
+// enumerates, so `wendy device list` alone leaves SPKI entries with no config
+// pin behind them — and an escape hatch that only reaches one of them leaves
+// the other's refusal permanent.
+func clearPinsGoverning(cfg *config.Config, pinKey string) bool {
+	if cfg == nil || pinKey == "" {
+		return false
+	}
+	cleared := false
+	var identityKeys []string
+	for _, key := range pinCandidateKeys(pinKey) {
+		pin, ok := cfg.DevicePinFor(key)
+		if !ok {
+			continue
+		}
+		cfg.ClearDevicePin(key)
+		cleared = true
+		// Read the pin BEFORE it is gone: it is the only place the (org, asset)
+		// pair needed to compute the SPKI store's key lives. A legacy pin (no
+		// AssetID) has no derivable key — not a failure, just nothing to remove.
+		if pin.AssetID != "" {
+			identityKeys = append(identityKeys, certs.WendyIdentity{
+				OrgID:      int32(pin.OrgID),
+				EntityType: "asset",
+				EntityID:   pin.AssetID,
+			}.IdentityKey())
+		}
+	}
+	if key := cachedIdentityKey(pinKey); key != "" {
+		identityKeys = append(identityKeys, key)
+	}
+	removeSPKIPins(identityKeys)
+	return cleared
+}
+
+// cachedIdentityKey derives the SPKI store's key for pinKey from the discovery
+// cache, which records the asset and org a device advertised. It is the only
+// lookup that reaches an SPKI entry belonging to a host with no asset-bearing
+// config pin — the `wendy device list` case above, where nothing else in local
+// state ties the hostname the user types to the asset URN the store is keyed
+// by.
+//
+// Reading unauthenticated discovery data here is safe in the way it is not on
+// the dial path: the worst an attacker-chosen asset id can do is make an unpin
+// remove a pin the user was already asking to remove. Returns "" when the cache
+// is unavailable, has no entry, or the entry carries no asset identity.
+func cachedIdentityKey(pinKey string) string {
+	entry, ok := cachedDeviceHostEntry(pinKey)
+	if !ok || entry.AssetID <= 0 || entry.OrgID <= 0 {
+		return ""
+	}
+	return certs.WendyIdentity{
+		OrgID:      entry.OrgID,
+		EntityType: "asset",
+		EntityID:   strconv.Itoa(int(entry.AssetID)),
+	}.IdentityKey()
+}
+
+// removeSPKIPins drops the given identity keys from the SPKI pin store.
+// Best-effort: an unopenable store leaves the config side of the unpin done,
+// which is strictly better than failing the command outright.
+func removeSPKIPins(identityKeys []string) {
+	if len(identityKeys) == 0 {
+		return
+	}
+	// Same config-directory resolution as openPinStore, but that helper returns
+	// certs.PinChecker, which only exposes CheckAndUpdate — not Remove. Open the
+	// concrete store directly.
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return
+	}
+	store, err := devicepin.Open(dir)
+	if err != nil {
+		return
+	}
+	for _, key := range identityKeys {
+		_ = store.Remove(key)
 	}
 }

--- a/go/internal/cli/commands/device_unpin.go
+++ b/go/internal/cli/commands/device_unpin.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
+)
+
+// newDeviceUnpinCmd is the escape hatch every identity refusal in
+// enforceDeviceIdentity and challengeUnprovisionedDevice points at by name.
+// Until this command exists, hitting one of those refusals is a dead end: the
+// CLI tells the user to run it, and there is nothing to run.
+//
+// Unpinning clears local trust state only. It never dials the device — the
+// whole point is to work when the device is offline, wiped, or gone, which is
+// exactly when a pin most needs clearing.
+func newDeviceUnpinCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unpin <hostname>",
+		Short: "Clear the recorded identity pin for a device",
+		Long: "Clear the recorded identity pin for a device, so the next connection to it\n" +
+			"records a fresh identity instead of being challenged against the old one.\n" +
+			"Use this after a legitimate reflash, factory reset, or re-enrollment —\n" +
+			"anything that made 'wendy device unpin' the CLI's own suggestion.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := args[0]
+			// pinKeyForAddr, not the raw argument: a pin recorded via
+			// `--device host.local:50051` files under "host.local" (the port
+			// stripped), and a user unpinning must be able to hand back exactly
+			// what they used to connect. This is the same bug fixed in
+			// set-default in Task 6 — do not reintroduce it here.
+			pinKey := pinKeyForAddr(hostname)
+
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			// Read the config pin BEFORE clearing it: it is the only place the
+			// (org, asset) pair needed to compute the SPKI store's key still
+			// lives. Clear first and that information is gone.
+			pin, hadPin := cfg.DevicePinFor(pinKey)
+			cfg.ClearDevicePin(pinKey)
+
+			// A legacy pin (no AssetID) has no derivable SPKI key. That is not a
+			// failure: clear the config pin and succeed, same as any other
+			// unpin.
+			if hadPin && pin.AssetID != "" {
+				// Same config-directory resolution as openPinStore, but that
+				// helper returns certs.PinChecker, which only exposes
+				// CheckAndUpdate — not Remove. Open the concrete store directly.
+				if dir, dirErr := config.ConfigDir(); dirErr == nil {
+					if store, openErr := devicepin.Open(dir); openErr == nil {
+						key := certs.WendyIdentity{
+							OrgID:      int32(pin.OrgID),
+							EntityType: "asset",
+							EntityID:   pin.AssetID,
+						}.IdentityKey()
+						_ = store.Remove(key)
+					}
+				}
+			}
+
+			if err := config.Save(cfg); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Unpinned %q. The next connection to it will record a fresh identity.\n", hostname)
+			return nil
+		},
+	}
+}

--- a/go/internal/cli/commands/device_unpin.go
+++ b/go/internal/cli/commands/device_unpin.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
@@ -10,97 +13,245 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 )
 
+// The two stores an unpin can clear, as they are named in its report. They are
+// keyed differently on purpose — one by the name the user dials, one by the
+// certificate's own identity URN — so a report that did not say which store an
+// entry came from would not tell the user what they had just given up.
+const (
+	clearedConfigPin   = "device pin"
+	clearedIdentityPin = "certificate key pin"
+)
+
+// clearedPin is one pin an unpin removed.
+//
+// It exists so the command can print what it did. Clearing is not a single
+// keyed delete: one unpin can reach several config keys and several SPKI
+// entries, and the version of this code that did that silently is what let an
+// over-broad clear (a hostile discovery-cache alias dragging another device's
+// pins along) go unnoticed. Anything removed gets named.
+type clearedPin struct {
+	// store is which of the two pin stores the entry came from.
+	store string
+	// key is the key the entry was filed under: a hostname for a config pin,
+	// an identity URN for an SPKI pin.
+	key string
+	// identity is the URN the entry names, or "" for a legacy config pin with
+	// no asset id — which names an organisation, not a device.
+	identity string
+}
+
 // newDeviceUnpinCmd is the escape hatch every identity refusal in
-// enforceDeviceIdentity and challengeUnprovisionedDevice points at by name.
-// Until this command exists, hitting one of those refusals is a dead end: the
-// CLI tells the user to run it, and there is nothing to run.
+// enforceDeviceIdentity, challengeUnprovisionedDevice, and spkiRefusal points
+// at by name. Until this command exists, hitting one of those refusals is a
+// dead end: the CLI tells the user to run it, and there is nothing to run.
+//
+// It takes either name a refusal can print, because the two refusals do not
+// print the same kind of name. A config-pin refusal names a hostname; an SPKI
+// refusal can only name the certificate identity URN the SPKI store is keyed
+// by, and for the dials that reach that store there is often no hostname to
+// offer — `wendy device list` and the picker dial the IP first, and nothing in
+// local state ties an IP to an asset URN. Accepting the URN is what makes those
+// refusals recoverable without hand-editing known_devices.json.
 //
 // Unpinning clears local trust state only. It never dials the device — the
 // whole point is to work when the device is offline, wiped, or gone, which is
 // exactly when a pin most needs clearing.
 func newDeviceUnpinCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "unpin <hostname>",
+		Use:   "unpin <hostname|identity-urn>",
 		Short: "Clear the recorded identity pin for a device",
 		Long: "Clear the recorded identity pin for a device, so the next connection to it\n" +
 			"records a fresh identity instead of being challenged against the old one.\n" +
+			"Accepts either the hostname you connect to or the identity URN a refusal\n" +
+			"prints (urn:wendy:org:<org>:asset:<id>).\n" +
 			"Use this after a legitimate reflash, factory reset, or re-enrollment —\n" +
 			"anything that made 'wendy device unpin' the CLI's own suggestion.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hostname := args[0]
-			// pinKeyForAddr, not the raw argument: a pin recorded via
-			// `--device host.local:50051` files under "host.local" (the port
-			// stripped), and a user unpinning must be able to hand back exactly
-			// what they used to connect. This is the same bug fixed in
-			// set-default in Task 6 — do not reintroduce it here.
-			pinKey := pinKeyForAddr(hostname)
+			target := strings.TrimSpace(args[0])
 
 			cfg, err := config.Load()
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)
 			}
 
-			clearPinsGoverning(cfg, pinKey)
+			var cleared []clearedPin
+			// Detect the URN form by parsing it, not by guessing at its shape: a
+			// hostname is never six colon-separated fields beginning
+			// "urn:wendy:org", and certs owns what a well-formed identity is.
+			if identity, urnErr := certs.ParseIdentityURN(target); urnErr == nil {
+				cleared = clearPinsForIdentity(cfg, identity)
+			} else {
+				// pinKeyForAddr, not the raw argument: a pin recorded via
+				// `--device host.local:50051` files under "host.local" (the port
+				// stripped), and a user unpinning must be able to hand back exactly
+				// what they used to connect. This is the same bug fixed in
+				// set-default in Task 6 — do not reintroduce it here.
+				cleared = clearPinsGoverning(cfg, pinKeyForAddr(target))
+			}
 
 			if err := config.Save(cfg); err != nil {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Unpinned %q. The next connection to it will record a fresh identity.\n", hostname)
+			printClearedPins(cmd.OutOrStdout(), cleared)
+			fmt.Fprintf(cmd.OutOrStdout(), "Unpinned %q. The next connection to it will record a fresh identity.\n", target)
 			return nil
 		},
 	}
 }
 
-// clearPinsGoverning drops every pin that could govern a dial to pinKey — the
-// config pins under each of the device's candidate keys, plus the SPKI entries
-// those pins identify — and reports whether any config pin was actually
-// removed. It mutates cfg; saving is the caller's job.
+// printClearedPins reports every entry an unpin removed, one line each.
 //
-// It clears EVERY candidate rather than only the one lookupPin would return,
-// because "unpin" has to terminate. A device pinned under both its mDNS
-// hostname and the cloud roster's asset name would otherwise refuse under one
-// pin, be unpinned, and refuse again under the other — a user watching that
-// happen learns the command does not work. Consulting the same candidate list
-// the dial path uses is what keeps the two in step: whatever a refusal could be
-// caused by is what this clears.
-//
-// SPKI entries are cleared unconditionally, not only when a config pin was
-// found. The two stores are written on different paths — getAgentVersionAtAddress
-// runs the ladder with the SPKI store for every device the mDNS prober
-// enumerates, so `wendy device list` alone leaves SPKI entries with no config
-// pin behind them — and an escape hatch that only reaches one of them leaves
-// the other's refusal permanent.
-func clearPinsGoverning(cfg *config.Config, pinKey string) bool {
-	if cfg == nil || pinKey == "" {
-		return false
+// Unpinning one name can legitimately clear several entries, and the user is
+// the only one who can tell "that is the device I meant" from "that is not my
+// device". Printing nothing when nothing matched is also the answer to
+// "unpinning something already unpinned" — the command still exits 0, it just
+// has nothing to report.
+func printClearedPins(w io.Writer, cleared []clearedPin) {
+	for _, c := range cleared {
+		identity := c.identity
+		if identity == "" {
+			identity = "no recorded identity"
+		}
+		fmt.Fprintf(w, "Cleared %s %q (%s)\n", c.store, c.key, identity)
 	}
-	cleared := false
+}
+
+// clearPinsForIdentity clears everything filed under one certificate identity:
+// the SPKI entry keyed by that URN, plus any config pin that derives the same
+// URN. Both halves matter — clearing only the SPKI entry would leave the config
+// pin behind to refuse the next dial under a different message, which is the
+// same dead end from the other direction, and the two stores drifting apart is
+// what makes an escape hatch feel unreliable.
+//
+// Unlike the hostname path there is no aliasing to reason about: the URN IS the
+// identity, so "every pin naming this identity" is exactly the right blast
+// radius and no discovery-derived data is consulted at all.
+func clearPinsForIdentity(cfg *config.Config, identity certs.WendyIdentity) []clearedPin {
+	key := identity.IdentityKey()
+	var cleared []clearedPin
+	for _, host := range configPinKeysForIdentity(cfg, key) {
+		cfg.ClearDevicePin(host)
+		cleared = append(cleared, clearedPin{store: clearedConfigPin, key: host, identity: key})
+	}
+	return append(cleared, removeSPKIPins([]string{key})...)
+}
+
+// configPinKeysForIdentity lists the config pin keys whose pin names
+// identityKey, sorted so the command's report is deterministic.
+func configPinKeysForIdentity(cfg *config.Config, identityKey string) []string {
+	if cfg == nil || identityKey == "" {
+		return nil
+	}
+	var keys []string
+	for host, pin := range cfg.DevicePins {
+		if configPinIdentityKey(pin) == identityKey {
+			keys = append(keys, host)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// clearPinsGoverning drops the pins that govern a dial to pinKey — the
+// governing config pin, the config pins under this device's other names, and
+// the SPKI entries those pins identify — and returns what it removed. It
+// mutates cfg; saving is the caller's job.
+//
+// It clears more than the single key lookupPin would return because "unpin" has
+// to terminate. A device pinned under both its mDNS hostname and the cloud
+// roster's asset name would otherwise refuse under one pin, be unpinned, and
+// refuse again under the other — a user watching that happen learns the command
+// does not work.
+//
+// The bound on that: an alias key is cleared only when its pin names the SAME
+// (org, asset) as the governing pin. The alias list comes from the discovery
+// cache, which is filled verbatim from unauthenticated mDNS TXT records, so an
+// attacker who spoofs the hostname a user is about to unpin can put any
+// displayname or mesh name they like in it — including another device's. Under
+// the previous rule (clear every candidate) that made `wendy device unpin
+// thor.local` delete the victim's pin and SPKI entry too, turning the escape
+// hatch into a downgrade primitive: the victim's next connect became a
+// permissive first use. Requiring the alias's pin to name the same device is
+// what makes a hostile alias inert — it names a pin for a different asset, so
+// it is not this device's pin, so it is left alone.
+//
+// A pin with no asset id is never matched as an alias. It names an
+// organisation, not a device, so "same identity" cannot be established for it,
+// and two unrelated legacy pins in one org must not be treated as one device.
+// The governing key itself is always cleared, so this only ever costs a second
+// unpin in the pathological case, never the escape hatch.
+//
+// SPKI entries are derived from the pins actually cleared, plus the discovery
+// cache's identity when there is no config pin at all. The second source is
+// what covers the store that gets written where no config pin ever does —
+// getAgentVersionAtAddress runs the ladder with the SPKI store for every device
+// the mDNS prober enumerates, so `wendy device list` alone leaves SPKI entries
+// with no config pin behind them. When a config pin does exist, the cache is
+// believed only where it agrees with that pin: a disagreeing cache is either
+// stale or hostile, and in neither case does it name this device.
+func clearPinsGoverning(cfg *config.Config, pinKey string) []clearedPin {
+	if cfg == nil || pinKey == "" {
+		return nil
+	}
+
+	// The governing pin is what a dial to pinKey would actually be judged
+	// against, so it is also what defines "this device" for everything below.
+	// Resolving it through the same lookupPin the dial path uses is what keeps
+	// the refusal and its escape hatch talking about the same pin.
+	governing, governingKey, pinned := lookupPin(cfg, pinKey)
+
+	var cleared []clearedPin
 	var identityKeys []string
 	for _, key := range pinCandidateKeys(pinKey) {
 		pin, ok := cfg.DevicePinFor(key)
 		if !ok {
 			continue
 		}
+		isGoverning := normalizeMDNSHost(key) == normalizeMDNSHost(governingKey)
+		if !isGoverning && !sameConfigPinIdentity(pin, governing) {
+			continue
+		}
 		cfg.ClearDevicePin(key)
-		cleared = true
 		// Read the pin BEFORE it is gone: it is the only place the (org, asset)
 		// pair needed to compute the SPKI store's key lives. A legacy pin (no
 		// AssetID) has no derivable key — not a failure, just nothing to remove.
-		if pin.AssetID != "" {
-			identityKeys = append(identityKeys, certs.WendyIdentity{
-				OrgID:      int32(pin.OrgID),
-				EntityType: "asset",
-				EntityID:   pin.AssetID,
-			}.IdentityKey())
+		identity := configPinIdentityKey(pin)
+		cleared = append(cleared, clearedPin{store: clearedConfigPin, key: key, identity: identity})
+		if identity != "" {
+			identityKeys = append(identityKeys, identity)
 		}
 	}
-	if key := cachedIdentityKey(pinKey); key != "" {
+
+	if key := cachedIdentityKey(pinKey); key != "" && (!pinned || key == configPinIdentityKey(governing)) {
 		identityKeys = append(identityKeys, key)
 	}
-	removeSPKIPins(identityKeys)
-	return cleared
+
+	return append(cleared, removeSPKIPins(identityKeys)...)
+}
+
+// configPinIdentityKey is the SPKI store key a config pin names, or "" for a
+// legacy pin written before asset ids were recorded — which names an
+// organisation and a cloud, not a device, and so identifies no SPKI entry.
+func configPinIdentityKey(pin config.DevicePin) string {
+	if pin.AssetID == "" {
+		return ""
+	}
+	return certs.WendyIdentity{
+		OrgID:      int32(pin.OrgID),
+		EntityType: "asset",
+		EntityID:   pin.AssetID,
+	}.IdentityKey()
+}
+
+// sameConfigPinIdentity reports whether two config pins name the same device —
+// same organisation and same asset. Pins with no asset id never match, not even
+// each other: they constrain an org, and treating two of them as one device is
+// how an unpin reaches a pin the user never named.
+func sameConfigPinIdentity(a, b config.DevicePin) bool {
+	key := configPinIdentityKey(a)
+	return key != "" && key == configPinIdentityKey(b)
 }
 
 // cachedIdentityKey derives the SPKI store's key for pinKey from the discovery
@@ -110,10 +261,18 @@ func clearPinsGoverning(cfg *config.Config, pinKey string) bool {
 // state ties the hostname the user types to the asset URN the store is keyed
 // by.
 //
-// Reading unauthenticated discovery data here is safe in the way it is not on
-// the dial path: the worst an attacker-chosen asset id can do is make an unpin
-// remove a pin the user was already asking to remove. Returns "" when the cache
-// is unavailable, has no entry, or the entry carries no asset identity.
+// What it returns is NOT trustworthy: Cache.Replace writes mDNS TXT records
+// verbatim, so an attacker on the LAN chooses this value for any hostname they
+// can answer for. It is safe only because of how the caller uses it — as a
+// candidate that must agree with the governing config pin before anything is
+// deleted, and as a sole source only when there is no config pin to disagree
+// with. An earlier version of this comment claimed the worst case was "removing
+// a pin the user was already asking to remove"; that was wrong, because it
+// assumed the advertised asset belonged to the device being unpinned, and the
+// whole point of spoofing it is that it does not.
+//
+// Returns "" when the cache is unavailable, has no entry, or the entry carries
+// no asset identity.
 func cachedIdentityKey(pinKey string) string {
 	entry, ok := cachedDeviceHostEntry(pinKey)
 	if !ok || entry.AssetID <= 0 || entry.OrgID <= 0 {
@@ -126,25 +285,56 @@ func cachedIdentityKey(pinKey string) string {
 	}.IdentityKey()
 }
 
-// removeSPKIPins drops the given identity keys from the SPKI pin store.
+// removeSPKIPins drops the given identity keys from the SPKI pin store and
+// reports the ones that were actually there. Duplicates are collapsed, so a key
+// reached twice (a config pin and the cache agreeing, as they should) is
+// reported once.
+//
 // Best-effort: an unopenable store leaves the config side of the unpin done,
 // which is strictly better than failing the command outright.
-func removeSPKIPins(identityKeys []string) {
+func removeSPKIPins(identityKeys []string) []clearedPin {
 	if len(identityKeys) == 0 {
-		return
+		return nil
 	}
 	// Same config-directory resolution as openPinStore, but that helper returns
 	// certs.PinChecker, which only exposes CheckAndUpdate — not Remove. Open the
 	// concrete store directly.
 	dir, err := config.ConfigDir()
 	if err != nil {
-		return
+		return nil
 	}
 	store, err := devicepin.Open(dir)
 	if err != nil {
-		return
+		return nil
 	}
+	var cleared []clearedPin
+	seen := map[string]bool{}
 	for _, key := range identityKeys {
-		_ = store.Remove(key)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		// Has before Remove: Remove reports success for a key that was never
+		// there, and reporting entries we did not remove would make the command's
+		// own account of its blast radius useless.
+		if !store.Has(key) {
+			continue
+		}
+		if err := store.Remove(key); err != nil {
+			continue
+		}
+		cleared = append(cleared, clearedPin{store: clearedIdentityPin, key: key, identity: key})
 	}
+	return cleared
+}
+
+// clearedAnyConfigPin reports whether a clear touched the config store, which
+// is the only half that needs cfg written back — the SPKI store flushes itself.
+func clearedAnyConfigPin(cleared []clearedPin) bool {
+	for _, c := range cleared {
+		if c.store == clearedConfigPin {
+			return true
+		}
+	}
+	return false
 }

--- a/go/internal/cli/commands/device_unpin_test.go
+++ b/go/internal/cli/commands/device_unpin_test.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
@@ -18,12 +20,21 @@ import (
 // bug in the test fixture, not in the store.
 func seedSPKIPin(t *testing.T, key string) {
 	t.Helper()
+	seedSPKIPins(t, key)
+}
+
+// seedSPKIPins is seedSPKIPin for more than one device, which is what the
+// blast-radius tests need: proving an unpin left another device's entry alone
+// requires another device's entry to exist.
+func seedSPKIPins(t *testing.T, keys ...string) {
+	t.Helper()
 	dir, err := config.ConfigDir()
 	if err != nil {
 		t.Fatalf("config dir: %v", err)
 	}
-	devices := map[string]devicepin.PinnedDevice{
-		key: {SPKIFingerprint: "sha256:deadbeef", DisplayName: "thor", LastSeen: "2026-01-01T00:00:00Z"},
+	devices := map[string]devicepin.PinnedDevice{}
+	for _, key := range keys {
+		devices[key] = devicepin.PinnedDevice{SPKIFingerprint: "sha256:deadbeef", DisplayName: "thor", LastSeen: "2026-01-01T00:00:00Z"}
 	}
 	data, err := json.Marshal(devices)
 	if err != nil {
@@ -203,6 +214,199 @@ func TestDeviceUnpinAcceptsHostPortAddress(t *testing.T) {
 	}
 	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
 		t.Error("SPKI pin survived unpin with an explicit port")
+	}
+}
+
+// runUnpin runs the command with its stdout captured, so a test can assert on
+// the report as well as on the stores.
+func runUnpin(t *testing.T, arg string) string {
+	t.Helper()
+	cmd := newDeviceUnpinCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.RunE(cmd, []string{arg}); err != nil {
+		t.Fatalf("unpin %q: %v", arg, err)
+	}
+	return out.String()
+}
+
+// TestDeviceUnpinAcceptsAnIdentityURN closes the escape hatch's other dead end.
+//
+// spkiRefusal fires with the SPKI store's key in hand and nothing else: the
+// picker and `wendy device list` dial lanAgentAddresses, whose first entry is
+// the IP, so the refusal names an IP that keys no config pin and whose asset no
+// cache lookup can derive (cachedDeviceHostEntry matches on Hostname). Agents
+// that never advertise `orgid` — the Swift macOS agent, Linux agents before
+// 2026-07-18 — leave the same gap even when a hostname is dialed. For both
+// populations the hostname-keyed unpin cleared nothing at all, and recovery
+// meant hand-editing known_devices.json.
+//
+// Given the URN the refusal prints, unpin must clear the SPKI entry AND any
+// config pin naming the same identity, so the two stores do not drift apart
+// into a second refusal under a different message.
+func TestDeviceUnpinAcceptsAnIdentityURN(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	setPinCache(t) // no cache entry: exactly the IP-dial / no-orgid shape
+	seedSPKIPins(t, "urn:wendy:org:7:asset:42", "urn:wendy:org:7:asset:99")
+
+	out := runUnpin(t, "urn:wendy:org:7:asset:42")
+
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived an unpin by its own store key: the refusal that named it has no other way out")
+	}
+	if pin, ok := readPins()["thor"]; ok {
+		t.Errorf("config pin naming the same identity survived (%+v): the stores drift and the next dial refuses under the other one", pin)
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:99"]; !ok {
+		t.Error("unpinning one identity removed another device's SPKI pin")
+	}
+	if !strings.Contains(out, "urn:wendy:org:7:asset:42") || !strings.Contains(out, "thor") {
+		t.Errorf("unpin reported %q, want it to name both entries it cleared", out)
+	}
+}
+
+// TestSPKIRefusalNamesAnArgumentUnpinCanActOn is the round trip the two halves
+// of Finding A only make sense together: the exact string spkiRefusal tells the
+// user to run must clear the entry that caused the refusal. Asserting the
+// message text and the command's behaviour separately would let them drift.
+func TestSPKIRefusalNamesAnArgumentUnpinCanActOn(t *testing.T) {
+	writePinTestConfig(t, nil)
+	setPinCache(t)
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	// The IP-dial shape: the ladder knows only the address it dialed.
+	err := spkiRefusal("192.168.1.9", &devicepin.PinMismatchError{
+		Key: "urn:wendy:org:7:asset:42", DisplayName: "orin",
+		Want: "sha256:aaa", Got: "sha256:bbb",
+	})
+
+	arg := unpinArgumentFrom(t, err.Error())
+	runUnpin(t, arg)
+
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Errorf("running the refusal's own suggested command (%q) cleared nothing; the refusal is a dead end", arg)
+	}
+}
+
+// unpinArgumentFrom extracts the argument a refusal told the user to pass to
+// `wendy device unpin`.
+func unpinArgumentFrom(t *testing.T, msg string) string {
+	t.Helper()
+	const marker = "wendy device unpin "
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		t.Fatalf("refusal %q names no unpin command at all", msg)
+	}
+	rest := msg[i+len(marker):]
+	return strings.TrimRight(strings.Fields(rest)[0], "'\"")
+}
+
+// TestDeviceUnpinLeavesAnotherDevicesPinsAlone is the adversarial case for the
+// blast radius, and the reason the "clear every candidate key" rule could not
+// stand.
+//
+// pinCandidateKeys' aliases come from the discovery cache, which Cache.Replace
+// fills verbatim from unauthenticated mDNS TXT records. An attacker who can
+// answer for the hostname the user is about to unpin chooses that entry's
+// displayname, mesh name, assetid and orgid — so pointing them at a victim
+// device made `wendy device unpin thor.local` delete the victim's config pin
+// and its SPKI entry too. The victim's next connect then started from a
+// permissive first use: an escape hatch turned into a downgrade primitive.
+//
+// Unpinning thor must clear thor's pins and nothing else.
+func TestDeviceUnpinLeavesAnotherDevicesPinsAlone(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"thor":   {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+		"victim": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "99"},
+	})
+	// A hostile answer for thor.local claiming the victim's names and asset.
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		Hostname:    "thor.local",
+		DisplayName: "victim",
+		MeshName:    "victim",
+		AssetID:     99,
+		OrgID:       7,
+	})
+	seedSPKIPins(t, "urn:wendy:org:7:asset:42", "urn:wendy:org:7:asset:99")
+
+	runUnpin(t, "thor.local")
+
+	pins := readPins()
+	if pin, ok := pins["thor"]; ok {
+		t.Errorf("the pin the user asked to clear survived: %+v", pin)
+	}
+	if _, ok := pins["victim"]; !ok {
+		t.Error("unpinning thor.local dropped another device's config pin, because an unauthenticated TXT record said the two were the same device; that device's next connect is now a permissive first use")
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:99"]; !ok {
+		t.Error("unpinning thor.local dropped another device's SPKI pin, from an asset id an attacker chose")
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("the SPKI pin for the device actually being unpinned survived")
+	}
+}
+
+// TestDeviceUnpinClearsEveryAliasOfTheSameDevice guards the property narrowing
+// the blast radius must not cost: unpinning by either name a device
+// legitimately answers to has to finish the job.
+//
+// `wendy cloud discover` files a pin under the roster's asset name while dials
+// name the device by its mDNS hostname, so one device really is pinned twice.
+// Both pins name the same asset, so both are this device's — clearing only the
+// governing one would refuse again under the other, and a command that has to
+// be run twice reads as a command that does not work.
+func TestDeviceUnpinClearsEveryAliasOfTheSameDevice(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendyos-calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceLAN},
+		"calm-zinnia":         {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceCloud},
+	})
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		Hostname:    "wendyos-calm-zinnia.local",
+		DisplayName: "calm-zinnia",
+	})
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	runUnpin(t, "wendyos-calm-zinnia.local")
+
+	for _, key := range []string{"wendyos-calm-zinnia", "calm-zinnia"} {
+		if pin, ok := readPins()[key]; ok {
+			t.Errorf("pin %q for the same asset survived (%+v); the next dial refuses under it and the user has to unpin twice", key, pin)
+		}
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived")
+	}
+}
+
+// TestDeviceUnpinIgnoresACacheThatDisagreesWithThePin covers the other half of
+// cachedIdentityKey's narrowing. The cache is consulted only where it agrees
+// with the governing config pin, or where there is no config pin at all (the
+// `wendy device list` case TestDeviceUnpinClearsSPKIPinWithNoConfigPin covers).
+// A cache that names a different asset for a pinned host is stale or hostile,
+// and either way it is not this device's SPKI entry to remove.
+func TestDeviceUnpinIgnoresACacheThatDisagreesWithThePin(t *testing.T) {
+	writePinTestConfig(t, map[string]config.DevicePin{
+		"thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	setPinCache(t, discoverycache.Entry{
+		ID:       "dev-1",
+		Hostname: "thor.local",
+		AssetID:  99,
+		OrgID:    7,
+	})
+	seedSPKIPins(t, "urn:wendy:org:7:asset:42", "urn:wendy:org:7:asset:99")
+
+	runUnpin(t, "thor.local")
+
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:99"]; !ok {
+		t.Error("an SPKI entry the discovery cache named — and the governing pin did not — was removed; that asset id is attacker-chosen")
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("the SPKI entry the governing pin names survived")
 	}
 }
 

--- a/go/internal/cli/commands/device_unpin_test.go
+++ b/go/internal/cli/commands/device_unpin_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
 )
 
 // seedSPKIPin writes a known_devices.json entry for key directly into the
@@ -78,6 +79,92 @@ func TestDeviceUnpinClearsBothStores(t *testing.T) {
 	}
 	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
 		t.Error("SPKI pin survived unpin: the identity refusal would fire again on the next connect")
+	}
+}
+
+// TestDeviceUnpinClearsAPinFoundUnderAnAlias is the dead end this closes.
+//
+// `wendy cloud discover` seeds pins under the name the cloud roster carries
+// (the asset name, which is the discovery cache's display name), while dials
+// name the device by its mDNS hostname. lookupPin already reconciles the two —
+// so a dial to "wendyos-calm-zinnia" is governed, and refused, by the pin filed
+// under "calm-zinnia" — but unpin cleared only the key it was handed. The
+// refusal named a key nothing was filed under, unpinning it removed nothing,
+// and the very next dial refused identically. Forever.
+func TestDeviceUnpinClearsAPinFoundUnderAnAlias(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42", Source: config.PinSourceCloud},
+	})
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "calm-zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+	})
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"wendyos-calm-zinnia.local"}); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+
+	if pin, ok := readPins()["calm-zinnia"]; ok {
+		t.Errorf("the pin that governs this host survived unpinning it by the name the refusal named (%+v); the next dial refuses identically and there is no way out", pin)
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived an alias-keyed unpin")
+	}
+}
+
+// TestDeviceUnpinClearsSPKIPinWithNoConfigPin covers the store that gets
+// written where no config pin ever does. getAgentVersionAtAddress runs the dial
+// ladder with the SPKI store for every device the mDNS prober enumerates, so
+// `wendy device list` alone SPKI-pins the whole LAN with no config pin behind
+// any of it. When one of those certificates is reissued, the old unpin declined
+// to touch the SPKI store at all (it required an asset-bearing config pin to
+// derive the key from), and recovery meant hand-editing known_devices.json.
+//
+// The discovery cache is what closes the gap: it records the asset and org the
+// device advertised, which is exactly the pair the store is keyed by.
+func TestDeviceUnpinClearsSPKIPinWithNoConfigPin(t *testing.T) {
+	writePinTestConfig(t, nil)
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "Thor",
+		Hostname:    "wendyos-thor.local",
+		AssetID:     42,
+		OrgID:       7,
+	})
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"wendyos-thor.local"}); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived unpin for a host with no config pin: the refusal it causes has no escape hatch but a text editor")
+	}
+}
+
+// TestClearDevicePinForRepinClearsSPKIStore holds set-default to the claim
+// pki/README.md already makes for it — that naming a device has "the same
+// clearing effect" as unpin. Leaving the SPKI half behind made that false for
+// the one refusal that has no other way out: set-default would clear the config
+// pin, reconnect, and be rejected again by the pin store it never touched.
+func TestClearDevicePinForRepinClearsSPKIStore(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	setPinCache(t) // empty cache: exactly the single-key legacy shape
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	clearDevicePinForRepin("wendy-thor.local")
+
+	if pin, ok := readPins()["wendy-thor"]; ok {
+		t.Errorf("config pin survived clearDevicePinForRepin: %+v", pin)
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived clearDevicePinForRepin: set-default cannot re-pin a device whose key rotated, though the docs say it can")
 	}
 }
 

--- a/go/internal/cli/commands/device_unpin_test.go
+++ b/go/internal/cli/commands/device_unpin_test.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
+)
+
+// seedSPKIPin writes a known_devices.json entry for key directly into the
+// wendy config directory (set up by writePinTestConfig beforehand), without
+// exercising CheckAndUpdate — that requires a live certificate. It mirrors
+// devicepin.Store's on-disk format exactly, so a discrepancy here would be a
+// bug in the test fixture, not in the store.
+func seedSPKIPin(t *testing.T, key string) {
+	t.Helper()
+	dir, err := config.ConfigDir()
+	if err != nil {
+		t.Fatalf("config dir: %v", err)
+	}
+	devices := map[string]devicepin.PinnedDevice{
+		key: {SPKIFingerprint: "sha256:deadbeef", DisplayName: "thor", LastSeen: "2026-01-01T00:00:00Z"},
+	}
+	data, err := json.Marshal(devices)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "known_devices.json"), data, 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+}
+
+// readSPKIPins loads known_devices.json back from the config dir for
+// assertions. A missing file (never written, or the store's own flush
+// deleted it — it never does, but nothing guarantees that) reads as no pins.
+func readSPKIPins(t *testing.T) map[string]devicepin.PinnedDevice {
+	t.Helper()
+	dir, err := config.ConfigDir()
+	if err != nil {
+		t.Fatalf("config dir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "known_devices.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read known_devices.json: %v", err)
+	}
+	var devices map[string]devicepin.PinnedDevice
+	if err := json.Unmarshal(data, &devices); err != nil {
+		t.Fatalf("unmarshal known_devices.json: %v", err)
+	}
+	return devices
+}
+
+// TestDeviceUnpinClearsBothStores is the test the whole command exists for.
+// Every identity refusal in enforceDeviceIdentity and
+// challengeUnprovisionedDevice tells the user to run `wendy device unpin
+// <host>`; if that only cleared one of the two independent pin stores, the
+// same refusal would fire again on the very next connection and the command
+// would look broken.
+func TestDeviceUnpinClearsBothStores(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"thor.local"}); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+
+	if pin, ok := readPins()["thor"]; ok {
+		t.Errorf("config pin survived unpin: %+v", pin)
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived unpin: the identity refusal would fire again on the next connect")
+	}
+}
+
+// TestDeviceUnpinUnknownHostIsNotAnError is the ambiguity ruling from the
+// design: the command's contract is "this host ends up unpinned", which is
+// already true for a host that was never pinned, so there is nothing to
+// report as a failure.
+func TestDeviceUnpinUnknownHostIsNotAnError(t *testing.T) {
+	writePinTestConfig(t, nil)
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"never-pinned.local"}); err != nil {
+		t.Fatalf("unpinning an unpinned host: want nil, got %v", err)
+	}
+}
+
+// TestDeviceUnpinAcceptsHostPortAddress covers the exact bug fixed in
+// set-default during Task 6: a pin recorded for a `--device
+// wendy-thor.local:50051` connection files under "wendy-thor.local" (the port
+// stripped by pinKeyForAddr), so unpinning must strip the port the same way —
+// passing the raw argument through would clear a key nothing was ever filed
+// under and leave the real pin, and the refusal, in place.
+func TestDeviceUnpinAcceptsHostPortAddress(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443", AssetID: "42"},
+	})
+	seedSPKIPin(t, "urn:wendy:org:7:asset:42")
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"wendy-thor.local:50051"}); err != nil {
+		t.Fatalf("unpin with an explicit port: %v", err)
+	}
+
+	if pin, ok := readPins()["wendy-thor"]; ok {
+		t.Errorf("config pin survived unpin with an explicit port: %+v", pin)
+	}
+	if _, ok := readSPKIPins(t)["urn:wendy:org:7:asset:42"]; ok {
+		t.Error("SPKI pin survived unpin with an explicit port")
+	}
+}
+
+// TestDeviceUnpinLegacyPinHasNoSPKIKey covers a pin written before asset ids
+// were recorded (config.DevicePin.AssetID == ""): there is no way to derive
+// the SPKI store's URN key from it, since that key requires an asset id. Per
+// the design's ambiguity ruling, this must clear the config pin and succeed
+// rather than fail — there is no SPKI entry to fail on, either, since a
+// legacy connection's certificate never had an asset id to pin in the first
+// place.
+func TestDeviceUnpinLegacyPinHasNoSPKIKey(t *testing.T) {
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.a.sh:443"},
+	})
+
+	cmd := newDeviceUnpinCmd()
+	if err := cmd.RunE(cmd, []string{"wendy-thor.local"}); err != nil {
+		t.Fatalf("unpin of a legacy (assetless) pin: want nil, got %v", err)
+	}
+	if pin, ok := readPins()["wendy-thor"]; ok {
+		t.Errorf("config pin survived unpin: %+v", pin)
+	}
+}

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -70,6 +70,9 @@ func pinKeyForAddr(addr string) string {
 // the host is unpinned or its pin predates asset ids. Nil means "first contact
 // is permissive" — the posture that keeps legacy and unprovisioned devices
 // working; the pin is written on the first successful connect.
+//
+// The lookup goes through lookupPin, so a pin recorded under any of the
+// device's names — hostname, mesh name, or display name — is honoured here.
 func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
 	if pinKey == "" {
 		return nil
@@ -78,15 +81,16 @@ func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
 	if err != nil {
 		return nil
 	}
-	pin, ok := cfg.DevicePinFor(pinKey)
+	pin, _, ok := lookupPin(cfg, pinKey)
 	if !ok || pin.AssetID == "" {
 		return nil
 	}
 	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
 }
 
-// isPinned reports whether pinKey has any recorded pin. A pinned host has been
-// reached over mTLS before, so the ladder must not offer it the plaintext rung.
+// isPinned reports whether pinKey has any recorded pin under any of its
+// candidate keys. A pinned host has been reached over mTLS before, so the
+// ladder must not offer it the plaintext rung.
 //
 // This deliberately asks local state a question with a yes/no answer instead of
 // inspecting the dial errors: the previous refusal was an accident of
@@ -100,8 +104,88 @@ func isPinned(pinKey string) bool {
 	if err != nil {
 		return false
 	}
-	_, ok := cfg.DevicePinFor(pinKey)
+	_, _, ok := lookupPin(cfg, pinKey)
 	return ok
+}
+
+// pinCandidateKeys returns the keys a pin for pinKey may have been recorded
+// under, most-specific first: the name the caller dialed, then — from the
+// discovery-cache entry whose hostname matches it — that device's mesh name and
+// display name. One device answers to all three, and different surfaces record
+// under different ones: enforceDevicePin records the dialed mDNS hostname
+// (wendyos-calm-zinnia), cloud seeding records the asset name the roster
+// carries (calm-zinnia, which is the cache's display name), and mesh dials name
+// the device by its mesh name. A cloud Asset carries only {Id, Name} — no
+// hostname — so the cloud side cannot record under the dial key, and the
+// reconciliation has to happen here on lookup.
+//
+// Duplicates are dropped under the same normalisation the pin store applies, so
+// an alias that is only a cosmetic variant of the dialed name never produces a
+// second, redundant candidate, and empty names are never looked up.
+//
+// Reading discovery-derived names to pick a key is safe in a way that reading
+// them to make a trust decision would not be: consulting an extra candidate can
+// only ever FIND a pin, never discard one, so an attacker-chosen alias can at
+// most impose a constraint that the real device fails — a stricter outcome, not
+// a bypass. The trust decision itself stays on the certificate.
+func pinCandidateKeys(pinKey string) []string {
+	if pinKey == "" {
+		return nil
+	}
+	candidates := []string{pinKey}
+	// Best effort by construction: cachedDeviceHostEntry reports false for an
+	// unopenable cache, an unreadable one, and a plain miss alike, and every
+	// one of those degrades to exactly the single-key list above.
+	entry, ok := cachedDeviceHostEntry(pinKey)
+	if !ok {
+		return candidates
+	}
+	seen := map[string]bool{normalizeMDNSHost(pinKey): true}
+	for _, alias := range []string{entry.MeshName, entry.DisplayName} {
+		norm := normalizeMDNSHost(alias)
+		if norm == "" || seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		candidates = append(candidates, alias)
+	}
+	return candidates
+}
+
+// lookupPin resolves the pin governing pinKey across every candidate key,
+// returning it, the key it was found under, and whether there was one.
+//
+// A cloud-sourced pin outranks a LAN-sourced one wherever each sits in the
+// candidate order: cloud learned the binding from the org's cloud over an
+// authenticated session, while a LAN pin records only what some host on the
+// local network presented. Among pins of equal source the earliest candidate
+// wins, which keeps the dialed name authoritative over an alias.
+//
+// Because the search only ever adds keys, a host pinned under pinKey stays
+// pinned no matter what the cache says or fails to say — the property that lets
+// the cache be consulted best-effort without a cache outage quietly switching
+// enforcement off.
+func lookupPin(cfg *config.Config, pinKey string) (config.DevicePin, string, bool) {
+	if cfg == nil {
+		return config.DevicePin{}, "", false
+	}
+	var best config.DevicePin
+	var bestKey string
+	found := false
+	for _, key := range pinCandidateKeys(pinKey) {
+		pin, ok := cfg.DevicePinFor(key)
+		if !ok {
+			continue
+		}
+		if !found {
+			best, bestKey, found = pin, key, true
+			continue
+		}
+		if best.Source != config.PinSourceCloud && pin.Source == config.PinSourceCloud {
+			best, bestKey = pin, key
+		}
+	}
+	return best, bestKey, found
 }
 
 // identityRefusal renders a wrong-device rejection. Same text in interactive,

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// dialTarget carries what the ladder needs to know about *who* it is dialing,
+// not just where. Before this, the ladder took a bare address, so the identity
+// the user asked for was gone by the time a certificate arrived — which is
+// exactly what let a spoofed mDNS answer redirect a connection to another
+// same-CA host.
+type dialTarget struct {
+	// PinKey is the name the user asked for (--device value, saved default, or
+	// the picker's device name) — never the resolved IP, which changes on
+	// ordinary DHCP churn and would train users to unpin reflexively. An empty
+	// PinKey disables pin enforcement for this dial.
+	PinKey string
+	// Addr is the host:port actually dialed.
+	Addr string
+	// Expected constrains the peer certificate. Non-nil only when a pin (or a
+	// cloud-seeded value) names a specific asset.
+	Expected *certs.WendyIdentity
+}
+
+// loadConfigForPinFn is a seam over config.Load for tests.
+var loadConfigForPinFn = config.Load
+
+// plaintextConnectFn is a seam over grpcclient.Connect — the ladder's last,
+// unauthenticated rung — so a test can prove that rung was never reached.
+var plaintextConnectFn = grpcclient.Connect
+
+// newDialTarget resolves the pin for pinKey and returns a target constrained by
+// it. Key resolution deliberately may read discovery-derived names: choosing
+// the wrong key can only ever produce a mismatch — a stricter outcome — never
+// a bypass, because the trust decision itself stays on the certificate.
+func newDialTarget(pinKey, addr string) dialTarget {
+	return dialTarget{PinKey: pinKey, Addr: addr, Expected: expectedIdentityFor(pinKey)}
+}
+
+// pinKeyForAddr extracts the pin key from the address a caller was asked to
+// reach, BEFORE any resolution: the host as the user named it. That is the same
+// key enforceDevicePin records under, so the two agree on what "this device"
+// means. A resolved IP is deliberately never used as a key — it changes on
+// ordinary DHCP churn — but an address the user typed as a literal IP is the
+// name they asked for, so it keys a pin like any other host.
+func pinKeyForAddr(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return strings.TrimSpace(addr)
+	}
+	return host
+}
+
+// expectedIdentityFor returns the asset identity pinned for pinKey, or nil when
+// the host is unpinned or its pin predates asset ids. Nil means "first contact
+// is permissive" — the posture that keeps legacy and unprovisioned devices
+// working; the pin is written on the first successful connect.
+func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
+	if pinKey == "" {
+		return nil
+	}
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return nil
+	}
+	pin, ok := cfg.DevicePinFor(pinKey)
+	if !ok || pin.AssetID == "" {
+		return nil
+	}
+	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
+}
+
+// isPinned reports whether pinKey has any recorded pin. A pinned host has been
+// reached over mTLS before, so the ladder must not offer it the plaintext rung.
+//
+// This deliberately asks local state a question with a yes/no answer instead of
+// inspecting the dial errors: the previous refusal was an accident of
+// isCertRejectionError happening to match gRPC's "authentication handshake
+// failed" wrapper, which any change to gRPC's error text would silently undo.
+func isPinned(pinKey string) bool {
+	if pinKey == "" {
+		return false
+	}
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return false
+	}
+	_, ok := cfg.DevicePinFor(pinKey)
+	return ok
+}
+
+// identityRefusal renders a wrong-device rejection. Same text in interactive,
+// JSON, and non-interactive modes — there is deliberately no "trust this?"
+// prompt, because a MITM warning that can be dismissed gets dismissed.
+func identityRefusal(pinKey string, im *certs.IdentityMismatchError) error {
+	got := "no wendy identity"
+	if im.GotAsset != "" {
+		got = fmt.Sprintf("asset %s in organization %d", im.GotAsset, im.GotOrg)
+	}
+	return fmt.Errorf(
+		"device %q is pinned to asset %s in organization %d, but the host answering presented %s; refusing to connect — if this device was legitimately replaced or re-enrolled, run 'wendy device unpin %s'",
+		pinKey, im.WantAsset, im.WantOrg, got, pinKey)
+}
+
+func pinnedHostWentUnauthenticatedError(pinKey string) error {
+	return fmt.Errorf(
+		"device %q is pinned to an enrolled identity but no authenticated endpoint answered; refusing to fall back to an unauthenticated connection — if it was reflashed or factory reset, run 'wendy device unpin %s'",
+		pinKey, pinKey)
+}

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -52,6 +52,28 @@ func (t dialTarget) refusalKey() string {
 	return t.PinKey
 }
 
+// pinned reports whether a pin governs this dial, answered entirely from what
+// newDialTarget already resolved. A pinned host has been reached over mTLS
+// before, so the ladder must not offer it the plaintext rung.
+//
+// It reads the target rather than re-reading pin state because one connect must
+// make ONE decision about what the pin says. The guard used to call back into
+// the config for a second, independent answer, which could disagree with the
+// first — a cloud seeding or an unpin landing from another process mid-ladder
+// would have the plaintext rung consult a pin state that never produced this
+// target's Expected or refusalKey. Deriving both from the same resolution makes
+// that disagreement unrepresentable.
+//
+// PinnedKey is non-empty for exactly the dials lookupPin found a pin for, and
+// never empty when it did: the key comes from pinCandidateKeys, which drops
+// empty candidates, so "a pin governs" and "we know the key it is filed under"
+// are the same fact. Expected is deliberately NOT consulted — it is set only
+// when a pin names an asset, so a pin without one would read as unpinned, and
+// the constraint Expected carries is enforced in VerifyConnection, not here.
+func (t dialTarget) pinned() bool {
+	return t.PinnedKey != ""
+}
+
 // loadConfigForPinFn is a seam over config.Load for tests.
 var loadConfigForPinFn = config.Load
 
@@ -135,19 +157,6 @@ func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
 		return nil
 	}
 	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
-}
-
-// isPinned reports whether pinKey has any recorded pin under any of its
-// candidate keys. A pinned host has been reached over mTLS before, so the
-// ladder must not offer it the plaintext rung.
-//
-// This deliberately asks local state a question with a yes/no answer instead of
-// inspecting the dial errors: the previous refusal was an accident of
-// isCertRejectionError happening to match gRPC's "authentication handshake
-// failed" wrapper, which any change to gRPC's error text would silently undo.
-func isPinned(pinKey string) bool {
-	_, _, ok := governingPin(pinKey)
-	return ok
 }
 
 // pinCandidateKeys returns the keys a pin for pinKey may have been recorded

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 )
 
 // dialTarget carries what the ladder needs to know about *who* it is dialing,
@@ -21,11 +23,33 @@ type dialTarget struct {
 	// ordinary DHCP churn and would train users to unpin reflexively. An empty
 	// PinKey disables pin enforcement for this dial.
 	PinKey string
+	// PinnedKey is the key the governing pin is ACTUALLY filed under, which is
+	// not always PinKey: lookupPin resolves a pin across every name the device
+	// answers to, so dialling "wendyos-calm-zinnia" can be governed by a pin
+	// recorded under the cloud roster's "calm-zinnia". Empty when no pin
+	// governs this dial.
+	//
+	// It exists because a refusal has to name a key `wendy device unpin` can
+	// act on. Naming the dialled key when an alias holds the pin sends the user
+	// to a command that clears nothing, and the next dial refuses identically —
+	// a permanent dead end dressed up as an escape hatch.
+	PinnedKey string
 	// Addr is the host:port actually dialed.
 	Addr string
 	// Expected constrains the peer certificate. Non-nil only when a pin (or a
 	// cloud-seeded value) names a specific asset.
 	Expected *certs.WendyIdentity
+}
+
+// refusalKey is the name a refusal for this dial must print: the key the pin is
+// filed under when one governs, else the name the user asked for. Falling back
+// to PinKey keeps a hand-built dialTarget (and any future caller that sets only
+// PinKey) naming something rather than an empty string.
+func (t dialTarget) refusalKey() string {
+	if t.PinnedKey != "" {
+		return t.PinnedKey
+	}
+	return t.PinKey
 }
 
 // loadConfigForPinFn is a seam over config.Load for tests.
@@ -44,12 +68,44 @@ var plaintextConnectFn = grpcclient.Connect
 // device and the plaintext rung.
 var identityMismatchFn = (*grpcclient.AgentConnection).IdentityMismatch
 
+// pinMismatchFn is the same seam for the SPKI store's rejection. It is seamed
+// for the same reason: only a real handshake against a device whose key rotated
+// can set the flag, so testing the ladder's REACTION to it — abort, no
+// plaintext rung, a message naming `wendy device unpin` — needs the read
+// stubbed rather than a live ML-DSA peer with a rotated keypair.
+var pinMismatchFn = (*grpcclient.AgentConnection).PinMismatch
+
 // newDialTarget resolves the pin for pinKey and returns a target constrained by
 // it. Key resolution deliberately may read discovery-derived names: choosing
 // the wrong key can only ever produce a mismatch — a stricter outcome — never
 // a bypass, because the trust decision itself stays on the certificate.
 func newDialTarget(pinKey, addr string) dialTarget {
-	return dialTarget{PinKey: pinKey, Addr: addr, Expected: expectedIdentityFor(pinKey)}
+	target := dialTarget{PinKey: pinKey, Addr: addr}
+	pin, key, ok := governingPin(pinKey)
+	if !ok {
+		return target
+	}
+	target.PinnedKey = key
+	if pin.AssetID != "" {
+		target.Expected = &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
+	}
+	return target
+}
+
+// governingPin resolves the pin that governs pinKey across every name the
+// device answers to, returning it and the key it is actually filed under. It is
+// the single reader of pin state on the dial path, so the identity a dial
+// enforces, the fact that it is pinned, and the key a refusal names can never
+// disagree about which pin they are talking about.
+func governingPin(pinKey string) (config.DevicePin, string, bool) {
+	if pinKey == "" {
+		return config.DevicePin{}, "", false
+	}
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return config.DevicePin{}, "", false
+	}
+	return lookupPin(cfg, pinKey)
 }
 
 // pinKeyForAddr extracts the pin key from the address a caller was asked to
@@ -74,14 +130,7 @@ func pinKeyForAddr(addr string) string {
 // The lookup goes through lookupPin, so a pin recorded under any of the
 // device's names — hostname, mesh name, or display name — is honoured here.
 func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
-	if pinKey == "" {
-		return nil
-	}
-	cfg, err := loadConfigForPinFn()
-	if err != nil {
-		return nil
-	}
-	pin, _, ok := lookupPin(cfg, pinKey)
+	pin, _, ok := governingPin(pinKey)
 	if !ok || pin.AssetID == "" {
 		return nil
 	}
@@ -97,14 +146,7 @@ func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
 // isCertRejectionError happening to match gRPC's "authentication handshake
 // failed" wrapper, which any change to gRPC's error text would silently undo.
 func isPinned(pinKey string) bool {
-	if pinKey == "" {
-		return false
-	}
-	cfg, err := loadConfigForPinFn()
-	if err != nil {
-		return false
-	}
-	_, _, ok := lookupPin(cfg, pinKey)
+	_, _, ok := governingPin(pinKey)
 	return ok
 }
 
@@ -198,6 +240,32 @@ func lookupPin(cfg *config.Config, pinKey string) (config.DevicePin, string, boo
 	return best, bestKey, found
 }
 
+// errDeviceIdentityRefused is what every refusal in this package answers
+// errors.Is to. It exists so a caller can tell "the device you asked for is not
+// what answered" apart from "nothing answered" WITHOUT matching on message
+// text: the picker's Bluetooth fallback turns on exactly that distinction, and
+// a fallback that silently reaches the rejected device over a second transport
+// is the refusal undone.
+var errDeviceIdentityRefused = errors.New("device identity refused")
+
+// deviceIdentityRefusalError carries a refusal's full user-facing text while
+// staying recognisable to errors.Is. The text is the whole message rather than
+// a wrap so the refusals read exactly as they did before this type existed.
+type deviceIdentityRefusalError struct{ msg string }
+
+func (e *deviceIdentityRefusalError) Error() string { return e.msg }
+
+func (e *deviceIdentityRefusalError) Is(target error) bool {
+	return target == errDeviceIdentityRefused
+}
+
+// refuseIdentity builds a refusal that errors.Is(err, errDeviceIdentityRefused)
+// recognises. Every refusal raised because the wrong device answered — here and
+// in device_pin.go — must go through it.
+func refuseIdentity(format string, args ...any) error {
+	return &deviceIdentityRefusalError{msg: fmt.Sprintf(format, args...)}
+}
+
 // identityRefusal renders a wrong-device rejection. Same text in interactive,
 // JSON, and non-interactive modes — there is deliberately no "trust this?"
 // prompt, because a MITM warning that can be dismissed gets dismissed.
@@ -206,13 +274,34 @@ func identityRefusal(pinKey string, im *certs.IdentityMismatchError) error {
 	if im.GotAsset != "" {
 		got = fmt.Sprintf("asset %s in organization %d", im.GotAsset, im.GotOrg)
 	}
-	return fmt.Errorf(
+	return refuseIdentity(
 		"device %q is pinned to asset %s in organization %d, but the host answering presented %s; refusing to connect — if this device was legitimately replaced or re-enrolled, run 'wendy device unpin %s'",
 		pinKey, im.WantAsset, im.WantOrg, got, pinKey)
 }
 
 func pinnedHostWentUnauthenticatedError(pinKey string) error {
-	return fmt.Errorf(
+	return refuseIdentity(
 		"device %q is pinned to an enrolled identity but no authenticated endpoint answered; refusing to fall back to an unauthenticated connection — if it was reflashed or factory reset, run 'wendy device unpin %s'",
 		pinKey, pinKey)
+}
+
+// spkiRefusal renders the OTHER pin's rejection: the SPKI store's, which is
+// keyed by the certificate's own asset URN rather than by hostname and fires
+// when a device's public key changes while its pinned certificate is still
+// valid.
+//
+// Without this the store's PinMismatchError reached the user only as whatever
+// text survived gRPC's handshake wrapper — a message that names neither the
+// host as the user knows it nor any way out, leaving hand-editing
+// known_devices.json as the only recovery. The SPKI store has no hostname in
+// it, so the key comes from the dial: pinKey when there is one, the store's own
+// display name otherwise.
+func spkiRefusal(pinKey string, pm *devicepin.PinMismatchError) error {
+	named := pinKey
+	if named == "" {
+		named = pm.DisplayName
+	}
+	return refuseIdentity(
+		"device %q presented a different certificate key than the one pinned for %s (pinned %s, now %s); refusing to connect — if its certificate was legitimately reissued, run 'wendy device unpin %s'",
+		named, pm.Key, pm.Want, pm.Got, named)
 }

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -161,6 +161,15 @@ func pinCandidateKeys(pinKey string) []string {
 // local network presented. Among pins of equal source the earliest candidate
 // wins, which keeps the dialed name authoritative over an alias.
 //
+// That precedence yields to one invariant: an asset-less cloud pin never
+// displaces an incumbent carrying an asset id. Cloud authority decides WHICH
+// binding to believe, and applying it is worth nothing if it leaves
+// expectedIdentityFor with no binding to enforce — a host constrained to one
+// asset would become constrained to none, which is exactly the same-CA-host
+// redirect this path exists to stop. An asset-less pin is a real state, not a
+// hypothetical: config's EvaluateDevicePin carries a dedicated branch for a
+// cloud-sourced pin with no asset id.
+//
 // Because the search only ever adds keys, a host pinned under pinKey stays
 // pinned no matter what the cache says or fails to say — the property that lets
 // the cache be consulted best-effort without a cache outage quietly switching
@@ -181,7 +190,8 @@ func lookupPin(cfg *config.Config, pinKey string) (config.DevicePin, string, boo
 			best, bestKey, found = pin, key, true
 			continue
 		}
-		if best.Source != config.PinSourceCloud && pin.Source == config.PinSourceCloud {
+		if best.Source != config.PinSourceCloud && pin.Source == config.PinSourceCloud &&
+			(pin.AssetID != "" || best.AssetID == "") {
 			best, bestKey = pin, key
 		}
 	}

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -165,11 +165,17 @@ func isPinned(pinKey string) bool {
 // an alias that is only a cosmetic variant of the dialed name never produces a
 // second, redundant candidate, and empty names are never looked up.
 //
-// Reading discovery-derived names to pick a key is safe in a way that reading
-// them to make a trust decision would not be: consulting an extra candidate can
-// only ever FIND a pin, never discard one, so an attacker-chosen alias can at
-// most impose a constraint that the real device fails — a stricter outcome, not
-// a bypass. The trust decision itself stays on the certificate.
+// Reading discovery-derived names to pick a key is safe FOR LOOKUP in a way
+// that reading them to make a trust decision would not be: consulting an extra
+// candidate can only ever FIND a pin, never discard one, so an attacker-chosen
+// alias can at most impose a constraint that the real device fails — a stricter
+// outcome, not a bypass. The trust decision itself stays on the certificate.
+//
+// That justification is about lookup and does not carry to clearing. A caller
+// that DELETES every candidate turns the same attacker-chosen alias into a way
+// to drop another device's pin, which is a bypass — see clearPinsGoverning,
+// which consumes this list but removes an alias's pin only when it names the
+// same device as the governing one.
 func pinCandidateKeys(pinKey string) []string {
 	if pinKey == "" {
 		return nil
@@ -296,12 +302,29 @@ func pinnedHostWentUnauthenticatedError(pinKey string) error {
 // known_devices.json as the only recovery. The SPKI store has no hostname in
 // it, so the key comes from the dial: pinKey when there is one, the store's own
 // display name otherwise.
+//
+// The command it prints names pm.Key — the SPKI store's own key — not the
+// hostname, even though the hostname is what the user recognises. Naming the
+// hostname is what made this refusal a dead end for the two populations that
+// hit it most: the picker and `wendy device list` dial the IP first, so the
+// message named an IP that keys nothing and whose asset nothing in local state
+// can derive; and agents that never advertise `orgid` (the Swift macOS agent,
+// Linux agents before 2026-07-18) leave the discovery cache with no identity to
+// derive it from either. pm.Key is in hand at the moment of refusal and is
+// exactly what the store is keyed by, so `wendy device unpin <urn>` reaches the
+// entry directly — and clears any config pin naming the same identity with it.
 func spkiRefusal(pinKey string, pm *devicepin.PinMismatchError) error {
 	named := pinKey
 	if named == "" {
 		named = pm.DisplayName
 	}
+	// A store key is always present in a real mismatch; fall back to the name
+	// only so a hand-built error still points at something.
+	unpinArg := pm.Key
+	if unpinArg == "" {
+		unpinArg = named
+	}
 	return refuseIdentity(
 		"device %q presented a different certificate key than the one pinned for %s (pinned %s, now %s); refusing to connect — if its certificate was legitimately reissued, run 'wendy device unpin %s'",
-		named, pm.Key, pm.Want, pm.Got, named)
+		named, pm.Key, pm.Want, pm.Got, unpinArg)
 }

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -35,6 +35,15 @@ var loadConfigForPinFn = config.Load
 // unauthenticated rung — so a test can prove that rung was never reached.
 var plaintextConnectFn = grpcclient.Connect
 
+// identityMismatchFn is a seam over the ladder's reading of a wrong-device
+// rejection. The flag itself can only be set by a real TLS handshake — the
+// VerifyConnection sink owns the unexported field — so seaming the ladder's
+// CONSUMPTION of it is what puts the abort under test without a live ML-DSA
+// peer. That abort matters on its own: once a cloud-seeded Expected can exist
+// for a host with no config pin, it is the only thing standing between a wrong
+// device and the plaintext rung.
+var identityMismatchFn = (*grpcclient.AgentConnection).IdentityMismatch
+
 // newDialTarget resolves the pin for pinKey and returns a target constrained by
 // it. Key resolution deliberately may read discovery-derived names: choosing
 // the wrong key can only ever produce a mismatch — a stricter outcome — never

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -8,9 +8,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +21,264 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
 )
+
+// setPinCache installs a deviceCacheLoadFn serving exactly entries, so a pin
+// lookup test controls the alias names (mesh/display) its candidate list can
+// see instead of reading whatever the developer's real ~/.wendy/devices.json
+// happens to hold.
+func setPinCache(t *testing.T, entries ...discoverycache.Entry) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "devices.json")
+	seedDeviceCache(t, path, entries...)
+	orig := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) { return discoverycache.LoadFrom(path) }
+	t.Cleanup(func() { deviceCacheLoadFn = orig })
+}
+
+// setFailingPinCache installs a deviceCacheLoadFn that cannot open the cache at
+// all — the degradation path every pin lookup must survive.
+func setFailingPinCache(t *testing.T) {
+	t.Helper()
+	orig := deviceCacheLoadFn
+	deviceCacheLoadFn = func() (*discoverycache.Cache, error) {
+		return nil, errors.New("device cache unavailable")
+	}
+	t.Cleanup(func() { deviceCacheLoadFn = orig })
+}
+
+// setPinConfig installs a config through the loadConfigForPinFn seam so a pin
+// lookup test never touches the real config file.
+func setPinConfig(t *testing.T, pins map[string]config.DevicePin) {
+	t.Helper()
+	cfg := &config.Config{DevicePins: pins}
+	orig := loadConfigForPinFn
+	loadConfigForPinFn = func() (*config.Config, error) { return cfg, nil }
+	t.Cleanup(func() { loadConfigForPinFn = orig })
+}
+
+// TestPinCandidateKeysSingleKeyWithoutCache: with nothing cached under the
+// dialled hostname there are no aliases to add, so the candidate list is
+// exactly today's single key. This is the shape every legacy caller sees.
+func TestPinCandidateKeysSingleKeyWithoutCache(t *testing.T) {
+	setPinCache(t) // empty cache, no entries at all
+
+	got := pinCandidateKeys("wendyos-calm-zinnia.local")
+	want := []string{"wendyos-calm-zinnia.local"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pinCandidateKeys = %q, want %q — an empty cache must degrade to the single dialled key", got, want)
+	}
+
+	if keys := pinCandidateKeys(""); len(keys) != 0 {
+		t.Fatalf("pinCandidateKeys(\"\") = %q, want none — an empty key disables pin enforcement", keys)
+	}
+}
+
+// TestPinCandidateKeysAddsMeshThenDisplayName: the cache entry matched by
+// hostname contributes its mesh name and then its display name, in that order,
+// after the dialled key. Deduplication is by the same normalisation the pin
+// store uses, so a display name that is only a cosmetic variant of the dialled
+// host does not produce a second, redundant candidate.
+func TestPinCandidateKeysAddsMeshThenDisplayName(t *testing.T) {
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "calm-zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+		MeshName:    "calm-zinnia.acme.cloud.wendy.dev",
+	})
+
+	got := pinCandidateKeys("wendyos-calm-zinnia.local")
+	want := []string{"wendyos-calm-zinnia.local", "calm-zinnia.acme.cloud.wendy.dev", "calm-zinnia"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pinCandidateKeys = %q, want %q (dialled key, then mesh name, then display name)", got, want)
+	}
+
+	// Dedup: a display name that normalises onto the dialled key must not
+	// repeat it, and an empty mesh name must not become an empty candidate.
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-2",
+		DisplayName: "WendyOS-Calm-Zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+	})
+	got = pinCandidateKeys("wendyos-calm-zinnia.local")
+	want = []string{"wendyos-calm-zinnia.local"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pinCandidateKeys = %q, want %q — empties dropped and the dialled key never repeated", got, want)
+	}
+}
+
+// TestExpectedIdentityForFindsPinUnderMeshName is the defect this task closes:
+// a pin recorded under a name that is not the mDNS hostname — cloud seeding
+// writes the asset name, and mesh addressing uses the mesh name — was inert
+// because every dial path looked up the hostname alone.
+func TestExpectedIdentityForFindsPinUnderMeshName(t *testing.T) {
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "calm-zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+		MeshName:    "calm-zinnia.acme.cloud.wendy.dev",
+	})
+	setPinConfig(t, map[string]config.DevicePin{
+		"calm-zinnia.acme.cloud.wendy.dev": {OrgID: 7, AssetID: "42", Source: config.PinSourceCloud},
+	})
+
+	got := expectedIdentityFor("wendyos-calm-zinnia.local")
+	if got == nil {
+		t.Fatal("expectedIdentityFor = nil for a host pinned under its mesh name; the pin is inert and enforcement is off")
+	}
+	want := certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"}
+	if *got != want {
+		t.Fatalf("expectedIdentityFor = %+v, want %+v", *got, want)
+	}
+	if !isPinned("wendyos-calm-zinnia.local") {
+		t.Fatal("isPinned = false for a host pinned under its mesh name; the ladder would offer it the plaintext rung")
+	}
+}
+
+// TestLookupPinCloudBeatsEarlierLAN: cloud spoke to the org over an
+// authenticated session, a LAN sighting did not — so a cloud pin under a later
+// candidate outranks a LAN pin under an earlier one. Among equal sources the
+// earliest candidate still wins.
+func TestLookupPinCloudBeatsEarlierLAN(t *testing.T) {
+	entry := discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "calm-zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+		MeshName:    "calm-zinnia.acme.cloud.wendy.dev",
+	}
+
+	t.Run("cloud under display name beats lan under the dialled key", func(t *testing.T) {
+		setPinCache(t, entry)
+		setPinConfig(t, map[string]config.DevicePin{
+			"wendyos-calm-zinnia":              {OrgID: 7, AssetID: "1", Source: config.PinSourceLAN},
+			"calm-zinnia.acme.cloud.wendy.dev": {OrgID: 7, AssetID: "2", Source: config.PinSourceLAN},
+			"calm-zinnia":                      {OrgID: 7, AssetID: "42", Source: config.PinSourceCloud},
+		})
+		cfg, err := loadConfigForPinFn()
+		if err != nil {
+			t.Fatalf("loadConfigForPinFn: %v", err)
+		}
+
+		pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+		if !ok {
+			t.Fatal("lookupPin found nothing despite three matching pins")
+		}
+		if key != "calm-zinnia" || pin.AssetID != "42" {
+			t.Fatalf("lookupPin = %+v under %q, want the cloud pin (asset 42) under \"calm-zinnia\"; cloud is authority regardless of candidate position", pin, key)
+		}
+		if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got == nil || got.EntityID != "42" {
+			t.Fatalf("expectedIdentityFor = %+v, want the cloud pin's asset 42", got)
+		}
+	})
+
+	t.Run("equal sources keep the earliest candidate", func(t *testing.T) {
+		setPinCache(t, entry)
+		setPinConfig(t, map[string]config.DevicePin{
+			"wendyos-calm-zinnia":              {OrgID: 7, AssetID: "1", Source: config.PinSourceLAN},
+			"calm-zinnia.acme.cloud.wendy.dev": {OrgID: 7, AssetID: "2", Source: config.PinSourceLAN},
+			"calm-zinnia":                      {OrgID: 7, AssetID: "3", Source: config.PinSourceLAN},
+		})
+		cfg, err := loadConfigForPinFn()
+		if err != nil {
+			t.Fatalf("loadConfigForPinFn: %v", err)
+		}
+
+		pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+		if !ok {
+			t.Fatal("lookupPin found nothing despite three matching pins")
+		}
+		if key != "wendyos-calm-zinnia.local" || pin.AssetID != "1" {
+			t.Fatalf("lookupPin = %+v under %q, want the dialled key's pin (asset 1); among equal sources the earliest candidate wins", pin, key)
+		}
+	})
+
+	t.Run("first cloud pin wins over a later cloud pin", func(t *testing.T) {
+		setPinCache(t, entry)
+		setPinConfig(t, map[string]config.DevicePin{
+			"calm-zinnia.acme.cloud.wendy.dev": {OrgID: 7, AssetID: "2", Source: config.PinSourceCloud},
+			"calm-zinnia":                      {OrgID: 7, AssetID: "3", Source: config.PinSourceCloud},
+		})
+		cfg, err := loadConfigForPinFn()
+		if err != nil {
+			t.Fatalf("loadConfigForPinFn: %v", err)
+		}
+
+		pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+		if !ok {
+			t.Fatal("lookupPin found nothing despite two matching cloud pins")
+		}
+		if key != "calm-zinnia.acme.cloud.wendy.dev" || pin.AssetID != "2" {
+			t.Fatalf("lookupPin = %+v under %q, want the mesh-name cloud pin (asset 2); it is the earlier candidate", pin, key)
+		}
+	})
+}
+
+// TestLookupPinCacheFailureDegradesToSingleKey is the regression that matters
+// most: an unreadable cache must fall back to today's single-key behaviour. If
+// it instead reported the host unpinned, enforcement would silently switch off
+// and the ladder would offer a pinned host the plaintext rung.
+func TestLookupPinCacheFailureDegradesToSingleKey(t *testing.T) {
+	setFailingPinCache(t)
+	setPinConfig(t, map[string]config.DevicePin{
+		"wendyos-calm-zinnia": {OrgID: 7, AssetID: "42", Source: config.PinSourceLAN},
+		// Reachable only via the cache's aliases, which are unavailable here.
+		"calm-zinnia": {OrgID: 7, AssetID: "43", Source: config.PinSourceCloud},
+	})
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		t.Fatalf("loadConfigForPinFn: %v", err)
+	}
+
+	if got := pinCandidateKeys("wendyos-calm-zinnia.local"); !reflect.DeepEqual(got, []string{"wendyos-calm-zinnia.local"}) {
+		t.Fatalf("pinCandidateKeys = %q, want just the dialled key when the cache cannot be opened", got)
+	}
+
+	pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+	if !ok {
+		t.Fatal("lookupPin reported UNPINNED because the cache could not be opened; a cache failure must never disable enforcement for a host that is pinned under its own key")
+	}
+	if key != "wendyos-calm-zinnia.local" || pin.AssetID != "42" {
+		t.Fatalf("lookupPin = %+v under %q, want the dialled key's pin (asset 42)", pin, key)
+	}
+	if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got == nil || got.EntityID != "42" {
+		t.Fatalf("expectedIdentityFor = %+v, want asset 42 — the constraint must survive a cache failure", got)
+	}
+	if !isPinned("wendyos-calm-zinnia.local") {
+		t.Fatal("isPinned = false after a cache failure; the pinned host would be offered the plaintext rung")
+	}
+}
+
+// TestIsPinnedAnyCandidate: a pin under any candidate makes the host pinned,
+// even when it carries no asset id (so it constrains nothing) — the pin's mere
+// existence is what forbids the plaintext rung.
+func TestIsPinnedAnyCandidate(t *testing.T) {
+	setPinCache(t, discoverycache.Entry{
+		ID:          "dev-1",
+		DisplayName: "calm-zinnia",
+		Hostname:    "wendyos-calm-zinnia.local",
+		MeshName:    "calm-zinnia.acme.cloud.wendy.dev",
+	})
+
+	for _, key := range []string{"wendyos-calm-zinnia", "calm-zinnia.acme.cloud.wendy.dev", "calm-zinnia"} {
+		t.Run("pinned under "+key, func(t *testing.T) {
+			setPinConfig(t, map[string]config.DevicePin{key: {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443"}})
+			if !isPinned("wendyos-calm-zinnia.local") {
+				t.Fatalf("isPinned = false with a pin recorded under %q, want true", key)
+			}
+			if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got != nil {
+				t.Fatalf("expectedIdentityFor = %+v, want nil — an asset-less pin constrains nothing", *got)
+			}
+		})
+	}
+
+	t.Run("no candidate pinned", func(t *testing.T) {
+		setPinConfig(t, map[string]config.DevicePin{"some-other-device": {OrgID: 7}})
+		if isPinned("wendyos-calm-zinnia.local") {
+			t.Fatal("isPinned = true with no pin under any candidate key")
+		}
+	})
+}
 
 func TestExpectedIdentityFor(t *testing.T) {
 	cases := []struct {
@@ -45,6 +305,10 @@ func TestExpectedIdentityFor(t *testing.T) {
 	// normalisation the ladder depends on.
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// An empty cache contributes no alias candidates, so this case
+			// stays a pure single-key lookup and never reads the developer's
+			// real ~/.wendy/devices.json.
+			setPinCache(t)
 			cfg := &config.Config{}
 			if tc.pin != nil {
 				cfg.DevicePins = map[string]config.DevicePin{"orin": *tc.pin}

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -132,8 +132,8 @@ func TestExpectedIdentityForFindsPinUnderMeshName(t *testing.T) {
 	if *got != want {
 		t.Fatalf("expectedIdentityFor = %+v, want %+v", *got, want)
 	}
-	if !isPinned("wendyos-calm-zinnia.local") {
-		t.Fatal("isPinned = false for a host pinned under its mesh name; the ladder would offer it the plaintext rung")
+	if !newDialTarget("wendyos-calm-zinnia.local", "10.0.0.9:50051").pinned() {
+		t.Fatal("dialTarget.pinned = false for a host pinned under its mesh name; the ladder would offer it the plaintext rung")
 	}
 }
 
@@ -297,15 +297,15 @@ func TestLookupPinCacheFailureDegradesToSingleKey(t *testing.T) {
 	if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got == nil || got.EntityID != "42" {
 		t.Fatalf("expectedIdentityFor = %+v, want asset 42 — the constraint must survive a cache failure", got)
 	}
-	if !isPinned("wendyos-calm-zinnia.local") {
-		t.Fatal("isPinned = false after a cache failure; the pinned host would be offered the plaintext rung")
+	if !newDialTarget("wendyos-calm-zinnia.local", "10.0.0.9:50051").pinned() {
+		t.Fatal("dialTarget.pinned = false after a cache failure; the pinned host would be offered the plaintext rung")
 	}
 }
 
-// TestIsPinnedAnyCandidate: a pin under any candidate makes the host pinned,
+// TestPinnedAnyCandidate: a pin under any candidate makes the host pinned,
 // even when it carries no asset id (so it constrains nothing) — the pin's mere
 // existence is what forbids the plaintext rung.
-func TestIsPinnedAnyCandidate(t *testing.T) {
+func TestPinnedAnyCandidate(t *testing.T) {
 	setPinCache(t, discoverycache.Entry{
 		ID:          "dev-1",
 		DisplayName: "calm-zinnia",
@@ -316,8 +316,8 @@ func TestIsPinnedAnyCandidate(t *testing.T) {
 	for _, key := range []string{"wendyos-calm-zinnia", "calm-zinnia.acme.cloud.wendy.dev", "calm-zinnia"} {
 		t.Run("pinned under "+key, func(t *testing.T) {
 			setPinConfig(t, map[string]config.DevicePin{key: {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443"}})
-			if !isPinned("wendyos-calm-zinnia.local") {
-				t.Fatalf("isPinned = false with a pin recorded under %q, want true", key)
+			if !newDialTarget("wendyos-calm-zinnia.local", "10.0.0.9:50051").pinned() {
+				t.Fatalf("dialTarget.pinned = false with a pin recorded under %q, want true", key)
 			}
 			if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got != nil {
 				t.Fatalf("expectedIdentityFor = %+v, want nil — an asset-less pin constrains nothing", *got)
@@ -327,8 +327,8 @@ func TestIsPinnedAnyCandidate(t *testing.T) {
 
 	t.Run("no candidate pinned", func(t *testing.T) {
 		setPinConfig(t, map[string]config.DevicePin{"some-other-device": {OrgID: 7}})
-		if isPinned("wendyos-calm-zinnia.local") {
-			t.Fatal("isPinned = true with no pin under any candidate key")
+		if newDialTarget("wendyos-calm-zinnia.local", "10.0.0.9:50051").pinned() {
+			t.Fatal("dialTarget.pinned = true with no pin under any candidate key")
 		}
 	})
 }
@@ -388,8 +388,8 @@ func TestExpectedIdentityFor(t *testing.T) {
 			if (target.Expected == nil) != (tc.want == nil) {
 				t.Fatalf("newDialTarget Expected = %v, want the same constraint as expectedIdentityFor (%v)", target.Expected, tc.want)
 			}
-			if want := tc.pin != nil; isPinned("orin.local") != want {
-				t.Fatalf("isPinned = %v, want %v", !want, want)
+			if want := tc.pin != nil; target.pinned() != want {
+				t.Fatalf("dialTarget.pinned = %v, want %v", !want, want)
 			}
 			if target.Addr != "10.0.0.9:50051" || target.PinKey != "orin.local" {
 				t.Fatalf("newDialTarget = %+v, want the requested name and the dialled address", target)
@@ -460,11 +460,70 @@ func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
 	}
 }
 
+// TestPlaintextGuardUsesTheTargetsResolvedPin locks in that one connect makes
+// ONE decision about what the pin says.
+//
+// The guard used to re-read pin state at the bottom of the ladder, independently
+// of the read that produced target.Expected and target.refusalKey. Those two
+// reads can disagree: every `wendy` invocation shares one config file, so a
+// cloud seeding or an `unpin` landing in another process while the mTLS rungs
+// are being tried changes the answer mid-connect. Disagreeing in the unpinned
+// direction is the dangerous one — it hands a host that was pinned when the
+// connect started an unauthenticated connection.
+//
+// The seam swap below stands in for that concurrent write. It is the honest
+// shape of the bug: nothing about the target changed, only the state a second
+// read would observe.
+func TestPlaintextGuardUsesTheTargetsResolvedPin(t *testing.T) {
+	setTempConfig(t, &config.Config{DevicePins: map[string]config.DevicePin{
+		"orin": {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443", AssetID: "42", Source: config.PinSourceLAN},
+	}})
+	setPinCache(t)
+
+	target := newDialTarget("orin.local", deadAgentAddr(t))
+	if !target.pinned() {
+		t.Fatal("test precondition: orin.local must be pinned at the moment the target is built")
+	}
+
+	// The pin vanishes after the target is resolved and before the ladder
+	// reaches its last rung.
+	origLoad := loadConfigForPinFn
+	loadConfigForPinFn = func() (*config.Config, error) { return &config.Config{}, nil }
+	t.Cleanup(func() { loadConfigForPinFn = origLoad })
+
+	plaintextCalls := 0
+	origPlaintext := plaintextConnectFn
+	plaintextConnectFn = func(context.Context, string) (*grpcclient.AgentConnection, error) {
+		plaintextCalls++
+		return grpcclient.NewFromConn(nil), nil
+	}
+	t.Cleanup(func() { plaintextConnectFn = origPlaintext })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	conn, _, err := dialAgentLadderWithCerts(ctx, target, []config.CertificateInfo{selfSignedCLICert(t, 7)})
+	if conn != nil {
+		conn.Close()
+	}
+
+	if plaintextCalls != 0 {
+		t.Fatalf("plaintext rung attempted %d times for a target that was pinned when the connect started; the guard re-read pin state instead of using the dial's own resolution", plaintextCalls)
+	}
+	if err == nil || !strings.Contains(err.Error(), "refusing to fall back to an unauthenticated connection") {
+		t.Fatalf("err = %v, want the pinned-host refusal", err)
+	}
+	// The refusal still names the key the governing pin was filed under, from
+	// the same resolution — not a key looked up again against the new state.
+	if !strings.Contains(err.Error(), "wendy device unpin orin.local") {
+		t.Fatalf("err = %v, want the refusal to name the resolved pin key", err)
+	}
+}
+
 // TestWrongDeviceAbortsLadder covers the other half of the enforcement: a peer
 // that proves it is the WRONG device ends the ladder there and then.
 //
-// The pin key here is deliberately UNPINNED, so isPinned cannot be what
-// suppresses the plaintext rung — only the abort can. That is the configuration
+// The pin key here is deliberately UNPINNED, so the pinned-host guard cannot be
+// what suppresses the plaintext rung — only the abort can. That is the configuration
 // Task 8 introduces for real: a cloud-seeded Expected with no config pin behind
 // it, where this abort is the single thing between a wrong device and an
 // unauthenticated connection.
@@ -473,7 +532,7 @@ func TestWrongDeviceAbortsLadder(t *testing.T) {
 	// As above: an explicit empty cache, so no alias key can turn this
 	// deliberately-unpinned host into a pinned one.
 	setPinCache(t)
-	if isPinned("orin.local") {
+	if newDialTarget("orin.local", "10.0.0.9:50051").pinned() {
 		t.Fatal("test precondition: orin.local must be unpinned, so only the abort can refuse plaintext")
 	}
 
@@ -627,12 +686,12 @@ func TestRefusalNamesTheKeyTheGoverningPinIsFiledUnder(t *testing.T) {
 // message naming neither the host as the user knows it nor any way out. The
 // pin key here is deliberately UNPINNED in config, which is the real shape of
 // the problem: `wendy device list` SPKI-pins every device the prober enumerates
-// without writing a single config pin, so isPinned cannot be what refuses the
-// plaintext rung here — only the abort can.
+// without writing a single config pin, so the pinned-host guard cannot be what
+// refuses the plaintext rung here — only the abort can.
 func TestSPKIMismatchAbortsLadderAndNamesUnpin(t *testing.T) {
 	setTempConfig(t, &config.Config{}) // no config pins at all
 	setPinCache(t)
-	if isPinned("orin.local") {
+	if newDialTarget("orin.local", "10.0.0.9:50051").pinned() {
 		t.Fatal("test precondition: orin.local must be unpinned in config")
 	}
 

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -672,8 +672,19 @@ func TestSPKIMismatchAbortsLadderAndNamesUnpin(t *testing.T) {
 	if err == nil {
 		t.Fatal("ladder returned no error for an SPKI pin rejection")
 	}
-	if !strings.Contains(err.Error(), "wendy device unpin orin.local") {
-		t.Fatalf("err = %v, want the SPKI refusal naming the unpin escape hatch; without it recovery means hand-editing known_devices.json", err)
+	// The command named must be one that clears the entry that caused THIS
+	// refusal. It used to assert "unpin orin.local", which reads right and does
+	// nothing: this test's own setup has no config pin and an empty discovery
+	// cache — the `wendy device list` shape — so a hostname-keyed unpin finds no
+	// key and no derivable asset, and the very next dial refuses identically.
+	// The store's key is the only name that reaches the entry.
+	if !strings.Contains(err.Error(), "wendy device unpin urn:wendy:org:7:asset:42") {
+		t.Fatalf("err = %v, want the SPKI refusal naming an unpin argument that actually clears the entry; naming the host leaves hand-editing known_devices.json as the only recovery", err)
+	}
+	// The host is still what the user recognises, so the refusal must keep
+	// naming it — the URN tells them what to run, not what broke.
+	if !strings.Contains(err.Error(), "orin.local") {
+		t.Fatalf("err = %v no longer names the host the user dialed", err)
 	}
 	if !errors.Is(err, errDeviceIdentityRefused) {
 		t.Fatalf("err = %v does not read as an identity refusal; the picker's BLE fallback would take it for an unreachable device", err)

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestExpectedIdentityFor(t *testing.T) {
+	cases := []struct {
+		name string
+		pin  *config.DevicePin // nil = unpinned
+		want *certs.WendyIdentity
+	}{
+		{name: "unpinned host is unconstrained", pin: nil, want: nil},
+		{
+			name: "pinned with asset constrains exactly",
+			pin:  &config.DevicePin{OrgID: 7, AssetID: "42"},
+			want: &certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"},
+		},
+		{
+			name: "pinned without an asset stays unconstrained",
+			pin:  &config.DevicePin{OrgID: 7},
+			want: nil,
+		},
+	}
+	// Drive expectedIdentityFor through a config injected via the
+	// loadConfigForPinFn seam so the test never touches the real config file.
+	// The pin is stored under the normalised key ("orin") and looked up by the
+	// name a user would type ("orin.local"), so this also covers the key
+	// normalisation the ladder depends on.
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			if tc.pin != nil {
+				cfg.DevicePins = map[string]config.DevicePin{"orin": *tc.pin}
+			}
+			orig := loadConfigForPinFn
+			loadConfigForPinFn = func() (*config.Config, error) { return cfg, nil }
+			t.Cleanup(func() { loadConfigForPinFn = orig })
+
+			got := expectedIdentityFor("orin.local")
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("expectedIdentityFor = %+v, want nil (an unconstrained dial)", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("expectedIdentityFor = nil, want %+v", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Fatalf("expectedIdentityFor = %+v, want %+v", *got, *tc.want)
+			}
+
+			// newDialTarget must carry exactly that constraint, and the pin's
+			// mere existence — asset or not — is what forbids the plaintext
+			// rung. A pin with no asset still means "this host has answered
+			// mTLS before".
+			target := newDialTarget("orin.local", "10.0.0.9:50051")
+			if (target.Expected == nil) != (tc.want == nil) {
+				t.Fatalf("newDialTarget Expected = %v, want the same constraint as expectedIdentityFor (%v)", target.Expected, tc.want)
+			}
+			if want := tc.pin != nil; isPinned("orin.local") != want {
+				t.Fatalf("isPinned = %v, want %v", !want, want)
+			}
+			if target.Addr != "10.0.0.9:50051" || target.PinKey != "orin.local" {
+				t.Fatalf("newDialTarget = %+v, want the requested name and the dialled address", target)
+			}
+		})
+	}
+}
+
+// TestPinnedHostSkipsPlaintextRung is the security-critical case: a host we
+// have seen over mTLS must never be reached unauthenticated, no matter what
+// the TXT records or the cache claim.
+//
+// The mTLS rungs here fail with a plain transport error (nothing is listening),
+// which is precisely the shape that today falls through to the plaintext rung —
+// isCertRejectionError does not, and must not, match it. The refusal therefore
+// has to come from the pin itself, not from error-string matching.
+func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
+	setTempConfig(t, &config.Config{DevicePins: map[string]config.DevicePin{
+		"orin": {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443", AssetID: "42", Source: config.PinSourceLAN},
+	}})
+
+	addr := deadAgentAddr(t)
+
+	plaintextCalls := 0
+	origPlaintext := plaintextConnectFn
+	plaintextConnectFn = func(ctx context.Context, address string) (*grpcclient.AgentConnection, error) {
+		plaintextCalls++
+		return grpcclient.NewFromConn(nil), nil
+	}
+	t.Cleanup(func() { plaintextConnectFn = origPlaintext })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	target := newDialTarget("orin.local", addr)
+	conn, mtlsErr, err := dialAgentLadderWithCerts(ctx, target, []config.CertificateInfo{selfSignedCLICert(t, 7)})
+	if conn != nil {
+		conn.Close()
+	}
+
+	if plaintextCalls != 0 {
+		t.Fatalf("plaintext rung attempted %d times for a pinned host; a host already reached over mTLS must never be dialled unauthenticated", plaintextCalls)
+	}
+	if conn != nil {
+		t.Fatalf("ladder returned a connection (%v) for a pinned host whose mTLS rungs all failed", conn)
+	}
+	if err == nil {
+		t.Fatal("ladder returned no error for a pinned host whose mTLS rungs all failed")
+	}
+	if !strings.Contains(err.Error(), "refusing to fall back to an unauthenticated connection") ||
+		!strings.Contains(err.Error(), "wendy device unpin orin.local") {
+		t.Fatalf("err = %v, want the pinned-host refusal naming the unpin escape hatch", err)
+	}
+	// The mTLS diagnostic must survive the refusal — it is the only clue to why
+	// no authenticated endpoint answered.
+	if mtlsErr == nil {
+		t.Fatal("mtlsErr = nil, want the last mTLS probe failure preserved for diagnostics")
+	}
+	// The load-bearing assertion for the guard's independence: this failure is
+	// NOT a cert rejection, so the pre-existing isCertRejectionError branch
+	// would have fallen straight through to plaintext.
+	if isCertRejectionError(mtlsErr) {
+		t.Fatalf("mtlsErr = %v is a cert rejection; this test must exercise the transport-error shape that otherwise reaches the plaintext rung", mtlsErr)
+	}
+}
+
+// deadAgentAddr returns a 127.0.0.1 address whose port AND port+1 both refuse
+// connections, so every rung of the ladder (which tries both) fails with a
+// transport error rather than anything cert-shaped.
+func deadAgentAddr(t *testing.T) string {
+	t.Helper()
+	for attempt := 0; attempt < 20; attempt++ {
+		first, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("reserving a port: %v", err)
+		}
+		port := first.Addr().(*net.TCPAddr).Port
+		second, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port+1))
+		first.Close()
+		if err != nil {
+			continue // port+1 is in use; try another pair
+		}
+		second.Close()
+		return fmt.Sprintf("127.0.0.1:%d", port)
+	}
+	t.Fatal("could not find two consecutive free ports")
+	return ""
+}
+
+// selfSignedCLICert builds a usable client CertificateInfo (loadable keypair
+// plus a chain PEM, both of which ConnectWithTLSExpecting requires before it
+// will dial) so the mTLS rungs fail at the transport, not while assembling
+// their TLS config.
+func selfSignedCLICert(t *testing.T, orgID int) config.CertificateInfo {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "wendy/test/cli"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	return config.CertificateInfo{
+		OrganizationID:      orgID,
+		PemCertificate:      certPEM,
+		PemPrivateKey:       keyPEM,
+		PemCertificateChain: certPEM,
+	}
+}

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
 )
 
@@ -523,6 +524,159 @@ func TestWrongDeviceAbortsLadder(t *testing.T) {
 	want := `device "orin.local" is pinned to asset 42 in organization 7, but the host answering presented asset 43 in organization 7`
 	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "wendy device unpin orin.local") {
 		t.Fatalf("err = %v, want the identity refusal naming both identities and the unpin escape hatch", err)
+	}
+	if mtlsErr == nil {
+		t.Fatal("mtlsErr = nil, want the mTLS probe failure preserved alongside the refusal")
+	}
+}
+
+// TestRefusalNamesTheKeyTheGoverningPinIsFiledUnder is the escape hatch's other
+// half. lookupPin resolves the governing pin across every name a device answers
+// to, so a dial to the mDNS hostname can be refused by a pin filed under the
+// cloud roster's asset name — and the refusal has to hand the user a key that
+// `wendy device unpin` can act on. Naming the DIALLED key instead points at a
+// command that clears nothing, and the next dial refuses identically.
+func TestRefusalNamesTheKeyTheGoverningPinIsFiledUnder(t *testing.T) {
+	setUp := func(t *testing.T) {
+		t.Helper()
+		setTempConfig(t, &config.Config{DevicePins: map[string]config.DevicePin{
+			// Filed under the display name, as cloud seeding writes it — never
+			// under the hostname the user dials.
+			"calm-zinnia": {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443", AssetID: "42", Source: config.PinSourceCloud},
+		}})
+		setPinCache(t, discoverycache.Entry{
+			ID:          "dev-1",
+			DisplayName: "calm-zinnia",
+			Hostname:    "wendyos-calm-zinnia.local",
+		})
+	}
+
+	t.Run("the target carries the matched key", func(t *testing.T) {
+		setUp(t)
+		target := newDialTarget("wendyos-calm-zinnia.local", "10.0.0.9:50051")
+		if target.PinnedKey != "calm-zinnia" {
+			t.Fatalf("PinnedKey = %q, want \"calm-zinnia\" — the key the pin is actually filed under", target.PinnedKey)
+		}
+		if target.refusalKey() != "calm-zinnia" {
+			t.Fatalf("refusalKey = %q, want \"calm-zinnia\"", target.refusalKey())
+		}
+		if target.Expected == nil || target.Expected.EntityID != "42" {
+			t.Fatalf("Expected = %v, want the alias pin's asset 42 still enforced", target.Expected)
+		}
+	})
+
+	t.Run("a wrong-device refusal names it", func(t *testing.T) {
+		setUp(t)
+		origMismatch := identityMismatchFn
+		identityMismatchFn = func(*grpcclient.AgentConnection) (*certs.IdentityMismatchError, bool) {
+			return &certs.IdentityMismatchError{WantOrg: 7, WantAsset: "42", GotOrg: 7, GotAsset: "43"}, true
+		}
+		origPlaintext := plaintextConnectFn
+		plaintextConnectFn = func(context.Context, string) (*grpcclient.AgentConnection, error) {
+			t.Error("plaintext rung attempted after a wrong-device rejection")
+			return grpcclient.NewFromConn(nil), nil
+		}
+		t.Cleanup(func() { identityMismatchFn, plaintextConnectFn = origMismatch, origPlaintext })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		target := newDialTarget("wendyos-calm-zinnia.local", deadAgentAddr(t))
+		conn, _, err := dialAgentLadderWithCerts(ctx, target, []config.CertificateInfo{selfSignedCLICert(t, 7)})
+		if conn != nil {
+			conn.Close()
+		}
+		if err == nil {
+			t.Fatal("no error for a wrong-device rejection")
+		}
+		if !strings.Contains(err.Error(), "wendy device unpin calm-zinnia") {
+			t.Fatalf("err = %v, want it to name 'wendy device unpin calm-zinnia' — the key that actually holds the pin", err)
+		}
+	})
+
+	t.Run("an unauthenticated-fallback refusal names it", func(t *testing.T) {
+		setUp(t)
+		origPlaintext := plaintextConnectFn
+		plaintextConnectFn = func(context.Context, string) (*grpcclient.AgentConnection, error) {
+			t.Error("plaintext rung attempted for a pinned host")
+			return grpcclient.NewFromConn(nil), nil
+		}
+		t.Cleanup(func() { plaintextConnectFn = origPlaintext })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		target := newDialTarget("wendyos-calm-zinnia.local", deadAgentAddr(t))
+		conn, _, err := dialAgentLadderWithCerts(ctx, target, []config.CertificateInfo{selfSignedCLICert(t, 7)})
+		if conn != nil {
+			conn.Close()
+		}
+		if err == nil {
+			t.Fatal("no error for a pinned host whose mTLS rungs all failed")
+		}
+		if !strings.Contains(err.Error(), "wendy device unpin calm-zinnia") {
+			t.Fatalf("err = %v, want it to name 'wendy device unpin calm-zinnia'", err)
+		}
+	})
+}
+
+// TestSPKIMismatchAbortsLadderAndNamesUnpin covers the OTHER pin store: the
+// SPKI one, keyed by the certificate's own asset URN, which hard-fails when a
+// device's public key changes while its pinned certificate is still valid.
+//
+// That rejection is raised inside VerifyConnection and reached the user only as
+// whatever survived gRPC's "authentication handshake failed" wrapper — a
+// message naming neither the host as the user knows it nor any way out. The
+// pin key here is deliberately UNPINNED in config, which is the real shape of
+// the problem: `wendy device list` SPKI-pins every device the prober enumerates
+// without writing a single config pin, so isPinned cannot be what refuses the
+// plaintext rung here — only the abort can.
+func TestSPKIMismatchAbortsLadderAndNamesUnpin(t *testing.T) {
+	setTempConfig(t, &config.Config{}) // no config pins at all
+	setPinCache(t)
+	if isPinned("orin.local") {
+		t.Fatal("test precondition: orin.local must be unpinned in config")
+	}
+
+	pinReads := 0
+	origPin := pinMismatchFn
+	pinMismatchFn = func(*grpcclient.AgentConnection) (*devicepin.PinMismatchError, bool) {
+		pinReads++
+		return &devicepin.PinMismatchError{
+			Key: "urn:wendy:org:7:asset:42", DisplayName: "orin",
+			Want: "sha256:aaa", Got: "sha256:bbb",
+		}, true
+	}
+	plaintextCalls := 0
+	origPlaintext := plaintextConnectFn
+	plaintextConnectFn = func(context.Context, string) (*grpcclient.AgentConnection, error) {
+		plaintextCalls++
+		return grpcclient.NewFromConn(nil), nil
+	}
+	t.Cleanup(func() { pinMismatchFn, plaintextConnectFn = origPin, origPlaintext })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Two certs × two ports = four rungs if the ladder kept going.
+	allCerts := []config.CertificateInfo{selfSignedCLICert(t, 7), selfSignedCLICert(t, 9)}
+	conn, mtlsErr, err := dialAgentLadderWithCerts(ctx, newDialTarget("orin.local", deadAgentAddr(t)), allCerts)
+	if conn != nil {
+		conn.Close()
+	}
+
+	if pinReads != 1 {
+		t.Fatalf("ladder examined %d rungs after an SPKI rejection, want exactly 1; the key belongs to the device, so every remaining cert and port fails identically", pinReads)
+	}
+	if plaintextCalls != 0 {
+		t.Fatalf("plaintext rung attempted %d times after an SPKI rejection", plaintextCalls)
+	}
+	if err == nil {
+		t.Fatal("ladder returned no error for an SPKI pin rejection")
+	}
+	if !strings.Contains(err.Error(), "wendy device unpin orin.local") {
+		t.Fatalf("err = %v, want the SPKI refusal naming the unpin escape hatch; without it recovery means hand-editing known_devices.json", err)
+	}
+	if !errors.Is(err, errDeviceIdentityRefused) {
+		t.Fatalf("err = %v does not read as an identity refusal; the picker's BLE fallback would take it for an unreachable device", err)
 	}
 	if mtlsErr == nil {
 		t.Fatal("mtlsErr = nil, want the mTLS probe failure preserved alongside the refusal")

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -139,6 +139,73 @@ func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
 	}
 }
 
+// TestWrongDeviceAbortsLadder covers the other half of the enforcement: a peer
+// that proves it is the WRONG device ends the ladder there and then.
+//
+// The pin key here is deliberately UNPINNED, so isPinned cannot be what
+// suppresses the plaintext rung — only the abort can. That is the configuration
+// Task 8 introduces for real: a cloud-seeded Expected with no config pin behind
+// it, where this abort is the single thing between a wrong device and an
+// unauthenticated connection.
+func TestWrongDeviceAbortsLadder(t *testing.T) {
+	setTempConfig(t, &config.Config{}) // no pins at all
+	if isPinned("orin.local") {
+		t.Fatal("test precondition: orin.local must be unpinned, so only the abort can refuse plaintext")
+	}
+
+	origMismatch := identityMismatchFn
+	mismatchReads := 0
+	identityMismatchFn = func(*grpcclient.AgentConnection) (*certs.IdentityMismatchError, bool) {
+		mismatchReads++
+		return &certs.IdentityMismatchError{WantOrg: 7, WantAsset: "42", GotOrg: 7, GotAsset: "43"}, true
+	}
+	plaintextCalls := 0
+	origPlaintext := plaintextConnectFn
+	plaintextConnectFn = func(ctx context.Context, address string) (*grpcclient.AgentConnection, error) {
+		plaintextCalls++
+		return grpcclient.NewFromConn(nil), nil
+	}
+	t.Cleanup(func() {
+		identityMismatchFn = origMismatch
+		plaintextConnectFn = origPlaintext
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Two certs × two ports = four rungs if the ladder kept going.
+	allCerts := []config.CertificateInfo{selfSignedCLICert(t, 7), selfSignedCLICert(t, 9)}
+	target := dialTarget{
+		PinKey:   "orin.local",
+		Addr:     deadAgentAddr(t),
+		Expected: &certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"},
+	}
+	conn, mtlsErr, err := dialAgentLadderWithCerts(ctx, target, allCerts)
+	if conn != nil {
+		conn.Close()
+	}
+
+	if mismatchReads != 1 {
+		t.Fatalf("ladder examined %d rungs after a wrong-device rejection, want exactly 1; every remaining cert and port would fail identically", mismatchReads)
+	}
+	if plaintextCalls != 0 {
+		t.Fatalf("plaintext rung attempted %d times after a wrong-device rejection", plaintextCalls)
+	}
+	if conn != nil {
+		t.Fatalf("ladder returned a connection (%v) to a device that proved it was the wrong one", conn)
+	}
+	if err == nil {
+		t.Fatal("ladder returned no error for a wrong-device rejection")
+	}
+	want := `device "orin.local" is pinned to asset 42 in organization 7, but the host answering presented asset 43 in organization 7`
+	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "wendy device unpin orin.local") {
+		t.Fatalf("err = %v, want the identity refusal naming both identities and the unpin escape hatch", err)
+	}
+	if mtlsErr == nil {
+		t.Fatal("mtlsErr = nil, want the mTLS probe failure preserved alongside the refusal")
+	}
+}
+
 // deadAgentAddr returns a 127.0.0.1 address whose port AND port+1 both refuse
 // connections, so every rung of the ladder (which tries both) fails with a
 // transport error rather than anything cert-shaped.

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -193,6 +193,58 @@ func TestLookupPinCloudBeatsEarlierLAN(t *testing.T) {
 		}
 	})
 
+	// Where rule 2 (cloud is authority) and rule 4 (consulting more candidates
+	// can only ever FIND a pin, never discard one) collide, the invariant wins.
+	// An asset-less cloud pin displacing an asset-bearing LAN pin would leave
+	// expectedIdentityFor nil — no exact-identity constraint at all — which is
+	// precisely the same-CA-host redirect dialTarget exists to stop. The state
+	// is contemplated by the data model: EvaluateDevicePin carries a dedicated
+	// Source==cloud && AssetID=="" branch.
+	t.Run("asset-less cloud pin does not displace an asset-bearing lan pin", func(t *testing.T) {
+		setPinCache(t, entry)
+		setPinConfig(t, map[string]config.DevicePin{
+			"wendyos-calm-zinnia": {OrgID: 7, AssetID: "1", Source: config.PinSourceLAN},
+			"calm-zinnia":         {OrgID: 7, AssetID: "", Source: config.PinSourceCloud},
+		})
+		cfg, err := loadConfigForPinFn()
+		if err != nil {
+			t.Fatalf("loadConfigForPinFn: %v", err)
+		}
+
+		pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+		if !ok {
+			t.Fatal("lookupPin found nothing despite two matching pins")
+		}
+		if key != "wendyos-calm-zinnia.local" || pin.AssetID != "1" {
+			t.Fatalf("lookupPin = %+v under %q, want the LAN pin (asset 1) under the dialled key; an asset-less cloud pin must not erase an exact-identity constraint", pin, key)
+		}
+		if got := expectedIdentityFor("wendyos-calm-zinnia.local"); got == nil || got.EntityID != "1" {
+			t.Fatalf("expectedIdentityFor = %+v, want asset 1 — consulting an extra candidate must never discard a constraint that was already there", got)
+		}
+	})
+
+	// The exception above is confined to the case where it protects a
+	// constraint: with nothing to lose, cloud precedence still applies.
+	t.Run("asset-less cloud pin still wins over an asset-less lan pin", func(t *testing.T) {
+		setPinCache(t, entry)
+		setPinConfig(t, map[string]config.DevicePin{
+			"wendyos-calm-zinnia": {OrgID: 7, CloudGRPC: "lan.example:443", Source: config.PinSourceLAN},
+			"calm-zinnia":         {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443", Source: config.PinSourceCloud},
+		})
+		cfg, err := loadConfigForPinFn()
+		if err != nil {
+			t.Fatalf("loadConfigForPinFn: %v", err)
+		}
+
+		pin, key, ok := lookupPin(cfg, "wendyos-calm-zinnia.local")
+		if !ok {
+			t.Fatal("lookupPin found nothing despite two matching pins")
+		}
+		if key != "calm-zinnia" || pin.Source != config.PinSourceCloud {
+			t.Fatalf("lookupPin = %+v under %q, want the cloud pin under \"calm-zinnia\"; neither pin carries an asset, so nothing is lost and cloud is still authority", pin, key)
+		}
+	})
+
 	t.Run("first cloud pin wins over a later cloud pin", func(t *testing.T) {
 		setPinCache(t, entry)
 		setPinConfig(t, map[string]config.DevicePin{
@@ -357,6 +409,10 @@ func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
 	setTempConfig(t, &config.Config{DevicePins: map[string]config.DevicePin{
 		"orin": {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443", AssetID: "42", Source: config.PinSourceLAN},
 	}})
+	// Pin lookup now consults the device cache for alias keys. Serve it an
+	// empty one explicitly rather than leaving this security test's determinism
+	// resting on setTempConfig's HOME happening to have no devices.json.
+	setPinCache(t)
 
 	addr := deadAgentAddr(t)
 
@@ -413,6 +469,9 @@ func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
 // unauthenticated connection.
 func TestWrongDeviceAbortsLadder(t *testing.T) {
 	setTempConfig(t, &config.Config{}) // no pins at all
+	// As above: an explicit empty cache, so no alias key can turn this
+	// deliberately-unpinned host into a pinned one.
+	setPinCache(t)
 	if isPinned("orin.local") {
 		t.Fatal("test precondition: orin.local must be unpinned, so only the abort can refuse plaintext")
 	}

--- a/go/internal/cli/commands/fleet.go
+++ b/go/internal/cli/commands/fleet.go
@@ -179,6 +179,7 @@ func runFleetGroupLs(ctx context.Context, cloudGRPC string) error {
 	if err != nil {
 		return err
 	}
+	seedPinsFromAssetsBestEffort(auth, assets)
 
 	counts := groupCounts(assets)
 	names := make([]string, 0, len(counts))
@@ -219,6 +220,7 @@ func runFleetGroupShow(ctx context.Context, cloudGRPC, group string) error {
 	if err != nil {
 		return err
 	}
+	seedPinsFromAssetsBestEffort(auth, assets)
 	members := assetsInGroup(assets, group)
 
 	if jsonOutput || !isInteractiveTerminal() {
@@ -262,6 +264,7 @@ func runFleetGroupMembership(ctx context.Context, cloudGRPC, group string, devic
 	if err != nil {
 		return err
 	}
+	seedPinsFromAssetsBestEffort(auth, assets)
 
 	conn, err := dialCloudGRPC(auth)
 	if err != nil {

--- a/go/internal/cli/commands/fleet_lan.go
+++ b/go/internal/cli/commands/fleet_lan.go
@@ -210,6 +210,7 @@ func cloudFleetTargets(ctx context.Context, group, cloudGRPC, brokerURL string) 
 	if err != nil {
 		return nil, err
 	}
+	seedPinsFromAssetsBestEffort(auth, assets)
 	if group != "" {
 		assets = assetsInGroup(assets, group)
 	}

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -71,6 +71,7 @@ func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, m
 		if err != nil {
 			return err
 		}
+		seedPinsFromAssetsBestEffort(auth, assets)
 		for name, comp := range manifest.Components {
 			targetsByComp[name] = cloudTargetsForTags(auth, assets, comp.Tags, brokerURL)
 			for _, a := range assetsWithAnyTag(assets, comp.Tags) {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1844,7 +1844,7 @@ func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts [
 						return conn, nil, nil
 					}
 					recordMTLSErr(mtlsAddr, probeErr)
-					if im, mismatched := conn.IdentityMismatch(); mismatched {
+					if im, mismatched := identityMismatchFn(conn); mismatched {
 						conn.Close()
 						// The device is wrong, not our certificate — every
 						// remaining cert and port would fail the same way, and

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1387,8 +1387,10 @@ const (
 // first. The returned lkgOutcome tells the caller how to fall through —
 // dialAgentLKG never surfaces its own failures as the connect's outcome.
 // Trust is unchanged: the same certs, verifiers, and pins run here as on
-// the ordinary path; the cache contributes routing only.
-func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+// the ordinary path; the cache contributes routing only — pinKey is the name
+// the caller was asked for, NOT the entry's IP or display name, so a poisoned
+// cache row cannot pick which identity this dial is allowed to accept.
+func dialAgentLKG(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 	addr := hostPort(e.IP, e.Port)
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	if !lkgTCPAlive(addr) {
@@ -1404,7 +1406,7 @@ func dialAgentLKG(ctx context.Context, e discoverycache.Entry) (*grpcclient.Agen
 		// treating it like a dead IP.
 		return nil, nil, lkgHandshakeFailed
 	}
-	conn, mtlsErr, err := dialAgentLadderWithCertsFn(ctx, addr, certs)
+	conn, mtlsErr, err := dialAgentLadderWithCertsFn(ctx, newDialTarget(pinKey, addr), certs)
 	if err != nil || conn == nil || !conn.IsMTLS {
 		// The entry advertised mTLS; a plaintext downgrade here would be
 		// surprising, so route it through the ordinary path instead.
@@ -1531,6 +1533,11 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	originalAddr := plaintextAddr
+	// The pin key is the host the caller was ASKED to reach, captured before
+	// any resolution, cache lookup, or retry can substitute an address for it.
+	// Every rung below dials with this same key, so which device is acceptable
+	// never depends on what discovery answered.
+	pinKey := pinKeyForAddr(originalAddr)
 	fromCache := false
 	if plainHost, plainPort, splitErr := net.SplitHostPort(plaintextAddr); splitErr == nil && net.ParseIP(plainHost) == nil {
 		if e, ok := cachedDeviceHostEntry(plainHost); ok && e.IP != "" {
@@ -1540,7 +1547,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 				// Last-known-good direct dial: the advertised mTLS endpoint
 				// with the entry's org's cert first, TCP-bounded so a dead
 				// IP costs at most lkgTCPConnectTimeout.
-				switch conn, mtlsErr, outcome := dialAgentLKGFn(ctx, e); outcome {
+				switch conn, mtlsErr, outcome := dialAgentLKGFn(ctx, e, pinKey); outcome {
 				case lkgConnected:
 					return conn, mtlsErr, nil
 				case lkgHandshakeFailed:
@@ -1575,7 +1582,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 		plaintextAddr = resolveAddrOnce(ctx, plaintextAddr)
 	}
 
-	conn, mtlsErr, err := dialAgentLadderFn(ctx, plaintextAddr)
+	conn, mtlsErr, err := dialAgentLadderFn(ctx, newDialTarget(pinKey, plaintextAddr))
 	if fromCache && !cacheFastPathReachableFn(ctx, conn, err) {
 		switch {
 		case ctx.Err() != nil:
@@ -1599,7 +1606,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 				if conn != nil {
 					conn.Close()
 				}
-				conn, mtlsErr, err = dialAgentLadderFn(ctx, retryAddr)
+				conn, mtlsErr, err = dialAgentLadderFn(ctx, newDialTarget(pinKey, retryAddr))
 			}
 		}
 	}
@@ -1750,7 +1757,14 @@ func cacheHostnameForStorage(host string) string {
 // its own. connectWithAutoTLSDiagnostics calls it for every connect —
 // resolved-address and device-cache fast path alike, including the fast
 // path's stale-cache retry — so all three share this exact same ladder.
-func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCerts []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+//
+// target.Addr is that address; target.PinKey and target.Expected are what the
+// user asked for, and they make this the single point where the two identity
+// rules hold: a peer that is the wrong device aborts the whole ladder (no
+// further cert, no further port), and a host with any pin is never offered the
+// plaintext rung.
+func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+	plaintextAddr := target.Addr
 	tlsDebug := os.Getenv("WENDY_TLS_DEBUG") != ""
 	var lastMTLSErr error
 	recordMTLSErr := func(addr string, err error) {
@@ -1808,7 +1822,7 @@ func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCert
 			for addrIdx, mtlsAddr := range mtlsAddrs {
 				for pos := range probeOrder {
 					i := probeOrder[pos]
-					conn, tlsErr := grpcclient.ConnectWithTLSAndPins(ctx, mtlsAddr, &allCerts[i], pins)
+					conn, tlsErr := grpcclient.ConnectWithTLSExpecting(ctx, mtlsAddr, &allCerts[i], pins, target.Expected)
 					if tlsErr != nil {
 						recordMTLSErr(mtlsAddr, tlsErr)
 						if tlsDebug {
@@ -1830,6 +1844,13 @@ func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCert
 						return conn, nil, nil
 					}
 					recordMTLSErr(mtlsAddr, probeErr)
+					if im, mismatched := conn.IdentityMismatch(); mismatched {
+						conn.Close()
+						// The device is wrong, not our certificate — every
+						// remaining cert and port would fail the same way, and
+						// the plaintext rung below must not be reached at all.
+						return nil, lastMTLSErr, identityRefusal(target.PinKey, im)
+					}
 					if tlsDebug {
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
 					}
@@ -1873,14 +1894,20 @@ func dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCert
 			}
 		}
 	}
-	conn, err := grpcclient.Connect(ctx, plaintextAddr)
+	if isPinned(target.PinKey) {
+		// A host we have already reached over mTLS must never be reached
+		// unauthenticated. Unlike provisionedAgentAdvertisedMTLS this reads
+		// local state, not a TXT record the attacker also controls.
+		return nil, lastMTLSErr, pinnedHostWentUnauthenticatedError(target.PinKey)
+	}
+	conn, err := plaintextConnectFn(ctx, plaintextAddr)
 	return conn, lastMTLSErr, err
 }
 
 // dialAgentLadder is dialAgentLadderWithCerts with the CLI's stored certs
 // in config order — the shape every non-fast-path caller wants.
-func dialAgentLadder(ctx context.Context, plaintextAddr string) (*grpcclient.AgentConnection, error, error) {
-	return dialAgentLadderWithCerts(ctx, plaintextAddr, loadAllCLICerts())
+func dialAgentLadder(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+	return dialAgentLadderWithCerts(ctx, target, loadAllCLICerts())
 }
 
 // dialAgentLadderWithCertsFn is a seam over dialAgentLadderWithCerts for
@@ -1942,8 +1969,15 @@ func isCertRejectionError(err error) bool {
 
 // provisionedAgentAdvertisedMTLS takes a short pre-connection LAN discovery
 // snapshot and checks whether the target address was already advertised as an
-// mTLS-only agent. Callers pass this result into the dial path; it is not
-// refreshed after a failed connection attempt.
+// mTLS-only agent.
+//
+// This is a PHRASING HINT FOR ERROR MESSAGES ONLY and must never be used as a
+// guard. What it reports comes from the device's own mDNS TXT records, which
+// whoever answered the address controls — so "it didn't advertise mTLS" is not
+// evidence that plaintext is safe. The rule that actually withholds the
+// plaintext rung is isPinned, which reads local pin state (see
+// dialAgentLadderWithCerts). This snapshot is also not refreshed after a failed
+// connection attempt.
 func provisionedAgentAdvertisedMTLS(ctx context.Context, plaintextAddr string) bool {
 	devices, err := discoverLANDevices(ctx, provisionedAgentMetadataDiscoveryTimeout)
 	if err != nil {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1120,7 +1120,7 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 		}
 		if !cfg.suppressUpdateCheck {
 			var updateErr error
-			conn, updateErr = checkAndOfferUpdate(ctx, conn)
+			conn, updateErr = checkAndOfferUpdateFn(ctx, conn)
 			if updateErr != nil {
 				return nil, updateErr
 			}
@@ -1208,6 +1208,52 @@ func pinKeyForLANDevice(d *models.LANDevice) string {
 		return ""
 	}
 	return strings.TrimSpace(d.Hostname)
+}
+
+// connectPickedLANDevice connects to the LAN half of a picked device at addr
+// and returns the selection, with the device pin enforced before anything else
+// is done over that connection. d.LAN must be non-nil.
+//
+// The ordering is the whole point. checkAndOfferUpdate can prompt "Update the
+// agent now?" and, on a yes, upload a wendy-agent binary and restart it — so it
+// must not run against a device whose identity is about to be rejected. That is
+// the invariant connectToAgent states for named targets, and the picker needs
+// it just as badly: mDNS is unauthenticated, so the row the user clicked is a
+// claim about which device answers there, not proof of it.
+//
+// A refusal is also not a reason to fall back to Bluetooth. The BLE fallback in
+// the connect-error branch is for a device that did not answer at all; a device
+// that answered as somebody else is a refusal, and reaching it over a second
+// transport instead would hand back the very device the pin just rejected.
+//
+// Note this also covers `wendy device set-default` with no argument, which
+// picks through here: a device whose identity changed can no longer be re-pinned
+// by picking it from the TUI. Naming it (`set-default <host>`, which drops the
+// pin first) or `wendy device unpin <host>` is the way back — a re-pin has to be
+// an act aimed at a specific device, not a row in a list mDNS filled in.
+func connectPickedLANDevice(ctx context.Context, d *models.DiscoveredDevice, addr string, suppressUpdateCheck bool) (*SelectedDevice, error) {
+	mtls := d.LAN.IsMTLS
+	conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, func() bool { return mtls })
+	if err != nil {
+		// LAN failed — fall back to BLE if available.
+		if d.Bluetooth != nil {
+			return &SelectedDevice{Bluetooth: d.Bluetooth}, nil
+		}
+		return nil, err
+	}
+
+	picked := &SelectedDevice{Agent: conn, PinKey: pinKeyForLANDevice(d.LAN)}
+	if pinErr := enforceSelectedDevicePin(picked); pinErr != nil {
+		return nil, pinErr
+	}
+	if !suppressUpdateCheck {
+		updatedConn, updateErr := checkAndOfferUpdateFn(ctx, picked.Agent)
+		if updateErr != nil {
+			return nil, updateErr
+		}
+		picked.Agent = updatedConn
+	}
+	return picked, nil
 }
 
 // connectWithAutoTLS tries to connect using mTLS if the CLI has auth certs,
@@ -2205,6 +2251,12 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 	return newConn, nil
 }
 
+// checkAndOfferUpdateFn is a seam over checkAndOfferUpdate. It exists for tests
+// that must prove the update check was NOT reached: it can upload and restart a
+// wendy-agent binary, so "did this run?" is a security assertion about the
+// identity gates that precede it, not an implementation detail.
+var checkAndOfferUpdateFn = checkAndOfferUpdate
+
 // performAgentUpdate downloads the latest release for the given osName/arch and
 // uploads it to conn. Pass nightly=true to fetch the latest prerelease instead
 // of stable. The agent will restart after this returns successfully.
@@ -2593,7 +2645,7 @@ func resolveTargetInner(ctx context.Context, opts ...resolveOption) (*SelectedDe
 		}
 		if !cfg.suppressUpdateCheck {
 			var updateErr error
-			conn, updateErr = checkAndOfferUpdate(ctx, conn)
+			conn, updateErr = checkAndOfferUpdateFn(ctx, conn)
 			if updateErr != nil {
 				return nil, updateErr
 			}
@@ -3197,23 +3249,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 				}
 				return nil, fmt.Errorf("selected LAN device has no usable address")
 			}
-			mtls := d.LAN.IsMTLS
-			conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, func() bool { return mtls })
-			if err == nil {
-				if !suppressUpdateCheck {
-					var updateErr error
-					conn, updateErr = checkAndOfferUpdate(ctx, conn)
-					if updateErr != nil {
-						return nil, updateErr
-					}
-				}
-				return &SelectedDevice{Agent: conn, PinKey: pinKeyForLANDevice(d.LAN)}, nil
-			}
-			// LAN failed — fall back to BLE if available.
-			if d.Bluetooth != nil {
-				return &SelectedDevice{Bluetooth: d.Bluetooth}, nil
-			}
-			return nil, err
+			return connectPickedLANDevice(ctx, d, addr, suppressUpdateCheck)
 		}
 
 		// Wendy Lite device — set both BLE and External+Provider when

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -753,6 +753,13 @@ type SelectedDevice struct {
 	Bluetooth *models.BluetoothDevice
 	External  *models.ExternalDevice
 	Provider  providers.DeviceProvider
+	// PinKey is the name the device pin for this selection is filed under: the
+	// hostname behind the picker row the user chose. It is the only part of a
+	// picker selection that identifies a device durably — the address came from
+	// discovery, and a pin keyed on a DHCP lease would be worthless. Empty for
+	// selections with no hostname to key on, which are left unenforced (see
+	// enforceSelectedDevicePin).
+	PinKey string
 }
 
 // Close releases any resources held by this SelectedDevice.
@@ -762,24 +769,34 @@ func (s *SelectedDevice) Close() {
 	}
 }
 
-func resolveDeviceAddress() (addr string, isDefault bool, err error) {
+// resolveDeviceAddress turns --device (or the saved default) into the address to
+// dial and the key its pin is filed under.
+//
+// pinKey is derived from addr by pinKeyForAddr — the very function the dial
+// ladder uses on the address it is handed — so the key a connection is CHECKED
+// against and the key it is DIALLED with are the same function of the same
+// input, and cannot drift apart. That matters more than it looks: a host pinned
+// under one key and verified under another would leave enforcement switched off
+// while every log line and config entry said it was on.
+func resolveDeviceAddress() (addr string, pinKey string, isDefault bool, err error) {
 	hostname := deviceFlag
 	if hostname == "" {
 		cfg, loadErr := config.Load()
 		if loadErr != nil {
-			return "", false, fmt.Errorf("loading config: %w", loadErr)
+			return "", "", false, fmt.Errorf("loading config: %w", loadErr)
 		}
 		hostname = cfg.DefaultDevice
 		isDefault = hostname != ""
 	}
 	if hostname == "" {
-		return "", false, fmt.Errorf("no device specified; use --device flag or set a default with 'wendy device set-default'")
+		return "", "", false, fmt.Errorf("no device specified; use --device flag or set a default with 'wendy device set-default'")
 	}
 	// If the hostname already contains a port, use it as-is.
-	if _, _, splitErr := net.SplitHostPort(hostname); splitErr == nil {
-		return hostname, isDefault, nil
+	addr = hostname
+	if _, _, splitErr := net.SplitHostPort(hostname); splitErr != nil {
+		addr = hostPort(hostname, defaultAgentPort)
 	}
-	return hostPort(hostname, defaultAgentPort), isDefault, nil
+	return addr, pinKeyForAddr(addr), isDefault, nil
 }
 
 // recoveryChoice represents the user's selection in the default-device recovery menu.
@@ -1027,13 +1044,12 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 		return conn, nil
 	}
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err == nil {
 		startedAt := time.Now()
-		hostname := addr
-		if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
-			hostname = host
-		}
+		// The name the user asked for, used both to talk about this device and
+		// to decide which device is acceptable — see resolveDeviceAddress.
+		hostname := pinKey
 		provisionedMTLS := deferProvisionedMTLSCheck(ctx, addr)
 		conn, connErr := connectResolvedAgentWithProvisionedHint(ctx, hostname, addr, isDefault, provisionedMTLS)
 		if connErr != nil {
@@ -1086,16 +1102,18 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 				return nil, connErr
 			}
 		}
-		// WDY-1149: verify the resolved default device is still the same device,
-		// in the same organisation and cloud, that was pinned here (and pin it on
-		// first use). This runs BEFORE the update check on purpose: that check can
-		// offer to upload an agent binary, which must never happen against a
-		// device whose identity we are about to reject.
-		if isDefault {
-			if pinErr := enforceDevicePin(hostname, conn); pinErr != nil {
-				conn.Close()
-				return nil, pinErr
-			}
+		// WDY-1149: verify the device that answered is still the same device, in
+		// the same organisation and cloud, that was pinned under this name (and
+		// pin it on first use). Every named target is checked, not just the saved
+		// default: --device is exactly as spoofable as a default, and a check that
+		// only covers the device you did not name is not a check.
+		//
+		// This runs BEFORE the update check on purpose: that check can offer to
+		// upload an agent binary, which must never happen against a device whose
+		// identity we are about to reject.
+		if pinErr := enforceDevicePin(pinKey, conn); pinErr != nil {
+			conn.Close()
+			return nil, pinErr
 		}
 		if !cfg.suppressProvisioningHint {
 			suggestProvisioning(conn)
@@ -1128,6 +1146,9 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 // support gRPC.
 func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpcclient.AgentConnection, error) {
 	if target.Agent != nil {
+		if pinErr := enforceSelectedDevicePin(target); pinErr != nil {
+			return nil, pinErr
+		}
 		if !cfg.suppressProvisioningHint {
 			suggestProvisioning(target.Agent)
 		}
@@ -1147,6 +1168,46 @@ func connectFromSelectedDevice(target *SelectedDevice, cfg resolveConfig) (*grpc
 	}
 
 	return nil, fmt.Errorf("selected device does not support gRPC agent commands")
+}
+
+// enforceSelectedDevicePin applies the device pin to a picker selection, and
+// closes the connection if it is refused.
+//
+// The dial ladder could not do this itself: the picker dials an address
+// discovery handed it, so by the time a certificate arrives the only record of
+// WHICH device the user chose is on the row they selected. A selection with no
+// key is left unenforced rather than pinned under a substitute — pinning device
+// A's certificate under device B's name is worse than not pinning at all,
+// because it looks like enforcement while checking nothing.
+func enforceSelectedDevicePin(target *SelectedDevice) error {
+	if target == nil || target.Agent == nil || target.PinKey == "" {
+		return nil
+	}
+	if err := enforceDevicePin(target.PinKey, target.Agent); err != nil {
+		target.Agent.Close()
+		target.Agent = nil
+		return err
+	}
+	return nil
+}
+
+// pinKeyForLANDevice is the pin key for a picker row: the device's HOSTNAME.
+//
+// Not its DisplayName, which is the tempting choice and the wrong one. On
+// WendyOS that is a Title-Cased friendly name from the `displayname` TXT record
+// ("Agx Orin") built from the device name, while the hostname is "wendyos-" +
+// that name ("wendyos-agx-orin.local") — one is not a transform of the other.
+// Keying picker pins on the display name would file them where the --device and
+// default-device paths (which key on the hostname, via pinKeyForAddr) never
+// look: the same device pinned twice under two names, each path blind to what
+// the other recorded, with nothing in the config or the output to show for it.
+// The hostname is also exactly what a user types for --device, which is what
+// makes it the one name every path can agree on.
+func pinKeyForLANDevice(d *models.LANDevice) string {
+	if d == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Hostname)
 }
 
 // connectWithAutoTLS tries to connect using mTLS if the CLI has auth certs,
@@ -2509,12 +2570,26 @@ func resolveTargetInner(ctx context.Context, opts ...resolveOption) (*SelectedDe
 				conn = refreshedConn
 			} else if isDefault && !jsonOutput && !cfg.nonInteractive && isInteractiveTerminal() {
 				// Default device is unreachable — offer interactive recovery.
-				return handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.includeBluetooth, cfg.suppressUpdateCheck)
+				recovered, recErr := handleDefaultDeviceRecovery(ctx, device, time.Since(startedAt), err, cfg.excludeProviderKeys, cfg.includeBluetooth, cfg.suppressUpdateCheck)
+				if recErr != nil {
+					return nil, recErr
+				}
+				if pinErr := enforceSelectedDevicePin(recovered); pinErr != nil {
+					return nil, pinErr
+				}
+				return recovered, nil
 			} else if isDefault {
 				return nil, defaultDeviceUnreachableError(device, err)
 			} else {
 				return nil, err
 			}
+		}
+		// Same pin key as connectToAgent's: the host of the address dialled, via
+		// the same pinKeyForAddr the ladder uses. resolveTarget reaches devices
+		// connectToAgent never sees, and an unchecked path is the whole attack.
+		if pinErr := enforceDevicePin(pinKeyForAddr(addr), conn); pinErr != nil {
+			conn.Close()
+			return nil, pinErr
 		}
 		if !cfg.suppressUpdateCheck {
 			var updateErr error
@@ -2532,7 +2607,14 @@ func resolveTargetInner(ctx context.Context, opts ...resolveOption) (*SelectedDe
 		return nil, fmt.Errorf("no device specified; use --device flag or set a default with 'wendy device set-default'")
 	}
 
-	return pickDevice(ctx, cfg.excludeProviderKeys, cfg.includeBluetooth, cfg.suppressUpdateCheck)
+	picked, pickErr := pickDevice(ctx, cfg.excludeProviderKeys, cfg.includeBluetooth, cfg.suppressUpdateCheck)
+	if pickErr != nil {
+		return nil, pickErr
+	}
+	if pinErr := enforceSelectedDevicePin(picked); pinErr != nil {
+		return nil, pinErr
+	}
+	return picked, nil
 }
 
 // findDeviceByID searches all available providers for a device whose ID
@@ -3125,7 +3207,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 						return nil, updateErr
 					}
 				}
-				return &SelectedDevice{Agent: conn}, nil
+				return &SelectedDevice{Agent: conn, PinKey: pinKeyForLANDevice(d.LAN)}, nil
 			}
 			// LAN failed — fall back to BLE if available.
 			if d.Bluetooth != nil {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -933,8 +933,12 @@ func formatElapsedSeconds(elapsed time.Duration) string {
 // it now (rather than after the probe) keeps the observation tied to this
 // connection attempt, matching the original eager-snapshot intent.
 func deferProvisionedMTLSCheck(ctx context.Context, addr string) func() bool {
+	// Snapshot the discovery hook here, on the caller's goroutine. The browse
+	// below outlives this function, and tests swap this seam back in t.Cleanup —
+	// reading it from inside the goroutine races that restore.
+	discover := discoverLANDevices
 	ch := make(chan bool, 1)
-	go func() { ch <- provisionedAgentAdvertisedMTLS(ctx, addr) }()
+	go func() { ch <- provisionedAgentAdvertisedMTLSVia(ctx, discover, addr) }()
 	var (
 		once sync.Once
 		res  bool
@@ -2115,7 +2119,19 @@ func isCertRejectionError(err error) bool {
 // dialAgentLadderWithCerts). This snapshot is also not refreshed after a failed
 // connection attempt.
 func provisionedAgentAdvertisedMTLS(ctx context.Context, plaintextAddr string) bool {
-	devices, err := discoverLANDevices(ctx, provisionedAgentMetadataDiscoveryTimeout)
+	return provisionedAgentAdvertisedMTLSVia(ctx, discoverLANDevices, plaintextAddr)
+}
+
+// provisionedAgentAdvertisedMTLSVia is provisionedAgentAdvertisedMTLS with the
+// discovery hook passed in rather than read from the package variable.
+//
+// deferProvisionedMTLSCheck runs this browse on a goroutine that outlives the
+// call that started it, so reading the seam in here would read it at an
+// unpredictable time — which races any test that restores the seam in
+// t.Cleanup while the browse is still in flight. Callers snapshot the hook on
+// their own goroutine and hand it over instead.
+func provisionedAgentAdvertisedMTLSVia(ctx context.Context, discover func(context.Context, time.Duration) ([]models.LANDevice, error), plaintextAddr string) bool {
+	devices, err := discover(ctx, provisionedAgentMetadataDiscoveryTimeout)
 	if err != nil {
 		return false
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1224,7 +1224,10 @@ func pinKeyForLANDevice(d *models.LANDevice) string {
 // A refusal is also not a reason to fall back to Bluetooth. The BLE fallback in
 // the connect-error branch is for a device that did not answer at all; a device
 // that answered as somebody else is a refusal, and reaching it over a second
-// transport instead would hand back the very device the pin just rejected.
+// transport instead would hand back the very device the pin just rejected. That
+// holds for both refusals that can reach here — the post-connect one below, and
+// the dial ladder's own, which arrives as a connect ERROR and so has to be
+// recognised before the fallback, not after it.
 //
 // Note this also covers `wendy device set-default` with no argument, which
 // picks through here: a device whose identity changed can no longer be re-pinned
@@ -1235,6 +1238,19 @@ func connectPickedLANDevice(ctx context.Context, d *models.DiscoveredDevice, add
 	mtls := d.LAN.IsMTLS
 	conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, func() bool { return mtls })
 	if err != nil {
+		// An identity refusal is not "the LAN attempt failed". The dial ladder
+		// raises one when the host answering proved it is somebody else, or when
+		// a pinned host offered only an unauthenticated endpoint — and the BLE
+		// half of this row is named by the same unauthenticated advertisement
+		// that named the LAN half. Falling back would reach the very peer the
+		// refusal just rejected, over a transport where nothing enforces the pin
+		// at all (attemptBLEConnect sets no ExpectedIdentity, and
+		// enforceSelectedDevicePin is a no-op for a Bluetooth selection), and
+		// report success. Typed, not text-matched: the wording of these refusals
+		// is not a contract, and a message rewrite must not silently reopen this.
+		if errors.Is(err, errDeviceIdentityRefused) {
+			return nil, err
+		}
 		// LAN failed — fall back to BLE if available.
 		if d.Bluetooth != nil {
 			return &SelectedDevice{Bluetooth: d.Bluetooth}, nil
@@ -1956,7 +1972,20 @@ func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts [
 						// The device is wrong, not our certificate — every
 						// remaining cert and port would fail the same way, and
 						// the plaintext rung below must not be reached at all.
-						return nil, lastMTLSErr, identityRefusal(target.PinKey, im)
+						// refusalKey, not PinKey: the pin that produced this
+						// constraint may be filed under one of the device's
+						// other names, and that is the key `wendy device unpin`
+						// has to be handed to clear it.
+						return nil, lastMTLSErr, identityRefusal(target.refusalKey(), im)
+					}
+					if pm, mismatched := pinMismatchFn(conn); mismatched {
+						conn.Close()
+						// The SPKI store rejected the peer's public key. Same
+						// reasoning as above — the key belongs to the device,
+						// not to our certificate — but this refusal also has to
+						// exist because gRPC's handshake wrapper is otherwise
+						// the only thing the user sees, and it names no way out.
+						return nil, lastMTLSErr, spkiRefusal(target.refusalKey(), pm)
 					}
 					if tlsDebug {
 						fmt.Fprintf(os.Stderr, "[tls-debug] GetAgentVersion(%s) error: %v\n", mtlsAddr, probeErr)
@@ -2005,7 +2034,7 @@ func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts [
 		// A host we have already reached over mTLS must never be reached
 		// unauthenticated. Unlike provisionedAgentAdvertisedMTLS this reads
 		// local state, not a TXT record the attacker also controls.
-		return nil, lastMTLSErr, pinnedHostWentUnauthenticatedError(target.PinKey)
+		return nil, lastMTLSErr, pinnedHostWentUnauthenticatedError(target.refusalKey())
 	}
 	conn, err := plaintextConnectFn(ctx, plaintextAddr)
 	return conn, lastMTLSErr, err

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2034,10 +2034,13 @@ func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts [
 			}
 		}
 	}
-	if isPinned(target.PinKey) {
+	if target.pinned() {
 		// A host we have already reached over mTLS must never be reached
-		// unauthenticated. Unlike provisionedAgentAdvertisedMTLS this reads
-		// local state, not a TXT record the attacker also controls.
+		// unauthenticated. Unlike provisionedAgentAdvertisedMTLS this rests on
+		// local state, not a TXT record the attacker also controls — and on the
+		// SAME resolution of that state that produced target.Expected and
+		// target.refusalKey, so the three can never disagree about which pin
+		// they are talking about (see dialTarget.pinned).
 		return nil, lastMTLSErr, pinnedHostWentUnauthenticatedError(target.refusalKey())
 	}
 	conn, err := plaintextConnectFn(ctx, plaintextAddr)
@@ -2115,9 +2118,9 @@ func isCertRejectionError(err error) bool {
 // guard. What it reports comes from the device's own mDNS TXT records, which
 // whoever answered the address controls — so "it didn't advertise mTLS" is not
 // evidence that plaintext is safe. The rule that actually withholds the
-// plaintext rung is isPinned, which reads local pin state (see
-// dialAgentLadderWithCerts). This snapshot is also not refreshed after a failed
-// connection attempt.
+// plaintext rung is dialTarget.pinned, which rests on the pin state resolved
+// for this dial (see dialAgentLadderWithCerts). This snapshot is also not
+// refreshed after a failed connection attempt.
 func provisionedAgentAdvertisedMTLS(ctx context.Context, plaintextAddr string) bool {
 	return provisionedAgentAdvertisedMTLSVia(ctx, discoverLANDevices, plaintextAddr)
 }

--- a/go/internal/cli/commands/helpers_lkg_test.go
+++ b/go/internal/cli/commands/helpers_lkg_test.go
@@ -49,15 +49,20 @@ func TestConnectFastPathStaleEntryZeroResolution(t *testing.T) {
 	}
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		if e.IP != "10.0.0.9" || e.Port != 50052 {
 			t.Errorf("LKG got entry %s:%d, want 10.0.0.9:50052", e.IP, e.Port)
+		}
+		// The pin key must be the name the caller asked for, not anything the
+		// cache row supplied.
+		if pinKey != "orin.local" {
+			t.Errorf("LKG pin key = %q, want the requested name %q", pinKey, "orin.local")
 		}
 		return want, nil, lkgConnected
 	}
 	origLadder := dialAgentLadderFn
-	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
-		t.Errorf("general ladder ran despite LKG success (addr %s)", addr)
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		t.Errorf("general ladder ran despite LKG success (addr %s)", target.Addr)
 		return nil, nil, errors.New("unreachable")
 	}
 	t.Cleanup(func() {
@@ -85,14 +90,14 @@ func TestConnectFastPathLKGHandshakeFailedFallsThroughToLadder(t *testing.T) {
 	}, 0)
 
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		return nil, nil, lkgHandshakeFailed // host alive, handshake didn't pan out
 	}
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	var ladderAddr string
 	origLadder := dialAgentLadderFn
-	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
-		ladderAddr = addr
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = target.Addr
 		return want, nil, nil
 	}
 	origReach := cacheFastPathReachableFn
@@ -121,7 +126,7 @@ func TestConnectFastPathLKGDeadTCPFallsThroughToFreshResolution(t *testing.T) {
 	}, 0)
 
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		return nil, nil, lkgDeadTCP // cached IP is dead
 	}
 	origLookup, origBrowse := osLookupHostFn, lanBrowseFn
@@ -135,8 +140,8 @@ func TestConnectFastPathLKGDeadTCPFallsThroughToFreshResolution(t *testing.T) {
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	var ladderAddrs []string
 	origLadder := dialAgentLadderFn
-	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
-		ladderAddrs = append(ladderAddrs, addr)
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		ladderAddrs = append(ladderAddrs, target.Addr)
 		return want, nil, nil
 	}
 	origReach := cacheFastPathReachableFn
@@ -170,7 +175,7 @@ func TestConnectFastPathLKGIneligibleDeadTCPFallsThroughToFreshResolution(t *tes
 		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
 	}, 0)
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		t.Error("LKG ran for a non-mTLS entry")
 		return nil, nil, lkgDeadTCP
 	}
@@ -189,8 +194,8 @@ func TestConnectFastPathLKGIneligibleDeadTCPFallsThroughToFreshResolution(t *tes
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	var ladderAddr string
 	origLadder := dialAgentLadderFn
-	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
-		ladderAddr = addr
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = target.Addr
 		return want, nil, nil
 	}
 	origReach := cacheFastPathReachableFn
@@ -219,7 +224,7 @@ func TestConnectFastPathLKGIneligibleLiveTCPUsesCachedIP(t *testing.T) {
 		ID: "dev-1", Hostname: "pi.local", IP: "10.0.0.7", Port: 50051, MTLS: false,
 	}, 0)
 	origLKG := dialAgentLKGFn
-	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry) (*grpcclient.AgentConnection, error, lkgOutcome) {
+	dialAgentLKGFn = func(ctx context.Context, e discoverycache.Entry, pinKey string) (*grpcclient.AgentConnection, error, lkgOutcome) {
 		t.Error("LKG ran for a non-mTLS entry")
 		return nil, nil, lkgDeadTCP
 	}
@@ -232,8 +237,8 @@ func TestConnectFastPathLKGIneligibleLiveTCPUsesCachedIP(t *testing.T) {
 	want := &grpcclient.AgentConnection{IsMTLS: true}
 	var ladderAddr string
 	origLadder := dialAgentLadderFn
-	dialAgentLadderFn = func(ctx context.Context, addr string) (*grpcclient.AgentConnection, error, error) {
-		ladderAddr = addr
+	dialAgentLadderFn = func(ctx context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		ladderAddr = target.Addr
 		return want, nil, nil
 	}
 	origReach := cacheFastPathReachableFn

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1099,7 +1099,7 @@ func TestConnectWithAutoTLSDiagnostics_RejectionClassNotRetried(t *testing.T) {
 
 	calls := 0
 	rejectionErr := newTLSHandshakeRejectedError(errors.New("cert rejected"))
-	dialAgentLadderFn = func(context.Context, string) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
 		calls++
 		return nil, nil, rejectionErr
 	}
@@ -1150,7 +1150,7 @@ func TestConnectWithAutoTLSDiagnostics_OrgMismatchNotRetried(t *testing.T) {
 	calls := 0
 	certs := []config.CertificateInfo{{OrganizationID: 3}}
 	orgErr := chooseRejectionError(context.Background(), 42, certs, errors.New("boom"))
-	dialAgentLadderFn = func(context.Context, string) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
 		calls++
 		return nil, nil, orgErr
 	}
@@ -1208,7 +1208,7 @@ func TestConnectWithAutoTLSDiagnostics_SameAddressRetrySkipped(t *testing.T) {
 	}
 
 	calls := 0
-	dialAgentLadderFn = func(context.Context, string) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
 		calls++
 		return nil, nil, errors.New("connection refused")
 	}
@@ -1255,7 +1255,7 @@ func TestConnectWithAutoTLSDiagnostics_SkipsRetryWhenContextExpired(t *testing.T
 	}
 
 	calls := 0
-	dialAgentLadderFn = func(context.Context, string) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderFn = func(context.Context, dialTarget) (*grpcclient.AgentConnection, error, error) {
 		calls++
 		return nil, nil, errors.New("connection refused")
 	}
@@ -1512,13 +1512,13 @@ func TestDialAgentLKGSkipsOnTCPPrecheckFailure(t *testing.T) {
 	}
 	ladderCalled := false
 	origLadder := dialAgentLadderWithCertsFn
-	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderWithCertsFn = func(ctx context.Context, target dialTarget, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
 		ladderCalled = true
 		return nil, nil, errors.New("must not be reached")
 	}
 	t.Cleanup(func() { tcpDialTimeoutFn = origTCP; dialAgentLadderWithCertsFn = origLadder })
 
-	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2}, "orin.local")
 	if outcome != lkgDeadTCP {
 		t.Fatalf("dialAgentLKG outcome = %v, want lkgDeadTCP", outcome)
 	}
@@ -1534,11 +1534,12 @@ func TestDialAgentLKGRotatesCertsAndDialsMTLSPort(t *testing.T) {
 		go c2.Close()
 		return c1, nil
 	}
-	var gotAddr string
+	var gotAddr, gotPinKey string
 	var gotOrgs []int
 	origLadder := dialAgentLadderWithCertsFn
-	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
-		gotAddr = addr
+	dialAgentLadderWithCertsFn = func(ctx context.Context, target dialTarget, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+		gotAddr = target.Addr
+		gotPinKey = target.PinKey
 		for _, c := range certs {
 			gotOrgs = append(gotOrgs, c.OrganizationID)
 		}
@@ -1554,12 +1555,15 @@ func TestDialAgentLKGRotatesCertsAndDialsMTLSPort(t *testing.T) {
 		loadAllCLICertsFn = origCerts
 	})
 
-	conn, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2})
+	conn, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true, OrgID: 2}, "orin.local")
 	if outcome != lkgConnected || conn == nil {
 		t.Fatalf("dialAgentLKG outcome = %v, conn = %v; want lkgConnected with a connection", outcome, conn)
 	}
 	if gotAddr != "10.0.0.9:50052" {
 		t.Errorf("dialed %q, want the entry's mTLS endpoint 10.0.0.9:50052", gotAddr)
+	}
+	if gotPinKey != "orin.local" {
+		t.Errorf("pin key = %q, want the caller's requested name orin.local (never the cached IP)", gotPinKey)
 	}
 	if fmt.Sprint(gotOrgs) != fmt.Sprint([]int{2, 1}) {
 		t.Errorf("cert org order = %v, want entry-org-first [2 1]", gotOrgs)
@@ -1574,7 +1578,7 @@ func TestDialAgentLKGFallsThroughOnPlaintextDowngrade(t *testing.T) {
 		return c1, nil
 	}
 	origLadder := dialAgentLadderWithCertsFn
-	dialAgentLadderWithCertsFn = func(ctx context.Context, addr string, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
+	dialAgentLadderWithCertsFn = func(ctx context.Context, target dialTarget, certs []config.CertificateInfo) (*grpcclient.AgentConnection, error, error) {
 		return grpcclient.NewFromConn(nil), nil, nil // IsMTLS=false: ladder fell to plaintext
 	}
 	origCerts := loadAllCLICertsFn
@@ -1585,7 +1589,7 @@ func TestDialAgentLKGFallsThroughOnPlaintextDowngrade(t *testing.T) {
 		loadAllCLICertsFn = origCerts
 	})
 
-	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true})
+	_, _, outcome := dialAgentLKG(context.Background(), discoverycache.Entry{IP: "10.0.0.9", Port: 50052, MTLS: true}, "orin.local")
 	if outcome != lkgHandshakeFailed {
 		t.Fatalf("LKG outcome = %v, want lkgHandshakeFailed for a plaintext downgrade of an entry advertised as mTLS", outcome)
 	}

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -482,7 +482,7 @@ func TestResolveDeviceAddress_Flag(t *testing.T) {
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = "my-device.local"
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -491,6 +491,9 @@ func TestResolveDeviceAddress_Flag(t *testing.T) {
 	}
 	if addr != "my-device.local:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "my-device.local:50051")
+	}
+	if pinKey != "my-device.local" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "my-device.local")
 	}
 }
 
@@ -501,7 +504,7 @@ func TestResolveDeviceAddress_DefaultDevice(t *testing.T) {
 
 	setTempConfig(t, &config.Config{DefaultDevice: "wendy-thor.local"})
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -511,6 +514,9 @@ func TestResolveDeviceAddress_DefaultDevice(t *testing.T) {
 	if addr != "wendy-thor.local:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "wendy-thor.local:50051")
 	}
+	if pinKey != "wendy-thor.local" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "wendy-thor.local")
+	}
 }
 
 func TestResolveDeviceAddress_ExplicitHostPortFlag(t *testing.T) {
@@ -518,7 +524,7 @@ func TestResolveDeviceAddress_ExplicitHostPortFlag(t *testing.T) {
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = "my-mac.local:50051"
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -527,6 +533,9 @@ func TestResolveDeviceAddress_ExplicitHostPortFlag(t *testing.T) {
 	}
 	if addr != "my-mac.local:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "my-mac.local:50051")
+	}
+	if pinKey != "my-mac.local" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "my-mac.local")
 	}
 }
 
@@ -537,7 +546,7 @@ func TestResolveDeviceAddress_ExplicitHostPortDefault(t *testing.T) {
 
 	setTempConfig(t, &config.Config{DefaultDevice: "my-mac.local:50051"})
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -547,6 +556,9 @@ func TestResolveDeviceAddress_ExplicitHostPortDefault(t *testing.T) {
 	if addr != "my-mac.local:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "my-mac.local:50051")
 	}
+	if pinKey != "my-mac.local" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "my-mac.local")
+	}
 }
 
 func TestResolveDeviceAddress_IPv6ZoneFlag(t *testing.T) {
@@ -554,7 +566,7 @@ func TestResolveDeviceAddress_IPv6ZoneFlag(t *testing.T) {
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = "fe80::8c13:12bf:4df8:b976%en24"
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -563,6 +575,9 @@ func TestResolveDeviceAddress_IPv6ZoneFlag(t *testing.T) {
 	}
 	if addr != "[fe80::8c13:12bf:4df8:b976%en24]:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "[fe80::8c13:12bf:4df8:b976%en24]:50051")
+	}
+	if pinKey != "fe80::8c13:12bf:4df8:b976%en24" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "fe80::8c13:12bf:4df8:b976%en24")
 	}
 }
 
@@ -573,7 +588,7 @@ func TestResolveDeviceAddress_IPv6DefaultDevice(t *testing.T) {
 
 	setTempConfig(t, &config.Config{DefaultDevice: "fe80::1%en0"})
 
-	addr, isDefault, err := resolveDeviceAddress()
+	addr, pinKey, isDefault, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -583,6 +598,9 @@ func TestResolveDeviceAddress_IPv6DefaultDevice(t *testing.T) {
 	if addr != "[fe80::1%en0]:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "[fe80::1%en0]:50051")
 	}
+	if pinKey != "fe80::1%en0" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "fe80::1%en0")
+	}
 }
 
 func TestResolveDeviceAddress_IPv6GlobalFlag(t *testing.T) {
@@ -590,12 +608,15 @@ func TestResolveDeviceAddress_IPv6GlobalFlag(t *testing.T) {
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = "2001:db8::1"
 
-	addr, _, err := resolveDeviceAddress()
+	addr, pinKey, _, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if addr != "[2001:db8::1]:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "[2001:db8::1]:50051")
+	}
+	if pinKey != "2001:db8::1" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "2001:db8::1")
 	}
 }
 
@@ -604,12 +625,15 @@ func TestResolveDeviceAddress_IPv4Flag(t *testing.T) {
 	defer func() { deviceFlag = origFlag }()
 	deviceFlag = "192.168.1.42"
 
-	addr, _, err := resolveDeviceAddress()
+	addr, pinKey, _, err := resolveDeviceAddress()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if addr != "192.168.1.42:50051" {
 		t.Fatalf("addr = %q, want %q", addr, "192.168.1.42:50051")
+	}
+	if pinKey != "192.168.1.42" {
+		t.Fatalf("pinKey = %q, want %q — the pin must be filed under the name the user typed, not the dialled address", pinKey, "192.168.1.42")
 	}
 }
 
@@ -620,7 +644,7 @@ func TestResolveDeviceAddress_NoDevice(t *testing.T) {
 
 	setTempConfig(t, &config.Config{})
 
-	_, _, err := resolveDeviceAddress()
+	_, _, _, err := resolveDeviceAddress()
 	if err == nil {
 		t.Fatal("expected error when no device is specified")
 	}

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -91,6 +91,11 @@ type AgentConnection struct {
 	// atomic; a pointer so "never fired" is distinguishable from a zero
 	// identity. nil for connections that never install the sink.
 	observedServerIdentity *atomic.Pointer[certs.WendyIdentity]
+	// identityMismatch holds the typed rejection raised inside VerifyConnection
+	// when the peer failed ExpectedIdentity. gRPC's lazy dial mangles that error
+	// into the first RPC's status, so the ladder reads it from here instead of
+	// string-matching. nil for connections that never install the sink.
+	identityMismatch *atomic.Pointer[certs.IdentityMismatchError]
 }
 
 // verifiedIdentitySink returns the OnVerifiedServerIdentity callback that
@@ -104,6 +109,18 @@ func verifiedIdentitySink(dst *atomic.Pointer[certs.WendyIdentity]) func(certs.W
 		}
 		stored := id
 		dst.Store(&stored)
+	}
+}
+
+// identityMismatchSink returns the callback that records an ExpectedIdentity
+// rejection. dst may be nil (enforcement not requested), in which case the
+// returned sink is a no-op, so callers need no nil check.
+func identityMismatchSink(dst *atomic.Pointer[certs.IdentityMismatchError]) func(*certs.IdentityMismatchError) {
+	return func(e *certs.IdentityMismatchError) {
+		if dst == nil || e == nil {
+			return
+		}
+		dst.Store(e)
 	}
 }
 
@@ -176,6 +193,8 @@ func newAgentTLSConfig(
 	pins certs.PinChecker,
 	observedOrg *atomic.Int32,
 	observedIdentity *atomic.Pointer[certs.WendyIdentity],
+	expected *certs.WendyIdentity,
+	mismatch *atomic.Pointer[certs.IdentityMismatchError],
 ) (*tls.Config, error) {
 	// Only load the leaf cert — not the chain. Go's TLS library calls
 	// x509.ParseCertificate on every cert sent in the handshake, and ML-DSA
@@ -194,9 +213,10 @@ func newAgentTLSConfig(
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
 	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
-		ChainPEM:      certInfo.PemCertificateChain,
-		ExpectedOrgID: int32(certInfo.OrganizationID),
-		PinStore:      pins,
+		ChainPEM:         certInfo.PemCertificateChain,
+		ExpectedOrgID:    int32(certInfo.OrganizationID),
+		PinStore:         pins,
+		ExpectedIdentity: expected,
 		OnServerIdentity: func(id certs.WendyIdentity) {
 			if id.OrgID != 0 {
 				observedOrg.Store(id.OrgID)
@@ -206,6 +226,23 @@ func newAgentTLSConfig(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("building TLS verifier: %w", err)
+	}
+	// Record a typed ExpectedIdentity rejection before any other wrap. gRPC's
+	// lazy dial mangles a VerifyConnection error into the first RPC's status,
+	// so the dial ladder needs this captured here rather than parsed out of
+	// that mangled error later. Placed closest to the verifier returned by
+	// BuildServerVerifyConnection — ahead of the WENDY_TLS_DEBUG and
+	// SetResumed wraps below — so it observes that verifier's own return
+	// value, not one a later wrap may have transformed.
+	sink := identityMismatchSink(mismatch)
+	verifyConnBase := verifyConn
+	verifyConn = func(cs tls.ConnectionState) error {
+		err := verifyConnBase(cs)
+		var im *certs.IdentityMismatchError
+		if errors.As(err, &im) {
+			sink(im)
+		}
+		return err
 	}
 	if os.Getenv("WENDY_TLS_DEBUG") != "" {
 		inner := verifyConn
@@ -256,9 +293,16 @@ func newAgentTLSConfig(
 }
 
 func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker) (*AgentConnection, error) {
+	return ConnectWithTLSExpecting(ctx, address, certInfo, pins, nil)
+}
+
+// ConnectWithTLSExpecting is ConnectWithTLSAndPins with a required peer
+// identity. A nil expected is exactly ConnectWithTLSAndPins.
+func ConnectWithTLSExpecting(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker, expected *certs.WendyIdentity) (*AgentConnection, error) {
 	observedOrg := new(atomic.Int32)
 	observedIdentity := new(atomic.Pointer[certs.WendyIdentity])
-	tlsCfg, err := newAgentTLSConfig(address, certInfo, pins, observedOrg, observedIdentity)
+	mismatch := new(atomic.Pointer[certs.IdentityMismatchError])
+	tlsCfg, err := newAgentTLSConfig(address, certInfo, pins, observedOrg, observedIdentity, expected, mismatch)
 	if err != nil {
 		return nil, err
 	}
@@ -287,6 +331,7 @@ func ConnectWithTLSAndPins(ctx context.Context, address string, certInfo *config
 	ac.CertInfo = certInfo
 	ac.observedServerOrg = observedOrg
 	ac.observedServerIdentity = observedIdentity
+	ac.identityMismatch = mismatch
 	return ac, nil
 }
 
@@ -381,9 +426,22 @@ func (c *AgentConnection) ObservedServerIdentity() (certs.WendyIdentity, bool) {
 	return *id, true
 }
 
+// IdentityMismatch reports the ExpectedIdentity rejection this connection hit,
+// if any. It is the ladder's signal that the *device* is wrong — as opposed to
+// our certificate being wrong — and therefore that retrying with other certs or
+// other ports is pointless.
+func (c *AgentConnection) IdentityMismatch() (*certs.IdentityMismatchError, bool) {
+	if c.identityMismatch == nil {
+		return nil, false
+	}
+	e := c.identityMismatch.Load()
+	return e, e != nil
+}
+
 func newAgentConnection(conn *grpc.ClientConn) *AgentConnection {
 	return &AgentConnection{
 		Conn:                conn,
+		identityMismatch:    new(atomic.Pointer[certs.IdentityMismatchError]),
 		AgentService:        agentpb.NewWendyAgentServiceClient(conn),
 		ContainerService:    agentpb.NewWendyContainerServiceClient(conn),
 		ShellService:        agentpb.NewWendyShellServiceClient(conn),

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/tlscache"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	"google.golang.org/grpc"
@@ -96,19 +97,56 @@ type AgentConnection struct {
 	// into the first RPC's status, so the ladder reads it from here instead of
 	// string-matching. nil for connections that never install the sink.
 	identityMismatch *atomic.Pointer[certs.IdentityMismatchError]
+	// pinMismatch holds the SPKI pin-store rejection raised inside
+	// VerifyConnection when the peer's public key changed while its pinned
+	// certificate was still valid. Captured for the same reason as
+	// identityMismatch: the ladder must recognise it by type, not by digging it
+	// out of gRPC's handshake-failure string. nil for connections that never
+	// install the sink.
+	pinMismatch *atomic.Pointer[devicepin.PinMismatchError]
 }
 
 // verifiedIdentitySink returns the OnVerifiedServerIdentity callback that
 // records the device identity behind a verified server certificate. Identities
 // without an org are dropped: org 0 is not a real Wendy org, so storing one
 // would let ObservedServerIdentity report an identity no certificate asserted.
+//
+// dst may be nil (observation not requested), in which case the returned sink is
+// a no-op — the same contract as identityMismatchSink below. This runs inside
+// VerifyConnection, so an unguarded nil would panic mid-handshake.
 func verifiedIdentitySink(dst *atomic.Pointer[certs.WendyIdentity]) func(certs.WendyIdentity) {
 	return func(id certs.WendyIdentity) {
-		if id.OrgID == 0 {
+		if dst == nil || id.OrgID == 0 {
 			return
 		}
 		stored := id
 		dst.Store(&stored)
+	}
+}
+
+// observedOrgSink returns the OnServerIdentity callback that records the
+// (unverified, diagnostics-only) org a server certificate claims. Same nil
+// contract as the sinks above, and for the same reason: it fires during the TLS
+// handshake, where a panic takes the connection down rather than surfacing as an
+// error.
+func observedOrgSink(dst *atomic.Int32) func(certs.WendyIdentity) {
+	return func(id certs.WendyIdentity) {
+		if dst == nil || id.OrgID == 0 {
+			return
+		}
+		dst.Store(id.OrgID)
+	}
+}
+
+// pinMismatchSink returns the callback that records an SPKI pin rejection from
+// the device pin store. dst may be nil (no pin store in play), in which case the
+// returned sink is a no-op.
+func pinMismatchSink(dst *atomic.Pointer[devicepin.PinMismatchError]) func(*devicepin.PinMismatchError) {
+	return func(e *devicepin.PinMismatchError) {
+		if dst == nil || e == nil {
+			return
+		}
+		dst.Store(e)
 	}
 }
 
@@ -195,6 +233,7 @@ func newAgentTLSConfig(
 	observedIdentity *atomic.Pointer[certs.WendyIdentity],
 	expected *certs.WendyIdentity,
 	mismatch *atomic.Pointer[certs.IdentityMismatchError],
+	pinMismatch *atomic.Pointer[devicepin.PinMismatchError],
 ) (*tls.Config, error) {
 	// Only load the leaf cert — not the chain. Go's TLS library calls
 	// x509.ParseCertificate on every cert sent in the handshake, and ML-DSA
@@ -213,15 +252,11 @@ func newAgentTLSConfig(
 		return nil, fmt.Errorf("loading TLS cert: %w", err)
 	}
 	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
-		ChainPEM:         certInfo.PemCertificateChain,
-		ExpectedOrgID:    int32(certInfo.OrganizationID),
-		PinStore:         pins,
-		ExpectedIdentity: expected,
-		OnServerIdentity: func(id certs.WendyIdentity) {
-			if id.OrgID != 0 {
-				observedOrg.Store(id.OrgID)
-			}
-		},
+		ChainPEM:                 certInfo.PemCertificateChain,
+		ExpectedOrgID:            int32(certInfo.OrganizationID),
+		PinStore:                 pins,
+		ExpectedIdentity:         expected,
+		OnServerIdentity:         observedOrgSink(observedOrg),
 		OnVerifiedServerIdentity: verifiedIdentitySink(observedIdentity),
 	})
 	if err != nil {
@@ -235,12 +270,22 @@ func newAgentTLSConfig(
 	// SetResumed wraps below — so it observes that verifier's own return
 	// value, not one a later wrap may have transformed.
 	sink := identityMismatchSink(mismatch)
+	// The SPKI store's rejection needs capturing here for the same reason and at
+	// the same point: it is raised inside VerifyConnection (step 3 of
+	// BuildServerVerifyConnection), and by the time the dial ladder sees it, it
+	// is a gRPC status string with the store's message buried in it. Without
+	// this the CLI could only recognise it by matching that text.
+	pinSink := pinMismatchSink(pinMismatch)
 	verifyConnBase := verifyConn
 	verifyConn = func(cs tls.ConnectionState) error {
 		err := verifyConnBase(cs)
 		var im *certs.IdentityMismatchError
 		if errors.As(err, &im) {
 			sink(im)
+		}
+		var pm *devicepin.PinMismatchError
+		if errors.As(err, &pm) {
+			pinSink(pm)
 		}
 		return err
 	}
@@ -302,7 +347,8 @@ func ConnectWithTLSExpecting(ctx context.Context, address string, certInfo *conf
 	observedOrg := new(atomic.Int32)
 	observedIdentity := new(atomic.Pointer[certs.WendyIdentity])
 	mismatch := new(atomic.Pointer[certs.IdentityMismatchError])
-	tlsCfg, err := newAgentTLSConfig(address, certInfo, pins, observedOrg, observedIdentity, expected, mismatch)
+	pinMismatch := new(atomic.Pointer[devicepin.PinMismatchError])
+	tlsCfg, err := newAgentTLSConfig(address, certInfo, pins, observedOrg, observedIdentity, expected, mismatch, pinMismatch)
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +378,7 @@ func ConnectWithTLSExpecting(ctx context.Context, address string, certInfo *conf
 	ac.observedServerOrg = observedOrg
 	ac.observedServerIdentity = observedIdentity
 	ac.identityMismatch = mismatch
+	ac.pinMismatch = pinMismatch
 	return ac, nil
 }
 
@@ -438,10 +485,24 @@ func (c *AgentConnection) IdentityMismatch() (*certs.IdentityMismatchError, bool
 	return e, e != nil
 }
 
+// PinMismatch reports the SPKI pin-store rejection this connection hit, if any.
+// Like IdentityMismatch it tells the ladder that the peer is the problem — the
+// key behind a device's asset identity changed — so no other certificate or
+// port can help, and the message the user needs is the one naming
+// `wendy device unpin`, not gRPC's handshake wrapper.
+func (c *AgentConnection) PinMismatch() (*devicepin.PinMismatchError, bool) {
+	if c.pinMismatch == nil {
+		return nil, false
+	}
+	e := c.pinMismatch.Load()
+	return e, e != nil
+}
+
 func newAgentConnection(conn *grpc.ClientConn) *AgentConnection {
 	return &AgentConnection{
 		Conn:                conn,
 		identityMismatch:    new(atomic.Pointer[certs.IdentityMismatchError]),
+		pinMismatch:         new(atomic.Pointer[devicepin.PinMismatchError]),
 		AgentService:        agentpb.NewWendyAgentServiceClient(conn),
 		ContainerService:    agentpb.NewWendyContainerServiceClient(conn),
 		ShellService:        agentpb.NewWendyShellServiceClient(conn),

--- a/go/internal/cli/grpcclient/identity_mismatch_test.go
+++ b/go/internal/cli/grpcclient/identity_mismatch_test.go
@@ -1,0 +1,49 @@
+package grpcclient
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+// TestIdentityMismatchNilConnection covers the accessor's contract on a
+// connection that never installed the sink (plaintext / NewFromConn).
+func TestIdentityMismatchNilConnection(t *testing.T) {
+	c := &AgentConnection{}
+	if got, ok := c.IdentityMismatch(); ok || got != nil {
+		t.Fatalf("want (nil, false), got (%v, %v)", got, ok)
+	}
+}
+
+// TestIdentityMismatchRecorded covers the sink → accessor round trip that the
+// dial ladder relies on to distinguish "wrong device" from "handshake failed".
+func TestIdentityMismatchRecorded(t *testing.T) {
+	c := newAgentConnection(nil)
+	sink := identityMismatchSink(c.identityMismatch)
+	sink(&certs.IdentityMismatchError{WantOrg: 7, WantAsset: "42", GotOrg: 7, GotAsset: "43"})
+
+	got, ok := c.IdentityMismatch()
+	if !ok {
+		t.Fatal("want ok=true after sink fired")
+	}
+	if got.WantAsset != "42" || got.GotAsset != "43" {
+		t.Fatalf("want 42→43, got %s→%s", got.WantAsset, got.GotAsset)
+	}
+}
+
+// TestVerifyConnectionNotVerifyPeerCertificate locks in the resumption-safety
+// invariant: a resumed TLS 1.3 handshake skips VerifyPeerCertificate entirely
+// and calls only VerifyConnection, so the identity check must live there or it
+// silently stops running after the first connect.
+func TestVerifyConnectionNotVerifyPeerCertificate(t *testing.T) {
+	cfg, err := newAgentTLSConfig("dev.local:50052", testCertInfo(t), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.VerifyConnection == nil {
+		t.Error("VerifyConnection must be set")
+	}
+	if cfg.VerifyPeerCertificate != nil {
+		t.Error("VerifyPeerCertificate must stay nil: a resumed handshake skips it")
+	}
+}

--- a/go/internal/cli/grpcclient/identity_mismatch_test.go
+++ b/go/internal/cli/grpcclient/identity_mismatch_test.go
@@ -4,7 +4,55 @@ import (
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 )
+
+// TestHandshakeSinksTolerateNoDestination covers the contract every sink wired
+// into BuildServerVerifyConnection shares: a nil destination means "this
+// observation was not requested", not "store into nothing".
+//
+// These callbacks run inside VerifyConnection, on the TLS handshake path.
+// verifiedIdentitySink and the OnServerIdentity callback both dereferenced
+// their destination unconditionally, so a caller that passed nil — which
+// newAgentTLSConfig's signature has always permitted, and which its own tests
+// do — hit a nil-pointer panic mid-verification. That the verifier wraps these
+// calls in a recover() is a safety net, not a licence: a recovered panic
+// silently drops the observation the sink existed to make.
+func TestHandshakeSinksTolerateNoDestination(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a sink with no destination panicked during TLS verification: %v", r)
+		}
+	}()
+	id := certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"}
+	verifiedIdentitySink(nil)(id)
+	observedOrgSink(nil)(id)
+	pinMismatchSink(nil)(&devicepin.PinMismatchError{Key: "urn:wendy:org:7:asset:42"})
+}
+
+// TestPinMismatchRecorded covers the sink → accessor round trip the dial ladder
+// reads to tell an SPKI key rotation apart from a handshake failure. Without it
+// the store's rejection reaches the user only as gRPC's wrapper text, which
+// names no way out.
+func TestPinMismatchRecorded(t *testing.T) {
+	c := newAgentConnection(nil)
+	pinMismatchSink(c.pinMismatch)(&devicepin.PinMismatchError{
+		Key: "urn:wendy:org:7:asset:42", DisplayName: "thor",
+		Want: "sha256:aaa", Got: "sha256:bbb",
+	})
+
+	got, ok := c.PinMismatch()
+	if !ok {
+		t.Fatal("want ok=true after the pin sink fired")
+	}
+	if got.Key != "urn:wendy:org:7:asset:42" || got.Got != "sha256:bbb" {
+		t.Fatalf("recorded %+v, want the store's own key and observed fingerprint", got)
+	}
+
+	if got, ok := (&AgentConnection{}).PinMismatch(); ok || got != nil {
+		t.Fatalf("a connection that never installed the sink: want (nil, false), got (%v, %v)", got, ok)
+	}
+}
 
 // TestIdentityMismatchNilConnection covers the accessor's contract on a
 // connection that never installed the sink (plaintext / NewFromConn).
@@ -36,7 +84,7 @@ func TestIdentityMismatchRecorded(t *testing.T) {
 // and calls only VerifyConnection, so the identity check must live there or it
 // silently stops running after the first connect.
 func TestVerifyConnectionNotVerifyPeerCertificate(t *testing.T) {
-	cfg, err := newAgentTLSConfig("dev.local:50052", testCertInfo(t), nil, nil, nil, nil, nil)
+	cfg, err := newAgentTLSConfig("dev.local:50052", testCertInfo(t), nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}

--- a/go/internal/cli/grpcclient/tls_config_test.go
+++ b/go/internal/cli/grpcclient/tls_config_test.go
@@ -73,7 +73,7 @@ func testCertInfo(t *testing.T) *config.CertificateInfo {
 func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]))
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
 
 func TestNewAgentTLSConfigHonorsStoreOff(t *testing.T) {
 	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]))
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestNewAgentTLSConfigDebugLogsResumption(t *testing.T) {
 	tlsDebugWriter = &buf
 	defer func() { tlsDebugWriter = origWriter }()
 
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]))
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}

--- a/go/internal/cli/grpcclient/tls_config_test.go
+++ b/go/internal/cli/grpcclient/tls_config_test.go
@@ -73,7 +73,7 @@ func testCertInfo(t *testing.T) *config.CertificateInfo {
 func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WENDY_TLS_SESSION_STORE", "file")
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestNewAgentTLSConfigSetsSessionCache(t *testing.T) {
 
 func TestNewAgentTLSConfigHonorsStoreOff(t *testing.T) {
 	t.Setenv("WENDY_TLS_SESSION_STORE", "off")
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestNewAgentTLSConfigDebugLogsResumption(t *testing.T) {
 	tlsDebugWriter = &buf
 	defer func() { tlsDebugWriter = origWriter }()
 
-	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil)
+	cfg, err := newAgentTLSConfig("192.168.1.10:50052", testCertInfo(t), nil, new(atomic.Int32), new(atomic.Pointer[certs.WendyIdentity]), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newAgentTLSConfig: %v", err)
 	}

--- a/go/internal/shared/certs/mldsa.go
+++ b/go/internal/shared/certs/mldsa.go
@@ -46,6 +46,27 @@ func (e *OrgMismatchError) Error() string {
 	return fmt.Sprintf("server certificate belongs to org %d, expected org %d", e.Got, e.Want)
 }
 
+// IdentityMismatchError is returned by the VerifyConnection callback when the
+// server certificate does not carry the exact asset identity the caller
+// required via ServerVerifyOpts.ExpectedIdentity. Unlike OrgMismatchError this
+// is never subject to grace mode: a certificate with no Wendy identity is a
+// mismatch, because the caller asked for a specific device and got something
+// that cannot prove it is that device.
+type IdentityMismatchError struct {
+	WantOrg   int32
+	WantAsset string
+	GotOrg    int32  // 0 when the certificate carried no Wendy identity
+	GotAsset  string // "" when the certificate carried no Wendy asset identity
+}
+
+func (e *IdentityMismatchError) Error() string {
+	if e.GotAsset == "" {
+		return fmt.Sprintf("device presented no wendy asset identity, expected asset %s in org %d", e.WantAsset, e.WantOrg)
+	}
+	return fmt.Sprintf("device presented asset %s in org %d, expected asset %s in org %d",
+		e.GotAsset, e.GotOrg, e.WantAsset, e.WantOrg)
+}
+
 // PinChecker is satisfied by *devicepin.Store. Defined here as an interface
 // so shared/certs does not import shared/devicepin (which would be circular).
 type PinChecker interface {
@@ -58,6 +79,16 @@ type ServerVerifyOpts struct {
 	ChainPEM      string     // required: PEM-encoded CA chain for ML-DSA-aware chain verification
 	ExpectedOrgID int32      // 0 = accept any org (still extracted for pinning key)
 	PinStore      PinChecker // nil = skip pinning
+	// ExpectedIdentity, when non-nil, requires the server leaf to carry an
+	// "asset" Wendy identity whose org and entity id match it exactly. This is
+	// the CLI-side counterpart of agent/mtls.NewClientTLSConfigExpectingPeer:
+	// chain validity alone only proves the peer holds a cert from a trusted CA,
+	// not that it is the device the caller asked for, so any other same-CA cert
+	// could otherwise answer at an mDNS-advertised address.
+	//
+	// Grace mode does not apply when this is set — a cert with no Wendy
+	// identity is a mismatch, not a legacy device to be tolerated.
+	ExpectedIdentity *WendyIdentity
 	// OnServerIdentity, when non-nil, is called with the server leaf's Wendy
 	// identity BEFORE chain verification and the org-mismatch check — so the
 	// observed org is captured on every outcome (success, chain-verify failure,
@@ -235,6 +266,27 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 		// OrgModeGrace behaviour in interceptor/mtls.go.
 		if hasIdentity && opts.ExpectedOrgID != 0 && identity.OrgID != opts.ExpectedOrgID {
 			return &OrgMismatchError{Want: opts.ExpectedOrgID, Got: identity.OrgID}
+		}
+
+		// Step 2b: exact device identity check. Deliberately after the org check
+		// so a cross-org impostor still reports OrgMismatchError, whose remedy
+		// (fetch that org's cert) differs from this one's (wrong device).
+		if opts.ExpectedIdentity != nil {
+			if !hasIdentity || identity.EntityType != "asset" {
+				return &IdentityMismatchError{
+					WantOrg:   opts.ExpectedIdentity.OrgID,
+					WantAsset: opts.ExpectedIdentity.EntityID,
+					GotOrg:    identity.OrgID,
+				}
+			}
+			if identity.OrgID != opts.ExpectedIdentity.OrgID || identity.EntityID != opts.ExpectedIdentity.EntityID {
+				return &IdentityMismatchError{
+					WantOrg:   opts.ExpectedIdentity.OrgID,
+					WantAsset: opts.ExpectedIdentity.EntityID,
+					GotOrg:    identity.OrgID,
+					GotAsset:  identity.EntityID,
+				}
+			}
 		}
 
 		// Step 3: SPKI pin check/update.

--- a/go/internal/shared/certs/mldsa.go
+++ b/go/internal/shared/certs/mldsa.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"time"
 
@@ -71,6 +72,29 @@ func (e *IdentityMismatchError) Error() string {
 // so shared/certs does not import shared/devicepin (which would be circular).
 type PinChecker interface {
 	CheckAndUpdate(leaf *x509.Certificate, displayName string) error
+}
+
+// BlockingPinError marks the subset of PinChecker errors that must fail the TLS
+// handshake. Only a rejection of the PEER — the pinned key changed while the
+// pinned certificate was still valid — is one; everything else a pin store can
+// fail at is about the store, not the device.
+//
+// The distinction has to be expressed here rather than by type-switching on
+// devicepin's error, because shared/certs cannot import shared/devicepin (that
+// is why PinChecker exists at all). Making it an interface the error opts into
+// keeps the direction of the dependency intact — devicepin already imports
+// certs — and states the rule in the one place that applies it: a PinChecker
+// error aborts a verified connection only if it says it is about the peer.
+//
+// Anything that does NOT implement this is treated as best-effort. A read-only
+// config directory or a full disk is an operational fault in local bookkeeping;
+// failing every mTLS connection over it would take a fleet offline for a reason
+// that has nothing to do with whether the device is who it claims to be.
+type BlockingPinError interface {
+	error
+	// BlockingPinRejection distinguishes this error from a persistence
+	// failure. It is a marker; it does nothing.
+	BlockingPinRejection()
 }
 
 // ServerVerifyOpts configures the server certificate verification callback
@@ -195,7 +219,8 @@ func verifyMLDSASignature(issuer, cert *x509.Certificate) error {
 //  1. Verifies the server cert chain with ML-DSA fallback (see mldsa.go)
 //  2. Extracts the server's Wendy org identity (IdentityFromCert)
 //  3. Returns OrgMismatchError if opts.ExpectedOrgID != 0 and orgs differ
-//  4. Calls opts.PinStore.CheckAndUpdate if PinStore is non-nil
+//  4. Calls opts.PinStore.CheckAndUpdate if PinStore is non-nil, failing the
+//     handshake only on a BlockingPinError
 //
 // InsecureSkipVerify must be true on the tls.Config — this callback is the
 // actual verification. Go's built-in verifier cannot parse ML-DSA chain certs
@@ -289,14 +314,21 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 			}
 		}
 
-		// Step 3: SPKI pin check/update.
+		// Step 3: SPKI pin check/update. Only a rejection of the peer aborts
+		// the handshake — see BlockingPinError. A pin store that cannot record
+		// what it just verified has failed at bookkeeping, and dropping an
+		// otherwise fully verified connection over that would turn a read-only
+		// config directory into a total loss of device access.
 		if opts.PinStore != nil && hasIdentity && identity.EntityType == "asset" {
 			displayName := leaf.Subject.CommonName
 			if displayName == "" {
 				displayName = identity.IdentityKey()
 			}
 			if pinErr := opts.PinStore.CheckAndUpdate(leaf, displayName); pinErr != nil {
-				return pinErr
+				var blocking BlockingPinError
+				if errors.As(pinErr, &blocking) {
+					return pinErr
+				}
 			}
 		}
 

--- a/go/internal/shared/certs/mldsa.go
+++ b/go/internal/shared/certs/mldsa.go
@@ -296,9 +296,7 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 				displayName = identity.IdentityKey()
 			}
 			if pinErr := opts.PinStore.CheckAndUpdate(leaf, displayName); pinErr != nil {
-				// Log but don't block — pin I/O failure is not a security failure
-				// when the chain has already been verified above.
-				_ = pinErr // callers that care about pinning use a Store that logs internally
+				return pinErr
 			}
 		}
 

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -36,6 +36,21 @@ func AssetURN(orgID, assetID int32) string {
 	return WendyIdentity{OrgID: orgID, EntityType: "asset", EntityID: strconv.Itoa(int(assetID))}.IdentityKey()
 }
 
+// ParseIdentityURN parses a canonical Wendy identity URN —
+// "urn:wendy:org:<org>:(user|asset):<id>", the exact string IdentityKey
+// produces — back into a WendyIdentity.
+//
+// It exists because that URN is user-facing: it is the key the device pin store
+// is filed under and the key an SPKI refusal prints, so `wendy device unpin`
+// has to accept it as an argument. Parsing goes through the same
+// parseWendyOrgURN the certificate path uses, so what the CLI accepts from a
+// user and what it reads out of a certificate can never drift apart — a second
+// hand-rolled parser here would be a second definition of what a Wendy identity
+// is.
+func ParseIdentityURN(urn string) (WendyIdentity, error) {
+	return parseWendyOrgURN(strings.TrimSpace(urn))
+}
+
 // IdentityFromCert extracts the Wendy org+entity identity from a certificate.
 //
 // Resolution order:

--- a/go/internal/shared/certs/server_verify_test.go
+++ b/go/internal/shared/certs/server_verify_test.go
@@ -325,3 +325,70 @@ func TestBuildServerVerifyConnection_OnServerIdentitySilentWhenNoIdentity(t *tes
 		t.Errorf("OnServerIdentity calls = %d, want 0 (no Wendy identity in cert)", calls)
 	}
 }
+
+func TestBuildServerVerifyConnection_ExpectedIdentity(t *testing.T) {
+	want := certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"}
+
+	cases := []struct {
+		name        string
+		sanURI      string
+		wantErr     bool
+		wantGotAsst string
+	}{
+		{name: "exact match", sanURI: "urn:wendy:org:7:asset:42"},
+		{name: "different asset, same org", sanURI: "urn:wendy:org:7:asset:43", wantErr: true, wantGotAsst: "43"},
+		{name: "same asset, different org", sanURI: "urn:wendy:org:9:asset:42", wantErr: true, wantGotAsst: "42"},
+		{name: "user URN is not an asset", sanURI: "urn:wendy:org:7:user:42", wantErr: true},
+		{name: "no wendy identity at all", sanURI: "", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverCert, chainPEM := selfSignedCert(t, "device", tc.sanURI)
+			expected := want
+			verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+				ChainPEM:         string(chainPEM),
+				ExpectedIdentity: &expected,
+			})
+			if err != nil {
+				t.Fatalf("BuildServerVerifyConnection: %v", err)
+			}
+
+			err = verifyConn(tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}})
+
+			var mismatch *certs.IdentityMismatchError
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("want accepted, got %v", err)
+				}
+				return
+			}
+			if !errors.As(err, &mismatch) {
+				t.Fatalf("want IdentityMismatchError, got %v", err)
+			}
+			if mismatch.WantOrg != 7 || mismatch.WantAsset != "42" {
+				t.Errorf("want side = org %d asset %q, want org 7 asset \"42\"", mismatch.WantOrg, mismatch.WantAsset)
+			}
+			if mismatch.GotAsset != tc.wantGotAsst {
+				t.Errorf("GotAsset = %q, want %q", mismatch.GotAsset, tc.wantGotAsst)
+			}
+		})
+	}
+}
+
+// TestBuildServerVerifyConnection_ExpectedIdentityNil locks in that
+// the new field is opt-in: with it unset, a no-URN cert still passes (grace
+// mode), which is what keeps unpinned legacy devices working.
+func TestBuildServerVerifyConnection_ExpectedIdentityNil(t *testing.T) {
+	serverCert, chainPEM := selfSignedCert(t, "device", "")
+	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+		ChainPEM:      string(chainPEM),
+		ExpectedOrgID: 7,
+	})
+	if err != nil {
+		t.Fatalf("BuildServerVerifyConnection: %v", err)
+	}
+	if err := verifyConn(tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}}); err != nil {
+		t.Fatalf("grace mode should accept a no-URN cert, got %v", err)
+	}
+}

--- a/go/internal/shared/certs/server_verify_test.go
+++ b/go/internal/shared/certs/server_verify_test.go
@@ -146,6 +146,15 @@ func (f *fakePinChecker) CheckAndUpdate(leaf *x509.Certificate, displayName stri
 	return f.onCheck(leaf, displayName)
 }
 
+// blockingPinError stands in for devicepin.PinMismatchError, which this package
+// cannot import (that circular import is the reason PinChecker is an interface
+// here). What it models is the only thing the verifier looks at: the error says
+// its rejection is about the peer.
+type blockingPinError struct{ msg string }
+
+func (e *blockingPinError) Error() string         { return e.msg }
+func (e *blockingPinError) BlockingPinRejection() {}
+
 func TestBuildServerVerifyConnection_OnServerIdentityFiresOnSuccess(t *testing.T) {
 	serverCert, chainPEM := selfSignedCert(t, "device", "urn:wendy:org:7:asset:42")
 
@@ -282,15 +291,21 @@ func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnChainFailur
 }
 
 // TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnPinRejection
-// locks in that a rejected SPKI pin (devicepin.PinMismatchError, or any other
-// PinChecker error) also keeps the trust-grade sink from firing. Device
-// pinning is a security control that trusts OnVerifiedServerIdentity's
-// output, so a pin failure must behave exactly like a chain or org failure
-// here: reject the connection and never reach this sink.
+// locks in that a rejected SPKI pin (devicepin.PinMismatchError) also keeps the
+// trust-grade sink from firing. Device pinning is a security control that
+// trusts OnVerifiedServerIdentity's output, so a pin REJECTION must behave
+// exactly like a chain or org failure here: reject the connection and never
+// reach this sink.
+//
+// The fake used to return a bare errors.New, back when the verifier failed on
+// any PinChecker error at all. It now returns a blocking one — the same
+// assertions, narrowed to the case they were always about. A pin store that
+// merely failed to WRITE is not a rejection of the device, and is covered by
+// TestBuildServerVerifyConnection_PinPersistenceFailureDoesNotBlock below.
 func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnPinRejection(t *testing.T) {
 	serverCert, chainPEM := selfSignedCert(t, "device", "urn:wendy:org:7:asset:42")
 
-	pinErr := errors.New("simulated pin mismatch")
+	pinErr := error(&blockingPinError{msg: "simulated pin mismatch"})
 	pin := &fakePinChecker{onCheck: func(leaf *x509.Certificate, name string) error {
 		return pinErr
 	}}
@@ -312,6 +327,48 @@ func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnPinRejectio
 	}
 	if calls != 0 {
 		t.Errorf("OnVerifiedServerIdentity calls = %d, want 0 (pin check rejected)", calls)
+	}
+}
+
+// TestBuildServerVerifyConnection_PinPersistenceFailureDoesNotBlock is the
+// other half of the rule, and the one with the operational teeth: a pin store
+// that cannot WRITE must not cost the user a device.
+//
+// The verifier used to return whatever CheckAndUpdate returned, so a read-only
+// config directory, a full disk, or a stale lock aborted every mTLS connection
+// the CLI made — a total loss of access with no security question anywhere
+// behind it. The store is bookkeeping; the certificate already verified. So the
+// connection must be accepted and the trust-grade sink must still fire, because
+// the identity it reports was verified by exactly the same checks as always.
+func TestBuildServerVerifyConnection_PinPersistenceFailureDoesNotBlock(t *testing.T) {
+	serverCert, chainPEM := selfSignedCert(t, "device", "urn:wendy:org:7:asset:42")
+
+	called := false
+	pin := &fakePinChecker{onCheck: func(leaf *x509.Certificate, name string) error {
+		called = true
+		return errors.New("writing pin store: open /ro/known_devices.json: read-only file system")
+	}}
+
+	var calls int
+	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+		ChainPEM:                 string(chainPEM),
+		ExpectedOrgID:            7,
+		PinStore:                 pin,
+		OnVerifiedServerIdentity: func(id certs.WendyIdentity) { calls++ },
+	})
+	if err != nil {
+		t.Fatalf("BuildServerVerifyConnection: %v", err)
+	}
+
+	cs := tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}}
+	if err := verifyConn(cs); err != nil {
+		t.Fatalf("verifyConn = %v, want nil: a pin-store WRITE failure must never abort a certificate that verified", err)
+	}
+	if !called {
+		t.Error("PinStore.CheckAndUpdate was not called")
+	}
+	if calls != 1 {
+		t.Errorf("OnVerifiedServerIdentity calls = %d, want 1 (the cert verified; only the bookkeeping failed)", calls)
 	}
 }
 

--- a/go/internal/shared/certs/server_verify_test.go
+++ b/go/internal/shared/certs/server_verify_test.go
@@ -281,6 +281,40 @@ func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnChainFailur
 	}
 }
 
+// TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnPinRejection
+// locks in that a rejected SPKI pin (devicepin.PinMismatchError, or any other
+// PinChecker error) also keeps the trust-grade sink from firing. Device
+// pinning is a security control that trusts OnVerifiedServerIdentity's
+// output, so a pin failure must behave exactly like a chain or org failure
+// here: reject the connection and never reach this sink.
+func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnPinRejection(t *testing.T) {
+	serverCert, chainPEM := selfSignedCert(t, "device", "urn:wendy:org:7:asset:42")
+
+	pinErr := errors.New("simulated pin mismatch")
+	pin := &fakePinChecker{onCheck: func(leaf *x509.Certificate, name string) error {
+		return pinErr
+	}}
+
+	var calls int
+	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+		ChainPEM:                 string(chainPEM),
+		ExpectedOrgID:            7,
+		PinStore:                 pin,
+		OnVerifiedServerIdentity: func(id certs.WendyIdentity) { calls++ },
+	})
+	if err != nil {
+		t.Fatalf("BuildServerVerifyConnection: %v", err)
+	}
+
+	cs := tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}}
+	if err := verifyConn(cs); !errors.Is(err, pinErr) {
+		t.Fatalf("verifyConn error = %v, want the pin error to propagate", err)
+	}
+	if calls != 0 {
+		t.Errorf("OnVerifiedServerIdentity calls = %d, want 0 (pin check rejected)", calls)
+	}
+}
+
 func TestBuildServerVerifyConnection_OnVerifiedServerIdentitySilentOnOrgMismatch(t *testing.T) {
 	serverCert, chainPEM := selfSignedCert(t, "device", "urn:wendy:org:7:asset:42")
 

--- a/go/internal/shared/config/devicepin.go
+++ b/go/internal/shared/config/devicepin.go
@@ -2,6 +2,14 @@ package config
 
 import "strings"
 
+// Pin sources. A pin's source records how much the CLI knows about it, which
+// decides who may overwrite it: cloud spoke to the org's cloud over an
+// authenticated session, lan only observed a certificate on the local network.
+const (
+	PinSourceLAN   = "lan"
+	PinSourceCloud = "cloud"
+)
+
 // DevicePin binds a device hostname to the organisation, cloud host, and asset
 // its TLS identity must belong to (WDY-1149). It is deliberately NOT a
 // certificate fingerprint: a device legitimately rotates or re-enrolls its
@@ -15,10 +23,14 @@ import "strings"
 // "urn:wendy:org:<org>:asset:<assetID>" URI SAN, kept as a string because that
 // is how the URN carries it. It is empty for pins written before asset ids were
 // pinned, and for devices whose certificate carries no asset identity at all.
+//
+// Source records where the pin came from: empty means a pin written before
+// sources were recorded, read as PinSourceLAN.
 type DevicePin struct {
 	OrgID     int    `json:"orgId"`
 	CloudGRPC string `json:"cloudGRPC"`
 	AssetID   string `json:"assetId,omitempty"`
+	Source    string `json:"source,omitempty"`
 }
 
 // PinVerdict is the result of comparing an observed device identity against the
@@ -71,6 +83,11 @@ func (c *Config) EvaluateDevicePin(hostname string, orgID int, cloudGRPC, assetI
 	case assetID == "":
 		return PinMatch
 	case pin.AssetID == "":
+		if pin.Source == PinSourceCloud {
+			// Cloud said this device has no asset identity; a LAN sighting is
+			// not evidence to the contrary.
+			return PinMatch
+		}
 		return PinAdoptAsset
 	case pin.AssetID != assetID:
 		return PinMismatch
@@ -79,12 +96,30 @@ func (c *Config) EvaluateDevicePin(hostname string, orgID int, cloudGRPC, assetI
 	}
 }
 
-// SetDevicePin records (or replaces) the pin for a hostname.
-func (c *Config) SetDevicePin(hostname string, orgID int, cloudGRPC, assetID string) {
+// PinSource returns the recorded source for a hostname's pin, defaulting to
+// PinSourceLAN for pins written before sources existed and for unpinned hosts.
+func (c *Config) PinSource(hostname string) string {
+	pin, ok := c.DevicePinFor(hostname)
+	if !ok || pin.Source == "" {
+		return PinSourceLAN
+	}
+	return pin.Source
+}
+
+// SetDevicePinFrom records a pin and where it came from. A cloud-sourced write
+// is authoritative and overwrites whatever was there.
+func (c *Config) SetDevicePinFrom(hostname string, orgID int, cloudGRPC, assetID, source string) {
 	if c.DevicePins == nil {
 		c.DevicePins = make(map[string]DevicePin)
 	}
-	c.DevicePins[normalizePinHost(hostname)] = DevicePin{OrgID: orgID, CloudGRPC: cloudGRPC, AssetID: assetID}
+	c.DevicePins[normalizePinHost(hostname)] = DevicePin{
+		OrgID: orgID, CloudGRPC: cloudGRPC, AssetID: assetID, Source: source,
+	}
+}
+
+// SetDevicePin records (or replaces) the pin for a hostname.
+func (c *Config) SetDevicePin(hostname string, orgID int, cloudGRPC, assetID string) {
+	c.SetDevicePinFrom(hostname, orgID, cloudGRPC, assetID, PinSourceLAN)
 }
 
 // ClearDevicePin drops the pin for a hostname. It is for the case where the

--- a/go/internal/shared/config/devicepin_test.go
+++ b/go/internal/shared/config/devicepin_test.go
@@ -125,3 +125,46 @@ func TestDevicePinRoundTripsThroughConfig(t *testing.T) {
 		t.Fatalf("asset did not round-trip through JSON, got %v", v)
 	}
 }
+
+func TestDevicePinSourcePrecedence(t *testing.T) {
+	const host = "wendy-thor.local"
+
+	t.Run("cloud write overwrites a lan pin", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceLAN)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "99", PinSourceCloud)
+
+		pin, _ := c.DevicePinFor(host)
+		if pin.AssetID != "99" || pin.Source != PinSourceCloud {
+			t.Fatalf("want asset 99 from cloud, got asset %q from %q", pin.AssetID, pin.Source)
+		}
+	})
+
+	t.Run("lan observation conflicting with a cloud pin is a mismatch", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceCloud)
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "43"); v != PinMismatch {
+			t.Fatalf("want PinMismatch, got %v", v)
+		}
+	})
+
+	t.Run("lan never backfills an asset into a cloud pin", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "", PinSourceCloud)
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "42"); v != PinMatch {
+			t.Fatalf("want PinMatch without adoption, got %v", v)
+		}
+	})
+
+	t.Run("legacy fieldless pin reads as lan", func(t *testing.T) {
+		c := &Config{DevicePins: map[string]DevicePin{
+			"wendy-thor": {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443"},
+		}}
+		if got := c.PinSource(host); got != PinSourceLAN {
+			t.Fatalf("want %q, got %q", PinSourceLAN, got)
+		}
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "42"); v != PinAdoptAsset {
+			t.Fatalf("want PinAdoptAsset, got %v", v)
+		}
+	})
+}

--- a/go/internal/shared/devicepin/store.go
+++ b/go/internal/shared/devicepin/store.go
@@ -104,6 +104,16 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 	return s.flush()
 }
 
+// Remove drops the pin for an identity key, so the next connection is a first
+// use. Removing an absent key is not an error.
+func (s *Store) Remove(key string) error {
+	if _, ok := s.devices[key]; !ok {
+		return nil
+	}
+	delete(s.devices, key)
+	return s.flush()
+}
+
 func (s *Store) flush() error {
 	data, err := json.MarshalIndent(s.devices, "", "  ")
 	if err != nil {

--- a/go/internal/shared/devicepin/store.go
+++ b/go/internal/shared/devicepin/store.go
@@ -21,7 +21,25 @@ const pinFileName = "known_devices.json"
 type PinnedDevice struct {
 	SPKIFingerprint string `json:"spkiFingerprint"` // "sha256:<hex>"
 	DisplayName     string `json:"displayName"`
-	LastSeen        string `json:"lastSeen"` // RFC3339
+	LastSeen        string `json:"lastSeen"`           // RFC3339
+	NotAfter        string `json:"notAfter,omitempty"` // RFC3339; pinned leaf's expiry
+}
+
+// PinMismatchError reports that a device identity presented a different public
+// key than the one pinned for it, while the pinned certificate was still valid.
+// A rotation that happens after the pinned cert expires is not an error — it is
+// renewal — so this only fires inside the pinned cert's validity window, where
+// a new key is unexplained.
+type PinMismatchError struct {
+	Key         string
+	DisplayName string
+	Want        string
+	Got         string
+}
+
+func (e *PinMismatchError) Error() string {
+	return fmt.Sprintf("device %q (%s) presented a different certificate key than pinned (pinned %s, now %s)",
+		e.DisplayName, e.Key, e.Want, e.Got)
 }
 
 // Store is a file-backed map from device identity key to PinnedDevice.
@@ -55,8 +73,9 @@ func Open(dir string) (*Store, error) {
 //   - Not an asset cert: skip (user certs and certs with no identity are not pinned)
 //   - Not previously pinned: store pin, return nil
 //   - Pinned, SPKI match: update LastSeen, return nil
-//   - Pinned, SPKI differs: warn to stderr (potential MITM or legitimate rotation),
-//     update pin, return nil
+//   - Pinned, SPKI differs, pinned cert still valid: hard fail with PinMismatchError
+//   - Pinned, SPKI differs, pinned cert expired (or predates NotAfter tracking):
+//     rotation by definition — update pin, return nil
 func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error {
 	identity, ok, err := certs.IdentityFromCert(leaf)
 	if err != nil || !ok || identity.EntityType != "asset" {
@@ -67,15 +86,20 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 	fingerprint := spkiFingerprint(leaf)
 
 	if existing, pinned := s.devices[key]; pinned && existing.SPKIFingerprint != fingerprint {
-		fmt.Fprintf(os.Stderr,
-			"WARNING: Device %q (%s) presented a different certificate than previously seen (was: %s, now: %s); if this is unexpected, a MITM attack may be in progress.\n",
-			displayName, key, existing.SPKIFingerprint, fingerprint)
+		// A key change while the pinned cert is still valid is unexplained: a
+		// renewal replaces an expiring cert, it does not race a live one.
+		if existing.NotAfter != "" {
+			if exp, parseErr := time.Parse(time.RFC3339, existing.NotAfter); parseErr == nil && time.Now().Before(exp) {
+				return &PinMismatchError{Key: key, DisplayName: displayName, Want: existing.SPKIFingerprint, Got: fingerprint}
+			}
+		}
 	}
 
 	s.devices[key] = PinnedDevice{
 		SPKIFingerprint: fingerprint,
 		DisplayName:     displayName,
 		LastSeen:        time.Now().UTC().Format(time.RFC3339),
+		NotAfter:        leaf.NotAfter.UTC().Format(time.RFC3339),
 	}
 	return s.flush()
 }

--- a/go/internal/shared/devicepin/store.go
+++ b/go/internal/shared/devicepin/store.go
@@ -104,6 +104,16 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 	return s.flush()
 }
 
+// Has reports whether a pin is recorded for an identity key. Remove treats an
+// absent key as success, which is right for the caller's contract but leaves it
+// unable to say what it actually removed — and an unpin that reports clearing
+// entries it never held is exactly the kind of vague reporting that let
+// over-broad clearing go unnoticed.
+func (s *Store) Has(key string) bool {
+	_, ok := s.devices[key]
+	return ok
+}
+
 // Remove drops the pin for an identity key, so the next connection is a first
 // use. Removing an absent key is not an error.
 func (s *Store) Remove(key string) error {

--- a/go/internal/shared/devicepin/store.go
+++ b/go/internal/shared/devicepin/store.go
@@ -42,6 +42,19 @@ func (e *PinMismatchError) Error() string {
 		e.DisplayName, e.Key, e.Want, e.Got)
 }
 
+// BlockingPinRejection marks this as the one CheckAndUpdate failure the TLS
+// verifier must drop a connection over: it says the PEER is not the one we
+// pinned. Every other way CheckAndUpdate can fail is a write to local
+// bookkeeping, which cannot make a verified device untrustworthy. See
+// certs.BlockingPinError.
+func (e *PinMismatchError) BlockingPinRejection() {}
+
+// Compile-time proof that the marker above really does satisfy the interface
+// the verifier tests for. Without it, dropping or renaming the method would
+// silently downgrade every key-change rejection to best-effort — the verifier
+// would just stop failing, and nothing in this package would notice.
+var _ certs.BlockingPinError = (*PinMismatchError)(nil)
+
 // Store is a file-backed map from device identity key to PinnedDevice.
 // It is not safe for concurrent use across multiple processes.
 type Store struct {
@@ -72,10 +85,25 @@ func Open(dir string) (*Store, error) {
 //
 //   - Not an asset cert: skip (user certs and certs with no identity are not pinned)
 //   - Not previously pinned: store pin, return nil
-//   - Pinned, SPKI match: update LastSeen, return nil
+//   - Pinned, SPKI match: refresh LastSeen in memory, return nil
 //   - Pinned, SPKI differs, pinned cert still valid: hard fail with PinMismatchError
 //   - Pinned, SPKI differs, pinned cert expired (or predates NotAfter tracking):
 //     rotation by definition — update pin, return nil
+//
+// Only the PinMismatchError is a rejection of the device. A returned write
+// failure means the verdict above stands but could not be recorded; it is
+// reported so a caller may log it, and deliberately does NOT implement
+// certs.BlockingPinError, so the TLS verifier lets the connection through. The
+// alternative — every mTLS connection failing because ~/.wendy is read-only —
+// is an outage with no security question behind it.
+//
+// The write is skipped entirely when the entry would come back identical apart
+// from LastSeen, which is the common path: a device whose key and expiry are
+// unchanged is every connection after the first. Nothing reads LastSeen (it is
+// there for a human reading known_devices.json), so it is refreshed in memory
+// and rides along on the next write that has a real reason to happen. NotAfter
+// is a different matter — CheckAndUpdate itself reads it to tell rotation from
+// mismatch — so any change to it still forces the write through.
 func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error {
 	identity, ok, err := certs.IdentityFromCert(leaf)
 	if err != nil || !ok || identity.EntityType != "asset" {
@@ -84,8 +112,10 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 
 	key := identity.IdentityKey()
 	fingerprint := spkiFingerprint(leaf)
+	notAfter := leaf.NotAfter.UTC().Format(time.RFC3339)
 
-	if existing, pinned := s.devices[key]; pinned && existing.SPKIFingerprint != fingerprint {
+	existing, pinned := s.devices[key]
+	if pinned && existing.SPKIFingerprint != fingerprint {
 		// A key change while the pinned cert is still valid is unexplained: a
 		// renewal replaces an expiring cert, it does not race a live one.
 		if existing.NotAfter != "" {
@@ -95,11 +125,19 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 		}
 	}
 
+	unchanged := pinned &&
+		existing.SPKIFingerprint == fingerprint &&
+		existing.NotAfter == notAfter &&
+		existing.DisplayName == displayName
+
 	s.devices[key] = PinnedDevice{
 		SPKIFingerprint: fingerprint,
 		DisplayName:     displayName,
 		LastSeen:        time.Now().UTC().Format(time.RFC3339),
-		NotAfter:        leaf.NotAfter.UTC().Format(time.RFC3339),
+		NotAfter:        notAfter,
+	}
+	if unchanged {
+		return nil
 	}
 	return s.flush()
 }

--- a/go/internal/shared/devicepin/store_test.go
+++ b/go/internal/shared/devicepin/store_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
 )
 
@@ -193,6 +194,30 @@ func TestCheckAndUpdateKeyChange(t *testing.T) {
 		}
 	})
 
+	t.Run("a key change is blocking, so the TLS verifier drops the connection", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := devicepin.Open(dir)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		first := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		if err := s.CheckAndUpdate(first, "thor"); err != nil {
+			t.Fatalf("first use: %v", err)
+		}
+
+		second := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		err = s.CheckAndUpdate(second, "thor")
+
+		// certs.BuildServerVerifyConnection fails the handshake on exactly this
+		// property and nothing else, so a PinMismatchError that stopped
+		// satisfying it would silently become advisory — the MITM protection
+		// gone with every existing test still green.
+		var blocking certs.BlockingPinError
+		if !errors.As(err, &blocking) {
+			t.Fatalf("CheckAndUpdate error = %v (%T), want one the TLS verifier treats as blocking", err, err)
+		}
+	})
+
 	t.Run("after the pinned cert expires it re-pins silently", func(t *testing.T) {
 		dir := t.TempDir()
 		s, err := devicepin.Open(dir)
@@ -209,4 +234,102 @@ func TestCheckAndUpdateKeyChange(t *testing.T) {
 			t.Fatalf("rotation after expiry must be accepted, got %v", err)
 		}
 	})
+}
+
+// unwritablePinFile plants an existing, read-only known_devices.json in dir so
+// the store can load it but never write it — the shape of a read-only config
+// directory, without depending on the test process's ability to chmod a
+// directory it owns.
+func unwritablePinFile(t *testing.T, dir string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: file mode bits do not prevent writes")
+	}
+	path := filepath.Join(dir, "known_devices.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o400); err != nil {
+		t.Fatalf("seeding read-only pin file: %v", err)
+	}
+	// t.TempDir's cleanup needs the file removable again.
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+}
+
+// TestCheckAndUpdate_PersistenceFailureIsNotBlocking is the regression this
+// pairs with on the verifier side: an unwritable pin store must report its
+// failure WITHOUT claiming the device was rejected. The verifier decides
+// whether to drop the connection purely on certs.BlockingPinError, so if this
+// error carried that marker, a read-only ~/.wendy would make every enrolled
+// device unreachable.
+func TestCheckAndUpdate_PersistenceFailureIsNotBlocking(t *testing.T) {
+	dir := t.TempDir()
+	unwritablePinFile(t, dir)
+
+	s, err := devicepin.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cert := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+	err = s.CheckAndUpdate(cert, "thor")
+	if err == nil {
+		t.Fatal("CheckAndUpdate = nil for an unwritable store; the failure must still be reported so a caller can log it")
+	}
+
+	var blocking certs.BlockingPinError
+	if errors.As(err, &blocking) {
+		t.Fatalf("CheckAndUpdate error = %v is marked blocking; a write failure is not a rejection of the device, and marking it one takes every device offline when ~/.wendy is read-only", err)
+	}
+	var mismatch *devicepin.PinMismatchError
+	if errors.As(err, &mismatch) {
+		t.Fatalf("CheckAndUpdate error = %v is a PinMismatchError; nothing about the peer's key changed", err)
+	}
+}
+
+// TestCheckAndUpdate_UnchangedEntrySkipsTheWrite covers the common path: the
+// same device, same key, same expiry, on every connection after the first.
+// Rewriting the file each time is pure write amplification, and it invents a
+// failure — a store that has nothing to record cannot fail to record it.
+//
+// Making the file unwritable after the pin is established is what makes the
+// claim observable: a write would surface as the (non-blocking) persistence
+// error, so nil proves none was attempted.
+func TestCheckAndUpdate_UnchangedEntrySkipsTheWrite(t *testing.T) {
+	dir := t.TempDir()
+	s, err := devicepin.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cert := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+	if err := s.CheckAndUpdate(cert, "thor"); err != nil {
+		t.Fatalf("first use: %v", err)
+	}
+
+	path := filepath.Join(dir, "known_devices.json")
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: file mode bits do not prevent writes")
+	}
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	if err := s.CheckAndUpdate(cert, "thor"); err != nil {
+		t.Fatalf("CheckAndUpdate = %v for an unchanged entry, want nil — nothing changed, so nothing should have been written", err)
+	}
+
+	// A genuinely changed entry must still be flushed. Only LastSeen is allowed
+	// to go stale in the file; every other field is either read by
+	// CheckAndUpdate itself (SPKIFingerprint, NotAfter) or shown to a human
+	// (DisplayName), so "skip the write" must not become "skip every write".
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if err := s.CheckAndUpdate(cert, "thor-renamed"); err != nil {
+		t.Fatalf("re-pin under a new display name: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading pin file: %v", err)
+	}
+	if !strings.Contains(string(data), "thor-renamed") {
+		t.Fatalf("pin file %s did not pick up the changed display name; a changed entry must still be flushed", data)
+	}
 }

--- a/go/internal/shared/devicepin/store_test.go
+++ b/go/internal/shared/devicepin/store_test.go
@@ -7,7 +7,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io"
+	"errors"
+	"fmt"
 	"math/big"
 	"net/url"
 	"os"
@@ -64,49 +65,28 @@ func TestStore_SameCert_UpdatesLastSeen(t *testing.T) {
 	}
 }
 
-func TestStore_DifferentCert_RotationAccepted(t *testing.T) {
-	dir := t.TempDir()
-	store, _ := devicepin.Open(dir)
-	cert1 := makeCert(t, "urn:wendy:org:7:asset:42")
-	_ = store.CheckAndUpdate(cert1, "My Device")
-	// Different cert, same identity key → rotation → accepted (with a warning to stderr).
-	cert2 := makeCert(t, "urn:wendy:org:7:asset:42")
-	if err := store.CheckAndUpdate(cert2, "My Device"); err != nil {
-		t.Errorf("CheckAndUpdate rotation: %v", err)
-	}
-}
-
-func TestStore_DifferentCert_WarnsOnMismatch(t *testing.T) {
+// TestStore_DifferentCert_WithinValidityIsRejected supersedes the old
+// "rotation accepted" / "warns on mismatch" behavior: SPKI pinning now fails
+// closed. A key change while the previously pinned cert is still valid is
+// unexplained (a renewal replaces an expiring cert, it does not race a live
+// one), so CheckAndUpdate must reject it instead of overwriting the pin with
+// a warning.
+func TestStore_DifferentCert_WithinValidityIsRejected(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := devicepin.Open(dir)
 	cert1 := makeCert(t, "urn:wendy:org:7:asset:42")
 	_ = store.CheckAndUpdate(cert1, "My Device")
 
-	// Capture stderr during the second call with a different cert.
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	oldStderr := os.Stderr
-	os.Stderr = w
-
+	// Different cert, same identity key, pinned cert still valid → hard fail.
 	cert2 := makeCert(t, "urn:wendy:org:7:asset:42")
-	callErr := store.CheckAndUpdate(cert2, "My Device")
+	err := store.CheckAndUpdate(cert2, "My Device")
 
-	w.Close()
-	os.Stderr = oldStderr
-
-	if callErr != nil {
-		t.Fatalf("CheckAndUpdate rotation returned error: %v", callErr)
+	var mismatch *devicepin.PinMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("want PinMismatchError, got %v", err)
 	}
-
-	output, _ := io.ReadAll(r)
-	got := string(output)
-	if !strings.Contains(got, "WARNING") {
-		t.Errorf("expected WARNING in stderr on SPKI mismatch; got: %q", got)
-	}
-	if !strings.Contains(got, "My Device") {
-		t.Errorf("expected device name in warning; got: %q", got)
+	if !strings.Contains(mismatch.DisplayName, "My Device") {
+		t.Errorf("mismatch.DisplayName = %q, want to contain %q", mismatch.DisplayName, "My Device")
 	}
 }
 
@@ -158,3 +138,75 @@ func TestStore_PersistsAcrossOpen(t *testing.T) {
 
 // unused import guard — pem is imported by the brief verbatim.
 var _ = pem.EncodeToMemory
+
+// assetCert generates a fresh self-signed asset cert with a URI SAN of
+// urn:wendy:org:<org>:asset:<assetID> and the given NotAfter. Modeled on
+// selfSignedCert in shared/certs/server_verify_test.go. A fresh key is
+// generated on every call, so two certs with the same org/assetID still
+// differ in SPKI — required for the mismatch test below to be meaningful.
+func assetCert(t *testing.T, org int32, assetID string, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-device"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	u, err := url.Parse(fmt.Sprintf("urn:wendy:org:%d:asset:%s", org, assetID))
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	tmpl.URIs = []*url.URL{u}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsing cert: %v", err)
+	}
+	return cert
+}
+
+func TestCheckAndUpdateKeyChange(t *testing.T) {
+	t.Run("within validity is a hard fail", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := devicepin.Open(dir)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		first := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		if err := s.CheckAndUpdate(first, "thor"); err != nil {
+			t.Fatalf("first use: %v", err)
+		}
+
+		second := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		err = s.CheckAndUpdate(second, "thor")
+
+		var mismatch *devicepin.PinMismatchError
+		if !errors.As(err, &mismatch) {
+			t.Fatalf("want PinMismatchError, got %v", err)
+		}
+	})
+
+	t.Run("after the pinned cert expires it re-pins silently", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := devicepin.Open(dir)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		expired := assetCert(t, 7, "42", time.Now().Add(-time.Hour))
+		if err := s.CheckAndUpdate(expired, "thor"); err != nil {
+			t.Fatalf("first use: %v", err)
+		}
+
+		renewed := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		if err := s.CheckAndUpdate(renewed, "thor"); err != nil {
+			t.Fatalf("rotation after expiry must be accepted, got %v", err)
+		}
+	})
+}

--- a/specs/2026-08-08-cli-device-identity-enforcement-design.md
+++ b/specs/2026-08-08-cli-device-identity-enforcement-design.md
@@ -172,6 +172,15 @@ key, the plaintext fallback is not attempted at all.** No dependence on the `tls
 TXT record, the cache's `MTLS` flag, or `isCertRejectionError`'s string matching
 — all three are attacker-influenced or fragile.
 
+The guard reads the pin state the dial already resolved (`dialTarget.pinned`,
+backed by `PinnedKey`), never a fresh lookup. One connect makes one decision
+about what the pin says: a second, independent read can observe a different
+answer — every `wendy` invocation shares one config file, so a cloud seeding or
+an `unpin` from another process lands mid-ladder — and disagreeing in the
+unpinned direction would hand a host that was pinned when the connect started an
+unauthenticated connection. Deriving the guard, `Expected`, and the refusal key
+from one resolution makes that disagreement unrepresentable.
+
 `provisionedAgentAdvertisedMTLS` (`helpers.go:1893` on #1619) loses its security role and
 survives only as a phrasing hint for the error message; its doc comment is
 updated to say so, because today it reads like a guard.
@@ -193,6 +202,17 @@ all.
 `devicepin.Store.CheckAndUpdate` returns a real error on key change, and
 `BuildServerVerifyConnection` step 3 propagates it instead of discarding it
 (`mldsa.go:234-238`).
+
+What propagates is the *rejection*, not every error the store can raise. Only a
+`PinMismatchError` — the peer's key changed inside the pinned certificate's
+validity window — aborts the handshake; a failure to WRITE the store does not.
+The store is local bookkeeping, and dropping an otherwise fully verified
+connection because `~/.wendy` is read-only or the disk is full is an outage with
+no security question behind it. Because `shared/certs` cannot import
+`shared/devicepin` (the reason `PinChecker` is an interface), the distinction is
+carried by a marker interface `certs.BlockingPinError` that the rejection
+implements and a write failure does not; a compile-time assertion in `devicepin`
+keeps the two halves from drifting apart silently.
 
 To keep that from breaking ordinary certificate renewal, the store records the
 pinned leaf's `NotAfter`. A key change is accepted silently — and re-pinned —

--- a/specs/2026-08-08-cli-device-identity-enforcement-design.md
+++ b/specs/2026-08-08-cli-device-identity-enforcement-design.md
@@ -1,0 +1,265 @@
+# CLI Device Identity Enforcement (follow-up to PR #1616 review)
+
+**Date:** 2026-08-08
+**Status:** Approved (design)
+**Branch:** `jo/cli-device-identity-enforcement` (stacked on
+`ed/lkg-connect-cache`, PR #1619, itself stacked on `ed/instant-mdns-discovery`,
+PR #1616)
+**Depends on:** `jo/pin-device-identity`, to be opened as its own PR against
+`main` first and merged into this branch (see *Sequencing*)
+
+## Problem
+
+mDNS TXT records are unauthenticated: anyone on the LAN can answer a browse
+with any content. PR #1616 consolidates the parsing of those records into
+`lanDeviceFromService` (`shared/discovery/mdns.go`), which derives a device's
+`ID`, `DisplayName`, `AssetID`, `OrgID`, `MeshName` and `IsMTLS` from them.
+Nothing downstream on the CLI path binds any of that to the certificate the
+device later presents.
+
+Concretely, on `main` today:
+
+1. **No identity binding.** `newAgentTLSConfig` (`cli/grpcclient/client.go:152`)
+   sets `InsecureSkipVerify: true` and passes `ExpectedOrgID:
+   int32(certInfo.OrganizationID)` — *the CLI's own* certificate org, never the
+   discovered one. `BuildServerVerifyConnection` (`shared/certs/mldsa.go:160`)
+   then checks chain, org, and SPKI pin only; `AssetID`, `ID`, and hostname are
+   never compared against `identity.EntityID`. Any host holding any certificate
+   chaining to the Wendy CA is accepted at whatever address mDNS supplied.
+2. **Grace mode widens it.** `mldsa.go:224` rejects only when the leaf carries a
+   Wendy identity *and* the org differs, so a chain-valid certificate with no
+   Wendy URN at all passes unconditionally.
+3. **Plaintext downgrade.** `dialAgentLadderWithCerts` falls back to
+   `grpcclient.Connect(ctx, plaintextAddr)` (`cli/commands/helpers.go:1355` on
+   `main`, `:1641` on #1616, `:1822` on #1619) unless every failure looked like
+   a cert rejection —
+   and `isCertRejectionError` explicitly excludes `"first record does not look
+   like a TLS handshake"`, which is exactly what a plaintext impostor produces.
+   The one guard, `provisionedAgentAdvertisedMTLS`, reads the spoofable `tls`
+   TXT bit.
+4. **Pinning does not backstop any of it.** `devicepin.Store.CheckAndUpdate`
+   (`shared/devicepin/store.go:60`) is keyed by the *certificate's own*
+   `urn:wendy:org:N:asset:M`, not by hostname, so a different asset answering at
+   a spoofed address is a fresh key rather than a mismatch — and a genuine
+   mismatch only warns before overwriting the pin and returning nil. The
+   hostname-keyed `enforceDevicePin` (`cli/commands/device_pin.go:45`) applies
+   only to the saved default device, and pins the *CLI's* org, so it cannot
+   distinguish two devices within one organisation.
+
+The agent already solves this for its own mesh dials:
+`agent/mtls.NewClientTLSConfigExpectingPeer` (`agent/mtls/server.go:178`) names
+this exact threat in its doc comment and requires `ident.OrgID == wantOrgID &&
+ident.EntityID == wantAssetID`. The CLI has no equivalent.
+
+**Impact.** Within one organisation, an attacker on the LAN can redirect a
+device name to a host it controls and be accepted over mTLS with any same-CA
+certificate; or serve plaintext gRPC and get an unauthenticated session; or
+poison `AssetID`/`MeshName` used for fleet peer URLs
+(`cli/commands/fleet_manifest.go:213`).
+
+This is pre-existing on `main` — #1616 consolidates the parsing rather than
+introducing the trust gap — but that consolidation is what makes a single
+chokepoint fix possible.
+
+## Approved decisions
+
+| Question | Decision |
+| --- | --- |
+| Trust anchor | Local TOFU pin: first verified mTLS connection to a name records `(orgID, assetID)`; later connections must match |
+| Mismatch policy | Hard fail with an explicit re-pin command — no interactive "trust this?" prompt |
+| Cloud's role | Cloud is authority: a cloud-verified identity seeds and overwrites the pin silently; a LAN observation never overwrites a cloud pin |
+| Legacy posture | Strict once pinned, permissive on first contact — unpinned hosts keep today's grace mode and plaintext fallback |
+| SPKI store | Hard fail on key change, with an expiry-based rotation window |
+
+## Design
+
+### 1. Enforcement inside the handshake
+
+`certs.ServerVerifyOpts` gains `ExpectedIdentity *WendyIdentity`. When non-nil,
+step 2 of `BuildServerVerifyConnection` requires the leaf to carry an **asset**
+identity whose org and entity ID match exactly; grace mode does not apply and a
+no-URN certificate is rejected. When nil, behaviour is exactly as today. This is
+deliberately the same shape as `agent/mtls.NewClientTLSConfigExpectingPeer`, so
+both sides of the fleet enforce identity identically.
+
+It must live in `VerifyConnection`, not `VerifyPeerCertificate`: a resumed TLS
+1.3 handshake skips `VerifyPeerCertificate` entirely and calls only
+`VerifyConnection`. The CLI's session cache (`tlscache`, PR #1612) makes
+resumption the common path, so a check in the wrong callback would silently stop
+running after the first connect — the gotcha `agent/mtls/server.go:212` already
+documents.
+
+Mismatch produces a typed `certs.IdentityMismatchError{WantOrg, WantAsset,
+GotOrg, GotAsset}`. Because `grpc.NewClient` is lazy, the error surfaces mangled
+inside the `GetAgentVersion` probe, so it is captured the way `observedServerOrg`
+already is — an atomic set inside the verifier, read back via
+`conn.IdentityMismatch()`. **On mismatch the dial ladder aborts immediately**
+rather than continuing to the next certificate or the next port: trying our other
+client certs is pointless when it is the *device* that is wrong, and aborting
+turns a security failure into a fast, legible one.
+
+### 2. Pin record
+
+`config.DevicePin` becomes:
+
+```go
+type DevicePin struct {
+    OrgID        int    `json:"orgId"`
+    CloudGRPC    string `json:"cloudGRPC"`
+    AssetID      string `json:"assetId,omitempty"`
+    Source       string `json:"source,omitempty"`       // "cloud" | "lan"
+    SPKI         string `json:"spki,omitempty"`
+    SPKINotAfter string `json:"spkiNotAfter,omitempty"` // RFC3339
+}
+```
+
+`OrgID`, `CloudGRPC`, `AssetID` and the `PinAdoptAsset` legacy-upgrade verdict
+come from the `jo/pin-device-identity` commit. This spec adds `Source`, `SPKI`,
+`SPKINotAfter`.
+
+"Cloud-verified" means an identity obtained over an authenticated session with
+the org's cloud — the asset roster returned by `fetchCloudAssetsFiltered`, or a
+cloud tunnel connection whose TLS terminates at cloud. It specifically does not
+mean "an identity that mentions a cloud host": `DevicePin.CloudGRPC` is a
+recorded attribute, not evidence.
+
+Precedence:
+
+- A cloud-verified identity writes `Source: "cloud"`, overwriting anything, and
+  refreshes silently — re-provisioning through cloud needs no manual unpin.
+- A LAN observation never overwrites a `Source: "cloud"` pin. Conflict is a hard
+  fail.
+- TOFU writes `Source: "lan"` only when no pin exists; a later cloud value
+  silently corrects it.
+- A pin with neither `AssetID` nor `Source` (written by an older CLI) is treated
+  as `Source: "lan"` with no asset constraint: org and cloud are enforced as
+  today and the asset is backfilled on the next successful connect. Existing
+  users are not locked out of their default device on first run after upgrade.
+
+### 3. Pin key: the name the user asked for
+
+Today the ladder receives a bare `plaintextAddr` string, so the requested
+identity is gone by dial time. Introduce:
+
+```go
+type dialTarget struct {
+    PinKey   string              // user-facing name; "" disables pin enforcement
+    Addr     string              // host:port actually dialed
+    Expected *certs.WendyIdentity // non-nil when a pin or cloud value constrains it
+}
+```
+
+threaded from `resolveDeviceAddress`, the picker, and the cloud connect path
+into `dialAgentLadderWithCerts`. #1619's `dialAgentLKG` funnels through
+`dialAgentLadderWithCertsFn`, so the single enforcement point covers the LKG
+fast path too, and #1619 already threads `originalAddr` for
+`cacheConnectSuccess` — that is the pin key.
+
+Keying on the requested name rather than the dialed IP matters: an IP-keyed pin
+false-positives on ordinary DHCP churn, which trains users to unpin reflexively.
+
+Cloud asset names and LAN hostnames do not always agree (`calm-zinnia` vs
+`wendyos-calm-zinnia.local`), so lookup tries hostname, then display name, then
+mesh name. The safety property that makes this acceptable: **key resolution may
+consult spoofable data, because choosing the wrong key can only ever produce a
+mismatch — a stricter outcome — never a bypass.** Trust decisions stay on the
+certificate; only key *selection* touches TXT-derived data.
+
+### 4. Plaintext downgrade
+
+The rule becomes state-based rather than TXT-based: **if a pin exists for the
+key, the plaintext fallback is not attempted at all.** No dependence on the `tls`
+TXT record, the cache's `MTLS` flag, or `isCertRejectionError`'s string matching
+— all three are attacker-influenced or fragile.
+
+`provisionedAgentAdvertisedMTLS` (`helpers.go:1893` on #1619) loses its security role and
+survives only as a phrasing hint for the error message; its doc comment is
+updated to say so, because today it reads like a guard.
+
+Unpinned hosts keep the fallback, which is what preserves provisioning for
+genuinely fresh devices. #1619's `dialAgentLKG` already declines a plaintext
+downgrade when the cache entry advertised mTLS; this change turns that heuristic
+into a rule anchored on the pin instead of on cache state.
+
+The `jo/pin-device-identity` commit's `challengeUnprovisionedDevice` covers the
+same case *after* connecting and prompts interactively. It is re-pointed at the
+hard-fail policy and retained as the backstop for the paths the ladder rule does
+not cover: connections whose `PinKey` resolves only after the transport is up
+(cloud tunnel), and `NewFromConn`-style connections that never run the ladder at
+all.
+
+### 5. SPKI pinning
+
+`devicepin.Store.CheckAndUpdate` returns a real error on key change, and
+`BuildServerVerifyConnection` step 3 propagates it instead of discarding it
+(`mldsa.go:234-238`).
+
+To keep that from breaking ordinary certificate renewal, the store records the
+pinned leaf's `NotAfter`. A key change is accepted silently — and re-pinned —
+when the previously pinned certificate has already expired, since that is
+rotation by definition; otherwise it hard-fails. A cloud-authoritative
+connection also refreshes the SPKI pin silently. Without one of these, a
+fleet-wide renewal becomes a manual unpin per device per user, which is the kind
+of friction that gets the check disabled later.
+
+### 6. Surface
+
+- **`wendy device unpin <hostname>`** clears both the `config.DevicePins` entry
+  and the `devicepin` SPKI entry. It is the single escape hatch every refusal
+  points at.
+- `wendy device set-default <host>` keeps the `clearDevicePinForRepin` behaviour
+  from `jo/pin-device-identity`: naming a device is an assertion that you mean
+  it, so the pin is dropped and re-established.
+- Refusal messages name the pinned identity, the observed identity, which field
+  changed, and the exact command to run. They are identical in interactive,
+  JSON, and non-interactive modes — no prompt, per the approved policy.
+- Cloud seeding hooks the two places the CLI already holds verified asset data:
+  the cloud tunnel connect path, and `fetchCloudAssetsFiltered` (used by
+  `wendy cloud discover`).
+
+### 7. Scope of enforcement
+
+Enforcement applies to every gRPC connection with a non-empty `PinKey`:
+`--device`, the saved default, picker selections, and cloud connects. This is
+the main behavioural widening over `jo/pin-device-identity`, which gates on
+`if isDefault`.
+
+## Sequencing
+
+1. `jo/pin-device-identity` is pushed as its own PR against `main` and reviewed
+   independently. It is a coherent, self-contained improvement (asset id in the
+   pin, verified-identity sink, unprovisioned challenge) and carries its own
+   tests.
+2. This branch is cut from `ed/lkg-connect-cache` (#1619) and merges
+   `jo/pin-device-identity` into it. Both touch `device_pin.go` and `helpers.go`,
+   so the merge is done here rather than left to the reviewer.
+3. On merge of #1616, #1619, and the pin PR, this branch is retargeted to
+   `main`.
+
+## Testing
+
+All of it runs without hardware:
+
+- **Verifier** (`shared/certs`): table-driven over match, wrong asset, wrong
+  org, no URN, user-URN instead of asset-URN, and a resumed handshake — the last
+  asserting the check still runs when `VerifyPeerCertificate` is skipped.
+- **Pin precedence** (`shared/config`): cloud-over-lan, lan-never-over-cloud,
+  legacy fieldless pin upgrade, asset backfill.
+- **SPKI** (`shared/devicepin`): mismatch within validity hard-fails; mismatch
+  after `NotAfter` re-pins silently; cloud refresh re-pins silently.
+- **Ladder** (`cli/commands`): identity mismatch aborts the ladder without
+  trying further certs or ports; a pinned host never reaches the plaintext rung;
+  an unpinned host still does; LKG fast path enforces identically.
+- **Key resolution**: hostname / display name / mesh name lookup order, and that
+  an unresolvable key fails closed for a pinned device.
+
+On-device verification is **not** claimed by this PR and will be listed as
+outstanding in the PR body.
+
+## Explicitly out of scope
+
+- The agent-side mesh path, which already pins correctly via
+  `NewClientTLSConfigExpectingPeer`.
+- The registry authorization gap tracked separately as WDY-2355.
+- Any change to how devices *advertise* TXT records — the fix is entirely on the
+  consuming side, since a hostile advertiser is the threat model.

--- a/specs/2026-08-08-cli-device-identity-enforcement-plan.md
+++ b/specs/2026-08-08-cli-device-identity-enforcement-plan.md
@@ -1,0 +1,1238 @@
+# CLI Device Identity Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Wendy CLI refuse a LAN device whose certificate does not match the identity pinned for the name the user asked for, so a spoofed mDNS answer can no longer redirect a connection to another same-CA host or downgrade it to plaintext.
+
+**Architecture:** One enforcement point (`ExpectedIdentity` inside `BuildServerVerifyConnection`'s `VerifyConnection` callback) fed by one state source (a hostname-keyed `config.DevicePin` that cloud can seed authoritatively). The dial ladder consults the pin before dialing, aborts on mismatch, and skips its plaintext rung entirely for a pinned host.
+
+**Tech Stack:** Go 1.x, `crypto/tls` + `crypto/x509`, gRPC (`grpc.NewClient`), Cobra CLI, standard `testing` package with table-driven tests.
+
+**Spec:** `specs/2026-08-08-cli-device-identity-enforcement-design.md`
+
+## Global Constraints
+
+- Branch: `jo/cli-device-identity-enforcement`, worktree `/Users/joannisorlandos/git/wendy/wendyos-device-identity`, based on `ed/lkg-connect-cache` (PR #1619).
+- Run tests from the `go/` directory. Full suite: `make test` (`go test ./... -v -count=1 -timeout 120s`). Single package during TDD: `go test ./internal/shared/certs/ -run TestName -v`.
+- Format with `gofmt -w -s .` (`make fmt`) before every commit; lint with `make lint`.
+- Enforcement must live in `tls.Config.VerifyConnection`, never `VerifyPeerCertificate` — a resumed TLS 1.3 handshake skips the latter, and `tlscache` makes resumption the common path.
+- Never widen the trust surface on an unpinned host: an unpinned host keeps grace mode and the plaintext fallback exactly as today.
+- Key resolution may read mDNS/TXT-derived data; trust decisions may not. Choosing the wrong pin key must only ever produce a stricter outcome.
+- Pin JSON fields are additive and `omitempty`; a config written by an older CLI must keep working (treated as `source: "lan"`, no asset constraint).
+- Commit messages end with the repo's `Co-Authored-By` / `Claude-Session` trailers.
+- Do not claim on-device verification. The PR body lists it as outstanding.
+
+---
+
+### Task 0: Land the prerequisite pin commit
+
+`jo/pin-device-identity` is an existing unpushed commit that this plan builds on (asset id in the pin, the `OnVerifiedServerIdentity` sink, `ClearDevicePin`, the unprovisioned challenge). It goes out as its own PR against `main` first, then merges into this branch.
+
+**Files:**
+- No new files. Verifies and publishes an existing commit, then merges it here.
+
+**Interfaces:**
+- Produces: `certs.ServerVerifyOpts.OnVerifiedServerIdentity func(WendyIdentity)`; `(*grpcclient.AgentConnection).ObservedServerIdentity() (certs.WendyIdentity, bool)`; `config.DevicePin{OrgID int, CloudGRPC string, AssetID string}`; `config.PinAdoptAsset`; `(*config.Config).EvaluateDevicePin(hostname string, orgID int, cloudGRPC, assetID string) PinVerdict`; `(*config.Config).SetDevicePin(hostname string, orgID int, cloudGRPC, assetID string)`; `(*config.Config).ClearDevicePin(hostname string)`; `commands.observedDeviceIdentity{mTLS bool, orgID int, assetID string}`; `commands.enforceDeviceIdentity(hostname string, obs observedDeviceIdentity) error`; `commands.clearDevicePinForRepin(hostname string)`.
+
+- [ ] **Step 1: Verify the existing commit builds and its tests pass**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos
+git worktree add /tmp/wendyos-pin-verify jo/pin-device-identity
+cd /tmp/wendyos-pin-verify/go
+gofmt -l . | tee /tmp/gofmt-out.txt
+go build ./... && go test ./internal/shared/config/ ./internal/shared/certs/ ./internal/cli/commands/ ./internal/cli/grpcclient/ -count=1
+```
+
+Expected: `gofmt -l` prints nothing, build succeeds, all four packages PASS. If anything fails, fix it on `jo/pin-device-identity` and amend before continuing — do not push a red branch.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+cd /tmp/wendyos-pin-verify
+git push -u origin jo/pin-device-identity
+gh pr create --base main --title "Pin device asset id, and refuse a pinned device that goes unprovisioned" --body "$(cat <<'EOF'
+## Summary
+Extends the WDY-1149 device pin from (organisation, cloud host) to (organisation, cloud host, **asset id**), so a different physical device answering at a pinned hostname is detected — not just a different trust domain.
+
+- `DevicePin.AssetID` from the verified server cert's `urn:wendy:org:<org>:asset:<id>` SAN.
+- New `OnVerifiedServerIdentity` sink in `BuildServerVerifyConnection`, fired only after chain + org checks pass — unlike `OnServerIdentity`, it is safe to pin against.
+- `PinAdoptAsset`: a pin written before asset ids existed backfills silently instead of being challenged.
+- A hostname previously seen enrolled that now answers with no certificate at all is challenged rather than silently accepted.
+- `wendy device set-default <host>` clears the pin first, so the "re-run set-default to re-pin" advice in every refusal actually works.
+
+## Verification
+- [x] Unit tests: pin evaluation (match / mismatch / legacy backfill / empty observed asset), verified-identity sink, unprovisioned challenge.
+- [ ] On-device — not verified.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW
+EOF
+)"
+cd / && git -C /Users/joannisorlandos/git/wendy/wendyos worktree remove /tmp/wendyos-pin-verify
+```
+
+- [ ] **Step 3: Merge it into this branch**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity
+git merge --no-ff jo/pin-device-identity -m "Merge jo/pin-device-identity (asset-id device pin) into identity enforcement"
+```
+
+Conflicts are expected in `go/internal/cli/commands/helpers.go` (both #1619 and the pin commit edit `connectToAgent`) and possibly `device_pin.go`. Resolve by keeping **both**: #1619's LKG fast path *and* the pin commit's `enforceDevicePin` call placed before the update check.
+
+- [ ] **Step 4: Verify the merge**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && go build ./... && go test ./internal/... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit if the merge needed resolution**
+
+```bash
+git add -A && git commit --no-edit
+```
+
+---
+
+### Task 1: `ExpectedIdentity` in the server verifier
+
+**Files:**
+- Modify: `go/internal/shared/certs/mldsa.go` (add `IdentityMismatchError` near `OrgMismatchError` at :38-47; add `ExpectedIdentity` to `ServerVerifyOpts` at :57-68; add the check after the org check at :224)
+- Test: `go/internal/shared/certs/server_verify_test.go` (reuses the existing `selfSignedCert` helper at :21)
+
+**Interfaces:**
+- Consumes: `certs.WendyIdentity{OrgID int32, EntityType string, EntityID string}` and `certs.IdentityFromCert` from `orgident.go`.
+- Produces: `certs.IdentityMismatchError{WantOrg int32, WantAsset string, GotOrg int32, GotAsset string}` and `certs.ServerVerifyOpts.ExpectedIdentity *certs.WendyIdentity`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `go/internal/shared/certs/server_verify_test.go`:
+
+```go
+func TestBuildServerVerifyConnection_ExpectedIdentity(t *testing.T) {
+	want := certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"}
+
+	cases := []struct {
+		name        string
+		sanURI      string
+		wantErr     bool
+		wantGotAsst string
+	}{
+		{name: "exact match", sanURI: "urn:wendy:org:7:asset:42"},
+		{name: "different asset, same org", sanURI: "urn:wendy:org:7:asset:43", wantErr: true, wantGotAsst: "43"},
+		{name: "same asset, different org", sanURI: "urn:wendy:org:9:asset:42", wantErr: true, wantGotAsst: "42"},
+		{name: "user URN is not an asset", sanURI: "urn:wendy:org:7:user:42", wantErr: true},
+		{name: "no wendy identity at all", sanURI: "", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverCert, chainPEM := selfSignedCert(t, "device", tc.sanURI)
+			expected := want
+			verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+				ChainPEM:         string(chainPEM),
+				ExpectedIdentity: &expected,
+			})
+			if err != nil {
+				t.Fatalf("BuildServerVerifyConnection: %v", err)
+			}
+
+			err = verifyConn(tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}})
+
+			var mismatch *certs.IdentityMismatchError
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("want accepted, got %v", err)
+				}
+				return
+			}
+			if !errors.As(err, &mismatch) {
+				t.Fatalf("want IdentityMismatchError, got %v", err)
+			}
+			if mismatch.WantOrg != 7 || mismatch.WantAsset != "42" {
+				t.Errorf("want side = org %d asset %q, want org 7 asset \"42\"", mismatch.WantOrg, mismatch.WantAsset)
+			}
+			if mismatch.GotAsset != tc.wantGotAsst {
+				t.Errorf("GotAsset = %q, want %q", mismatch.GotAsset, tc.wantGotAsst)
+			}
+		})
+	}
+}
+
+// TestBuildServerVerifyConnection_ExpectedIdentityNilIsPermissive locks in that
+// the new field is opt-in: with it unset, a no-URN cert still passes (grace
+// mode), which is what keeps unpinned legacy devices working.
+func TestBuildServerVerifyConnection_ExpectedIdentityNil(t *testing.T) {
+	serverCert, chainPEM := selfSignedCert(t, "device", "")
+	verifyConn, err := certs.BuildServerVerifyConnection(certs.ServerVerifyOpts{
+		ChainPEM:      string(chainPEM),
+		ExpectedOrgID: 7,
+	})
+	if err != nil {
+		t.Fatalf("BuildServerVerifyConnection: %v", err)
+	}
+	if err := verifyConn(tls.ConnectionState{PeerCertificates: []*x509.Certificate{serverCert}}); err != nil {
+		t.Fatalf("grace mode should accept a no-URN cert, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/shared/certs/ -run TestBuildServerVerifyConnection_ExpectedIdentity -v`
+Expected: FAIL — `unknown field ExpectedIdentity in struct literal` and `undefined: certs.IdentityMismatchError`.
+
+- [ ] **Step 3: Add the error type**
+
+In `go/internal/shared/certs/mldsa.go`, after `OrgMismatchError.Error()` (:47):
+
+```go
+// IdentityMismatchError is returned by the VerifyConnection callback when the
+// server certificate does not carry the exact asset identity the caller
+// required via ServerVerifyOpts.ExpectedIdentity. Unlike OrgMismatchError this
+// is never subject to grace mode: a certificate with no Wendy identity is a
+// mismatch, because the caller asked for a specific device and got something
+// that cannot prove it is that device.
+type IdentityMismatchError struct {
+	WantOrg   int32
+	WantAsset string
+	GotOrg    int32  // 0 when the certificate carried no Wendy identity
+	GotAsset  string // "" when the certificate carried no Wendy asset identity
+}
+
+func (e *IdentityMismatchError) Error() string {
+	if e.GotAsset == "" {
+		return fmt.Sprintf("device presented no wendy asset identity, expected asset %s in org %d", e.WantAsset, e.WantOrg)
+	}
+	return fmt.Sprintf("device presented asset %s in org %d, expected asset %s in org %d",
+		e.GotAsset, e.GotOrg, e.WantAsset, e.WantOrg)
+}
+```
+
+- [ ] **Step 4: Add the opts field**
+
+In `ServerVerifyOpts`, after `PinStore`:
+
+```go
+	// ExpectedIdentity, when non-nil, requires the server leaf to carry an
+	// "asset" Wendy identity whose org and entity id match it exactly. This is
+	// the CLI-side counterpart of agent/mtls.NewClientTLSConfigExpectingPeer:
+	// chain validity alone only proves the peer holds a cert from a trusted CA,
+	// not that it is the device the caller asked for, so any other same-CA cert
+	// could otherwise answer at an mDNS-advertised address.
+	//
+	// Grace mode does not apply when this is set — a cert with no Wendy
+	// identity is a mismatch, not a legacy device to be tolerated.
+	ExpectedIdentity *WendyIdentity
+```
+
+- [ ] **Step 5: Add the check**
+
+In `BuildServerVerifyConnection`, immediately after the existing org check (the `if hasIdentity && opts.ExpectedOrgID != 0 ...` block at :224) and before the SPKI step:
+
+```go
+		// Step 2b: exact device identity check. Deliberately after the org check
+		// so a cross-org impostor still reports OrgMismatchError, whose remedy
+		// (fetch that org's cert) differs from this one's (wrong device).
+		if opts.ExpectedIdentity != nil {
+			if !hasIdentity || identity.EntityType != "asset" {
+				return &IdentityMismatchError{
+					WantOrg:   opts.ExpectedIdentity.OrgID,
+					WantAsset: opts.ExpectedIdentity.EntityID,
+					GotOrg:    identity.OrgID,
+				}
+			}
+			if identity.OrgID != opts.ExpectedIdentity.OrgID || identity.EntityID != opts.ExpectedIdentity.EntityID {
+				return &IdentityMismatchError{
+					WantOrg:   opts.ExpectedIdentity.OrgID,
+					WantAsset: opts.ExpectedIdentity.EntityID,
+					GotOrg:    identity.OrgID,
+					GotAsset:  identity.EntityID,
+				}
+			}
+		}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd go && go test ./internal/shared/certs/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/shared/certs/
+git commit -m "certs: add ExpectedIdentity to the server verifier
+
+Chain validity alone proves only that a peer holds a cert from a trusted
+CA, not that it is the device the caller asked for. ExpectedIdentity
+requires an exact asset URN match, with no grace mode, mirroring the
+agent's NewClientTLSConfigExpectingPeer.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 2: Surface the mismatch on `AgentConnection`
+
+`grpc.NewClient` is lazy, so a `VerifyConnection` error surfaces mangled inside the first RPC. Capture the typed error the same way `observedServerOrg` is captured.
+
+**Files:**
+- Modify: `go/internal/cli/grpcclient/client.go` (`AgentConnection` struct at :74; `newAgentTLSConfig` at :152; `ConnectWithTLSAndPins` at :226)
+- Test: `go/internal/cli/grpcclient/identity_mismatch_test.go` (create)
+
+**Interfaces:**
+- Consumes: `certs.IdentityMismatchError`, `certs.ServerVerifyOpts.ExpectedIdentity` (Task 1).
+- Produces: `newAgentTLSConfig(address string, certInfo *config.CertificateInfo, pins certs.PinChecker, observedOrg *atomic.Int32, observedIdentity *atomic.Pointer[certs.WendyIdentity], expected *certs.WendyIdentity, mismatch *atomic.Pointer[certs.IdentityMismatchError]) (*tls.Config, error)`; `ConnectWithTLSExpecting(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker, expected *certs.WendyIdentity) (*AgentConnection, error)`; `(*AgentConnection).IdentityMismatch() (*certs.IdentityMismatchError, bool)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/cli/grpcclient/identity_mismatch_test.go`:
+
+```go
+package grpcclient
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+// TestIdentityMismatchNilConnection covers the accessor's contract on a
+// connection that never installed the sink (plaintext / NewFromConn).
+func TestIdentityMismatchNilConnection(t *testing.T) {
+	c := &AgentConnection{}
+	if got, ok := c.IdentityMismatch(); ok || got != nil {
+		t.Fatalf("want (nil, false), got (%v, %v)", got, ok)
+	}
+}
+
+// TestIdentityMismatchRecorded covers the sink → accessor round trip that the
+// dial ladder relies on to distinguish "wrong device" from "handshake failed".
+func TestIdentityMismatchRecorded(t *testing.T) {
+	c := newAgentConnection(nil)
+	sink := identityMismatchSink(c.identityMismatch)
+	sink(&certs.IdentityMismatchError{WantOrg: 7, WantAsset: "42", GotOrg: 7, GotAsset: "43"})
+
+	got, ok := c.IdentityMismatch()
+	if !ok {
+		t.Fatal("want ok=true after sink fired")
+	}
+	if got.WantAsset != "42" || got.GotAsset != "43" {
+		t.Fatalf("want 42→43, got %s→%s", got.WantAsset, got.GotAsset)
+	}
+}
+
+// TestVerifyConnectionNotVerifyPeerCertificate locks in the resumption-safety
+// invariant: a resumed TLS 1.3 handshake skips VerifyPeerCertificate entirely
+// and calls only VerifyConnection, so the identity check must live there or it
+// silently stops running after the first connect.
+func TestVerifyConnectionNotVerifyPeerCertificate(t *testing.T) {
+	cfg, err := newAgentTLSConfig("dev.local:50052", testCertInfo(t), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newAgentTLSConfig: %v", err)
+	}
+	if cfg.VerifyConnection == nil {
+		t.Error("VerifyConnection must be set")
+	}
+	if cfg.VerifyPeerCertificate != nil {
+		t.Error("VerifyPeerCertificate must stay nil: a resumed handshake skips it")
+	}
+}
+```
+
+Add a `testCertInfo` helper in the same file that builds a `*config.CertificateInfo` with a self-signed leaf, key, and chain PEM. Copy the generation approach from `go/internal/shared/certs/server_verify_test.go:21` (`selfSignedCert`), additionally PEM-encoding the EC private key with `x509.MarshalECPrivateKey` so `tls.X509KeyPair` accepts it.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/cli/grpcclient/ -run 'TestIdentityMismatch|TestVerifyConnection' -v`
+Expected: FAIL — `undefined: identityMismatchSink`, unknown field `identityMismatch`, and a signature mismatch on `newAgentTLSConfig`.
+
+- [ ] **Step 3: Add the field, sink, and accessor**
+
+In `AgentConnection` (after `observedServerIdentity`):
+
+```go
+	// identityMismatch holds the typed rejection raised inside VerifyConnection
+	// when the peer failed ExpectedIdentity. gRPC's lazy dial mangles that error
+	// into the first RPC's status, so the ladder reads it from here instead of
+	// string-matching. nil for connections that never install the sink.
+	identityMismatch *atomic.Pointer[certs.IdentityMismatchError]
+```
+
+```go
+// identityMismatchSink returns the callback that records an ExpectedIdentity
+// rejection. dst may be nil (enforcement not requested), in which case the
+// returned sink is a no-op, so callers need no nil check.
+func identityMismatchSink(dst *atomic.Pointer[certs.IdentityMismatchError]) func(*certs.IdentityMismatchError) {
+	return func(e *certs.IdentityMismatchError) {
+		if dst == nil || e == nil {
+			return
+		}
+		dst.Store(e)
+	}
+}
+
+// IdentityMismatch reports the ExpectedIdentity rejection this connection hit,
+// if any. It is the ladder's signal that the *device* is wrong — as opposed to
+// our certificate being wrong — and therefore that retrying with other certs or
+// other ports is pointless.
+func (c *AgentConnection) IdentityMismatch() (*certs.IdentityMismatchError, bool) {
+	if c.identityMismatch == nil {
+		return nil, false
+	}
+	e := c.identityMismatch.Load()
+	return e, e != nil
+}
+```
+
+In `newAgentConnection`, initialise `identityMismatch: new(atomic.Pointer[certs.IdentityMismatchError])`.
+
+- [ ] **Step 4: Thread it through the TLS config**
+
+Extend `newAgentTLSConfig`'s signature to the one in **Interfaces** above, pass `ExpectedIdentity: expected` into `certs.BuildServerVerifyConnection`, and wrap the returned verifier so a typed mismatch is recorded before being returned:
+
+```go
+	sink := identityMismatchSink(mismatch)
+	inner := verifyConn
+	verifyConn = func(cs tls.ConnectionState) error {
+		err := inner(cs)
+		var im *certs.IdentityMismatchError
+		if errors.As(err, &im) {
+			sink(im)
+		}
+		return err
+	}
+```
+
+Place this wrap **before** the existing `WENDY_TLS_DEBUG` and `SetResumed` wraps so it observes the verifier's own result.
+
+- [ ] **Step 5: Add the public entry point**
+
+```go
+// ConnectWithTLSExpecting is ConnectWithTLSAndPins with a required peer
+// identity. A nil expected is exactly ConnectWithTLSAndPins.
+func ConnectWithTLSExpecting(ctx context.Context, address string, certInfo *config.CertificateInfo, pins certs.PinChecker, expected *certs.WendyIdentity) (*AgentConnection, error) {
+```
+
+Move `ConnectWithTLSAndPins`'s body into it, add the two new atomics, and make `ConnectWithTLSAndPins` delegate with `expected = nil` so every existing caller is unchanged.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd go && go test ./internal/cli/grpcclient/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/cli/grpcclient/
+git commit -m "grpcclient: expose ExpectedIdentity rejections as a typed signal
+
+gRPC's lazy dial mangles a VerifyConnection error into the first RPC's
+status. Record the typed IdentityMismatchError inside the verifier so the
+dial ladder can tell 'wrong device' from 'wrong cert' without string
+matching.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 3: Pin source precedence
+
+**Files:**
+- Modify: `go/internal/shared/config/devicepin.go`
+- Test: `go/internal/shared/config/devicepin_test.go`
+
+**Interfaces:**
+- Consumes: `config.DevicePin`, `config.PinVerdict`, `EvaluateDevicePin`, `SetDevicePin`, `PinAdoptAsset` (Task 0).
+- Produces: `config.PinSourceLAN = "lan"`, `config.PinSourceCloud = "cloud"`; `DevicePin.Source string`; `(*Config).SetDevicePinFrom(hostname string, orgID int, cloudGRPC, assetID, source string)`; `(*Config).PinSource(hostname string) string`.
+
+Cloud writes never consult the verdict — the cloud path calls `SetDevicePinFrom(..., PinSourceCloud)` unconditionally, which is what "cloud overwrites anything" means. `EvaluateDevicePin` therefore only ever judges LAN observations, and gains exactly one new rule: **a LAN observation must not backfill an asset id into a cloud-sourced pin.**
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `go/internal/shared/config/devicepin_test.go`:
+
+```go
+func TestDevicePinSourcePrecedence(t *testing.T) {
+	const host = "wendy-thor.local"
+
+	t.Run("cloud write overwrites a lan pin", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceLAN)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "99", PinSourceCloud)
+
+		pin, _ := c.DevicePinFor(host)
+		if pin.AssetID != "99" || pin.Source != PinSourceCloud {
+			t.Fatalf("want asset 99 from cloud, got asset %q from %q", pin.AssetID, pin.Source)
+		}
+	})
+
+	t.Run("lan observation conflicting with a cloud pin is a mismatch", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceCloud)
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "43"); v != PinMismatch {
+			t.Fatalf("want PinMismatch, got %v", v)
+		}
+	})
+
+	t.Run("lan never backfills an asset into a cloud pin", func(t *testing.T) {
+		c := &Config{}
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "", PinSourceCloud)
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "42"); v != PinMatch {
+			t.Fatalf("want PinMatch without adoption, got %v", v)
+		}
+	})
+
+	t.Run("legacy fieldless pin reads as lan", func(t *testing.T) {
+		c := &Config{DevicePins: map[string]DevicePin{
+			host: {OrgID: 7, CloudGRPC: "grpc.wendy.dev:443"},
+		}}
+		if got := c.PinSource(host); got != PinSourceLAN {
+			t.Fatalf("want %q, got %q", PinSourceLAN, got)
+		}
+		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "42"); v != PinAdoptAsset {
+			t.Fatalf("want PinAdoptAsset, got %v", v)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/shared/config/ -run TestDevicePinSourcePrecedence -v`
+Expected: FAIL — `undefined: PinSourceLAN`, `c.SetDevicePinFrom undefined`, `c.PinSource undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `go/internal/shared/config/devicepin.go`:
+
+```go
+// Pin sources. A pin's source records how much the CLI knows about it, which
+// decides who may overwrite it: cloud spoke to the org's cloud over an
+// authenticated session, lan only observed a certificate on the local network.
+const (
+	PinSourceLAN   = "lan"
+	PinSourceCloud = "cloud"
+)
+```
+
+Add `Source string \`json:"source,omitempty"\`` to `DevicePin`, documented as: empty means a pin written before sources were recorded, read as `PinSourceLAN`.
+
+```go
+// PinSource returns the recorded source for a hostname's pin, defaulting to
+// PinSourceLAN for pins written before sources existed and for unpinned hosts.
+func (c *Config) PinSource(hostname string) string {
+	pin, ok := c.DevicePinFor(hostname)
+	if !ok || pin.Source == "" {
+		return PinSourceLAN
+	}
+	return pin.Source
+}
+
+// SetDevicePinFrom records a pin and where it came from. A cloud-sourced write
+// is authoritative and overwrites whatever was there.
+func (c *Config) SetDevicePinFrom(hostname string, orgID int, cloudGRPC, assetID, source string) {
+	if c.DevicePins == nil {
+		c.DevicePins = make(map[string]DevicePin)
+	}
+	c.DevicePins[normalizePinHost(hostname)] = DevicePin{
+		OrgID: orgID, CloudGRPC: cloudGRPC, AssetID: assetID, Source: source,
+	}
+}
+```
+
+Make the existing `SetDevicePin` delegate: `c.SetDevicePinFrom(hostname, orgID, cloudGRPC, assetID, PinSourceLAN)`.
+
+In `EvaluateDevicePin`, change the `case pin.AssetID == "":` arm to withhold adoption from cloud pins:
+
+```go
+	case pin.AssetID == "":
+		if pin.Source == PinSourceCloud {
+			// Cloud said this device has no asset identity; a LAN sighting is
+			// not evidence to the contrary.
+			return PinMatch
+		}
+		return PinAdoptAsset
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd go && go test ./internal/shared/config/ -count=1`
+Expected: PASS (including the pre-existing `TestEvaluateDevicePin` cases from Task 0).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/shared/config/
+git commit -m "config: record where a device pin came from
+
+Cloud spoke to the org over an authenticated session; LAN only saw a
+certificate on the local network. Cloud writes overwrite anything; a LAN
+sighting never backfills an asset id into a cloud pin.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 4: SPKI hard fail with a rotation window
+
+**Files:**
+- Modify: `go/internal/shared/devicepin/store.go` (`PinnedDevice` at :21, `CheckAndUpdate` at :60)
+- Modify: `go/internal/shared/certs/mldsa.go` (stop discarding the pin error at :235)
+- Test: `go/internal/shared/devicepin/store_test.go`
+
+**Interfaces:**
+- Produces: `devicepin.PinMismatchError{Key, DisplayName, Want, Got string}`; `PinnedDevice.NotAfter string` (RFC3339).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `go/internal/shared/devicepin/store_test.go`:
+
+```go
+func TestCheckAndUpdateKeyChange(t *testing.T) {
+	t.Run("within validity is a hard fail", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := Open(dir)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		first := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		if err := s.CheckAndUpdate(first, "thor"); err != nil {
+			t.Fatalf("first use: %v", err)
+		}
+
+		second := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		err = s.CheckAndUpdate(second, "thor")
+
+		var mismatch *PinMismatchError
+		if !errors.As(err, &mismatch) {
+			t.Fatalf("want PinMismatchError, got %v", err)
+		}
+	})
+
+	t.Run("after the pinned cert expires it re-pins silently", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := Open(dir)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		expired := assetCert(t, 7, "42", time.Now().Add(-time.Hour))
+		if err := s.CheckAndUpdate(expired, "thor"); err != nil {
+			t.Fatalf("first use: %v", err)
+		}
+
+		renewed := assetCert(t, 7, "42", time.Now().Add(24*time.Hour))
+		if err := s.CheckAndUpdate(renewed, "thor"); err != nil {
+			t.Fatalf("rotation after expiry must be accepted, got %v", err)
+		}
+	})
+}
+```
+
+Add an `assetCert(t *testing.T, org int32, assetID string, notAfter time.Time) *x509.Certificate` helper following `selfSignedCert` in `go/internal/shared/certs/server_verify_test.go:21`, setting `NotAfter: notAfter` and the URI SAN `certs.AssetURN`-style string `urn:wendy:org:<org>:asset:<assetID>`. Generate a fresh key per call so two calls differ in SPKI.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/shared/devicepin/ -run TestCheckAndUpdateKeyChange -v`
+Expected: FAIL — `undefined: PinMismatchError`, and the "within validity" case returns nil.
+
+- [ ] **Step 3: Implement**
+
+Add `NotAfter string \`json:"notAfter,omitempty"\`` to `PinnedDevice`, and:
+
+```go
+// PinMismatchError reports that a device identity presented a different public
+// key than the one pinned for it, while the pinned certificate was still valid.
+// A rotation that happens after the pinned cert expires is not an error — it is
+// renewal — so this only fires inside the pinned cert's validity window, where
+// a new key is unexplained.
+type PinMismatchError struct {
+	Key         string
+	DisplayName string
+	Want        string
+	Got         string
+}
+
+func (e *PinMismatchError) Error() string {
+	return fmt.Sprintf("device %q (%s) presented a different certificate key than pinned (pinned %s, now %s)",
+		e.DisplayName, e.Key, e.Want, e.Got)
+}
+```
+
+Replace the warn-and-overwrite block in `CheckAndUpdate` (:69-73):
+
+```go
+	if existing, pinned := s.devices[key]; pinned && existing.SPKIFingerprint != fingerprint {
+		// A key change while the pinned cert is still valid is unexplained: a
+		// renewal replaces an expiring cert, it does not race a live one.
+		if existing.NotAfter != "" {
+			if exp, parseErr := time.Parse(time.RFC3339, existing.NotAfter); parseErr == nil && time.Now().Before(exp) {
+				return &PinMismatchError{Key: key, DisplayName: displayName, Want: existing.SPKIFingerprint, Got: fingerprint}
+			}
+		}
+	}
+```
+
+Record `NotAfter: leaf.NotAfter.UTC().Format(time.RFC3339)` in the stored `PinnedDevice`. A pin written before `NotAfter` existed has an empty value and falls through to re-pin, which is the safe direction for an upgrade.
+
+- [ ] **Step 4: Stop discarding the error in the verifier**
+
+In `go/internal/shared/certs/mldsa.go`, replace the step-3 discard (:234-238) with:
+
+```go
+			if pinErr := opts.PinStore.CheckAndUpdate(leaf, displayName); pinErr != nil {
+				return pinErr
+			}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd go && go test ./internal/shared/devicepin/ ./internal/shared/certs/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/shared/devicepin/ go/internal/shared/certs/
+git commit -m "devicepin: fail closed on an unexplained key change
+
+The store warned and then overwrote the pin, and the verifier discarded
+the error, so SPKI pinning enforced nothing. Fail the handshake instead —
+but only inside the pinned cert's validity window, so ordinary renewal
+still re-pins silently.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 5: `dialTarget` and ladder enforcement
+
+**Files:**
+- Modify: `go/internal/cli/commands/helpers.go` (`dialAgentLadderWithCerts` at :1729, `dialAgentLadder` at :1829, `dialAgentLKG` at :1367, `provisionedAgentAdvertisedMTLS` at :1893)
+- Create: `go/internal/cli/commands/dial_target.go`
+- Test: `go/internal/cli/commands/dial_target_test.go`
+
+**Interfaces:**
+- Consumes: `grpcclient.ConnectWithTLSExpecting`, `(*AgentConnection).IdentityMismatch` (Task 2); `config.PinSource`, `DevicePin.AssetID` (Task 3).
+- Produces: `commands.dialTarget{PinKey, Addr string, Expected *certs.WendyIdentity}`; `commands.newDialTarget(pinKey, addr string) dialTarget`; `commands.expectedIdentityFor(pinKey string) *certs.WendyIdentity`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/cli/commands/dial_target_test.go`:
+
+```go
+package commands
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestExpectedIdentityFor(t *testing.T) {
+	cases := []struct {
+		name string
+		pin  *config.DevicePin // nil = unpinned
+		want *certs.WendyIdentity
+	}{
+		{name: "unpinned host is unconstrained", pin: nil, want: nil},
+		{
+			name: "pinned with asset constrains exactly",
+			pin:  &config.DevicePin{OrgID: 7, AssetID: "42"},
+			want: &certs.WendyIdentity{OrgID: 7, EntityType: "asset", EntityID: "42"},
+		},
+		{
+			name: "pinned without an asset stays unconstrained",
+			pin:  &config.DevicePin{OrgID: 7},
+			want: nil,
+		},
+	}
+	// Drive expectedIdentityFor through a config injected via the
+	// loadConfigForPinFn seam so the test never touches the real config file.
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { /* body per Step 3 */ })
+	}
+}
+
+// TestPinnedHostSkipsPlaintextRung is the security-critical case: a host we
+// have seen over mTLS must never be reached unauthenticated, no matter what
+// the TXT records or the cache claim.
+func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
+	// Arrange a dialTarget whose PinKey resolves to a pin, stub the mTLS rungs
+	// to fail with a non-cert transport error (the shape that today falls
+	// through to plaintext), and assert grpcclient.Connect is never called.
+}
+```
+
+Fill both bodies using the existing seams in `helpers.go` (`dialAgentLadderWithCertsFn`, `loadAllCLICertsFn`); add a `loadConfigForPinFn = config.Load` seam and a `plaintextConnectFn = grpcclient.Connect` seam in `dial_target.go` so the plaintext rung is observable from a test.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run 'TestExpectedIdentityFor|TestPinnedHostSkipsPlaintextRung' -v`
+Expected: FAIL — `undefined: expectedIdentityFor`, `undefined: dialTarget`.
+
+- [ ] **Step 3: Create `dial_target.go`**
+
+```go
+package commands
+
+// dialTarget carries what the ladder needs to know about *who* it is dialing,
+// not just where. Before this, the ladder took a bare address, so the identity
+// the user asked for was gone by the time a certificate arrived — which is
+// exactly what let a spoofed mDNS answer redirect a connection to another
+// same-CA host.
+type dialTarget struct {
+	// PinKey is the name the user asked for (--device value, saved default, or
+	// the picker's device name) — never the resolved IP, which changes on
+	// ordinary DHCP churn and would train users to unpin reflexively. An empty
+	// PinKey disables pin enforcement for this dial.
+	PinKey string
+	// Addr is the host:port actually dialed.
+	Addr string
+	// Expected constrains the peer certificate. Non-nil only when a pin (or a
+	// cloud-seeded value) names a specific asset.
+	Expected *certs.WendyIdentity
+}
+
+// loadConfigForPinFn is a seam over config.Load for tests.
+var loadConfigForPinFn = config.Load
+
+// newDialTarget resolves the pin for pinKey and returns a target constrained by
+// it. Key resolution deliberately may read discovery-derived names: choosing
+// the wrong key can only ever produce a mismatch — a stricter outcome — never
+// a bypass, because the trust decision itself stays on the certificate.
+func newDialTarget(pinKey, addr string) dialTarget {
+	return dialTarget{PinKey: pinKey, Addr: addr, Expected: expectedIdentityFor(pinKey)}
+}
+
+// expectedIdentityFor returns the asset identity pinned for pinKey, or nil when
+// the host is unpinned or its pin predates asset ids. Nil means "first contact
+// is permissive" — the posture that keeps legacy and unprovisioned devices
+// working; the pin is written on the first successful connect.
+func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
+	if pinKey == "" {
+		return nil
+	}
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return nil
+	}
+	pin, ok := cfg.DevicePinFor(pinKey)
+	if !ok || pin.AssetID == "" {
+		return nil
+	}
+	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
+}
+
+// isPinned reports whether pinKey has any recorded pin. A pinned host has been
+// reached over mTLS before, so the ladder must not offer it the plaintext rung.
+func isPinned(pinKey string) bool {
+	if pinKey == "" {
+		return false
+	}
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return false
+	}
+	_, ok := cfg.DevicePinFor(pinKey)
+	return ok
+}
+```
+
+- [ ] **Step 4: Change the ladder signature and enforce**
+
+In `helpers.go`, change `dialAgentLadderWithCerts(ctx context.Context, plaintextAddr string, allCerts []config.CertificateInfo)` to take `target dialTarget` instead of `plaintextAddr string`, with `plaintextAddr := target.Addr` as the first line so the body is otherwise untouched. Then:
+
+1. Replace the per-cert dial `grpcclient.ConnectWithTLSAndPins(ctx, mtlsAddr, &allCerts[i], pins)` with `grpcclient.ConnectWithTLSExpecting(ctx, mtlsAddr, &allCerts[i], pins, target.Expected)`.
+2. Immediately after `recordMTLSErr(mtlsAddr, probeErr)`, abort on a wrong device:
+
+```go
+					if im, mismatched := conn.IdentityMismatch(); mismatched {
+						conn.Close()
+						// The device is wrong, not our certificate — every
+						// remaining cert and port would fail the same way, and
+						// the plaintext rung below must not be reached at all.
+						return nil, lastMTLSErr, identityRefusal(target.PinKey, im)
+					}
+```
+
+3. Guard the plaintext rung (the `conn, err := grpcclient.Connect(ctx, plaintextAddr)` at :1822):
+
+```go
+	if isPinned(target.PinKey) {
+		// A host we have already reached over mTLS must never be reached
+		// unauthenticated. Unlike provisionedAgentAdvertisedMTLS this reads
+		// local state, not a TXT record the attacker also controls.
+		return nil, lastMTLSErr, pinnedHostWentUnauthenticatedError(target.PinKey)
+	}
+	conn, err := plaintextConnectFn(ctx, plaintextAddr)
+```
+
+4. Update `dialAgentLadder` to take a `dialTarget`, and `dialAgentLKG` to build one via `newDialTarget(originalPinKey, hostPort(e.IP, e.Port))` — `dialAgentLKG` gains the pin key as a parameter from its caller, which already has `originalAddr`.
+5. Update `provisionedAgentAdvertisedMTLS`'s doc comment: it is now a phrasing hint for error messages only and must not be used as a guard.
+
+Find every remaining call site and update it:
+
+```bash
+cd go && grep -rn "dialAgentLadderWithCerts\|dialAgentLadder(\|dialAgentLKG(" internal/cli/commands/
+```
+
+- [ ] **Step 5: Add the two error constructors**
+
+In `dial_target.go`:
+
+```go
+// identityRefusal renders a wrong-device rejection. Same text in interactive,
+// JSON, and non-interactive modes — there is deliberately no "trust this?"
+// prompt, because a MITM warning that can be dismissed gets dismissed.
+func identityRefusal(pinKey string, im *certs.IdentityMismatchError) error {
+	got := "no wendy identity"
+	if im.GotAsset != "" {
+		got = fmt.Sprintf("asset %s in organization %d", im.GotAsset, im.GotOrg)
+	}
+	return fmt.Errorf(
+		"device %q is pinned to asset %s in organization %d, but the host answering presented %s; refusing to connect — if this device was legitimately replaced or re-enrolled, run 'wendy device unpin %s'",
+		pinKey, im.WantAsset, im.WantOrg, got, pinKey)
+}
+
+func pinnedHostWentUnauthenticatedError(pinKey string) error {
+	return fmt.Errorf(
+		"device %q is pinned to an enrolled identity but no authenticated endpoint answered; refusing to fall back to an unauthenticated connection — if it was reflashed or factory reset, run 'wendy device unpin %s'",
+		pinKey, pinKey)
+}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd go && go test ./internal/cli/commands/ -count=1`
+Expected: PASS. Pre-existing connect-flow tests from #1619 may need their `dialAgentLadderWithCertsFn` stubs updated to the new signature — update them, do not weaken their assertions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/cli/commands/
+git commit -m "cli: bind the dialed device to the name the user asked for
+
+The ladder took a bare address, so the requested identity was gone by the
+time a certificate arrived. dialTarget carries the pin key and expected
+asset down to the handshake: a mismatch aborts the ladder outright, and a
+pinned host never reaches the plaintext rung.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 6: Enforce on every connection, not just the default device
+
+**Files:**
+- Modify: `go/internal/cli/commands/helpers.go` (`resolveDeviceAddress` at :765, the `if isDefault` pin gate in `connectToAgent`)
+- Modify: `go/internal/cli/commands/device_pin.go` (`enforceDeviceIdentity` — drop the interactive prompt)
+- Test: `go/internal/cli/commands/device_pin_test.go`
+
+**Interfaces:**
+- Consumes: `newDialTarget`, `identityRefusal` (Task 5); `enforceDeviceIdentity`, `observedDeviceIdentity` (Task 0).
+- Produces: `resolveDeviceAddress() (addr string, pinKey string, isDefault bool, err error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `go/internal/cli/commands/device_pin_test.go`:
+
+```go
+// TestEnforceDeviceIdentityHardFails covers the approved policy change: a
+// mismatch is refused identically in every mode, with no prompt.
+func TestEnforceDeviceIdentityHardFails(t *testing.T) {
+	// Arrange a config with a pin for "thor.local" at org 7 asset 42, then
+	// call enforceDeviceIdentity with an observation of org 7 asset 43 while
+	// isInteractiveTerminal() reports true. Assert a non-nil error and that
+	// tui.ConfirmNoDefaultDanger was never invoked.
+}
+
+// TestEnforceDeviceIdentityAppliesToNonDefault guards the scope widening.
+func TestEnforceDeviceIdentityAppliesToNonDefault(t *testing.T) {
+	// Arrange --device pointing at a pinned host with a conflicting identity;
+	// assert connectToAgent returns the refusal rather than a connection.
+}
+```
+
+Write both bodies against the existing seams in `device_pin_test.go` from Task 0 (which already stubs config load/save and terminal detection); mirror their arrangement rather than inventing new ones.
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestEnforceDeviceIdentity -v`
+Expected: FAIL — the current code prompts and accepts.
+
+- [ ] **Step 3: Replace the prompt with a refusal**
+
+In `enforceDeviceIdentity`'s `default: // config.PinMismatch` arm, delete the `tui.ConfirmNoDefaultDanger` branch and the re-pin that follows it, and return the refusal unconditionally after `printIdentityChangeWarning`:
+
+```go
+		return fmt.Errorf("device %q identity changed (organization/cloud/asset); refusing to connect — if this is expected, run 'wendy device unpin %s'", hostname, hostname)
+```
+
+Apply the same change to `challengeUnprovisionedDevice`: keep the explanatory output, drop the prompt, always return the error.
+
+- [ ] **Step 4: Widen the scope**
+
+Change `resolveDeviceAddress` to also return the pin key (the raw `hostname` before `hostPort` is applied, since that is the name the user typed), and in `connectToAgent` replace `if isDefault { ... enforceDevicePin ... }` with an unconditional call using that pin key. Pass the same key into the dial path via `newDialTarget`.
+
+For picker-selected devices, use the selected device's `DisplayName` as the pin key in `connectFromSelectedDevice`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd go && go test ./internal/cli/commands/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/cli/commands/
+git commit -m "cli: enforce the device pin on every connection, and stop prompting
+
+Pinning covered only the saved default device, so --device and picker
+selections were unchecked. A mismatch now refuses identically in every
+mode: a MITM warning that can be dismissed gets dismissed.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 7: `wendy device unpin`
+
+**Files:**
+- Modify: `go/internal/cli/commands/device.go` (register alongside `newDeviceSetDefaultCmd` at :476)
+- Create: `go/internal/cli/commands/device_unpin.go`
+- Test: `go/internal/cli/commands/device_unpin_test.go`
+
+**Interfaces:**
+- Consumes: `(*config.Config).ClearDevicePin` (Task 0); `devicepin.Open` and the store's key format `certs.WendyIdentity.IdentityKey()`.
+- Produces: `newDeviceUnpinCmd() *cobra.Command`; `(*devicepin.Store).Remove(key string) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `go/internal/cli/commands/device_unpin_test.go`:
+
+```go
+func TestDeviceUnpinClearsBothStores(t *testing.T) {
+	// Arrange: a config pin for "thor.local" (org 7, asset 42) and a devicepin
+	// SPKI entry keyed "urn:wendy:org:7:asset:42".
+	// Act: run the unpin command for "thor.local".
+	// Assert: config.DevicePinFor returns !ok, and the SPKI entry is gone.
+}
+
+func TestDeviceUnpinUnknownHostIsNotAnError(t *testing.T) {
+	// Unpinning an unpinned host succeeds quietly: the command's job is to
+	// leave the host unpinned, which it already is.
+}
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestDeviceUnpin -v`
+Expected: FAIL — `undefined: newDeviceUnpinCmd`.
+
+- [ ] **Step 3: Add `Remove` to the SPKI store**
+
+In `go/internal/shared/devicepin/store.go`:
+
+```go
+// Remove drops the pin for an identity key, so the next connection is a first
+// use. Removing an absent key is not an error.
+func (s *Store) Remove(key string) error {
+	if _, ok := s.devices[key]; !ok {
+		return nil
+	}
+	delete(s.devices, key)
+	return s.flush()
+}
+```
+
+- [ ] **Step 4: Implement the command**
+
+Create `go/internal/cli/commands/device_unpin.go` with a Cobra command `unpin <hostname>` (`Args: cobra.ExactArgs(1)`) that loads the config, reads the pin so it can derive the SPKI key `certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}.IdentityKey()`, calls `cfg.ClearDevicePin(hostname)` and `store.Remove(key)`, saves, and prints:
+
+```
+Unpinned "thor.local". The next connection to it will record a fresh identity.
+```
+
+Register it in `device.go` next to `newDeviceSetDefaultCmd()`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd go && go test ./internal/cli/commands/ ./internal/shared/devicepin/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/cli/commands/ go/internal/shared/devicepin/
+git commit -m "cli: add 'wendy device unpin'
+
+Every identity refusal points at this command, so it has to exist and has
+to clear both pin stores — the hostname-keyed config pin and the
+identity-keyed SPKI pin.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 8: Cloud seeding
+
+**Files:**
+- Modify: `go/internal/cli/commands/cloud_discover.go` (`fetchCloudAssetsFiltered` call sites)
+- Create: `go/internal/cli/commands/cloud_pin_seed.go`
+- Test: `go/internal/cli/commands/cloud_pin_seed_test.go`
+
+**Interfaces:**
+- Consumes: `cloudpb.Asset` (`GetId()`, `GetName()`), `(*config.Config).SetDevicePinFrom`, `config.PinSourceCloud` (Task 3).
+- Produces: `seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC string) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSeedPinsFromCloudAssets(t *testing.T) {
+	t.Run("writes a cloud-sourced pin per asset", func(t *testing.T) {
+		// assets: {Id: 42, Name: "calm-zinnia"} → pin "calm-zinnia" is
+		// org 7 / asset "42" / PinSourceCloud.
+	})
+	t.Run("overwrites a conflicting lan pin", func(t *testing.T) {
+		// Pre-seed "calm-zinnia" as lan/asset 99; after seeding it is
+		// cloud/asset 42, with no error and no prompt.
+	})
+	t.Run("skips assets with no name", func(t *testing.T) {
+		// An unnamed asset has no key to pin under; it must be skipped, not
+		// pinned under "".
+	})
+}
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd go && go test ./internal/cli/commands/ -run TestSeedPinsFromCloudAssets -v`
+Expected: FAIL — `undefined: seedPinsFromCloudAssets`.
+
+- [ ] **Step 3: Implement**
+
+```go
+// seedPinsFromCloudAssets records the org's asset roster as cloud-sourced pins.
+// The cloud spoke over an authenticated session, so this is authority, not a
+// sighting: it overwrites whatever a LAN observation recorded, and closes the
+// trust-on-first-use window for every device the cloud knows about before the
+// CLI ever meets it on the network.
+func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC string) error {
+	cfg, err := loadConfigForPinFn()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for _, a := range assets {
+		name := a.GetName()
+		if name == "" {
+			continue
+		}
+		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, strconv.Itoa(int(a.GetId())), config.PinSourceCloud)
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return config.Save(cfg)
+}
+```
+
+Call it from each place `fetchCloudAssetsFiltered` returns successfully, best-effort: a seeding failure must never block the command the user actually ran, so log at debug and continue.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd go && go test ./internal/cli/commands/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go && gofmt -w -s . && cd ..
+git add go/internal/cli/commands/
+git commit -m "cli: seed device pins from the cloud asset roster
+
+Cloud is authority: it spoke to the org over an authenticated session, so
+its asset ids overwrite anything a LAN sighting recorded and close the
+trust-on-first-use window before the CLI meets the device on the network.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+```
+
+---
+
+### Task 9: Documentation and PR
+
+**Files:**
+- Modify: `go/internal/cli/assets/docs/pki/README.md` (pinning section — extended by Task 0's commit; document sources, the rotation window, and `unpin`)
+- Modify: `go/internal/cli/assets/docs/wendyos/networking/mdns.md:119` (the paragraph claiming `tls=true` decides how a device is contacted — it no longer decides trust)
+
+- [ ] **Step 1: Update the mDNS doc**
+
+Replace the trust implication at `mdns.md:119` with a statement that TXT records are unauthenticated and are used for routing and display only; the device's identity is what its certificate proves, checked against the pin recorded for the name being connected to.
+
+- [ ] **Step 2: Update the PKI doc**
+
+Document: pin sources (`lan` vs `cloud`) and their precedence; that a mismatch refuses without a prompt; the SPKI rotation window; and `wendy device unpin <host>` as the single escape hatch.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity/go
+gofmt -l . && make lint && make test
+```
+
+Expected: no gofmt output, lint clean, all tests PASS. Fix anything that fails before opening the PR.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+cd /Users/joannisorlandos/git/wendy/wendyos-device-identity
+git add go/internal/cli/assets/docs/
+git commit -m "docs: mDNS TXT records are routing, not trust
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01C9ZxDP3ea5YmqPe2tc6fsW"
+git push -u origin jo/cli-device-identity-enforcement
+```
+
+- [ ] **Step 5: Open the PR**
+
+Base it on `ed/lkg-connect-cache`. The body must state plainly: the trust gap is pre-existing on `main` (#1616 consolidated the TXT parsing rather than introducing it); this branch contains the `jo/pin-device-identity` commit under separate review; and **on-device verification has not been performed**. Link the review comment that started this (`https://github.com/wendylabsinc/WendyOS/pull/1616#discussion_r3742488639`) and the spec.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §1 enforcement → Tasks 1–2; §2 pin record → Tasks 0, 3; §3 pin key → Task 5; §4 plaintext → Task 5; §5 SPKI → Task 4; §6 surface → Tasks 6–8; §7 scope → Task 6; Sequencing → Task 0; Testing → distributed across all tasks; docs → Task 9. No section is unimplemented.
+
+**Known softness:** Tasks 5–8 describe several test bodies as arrangements against existing seams rather than quoting them in full, because the seams they must use (`device_pin_test.go`'s config/terminal stubs) arrive with Task 0's commit and cannot be quoted accurately until that merge lands. The implementer must write real assertions there, not skip them. Task 5 Step 4 also requires a grep-driven sweep of call sites rather than an exhaustive list, since #1619's callers move as it evolves.

--- a/specs/2026-08-08-cli-device-identity-enforcement-plan.md
+++ b/specs/2026-08-08-cli-device-identity-enforcement-plan.md
@@ -1231,8 +1231,46 @@ Base it on `ed/lkg-connect-cache`. The body must state plainly: the trust gap is
 
 ---
 
+### Task 10: Multi-key pin lookup
+
+**Added after Task 8 revealed a plan defect.** Design §3 requires that pin "lookup tries hostname, then display name, then mesh name", and §Testing requires a test for that lookup order — but no task implemented it. `expectedIdentityFor` and `isPinned` each do a single `DevicePinFor(pinKey)`. Consequence: Task 8's cloud seeding writes pins keyed by the cloud asset name (`calm-zinnia`) while every dial path looks up the mDNS hostname (`wendyos-calm-zinnia`), so those pins are inert. `cloudpb.Asset` carries only `{Id, Name}` — no hostname — so cloud cannot supply the dial key directly; the lookup side has to reconcile.
+
+**Files:**
+- Modify: `go/internal/cli/commands/dial_target.go` (`expectedIdentityFor`, `isPinned`)
+- Test: `go/internal/cli/commands/dial_target_test.go`
+
+**Interfaces:**
+- Consumes: `discoverycache.Entry{Hostname, DisplayName, MeshName string}`; `cachedDeviceEntry(cache *discoverycache.Cache, host string) (discoverycache.Entry, bool)` in `helpers.go`; `(*config.Config).DevicePinFor`; `config.PinSourceCloud`.
+- Produces: `pinCandidateKeys(pinKey string) []string`; `lookupPin(cfg *config.Config, pinKey string) (config.DevicePin, string, bool)` returning the winning pin, the key it was found under, and whether one was found.
+
+**Rules:**
+1. Candidates are `pinKey` first, then — from the discovery-cache entry whose hostname matches `pinKey` — its `MeshName` and `DisplayName`. Deduplicated, empties dropped, `pinKey` never repeated.
+2. **A cloud-sourced pin wins over a LAN-sourced one** regardless of position, since cloud is authority. Among pins of equal source, the earliest candidate wins.
+3. Cache access is best-effort: any failure degrades to the single-key behaviour. A cache miss must never make a host that *was* pinned read as unpinned.
+4. The safety property that licenses reading discovery data here: consulting more keys can only ever *find* a pin, never discard one, so a wrong candidate produces a stricter outcome — never a bypass. Trust decisions stay on the certificate.
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover, with real assertions: single-key match still works with no cache; a pin written under the mesh name is found when dialing the hostname; a cloud pin under one candidate beats a LAN pin under an earlier candidate; a cache read failure degrades to single-key rather than reporting unpinned; and `isPinned` returns true when any candidate is pinned. Reuse `setTempConfig` and the cache helpers already in this package's tests.
+
+- [ ] **Step 2: Run them to confirm they fail**
+
+Run: `cd go && go test ./internal/cli/commands/ -run 'PinCandidate|LookupPin|ExpectedIdentityFor|IsPinned' -v`
+
+- [ ] **Step 3: Implement `pinCandidateKeys` and `lookupPin`, and route both accessors through them**
+
+- [ ] **Step 4: Run the suite**
+
+Run: `cd go && go test ./internal/cli/commands/ -count=1`
+
+- [ ] **Step 5: Commit**
+
+---
+
 ## Self-Review
 
-**Spec coverage:** §1 enforcement → Tasks 1–2; §2 pin record → Tasks 0, 3; §3 pin key → Task 5; §4 plaintext → Task 5; §5 SPKI → Task 4; §6 surface → Tasks 6–8; §7 scope → Task 6; Sequencing → Task 0; Testing → distributed across all tasks; docs → Task 9. No section is unimplemented.
+**Spec coverage:** §1 enforcement → Tasks 1–2; §2 pin record → Tasks 0, 3; §3 pin key → Tasks 5 and 10; §4 plaintext → Task 5; §5 SPKI → Task 4; §6 surface → Tasks 6–8; §7 scope → Task 6; Sequencing → Task 0; Testing → distributed across all tasks; docs → Task 9. No section is unimplemented.
+
+**Correction (2026-08-09):** the original coverage claim above was wrong — it mapped design §3 to Task 5 alone, but §3's multi-key lookup requirement had no task. Task 10 was added to close it after Task 8 surfaced the gap.
 
 **Known softness:** Tasks 5–8 describe several test bodies as arrangements against existing seams rather than quoting them in full, because the seams they must use (`device_pin_test.go`'s config/terminal stubs) arrive with Task 0's commit and cannot be quoted accurately until that merge lands. The implementer must write real assertions there, not skip them. Task 5 Step 4 also requires a grep-driven sweep of call sites rather than an exhaustive list, since #1619's callers move as it evolves.


### PR DESCRIPTION
## What this fixes

An mDNS TXT record (`tls=true`, `name=...`, `displayname=...`) on `_wendyos._udp` is advertised in plaintext by whatever host answers on the local network — it is not authenticated. Before this branch, the CLI dial ladder used that record only to pick a port, and the certificate check that followed verified chain + org but never verified that the certificate belonged to the *specific device* the user asked to reach. Any host holding a same-org, same-CA certificate (a second enrolled device, or a device that was wiped and re-enrolled) could answer for another device's mDNS name and pass every check the CLI ran.

**This trust gap is pre-existing on `main`.** PR #1616 (`ed/instant-mdns-discovery`) consolidated the mDNS TXT record parsing into one place — it did not introduce the gap, it made the existing gap easier to see and fix in one spot. The review comment that started this work: https://github.com/wendylabsinc/WendyOS/pull/1616#discussion_r3742488639

## What this branch does

- `certs.ServerVerifyOpts.ExpectedIdentity`: when the caller pins a specific asset, the peer's leaf certificate must carry an `asset` Wendy identity matching org and entity id **exactly**, with no grace mode. This runs inside `tls.Config.VerifyConnection`, not `VerifyPeerCertificate` — a resumed TLS 1.3 handshake skips the latter but not the former.
- The dial ladder aborts immediately on a wrong-device rejection (no further cert or port is tried), and a hostname carrying any pin is never offered the unauthenticated plaintext rung.
- `config.DevicePin` gained `AssetID` and `Source` (`lan`/`cloud`). A cloud-sourced pin write is authoritative and overwrites whatever was there; a LAN sighting never backfills an asset id into a cloud pin, and never displaces a cloud pin in a way that would erase an existing exact-identity constraint.
- Pin lookup now checks the dialed name, then (best-effort, via the discovery cache) the device's mesh name, then its display name — one device can be pinned under any of the names it answers to.
- Pins are seeded from the org's cloud asset roster, closing the trust-on-first-use window for every device the cloud already knows about, before the CLI ever meets it on the network.
- SPKI pinning (BLE, LAN gRPC, cloud tunnel) fails closed on an unexplained key change, but accepts a key change once the previously pinned certificate has expired — that's rotation, not an attack.
- Every identity refusal reads identically whether the CLI is interactive, `--json`, or non-interactive. There is deliberately no "trust this anyway?" prompt — a MITM warning that can be dismissed gets dismissed. The single escape hatch is `wendy device unpin <hostname>`.
- Docs updated: `pki/README.md`'s pinning section now documents sources/precedence, the no-prompt refusal behaviour, the SPKI rotation window, the multi-key lookup order, and `unpin`; `mdns.md` no longer implies that a TXT record decides trust.

## Branch stacking note

This branch was built on top of `ed/lkg-connect-cache` (PR #1619) and includes the `jo/pin-device-identity` commit (asset-id device pinning), which was originally intended to land separately as **PR #1632**. Both `ed/lkg-connect-cache` and `jo/pin-device-identity` have since been **merged into `main`** while this branch was in progress, so:

- This PR is opened against `main`, not `ed/lkg-connect-cache` — that branch no longer exists upstream.
- The resulting diff is small and scoped to this task's actual work; the prerequisite content already landed via #1619 and #1632 and does not reappear as new changes here.

## Verification

- `gofmt -l .` — clean.
- `go build ./...` — clean.
- `make test` — all packages pass except `TestMDNSStreamBackend` in `internal/shared/discovery`, which fails in this environment for local Bonjour/mDNS reasons unrelated to this branch (it fails the same way on the pre-branch commit). Not fixed, not blocking.
- `make lint` reports pre-existing `golangci-lint` findings (unused funcs, staticcheck quickfixes, etc.) spread across files this branch never touches (e.g. `ipcam/dhcp.go`, `oci/entitlements.go`, `wifitable/model.go`). None of them are in files this branch's commits modified. `make lint` is not wired into CI for this repo (no workflow invokes it), so this is pre-existing repo noise, not a regression.

**On-device verification has NOT been performed.** Everything above is unit/integration-tested against synthetic certificates and in-process TLS; no real WendyOS device, real enrollment, or real mDNS spoof was exercised against this code.

## References

- Spec: `specs/2026-08-08-cli-device-identity-enforcement-design.md`
- Plan: `specs/2026-08-08-cli-device-identity-enforcement-plan.md`
- Review comment that started this: https://github.com/wendylabsinc/WendyOS/pull/1616#discussion_r3742488639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
