### PR TITLE
fix(ipcam): keep a claimed camera link addressed

### DIFF
--- a/go/internal/agent/ipcam/link.go
+++ b/go/internal/agent/ipcam/link.go
@@ -63,8 +63,24 @@ type Interface struct {
 	Carrier   bool
 	Up        bool
 	HasIPv4   bool
+	IPv4s     []net.IP
 	Loopback  bool
 	PointToPo bool // point-to-point, e.g. a tunnel; never a camera link
+}
+
+// HasAddress reports whether ip is currently configured on the link.
+//
+// HasIPv4 is not enough to answer this: a claimed link that has had our segment
+// address stripped by whatever else manages the interface can still hold some
+// other IPv4 address, and treating that as "still configured" is exactly how the
+// camera segment goes silently dead.
+func (i Interface) HasAddress(ip net.IP) bool {
+	for _, have := range i.IPv4s {
+		if have.Equal(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // Eligible reports whether a link could host a camera segment. This is the check
@@ -206,6 +222,28 @@ func (g *LinkGuard) ShouldClaim(link string, now time.Time) bool {
 	return true
 }
 
+// RestoreClaim moves a link straight to serving, for a segment this agent is
+// known to have served before an restart. It records the claim the same way
+// ShouldClaim does and refuses for the same reasons.
+//
+// The unanswered-DISCOVER window is not required here because the evidence it
+// gathers has already been gathered: the link was claimed in an earlier process
+// and a camera holds a lease on it. Waiting for the camera to speak again would
+// mean waiting up to LeaseWindow, during which the segment has no address and
+// the camera is unreachable. Callers still listen for a competing server first;
+// a disqualifying reply seen in that window leaves the state non-Observing and
+// this returns false.
+func (g *LinkGuard) RestoreClaim(link string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	d := g.decision(link)
+	if d.state != LinkObserving {
+		return false
+	}
+	d.state = LinkServing
+	return true
+}
+
 // Disqualify marks a link as never servable, for reasons outside DHCP traffic
 // such as failing to configure an address on it.
 func (g *LinkGuard) Disqualify(link string) {
@@ -261,6 +299,18 @@ func SegmentFor(index int) CameraSegment {
 	}
 }
 
+// SegmentIndexFor returns the camera segment an address belongs to, and whether
+// it belongs to one at all. It is how a lease recorded in the registry names the
+// segment that must be restored after a restart, rather than whichever segment
+// happens to be free.
+func SegmentIndexFor(ip net.IP) (int, bool) {
+	v4 := ip.To4()
+	if v4 == nil || v4[0] != 10 || v4[1] != 98 {
+		return 0, false
+	}
+	return int(v4[2]), true
+}
+
 // CIDR renders the server address in the form `ip addr add` expects.
 func (s CameraSegment) CIDR() string {
 	ones, _ := s.Mask.Size()
@@ -273,12 +323,13 @@ func InterfacesFrom(ifaces []net.Interface, carrier func(name string) bool) []In
 	out := make([]Interface, 0, len(ifaces))
 	for _, iface := range ifaces {
 		addrs, err := iface.Addrs()
-		hasIPv4 := false
+		var ipv4s []net.IP
 		if err == nil {
 			for _, addr := range addrs {
-				if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
-					hasIPv4 = true
-					break
+				if ipnet, ok := addr.(*net.IPNet); ok {
+					if v4 := ipnet.IP.To4(); v4 != nil {
+						ipv4s = append(ipv4s, v4)
+					}
 				}
 			}
 		}
@@ -287,7 +338,8 @@ func InterfacesFrom(ifaces []net.Interface, carrier func(name string) bool) []In
 			MAC:       iface.HardwareAddr,
 			Carrier:   carrier(iface.Name),
 			Up:        iface.Flags&net.FlagUp != 0,
-			HasIPv4:   hasIPv4,
+			HasIPv4:   len(ipv4s) > 0,
+			IPv4s:     ipv4s,
 			Loopback:  iface.Flags&net.FlagLoopback != 0,
 			PointToPo: iface.Flags&net.FlagPointToPoint != 0,
 		})

--- a/go/internal/agent/ipcam/linkmanager.go
+++ b/go/internal/agent/ipcam/linkmanager.go
@@ -30,26 +30,28 @@ type LinkManager struct {
 	serve          func(ctx context.Context, link string, seg CameraSegment, pool *LeasePool, onLease func(net.HardwareAddr, net.IP, string)) error
 	now            func() time.Time
 
-	mu      sync.Mutex
-	claimed map[string]CameraSegment
-	pools   map[string]*LeasePool
-	running map[string]bool
-	stop    map[string]context.CancelFunc // cancels a claimed link's server
-	downFor map[string]int                // consecutive scans with no carrier
+	mu            sync.Mutex
+	claimed       map[string]CameraSegment
+	pools         map[string]*LeasePool
+	running       map[string]bool
+	stop          map[string]context.CancelFunc // cancels a claimed link's server
+	downFor       map[string]int                // consecutive scans with no carrier
+	watchingSince map[string]time.Time          // when this process began watching a link
 }
 
 // NewLinkManager returns a manager writing discovered cameras into reg.
 func NewLinkManager(reg *Registry, logger *zap.Logger) *LinkManager {
 	m := &LinkManager{
-		reg:     reg,
-		guard:   NewLinkGuard(),
-		logger:  logger,
-		now:     time.Now,
-		claimed: make(map[string]CameraSegment),
-		pools:   make(map[string]*LeasePool),
-		running: make(map[string]bool),
-		stop:    make(map[string]context.CancelFunc),
-		downFor: make(map[string]int),
+		reg:           reg,
+		guard:         NewLinkGuard(),
+		logger:        logger,
+		now:           time.Now,
+		claimed:       make(map[string]CameraSegment),
+		pools:         make(map[string]*LeasePool),
+		running:       make(map[string]bool),
+		stop:          make(map[string]context.CancelFunc),
+		downFor:       make(map[string]int),
+		watchingSince: make(map[string]time.Time),
 	}
 	m.carrier = sysfsCarrier
 	m.listInterfaces = func() ([]Interface, error) {
@@ -113,10 +115,17 @@ func (m *LinkManager) scanOnce(ctx context.Context) {
 		// carrier releases it; re-testing eligibility here would release the link
 		// on the very next scan and then re-claim it on the next DISCOVER,
 		// spawning a second server each time round.
-		if m.isClaimed(iface.Name) {
+		if seg, claimed := m.claimedSegment(iface.Name); claimed {
 			if m.carrierLost(iface) {
 				m.release(iface.Name)
+				continue
 			}
+			// Carrier alone is not proof the segment still works. Whatever else
+			// manages this interface can strip the address we added, and nothing
+			// tells us when it does: the DHCP watcher is a packet socket and the
+			// server binds INADDR_ANY, so leases keep flowing on an addressless
+			// link while every route to the camera is gone.
+			m.reassertAddress(iface, seg)
 			continue
 		}
 		if !iface.Eligible() {
@@ -129,10 +138,72 @@ func (m *LinkManager) scanOnce(ctx context.Context) {
 		}
 		m.noteCarrierUp(iface.Name)
 		m.ensureWatching(ctx, iface.Name)
+		if seg, ok := m.restorableSegment(iface.Name); ok {
+			if m.guard.RestoreClaim(iface.Name) {
+				m.logger.Info("restoring camera link claim from a previous run",
+					zap.String("link", iface.Name), zap.String("address", seg.CIDR()))
+				m.claim(ctx, iface.Name, &seg)
+			}
+			continue
+		}
 		if m.guard.ShouldClaim(iface.Name, m.now()) {
-			m.claim(ctx, iface.Name)
+			m.claim(ctx, iface.Name, nil)
 		}
 	}
+}
+
+// reassertAddress puts our segment address back on a claimed link that has lost
+// it. Losing it is silent and permanent otherwise: scanOnce judges a claimed
+// link on carrier only, so nothing would ever notice or retry.
+func (m *LinkManager) reassertAddress(iface Interface, seg CameraSegment) {
+	if iface.HasAddress(seg.ServerIP) {
+		return
+	}
+	// Warn, not Info: the address disappearing under us means something else is
+	// managing this interface, and that is worth seeing in production logs.
+	m.logger.Warn("camera link lost its address, restoring it",
+		zap.String("link", iface.Name), zap.String("cidr", seg.CIDR()))
+	if err := m.addAddress(iface.Name, seg.CIDR()); err != nil {
+		// Deliberately not disqualifying: the cause is usually transient, and
+		// disqualifying would strand the segment until carrier is lost. The next
+		// scan tries again.
+		m.logger.Warn("restoring camera link address failed",
+			zap.String("link", iface.Name), zap.String("cidr", seg.CIDR()), zap.Error(err))
+	}
+}
+
+// restorableSegment returns the segment a link should reclaim after an agent
+// restart, and whether there is one.
+//
+// LinkManager state is in-process, so a restart forgets every claim, while the
+// registry remembers the camera and the address it holds. Without this the link
+// waits for the camera to speak DHCP again, which a camera holding a lease will
+// not do for up to LeaseWindow — twelve hours during which it is unreachable.
+//
+// The competing-server guard is still honoured: the link must have been watched
+// for unansweredWindow first, so a foreign OFFER has had the same chance to
+// disqualify it as it does on a first claim.
+func (m *LinkManager) restorableSegment(link string) (CameraSegment, bool) {
+	if m.reg == nil {
+		return CameraSegment{}, false
+	}
+	m.mu.Lock()
+	since, watching := m.watchingSince[link]
+	m.mu.Unlock()
+	if !watching || m.now().Sub(since) < unansweredWindow {
+		return CameraSegment{}, false
+	}
+	for _, cam := range m.reg.List() {
+		if cam.Link != link || cam.Address == "" {
+			continue
+		}
+		index, ok := SegmentIndexFor(net.ParseIP(cam.Address))
+		if !ok {
+			continue
+		}
+		return SegmentFor(index), true
+	}
+	return CameraSegment{}, false
 }
 
 // ensureWatching starts one passive DHCP watcher per link.
@@ -143,6 +214,9 @@ func (m *LinkManager) ensureWatching(ctx context.Context, link string) {
 		return
 	}
 	m.running[link] = true
+	// The clock a restored claim waits on: it is how long we have been listening
+	// for a competing DHCP server on this link in this process.
+	m.watchingSince[link] = m.now()
 	m.mu.Unlock()
 
 	// Info, not Debug: when a camera does not appear, the first question is
@@ -154,6 +228,7 @@ func (m *LinkManager) ensureWatching(ctx context.Context, link string) {
 		defer func() {
 			m.mu.Lock()
 			delete(m.running, link)
+			delete(m.watchingSince, link)
 			m.mu.Unlock()
 		}()
 		err := m.watch(ctx, link, func(p *Packet) {
@@ -202,14 +277,16 @@ func (m *LinkManager) noteClient(link string, p *Packet) {
 	}
 }
 
-// claim configures the link and starts serving leases on it.
-func (m *LinkManager) claim(ctx context.Context, link string) {
+// claim configures the link and starts serving leases on it. A non-nil preferred
+// segment is used when it is free, which is how a restored claim keeps the
+// subnet the camera already holds a lease on.
+func (m *LinkManager) claim(ctx context.Context, link string, preferred *CameraSegment) {
 	m.mu.Lock()
 	if _, exists := m.claimed[link]; exists {
 		m.mu.Unlock()
 		return
 	}
-	seg, ok := m.nextSegmentLocked()
+	seg, ok := m.chooseSegmentLocked(preferred)
 	if !ok {
 		m.mu.Unlock()
 		m.logger.Warn("no camera link subnet available", zap.String("link", link))
@@ -272,20 +349,32 @@ func (m *LinkManager) claim(ctx context.Context, link string) {
 	}()
 }
 
+// chooseSegmentLocked returns the segment a claim should use: the preferred one
+// when it is free, otherwise the lowest unused. Callers hold m.mu.
+func (m *LinkManager) chooseSegmentLocked(preferred *CameraSegment) (CameraSegment, bool) {
+	if preferred != nil && !m.segmentUsedLocked(*preferred) {
+		return *preferred, true
+	}
+	return m.nextSegmentLocked()
+}
+
+// segmentUsedLocked reports whether a segment is already claimed by some link.
+// Callers hold m.mu.
+func (m *LinkManager) segmentUsedLocked(seg CameraSegment) bool {
+	for _, claimed := range m.claimed {
+		if claimed.ServerIP.Equal(seg.ServerIP) {
+			return true
+		}
+	}
+	return false
+}
+
 // nextSegmentLocked returns the lowest unused camera subnet. Reusing holes is
 // important: len(m.claimed) can name a subnet that is still active after a
 // lower-numbered link has been released. Callers hold m.mu.
 func (m *LinkManager) nextSegmentLocked() (CameraSegment, bool) {
-	for index := 0; index < 256; index++ {
-		candidate := SegmentFor(index)
-		used := false
-		for _, claimed := range m.claimed {
-			if claimed.ServerIP.Equal(candidate.ServerIP) {
-				used = true
-				break
-			}
-		}
-		if !used {
+	for index := range 256 {
+		if candidate := SegmentFor(index); !m.segmentUsedLocked(candidate) {
 			return candidate, true
 		}
 	}
@@ -318,10 +407,16 @@ func (m *LinkManager) recordLease(link string, mac net.HardwareAddr, addr net.IP
 }
 
 func (m *LinkManager) isClaimed(link string) bool {
+	_, ok := m.claimedSegment(link)
+	return ok
+}
+
+// claimedSegment returns the segment a link is claimed with, if it is claimed.
+func (m *LinkManager) claimedSegment(link string) (CameraSegment, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_, ok := m.claimed[link]
-	return ok
+	seg, ok := m.claimed[link]
+	return seg, ok
 }
 
 // dropClaim forgets a link's claim bookkeeping and stops its server, leaving the

--- a/go/internal/agent/ipcam/linkmanager_test.go
+++ b/go/internal/agent/ipcam/linkmanager_test.go
@@ -58,6 +58,9 @@ func newManagerHarness(t *testing.T, ifaces []Interface) *managerHarness {
 		defer h.mu.Unlock()
 		return h.nowValue
 	}
+	// Configuring an address mutates the fake interface list, so a claimed link
+	// reports the address it was given. Without that the manager cannot tell an
+	// address it configured from one that has been stripped out from under it.
 	m.addAddress = func(link, cidr string) error {
 		h.mu.Lock()
 		defer h.mu.Unlock()
@@ -65,12 +68,14 @@ func newManagerHarness(t *testing.T, ifaces []Interface) *managerHarness {
 			return h.addErr
 		}
 		h.added = append(h.added, link+" "+cidr)
+		h.setAddressLocked(link, cidr, true)
 		return nil
 	}
 	m.delAddress = func(link, cidr string) error {
 		h.mu.Lock()
 		defer h.mu.Unlock()
 		h.removed = append(h.removed, link+" "+cidr)
+		h.setAddressLocked(link, cidr, false)
 		return nil
 	}
 	m.watch = func(ctx context.Context, link string, onPacket func(*Packet)) error {
@@ -93,6 +98,39 @@ func newManagerHarness(t *testing.T, ifaces []Interface) *managerHarness {
 	}
 	h.mgr = m
 	return h
+}
+
+// setAddressLocked adds or removes an address on the fake interface, mirroring
+// what `ip addr add/del` would do. Callers hold h.mu.
+func (h *managerHarness) setAddressLocked(link, cidr string, present bool) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return
+	}
+	for i := range h.ifaces {
+		if h.ifaces[i].Name != link {
+			continue
+		}
+		var kept []net.IP
+		for _, have := range h.ifaces[i].IPv4s {
+			if !have.Equal(ip) {
+				kept = append(kept, have)
+			}
+		}
+		if present {
+			kept = append(kept, ip.To4())
+		}
+		h.ifaces[i].IPv4s = kept
+		h.ifaces[i].HasIPv4 = len(kept) > 0
+	}
+}
+
+// stripAddress removes an address behind the manager's back, which is what a
+// host network manager reconciling the interface does.
+func (h *managerHarness) stripAddress(link, cidr string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.setAddressLocked(link, cidr, false)
 }
 
 // waitFor polls until cond holds, so tests do not depend on goroutine timing.
@@ -144,12 +182,16 @@ func claimEth0(t *testing.T, h *managerHarness, ctx context.Context) {
 	waitFor(t, "eth0 to be served", func() bool { return len(h.servedLinks()) >= 1 })
 }
 
-// carrierDown replaces the interface list with a link that has lost carrier but
-// still carries the address we configured, which is the real post-blip state.
+// carrierDown drops carrier on a link while leaving the address we configured in
+// place, which is the real post-blip state.
 func (h *managerHarness) carrierDown(name string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.ifaces = []Interface{{Name: name, Carrier: false, Up: true, HasIPv4: true}}
+	for i := range h.ifaces {
+		if h.ifaces[i].Name == name {
+			h.ifaces[i].Carrier = false
+		}
+	}
 }
 
 func (h *managerHarness) feed(link string, p *Packet) {
@@ -467,12 +509,14 @@ func TestManagerKeepsClaimedLinkAfterItGetsAnAddress(t *testing.T) {
 	h.mgr.scanOnce(ctx)
 	waitFor(t, "eth0 to be served", func() bool { return len(h.servedLinks()) == 1 })
 
-	// The link now reports an address, exactly as it does once we configure it.
+	// Claiming configured the address, so the link now reports one and therefore
+	// fails the eligibility test that got it claimed. It must stay claimed anyway.
 	h.mu.Lock()
-	withAddress := cabledEth("eth0")
-	withAddress.HasIPv4 = true
-	h.ifaces = []Interface{withAddress}
+	reportsAddress := h.ifaces[0].HasIPv4 && h.ifaces[0].HasAddress(SegmentFor(0).ServerIP)
 	h.mu.Unlock()
+	if !reportsAddress {
+		t.Fatal("claimed link does not report the address that was configured on it")
+	}
 
 	h.advance(scanInterval)
 	h.mgr.scanOnce(ctx)
@@ -704,5 +748,196 @@ func TestManagerReclaimsAfterRelease(t *testing.T) {
 	waitFor(t, "eth0 to be served again", func() bool { return len(h.servedLinks()) == 2 })
 	if got := h.mgr.State("eth0"); got != LinkServing {
 		t.Fatalf("state = %v, want serving after re-claim", got)
+	}
+}
+
+// The bug this guards: whatever else manages the interface can strip the address
+// we added, and a claimed link is otherwise judged on carrier alone. DHCP keeps
+// working on an addressless link — the watcher is a packet socket and the server
+// binds INADDR_ANY — so leases go on being handed out while every route to the
+// camera is gone, and nothing ever notices.
+func TestManagerRestoresStrippedAddressOnClaimedLink(t *testing.T) {
+	h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	claimEth0(t, h, ctx)
+
+	segment := SegmentFor(0).CIDR()
+	if got := h.addedAddresses(); len(got) != 1 {
+		t.Fatalf("configured %v, want one address for the claim", got)
+	}
+
+	// Scanning a healthy claimed link must not touch the address.
+	h.mgr.scanOnce(ctx)
+	if got := h.addedAddresses(); len(got) != 1 {
+		t.Fatalf("configured %v, want no re-add while the address is present", got)
+	}
+
+	h.stripAddress("eth0", segment)
+	h.mgr.scanOnce(ctx)
+
+	if got := h.addedAddresses(); len(got) != 2 || got[1] != "eth0 "+segment {
+		t.Fatalf("configured %v, want the stripped address restored", got)
+	}
+	if got := h.removedAddresses(); len(got) != 0 {
+		t.Fatalf("removed %v, want the claim left intact", got)
+	}
+	if !h.mgr.isClaimed("eth0") {
+		t.Fatal("eth0 was released, want the claim kept across an address loss")
+	}
+	// Restored means restored: the next scan sees it present and leaves it alone.
+	h.mgr.scanOnce(ctx)
+	if got := h.addedAddresses(); len(got) != 2 {
+		t.Fatalf("configured %v, want no further re-add", got)
+	}
+}
+
+// A failed restore is retried rather than disqualifying the link, because the
+// usual cause is transient and disqualifying would strand the segment until
+// carrier is lost.
+func TestManagerRetriesFailedAddressRestore(t *testing.T) {
+	h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	claimEth0(t, h, ctx)
+
+	segment := SegmentFor(0).CIDR()
+	h.stripAddress("eth0", segment)
+	h.mu.Lock()
+	h.addErr = errors.New("device busy")
+	h.mu.Unlock()
+	h.mgr.scanOnce(ctx)
+
+	if got := h.mgr.State("eth0"); got != LinkServing {
+		t.Fatalf("state = %v, want serving after a failed restore", got)
+	}
+
+	h.mu.Lock()
+	h.addErr = nil
+	h.mu.Unlock()
+	h.mgr.scanOnce(ctx)
+	if got := h.addedAddresses(); len(got) != 2 {
+		t.Fatalf("configured %v, want the restore retried on the next scan", got)
+	}
+}
+
+// LinkManager state is in-process, so a restart forgets every claim while the
+// registry remembers the camera. A camera holding a lease says nothing for up to
+// LeaseWindow, so waiting for DHCP traffic leaves it unreachable for twelve
+// hours. The claim is restored from the registry instead.
+func TestManagerRestoresClaimFromRegistryAfterRestart(t *testing.T) {
+	h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := h.reg.Upsert(Camera{
+		MAC:     "ec:71:db:2a:ae:7e",
+		Address: "10.98.0.50",
+		Link:    "eth0",
+		Model:   "RLC-520A",
+	}); err != nil {
+		t.Fatalf("seeding registry: %v", err)
+	}
+
+	// First scan only starts listening: restoring immediately would skip the
+	// window in which a competing DHCP server gets to disqualify the link.
+	h.mgr.scanOnce(ctx)
+	waitFor(t, "eth0 to be watched", func() bool { return len(h.watchedLinks()) == 1 })
+	if got := h.servedLinks(); len(got) != 0 {
+		t.Fatalf("served %v before listening for a competing server", got)
+	}
+
+	h.advance(unansweredWindow)
+	h.mgr.scanOnce(ctx)
+
+	waitFor(t, "eth0 to be served", func() bool { return len(h.servedLinks()) == 1 })
+	if got := h.addedAddresses(); len(got) != 1 || got[0] != "eth0 "+SegmentFor(0).CIDR() {
+		t.Fatalf("configured %v, want the segment the camera already holds a lease on", got)
+	}
+}
+
+// A restored claim must keep the camera's existing subnet, not whichever segment
+// happens to be free, or the lease the camera holds would be off-subnet.
+func TestManagerRestoredClaimKeepsCameraSegment(t *testing.T) {
+	h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := h.reg.Upsert(Camera{
+		MAC:     "ec:71:db:2a:ae:7e",
+		Address: "10.98.3.50",
+		Link:    "eth0",
+	}); err != nil {
+		t.Fatalf("seeding registry: %v", err)
+	}
+
+	h.mgr.scanOnce(ctx)
+	waitFor(t, "eth0 to be watched", func() bool { return len(h.watchedLinks()) == 1 })
+	h.advance(unansweredWindow)
+	h.mgr.scanOnce(ctx)
+
+	waitFor(t, "eth0 to be served", func() bool { return len(h.servedLinks()) == 1 })
+	if got := h.addedAddresses(); len(got) != 1 || got[0] != "eth0 "+SegmentFor(3).CIDR() {
+		t.Fatalf("configured %v, want 10.98.3.1/24 to match the camera's lease", got)
+	}
+}
+
+// The competing-server guard outranks a restore: a foreign OFFER seen while we
+// are listening means this link is not ours, whatever the registry remembers.
+func TestManagerDoesNotRestoreClaimOnDisqualifiedLink(t *testing.T) {
+	h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := h.reg.Upsert(Camera{
+		MAC:     "ec:71:db:2a:ae:7e",
+		Address: "10.98.0.50",
+		Link:    "eth0",
+	}); err != nil {
+		t.Fatalf("seeding registry: %v", err)
+	}
+
+	h.mgr.scanOnce(ctx)
+	waitFor(t, "eth0 to be watched", func() bool { return len(h.watchedLinks()) == 1 })
+	h.feed("eth0", &Packet{Type: Offer, XID: 1, ServerID: net.IPv4(192, 168, 1, 1)})
+	h.advance(unansweredWindow)
+	h.mgr.scanOnce(ctx)
+
+	if got := h.servedLinks(); len(got) != 0 {
+		t.Fatalf("served %v on a link another DHCP server owns", got)
+	}
+	if got := h.addedAddresses(); len(got) != 0 {
+		t.Fatalf("configured %v on a disqualified link", got)
+	}
+}
+
+// A registry entry for a different link, or an address outside the camera
+// subnets, is not evidence that this link was ever ours.
+func TestManagerDoesNotRestoreClaimWithoutMatchingCamera(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cam  Camera
+	}{
+		{"another link", Camera{MAC: "ec:71:db:2a:ae:01", Address: "10.98.0.50", Link: "eth1"}},
+		{"foreign subnet", Camera{MAC: "ec:71:db:2a:ae:02", Address: "192.168.2.69", Link: "eth0"}},
+		{"no address", Camera{MAC: "ec:71:db:2a:ae:03", Link: "eth0"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newManagerHarness(t, []Interface{cabledEth("eth0")})
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if _, err := h.reg.Upsert(tc.cam); err != nil {
+				t.Fatalf("seeding registry: %v", err)
+			}
+			h.mgr.scanOnce(ctx)
+			waitFor(t, "eth0 to be watched", func() bool { return len(h.watchedLinks()) == 1 })
+			h.advance(unansweredWindow)
+			h.mgr.scanOnce(ctx)
+
+			if got := h.servedLinks(); len(got) != 0 {
+				t.Fatalf("served %v without evidence the link was ours", got)
+			}
+		})
 	}
 }

--- a/go/internal/agent/ipcam/rtsp.go
+++ b/go/internal/agent/ipcam/rtsp.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Default RTSP paths. Reolink uses these and they are the de facto convention for
@@ -15,8 +17,34 @@ import (
 const (
 	defaultMainPath = "/h264Preview_01_main"
 	defaultSubPath  = "/h264Preview_01_sub"
-	defaultRTSPPort = 554
+	// RTSPPort is the port a camera serves streams on, and the one to test when
+	// deciding whether a camera is reachable at all.
+	RTSPPort        = 554
+	defaultRTSPPort = RTSPPort
 )
+
+// ReachTimeout bounds a reachability test against a camera. A camera on its own
+// cabled segment answers in milliseconds; two seconds is generous and is far
+// better than the twenty a stalled RTSP connect takes to give up.
+const ReachTimeout = 2 * time.Second
+
+// Reachable reports whether a camera accepts a TCP connection on its RTSP port.
+//
+// This tests the port the stream actually needs, rather than the registry's
+// Online flag: that flag comes from a probe of port 80, which some cameras do
+// not serve at all, so gating a stream on it would refuse cameras that work.
+func Reachable(address string) bool {
+	if address == "" {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp",
+		net.JoinHostPort(address, strconv.Itoa(RTSPPort)), ReachTimeout)
+	if err != nil {
+		return false
+	}
+	conn.Close() //nolint:errcheck
+	return true
+}
 
 // StreamChoice selects which of a camera's streams to open.
 type StreamChoice int
@@ -99,6 +127,54 @@ func RedactURL(rawurl string) string {
 	}
 	u.User = url.User("<redacted>")
 	return u.String()
+}
+
+// credentialInURL matches the userinfo of any URL, which is the only shape a
+// camera password takes in a GStreamer diagnostic: it is carried in the pipeline
+// as the userinfo of an rtsp:// location and is echoed back inside that URL.
+var credentialInURL = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/@]*@`)
+
+// RedactText removes credentials from free-form text so a GStreamer diagnostic
+// can be shown instead of discarded.
+//
+// Two passes, because either alone is insufficient. The URL pass catches the
+// password wherever a library echoes the location back, including forms this
+// code never built. The literal pass catches a secret that appears outside a URL,
+// such as a property dump. Anything unparseable stays redacted rather than being
+// let through.
+func RedactText(text string, secrets ...string) string {
+	for _, secret := range secrets {
+		if secret == "" {
+			continue
+		}
+		text = strings.ReplaceAll(text, secret, "<redacted>")
+	}
+	return credentialInURL.ReplaceAllString(text, "${1}<redacted>@")
+}
+
+// SecretsIn returns the credential material carried by pipeline tokens, so a
+// diagnostic produced from those tokens can be scrubbed of it.
+func SecretsIn(args []string) []string {
+	var out []string
+	for _, arg := range args {
+		raw, ok := strings.CutPrefix(arg, "location=")
+		if !ok {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil || u.User == nil {
+			continue
+		}
+		out = append(out, u.User.Username())
+		if password, set := u.User.Password(); set {
+			out = append(out, password)
+		}
+		// The percent-encoded spelling is what actually appears in the pipeline
+		// string, and it differs from the decoded one whenever the password
+		// contains a reserved character.
+		out = append(out, u.User.String())
+	}
+	return out
 }
 
 // PipelineArgs returns GStreamer pipeline tokens that pull an RTSP stream and

--- a/go/internal/agent/ipcam/rtsp_test.go
+++ b/go/internal/agent/ipcam/rtsp_test.go
@@ -2,6 +2,8 @@ package ipcam
 
 import (
 	"errors"
+	"net"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -165,5 +167,78 @@ func TestFormatUnreachable(t *testing.T) {
 	got := FormatUnreachable(c)
 	if !strings.Contains(got, "10.98.0.50") || !strings.Contains(got, "2026-08-05") {
 		t.Fatalf("message = %q, want the address and when it was last seen", got)
+	}
+}
+
+// A GStreamer diagnostic is worth showing, but it echoes the location property
+// back, and that property carries the camera password.
+func TestRedactTextRemovesCredentialsFromDiagnostics(t *testing.T) {
+	args := PipelineArgs("rtsp://admin:hunter2@10.98.0.50:554/h264Preview_01_sub")
+	diagnostic := "ERROR from element rtspsrc0: Could not open resource for reading and writing.\n" +
+		"gstrtspsrc.c(9105): gst_rtspsrc_retrieve_sdp (): location=rtsp://admin:hunter2@10.98.0.50:554/h264Preview_01_sub\n" +
+		"Failed to connect. (Timeout while waiting for server response)"
+
+	got := RedactText(diagnostic, SecretsIn(args)...)
+
+	if strings.Contains(got, "hunter2") {
+		t.Fatalf("password survived redaction: %s", got)
+	}
+	// The part that makes the diagnostic worth keeping must survive.
+	if !strings.Contains(got, "Failed to connect") || !strings.Contains(got, "10.98.0.50") {
+		t.Fatalf("redaction destroyed the diagnostic: %s", got)
+	}
+}
+
+// A password containing reserved characters appears percent-encoded in the
+// pipeline, so the literal pass alone would miss it and the URL pass alone would
+// miss any copy outside a URL. Both spellings must go.
+func TestRedactTextRemovesEncodedAndBareCredentials(t *testing.T) {
+	secret := "p@ss:word/1"
+	args := PipelineArgs("rtsp://" + url.UserPassword("admin", secret).String() + "@10.98.0.50:554/x")
+	encoded := url.UserPassword("admin", secret).String()
+	diagnostic := "location=rtsp://" + encoded + "@10.98.0.50:554/x and a bare copy " + secret
+
+	got := RedactText(diagnostic, SecretsIn(args)...)
+
+	if strings.Contains(got, secret) || strings.Contains(got, encoded) {
+		t.Fatalf("credential survived redaction: %s", got)
+	}
+}
+
+// Redaction must not depend on this package having built the URL: a library can
+// echo back a form we never produced.
+func TestRedactTextRemovesUnknownURLCredentials(t *testing.T) {
+	got := RedactText("failed on rtsp://someone:secret@10.98.0.50:554/x")
+	if strings.Contains(got, "secret") {
+		t.Fatalf("credential survived redaction: %s", got)
+	}
+	if !strings.Contains(got, "10.98.0.50") {
+		t.Fatalf("host was destroyed: %s", got)
+	}
+}
+
+func TestSecretsInIgnoresPipelineWithoutLocation(t *testing.T) {
+	if got := SecretsIn([]string{"rtspsrc", "protocols=tcp", "!", "fdsink", "fd=1"}); len(got) != 0 {
+		t.Fatalf("SecretsIn = %v, want nothing", got)
+	}
+}
+
+func TestSegmentIndexFor(t *testing.T) {
+	for _, tc := range []struct {
+		address string
+		index   int
+		ok      bool
+	}{
+		{"10.98.0.50", 0, true},
+		{"10.98.3.50", 3, true},
+		{"10.98.255.1", 255, true},
+		{"192.168.2.69", 0, false},
+		{"10.99.0.50", 0, false},
+		{"", 0, false},
+	} {
+		index, ok := SegmentIndexFor(net.ParseIP(tc.address))
+		if ok != tc.ok || index != tc.index {
+			t.Errorf("SegmentIndexFor(%q) = %d, %v; want %d, %v", tc.address, index, ok, tc.index, tc.ok)
+		}
 	}
 }

--- a/go/internal/agent/services/ipcam_gstreamer_process.go
+++ b/go/internal/agent/services/ipcam_gstreamer_process.go
@@ -8,6 +8,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
 )
 
 const ipCameraGStreamerUtility = "ipcam-gstreamer"
@@ -22,8 +25,13 @@ func newIPCameraGStreamerCommand(ctx context.Context, executable string) *exec.C
 // gstreamerFrames runs the in-process GStreamer API inside a short-lived copy of
 // the agent executable. This keeps plugins isolated from the server process while
 // moving the credential-bearing pipeline over a private stdin pipe instead of a
-// process argument. Raw helper stderr is never returned or logged because a
-// GStreamer diagnostic may repeat element property values.
+// process argument.
+//
+// Helper stderr is returned, but only after redaction: a GStreamer diagnostic may
+// repeat element property values, and the location property carries the camera
+// password. Discarding it instead, as this did originally, collapses every
+// distinct failure — no route to the camera, wrong password, missing plugin —
+// into one message that names none of them.
 func (s *VideoService) gstreamerFrames(ctx context.Context, args []string, onFrame func([]byte)) error {
 	executable, err := os.Executable()
 	if err != nil {
@@ -38,9 +46,9 @@ func (s *VideoService) gstreamerFrames(ctx context.Context, args []string, onFra
 	if err != nil {
 		return fmt.Errorf("creating GStreamer output pipe: %w", err)
 	}
-	// Capture a bounded amount solely to keep the child from blocking if a
-	// library writes diagnostics. It is intentionally discarded on every path.
-	cmd.Stderr = &limitedBuffer{limit: maxStderrBytes}
+	// Bounded so a misbehaving child cannot exhaust the heap through stderr.
+	diagnostics := &limitedBuffer{limit: maxStderrBytes}
+	cmd.Stderr = diagnostics
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting GStreamer helper: %w", err)
 	}
@@ -80,7 +88,20 @@ func (s *VideoService) gstreamerFrames(ctx context.Context, args []string, onFra
 		return nil
 	}
 	if waitErr != nil {
-		return errors.New("GStreamer capture pipeline failed")
+		return gstreamerFailure(diagnostics, args)
 	}
 	return nil
+}
+
+// gstreamerFailure builds the capture error, carrying the helper's own
+// diagnostic when there is one and it survives redaction.
+func gstreamerFailure(diagnostics *limitedBuffer, args []string) error {
+	detail := ipcam.RedactText(strings.TrimSpace(diagnostics.buf.String()), ipcam.SecretsIn(args)...)
+	// Collapse to a single line: this is joined into a gRPC status message, and a
+	// multi-line status renders badly wherever it is finally printed.
+	detail = strings.Join(strings.Fields(detail), " ")
+	if detail == "" {
+		return errors.New("GStreamer capture pipeline failed")
+	}
+	return fmt.Errorf("GStreamer capture pipeline failed: %s", detail)
 }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -468,6 +468,10 @@ type VideoService struct {
 	// runGStreamer is the injection seam for the network capture subprocess.
 	runGStreamer func(ctx context.Context, args []string, onFrame func([]byte)) error
 
+	// cameraReachable tests a camera's RTSP port before a stream is started.
+	// Injectable so preflight is testable without a socket.
+	cameraReachable func(address string) bool
+
 	// CSI/ribbon-camera seams (injectable for tests). classifyTransport maps a
 	// /dev/videoN base to its transport (USB/CSI/Unknown); enumerateLibcamera
 	// lists libcamera-visible cameras; isJetson selects the Argus capture path.
@@ -536,6 +540,7 @@ func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
 	svc.discoverer = ipcam.NewDiscoverer(svc.registry, logger)
 	svc.links = ipcam.NewLinkManager(svc.registry, logger)
 	svc.runGStreamer = svc.gstreamerFrames
+	svc.cameraReachable = ipcam.Reachable
 	return svc
 }
 
@@ -1180,14 +1185,24 @@ func (s *VideoService) streamIPCamera(stream grpc.ServerStreamingServer[agentpb.
 	return s.pumpFrames(stream, h, ch)
 }
 
-// preflightIPCamera checks the two conditions that would otherwise surface as a
-// producer dying the instant it starts: no stored login, and no known address.
+// preflightIPCamera checks the conditions that would otherwise surface as a
+// producer dying the instant it starts: no stored login, no known address, and a
+// camera that cannot be reached at all.
+//
+// The reachability test matters more than it looks. A camera whose segment has
+// lost its address is not merely absent: the request falls to the default route,
+// is black-holed on the uplink, and RTSP spends twenty seconds timing out before
+// reporting a generic pipeline failure. Testing the port first turns that into an
+// immediate message naming the address and when the camera was last seen.
 func (s *VideoService) preflightIPCamera(cam ipcam.Camera) error {
 	cred, err := s.ipCameraCredentials(cam)
 	if err != nil {
 		return err
 	}
 	if _, err := ipcam.StreamURL(cam, cred, ipcam.StreamAuto); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "%s", ipcam.FormatUnreachable(cam))
+	}
+	if !s.cameraReachable(cam.Address) {
 		return status.Errorf(codes.FailedPrecondition, "%s", ipcam.FormatUnreachable(cam))
 	}
 	return nil

--- a/go/internal/agent/services/video_service_ipcam_test.go
+++ b/go/internal/agent/services/video_service_ipcam_test.go
@@ -73,6 +73,9 @@ func newIPTestService(t *testing.T) *VideoService {
 	}
 	s.globDevices = func() ([]string, error) { return nil, nil }
 	s.enumerateLibcamera = func(ctx context.Context) (map[string]string, error) { return nil, nil }
+	// Reachable by default so tests exercise the path under test rather than the
+	// preflight; the tests that care about reachability override this.
+	s.cameraReachable = func(string) bool { return true }
 	return s
 }
 
@@ -426,4 +429,86 @@ func TestListWithoutRegistryIsUnaffected(t *testing.T) {
 		&agentpb.SetCameraCredentialsRequest{DeviceId: 200, Username: "u"}); status.Code(err) != codes.Unavailable {
 		t.Fatalf("code = %v, want Unavailable", status.Code(err))
 	}
+}
+
+// A camera that cannot be reached must fail immediately and say so. Without the
+// preflight the RTSP connect is black-holed, takes twenty seconds to time out,
+// and reports a generic pipeline failure that names neither the camera nor the
+// address.
+func TestStreamVideoRefusesUnreachableCamera(t *testing.T) {
+	s := newIPTestService(t)
+	cam := registerTestCamera(t, s)
+	if _, err := s.SetCameraCredentials(context.Background(), &agentpb.SetCameraCredentialsRequest{
+		DeviceId: cam.ID, Username: "admin", Password: "hunter2",
+	}); err != nil {
+		t.Fatalf("SetCameraCredentials: %v", err)
+	}
+
+	var dialled string
+	s.cameraReachable = func(address string) bool {
+		dialled = address
+		return false
+	}
+	s.runGStreamer = func(context.Context, []string, func([]byte)) error {
+		t.Error("capture started against an unreachable camera")
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := s.StreamVideo(&agentpb.StreamVideoRequest{DeviceId: cam.ID}, newFakeVideoStream(ctx))
+	if err == nil {
+		t.Fatal("StreamVideo succeeded against an unreachable camera")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("code = %v, want FailedPrecondition", got)
+	}
+	if !strings.Contains(err.Error(), "10.98.0.50") {
+		t.Fatalf("error %q does not name the address", err)
+	}
+	if dialled != "10.98.0.50" {
+		t.Fatalf("dialled %q, want the camera's address", dialled)
+	}
+}
+
+// The reachability test uses the RTSP port, not the registry's Online flag. That
+// flag comes from a probe of port 80, which some cameras do not serve, so gating
+// on it would refuse cameras that stream perfectly well.
+func TestStreamVideoStreamsOfflineButReachableCamera(t *testing.T) {
+	s := newIPTestService(t)
+	cam := registerTestCamera(t, s)
+	if _, err := s.SetCameraCredentials(context.Background(), &agentpb.SetCameraCredentialsRequest{
+		DeviceId: cam.ID, Username: "admin", Password: "hunter2",
+	}); err != nil {
+		t.Fatalf("SetCameraCredentials: %v", err)
+	}
+	// Explicitly offline by the port-80 probe.
+	s.registry.MarkSeen(cam.MAC, "", false)
+	if got, _ := s.registry.Get(cam.ID); got.Online {
+		t.Fatal("camera is online, want the offline case under test")
+	}
+
+	started := make(chan struct{})
+	s.runGStreamer = func(ctx context.Context, _ []string, _ func([]byte)) error {
+		close(started)
+		<-ctx.Done()
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- s.StreamVideo(&agentpb.StreamVideoRequest{DeviceId: cam.ID}, newFakeVideoStream(ctx))
+	}()
+
+	select {
+	case <-started:
+	case err := <-done:
+		t.Fatalf("StreamVideo returned %v instead of streaming a reachable camera", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for capture to start")
+	}
+	cancel()
+	<-done
 }


### PR DESCRIPTION
## The bug

A Reolink RLC-520A cabled into a Jetson Orin Nano's `eth0` went permanently unreachable, while every log said it was healthy.

```
$ wendy device camera view
Streaming video (Ctrl+C to stop)...
✗ receiving video: GStreamer capture pipeline failed     # 20s later
```

`camera list` showed the camera registered at `10.98.0.50`, and the agent log showed it renewing its DHCP lease right up to the failure.

## The cause

`eth0` had lost the `10.98.0.1/24` the agent configured on it. `wendy device info` listed only `wlan0`.

Nothing noticed, because nothing looks. `scanOnce` judges a *claimed* link on carrier alone — the address it added is never re-checked. And DHCP keeps working without an address: the watcher is an `AF_PACKET` socket and the server binds `INADDR_ANY` with `SO_BINDTODEVICE`. So leases went on being handed out, and the logs looked healthy, while every route to the camera was gone.

With no address on that subnet, requests to `10.98.0.50` fell to the default route, were black-holed on the uplink, and RTSP spent its full 20 s connect timeout before dying. An older agent, before helper stderr was discarded, said exactly what was wrong:

```
gst_rtspsrc_retrieve_sdp (): Failed to connect. (Timeout while waiting for server response)
```

PR #1578 hardened the transitions the agent itself drives — segment reuse, withdrawing on a competing server, recovering a failed server. None of them covers an address disappearing from underneath a live claim.

## The fix

**A claimed link re-asserts its address on every scan**, logging a warning when it has to. `Interface.IPv4s` + `HasAddress` make "our segment address" distinguishable from "some address" — `HasIPv4` alone cannot tell those apart. A failed restore is retried rather than disqualifying the link, which would strand the segment until carrier is lost.

**A claim is restored from the registry after an agent restart.** Manager state is in-process, so a restart forgot the claim while the registry remembered the camera — and a camera already holding a lease says nothing for up to `LeaseWindow`, leaving the link addressless for twelve hours. The restore keeps the camera's existing subnet rather than whichever segment is free, and the link is still watched for `unansweredWindow` first, so a competing server gets the same chance to disqualify it as on a first claim.

**`StreamVideo` preflights the camera's RTSP port** and fails immediately with `FormatUnreachable`, naming the address and when the camera was last seen, instead of hanging 20 s for a generic error.

The registry's `Online` flag is deliberately *not* used for this. It comes from a probe of port 80, and this very camera reports `online: false` while streaming perfectly — gating on it would refuse working cameras.

**Helper stderr is redacted rather than discarded**, so a failure says which failure it was. Redaction covers the literal secret, its percent-encoded spelling, and any URL userinfo, so a form this code never built is still caught.

## Verification

On the affected hardware:

| | before | after |
|---|---|---|
| `eth0` | no IPv4 | `10.98.0.1`, within one scan |
| `camera view --stdout` | 36 B, error at 22 s | 597 KB, streaming until stopped at 40 s |

The bytes are real video: 348 access units, 9 IDR keyframes, SPS/PPS before each.

20 new test cases. `go test ./...` is green except `TestMDNSStreamBackend`, which fails identically on a clean `main` — pre-existing, macOS-only, unrelated package.

## Note

What strips the address is still unknown — most likely whatever manages `eth0` on the host reconciling it. The fix does not depend on knowing, and it now logs `camera link lost its address, restoring it` at WARN, so the next occurrence will say so instead of going silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QY4gudb7z2YECibo2BLCtf