### PR TITLE
perf(ipcam): stop the relay adding latency of its own

### DIFF
--- a/go/internal/agent/ipcam/rtsp.go
+++ b/go/internal/agent/ipcam/rtsp.go
@@ -189,17 +189,31 @@ func SecretsIn(args []string) []string {
 // start decoding, and what the command-line interface's keyframe buffer relies
 // on. TCP interleaving is forced so UDP loss does not surface as decode
 // corruption.
+//
+// Two settings exist purely to keep the relay from adding latency of its own:
+//
+// latency=0 — a jitter buffer absorbs reordering and variable delay, both of
+// which are properties of RTP over UDP. This pipeline forces TCP, where the
+// transport already guarantees ordered delivery, so any jitter buffer depth is
+// delay added to every frame in exchange for nothing. drop-on-latency stays at
+// its default of false, so a depth of zero delays rather than discards.
+//
+// sync=false — fdsink inherits GstBaseSink, which by default holds each buffer
+// until its presentation time. That is right for a sink that renders and wrong
+// for one that relays: it paces the byte stream to the pipeline clock, adding
+// the pipeline's latency a second time on top of the jitter buffer's. Whatever
+// eventually displays these frames does its own timing.
 func PipelineArgs(streamURL string) []string {
 	return []string{
 		"rtspsrc",
 		"location=" + streamURL,
 		"protocols=tcp",
-		"latency=200",
+		"latency=0",
 		"timeout=5000000",
 		"!", "rtph264depay",
 		"!", "h264parse", "config-interval=-1",
 		"!", "video/x-h264,stream-format=byte-stream,alignment=au",
-		"!", "fdsink", "fd=1",
+		"!", "fdsink", "fd=1", "sync=false",
 	}
 }
 

--- a/go/internal/agent/ipcam/rtsp_test.go
+++ b/go/internal/agent/ipcam/rtsp_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -240,5 +241,33 @@ func TestSegmentIndexFor(t *testing.T) {
 		if ok != tc.ok || index != tc.index {
 			t.Errorf("SegmentIndexFor(%q) = %d, %v; want %d, %v", tc.address, index, ok, tc.index, tc.ok)
 		}
+	}
+}
+
+// The relay must not pace or buffer the stream on its own account. Both of these
+// were costing a frame's worth of delay or more on every frame, on a path whose
+// only job is to move bytes.
+func TestPipelineArgsAddsNoLatencyOfItsOwn(t *testing.T) {
+	args := PipelineArgs("rtsp://admin:p@10.98.0.50:554/x")
+	joined := strings.Join(args, " ")
+
+	// A jitter buffer only earns its delay on a reordering transport, and this
+	// pipeline forces TCP.
+	if !strings.Contains(joined, "latency=0") {
+		t.Errorf("jitter buffer adds delay on an ordered transport: %s", joined)
+	}
+	// fdsink is a GstBaseSink, so without this it holds every buffer until its
+	// presentation time — clock-pacing a relay.
+	fdsinkAt := -1
+	for i, arg := range args {
+		if arg == "fdsink" {
+			fdsinkAt = i
+		}
+	}
+	if fdsinkAt < 0 {
+		t.Fatalf("pipeline has no fdsink: %s", joined)
+	}
+	if !slices.Contains(args[fdsinkAt:], "sync=false") {
+		t.Errorf("fdsink paces output to the clock: %s", joined)
 	}
 }


### PR DESCRIPTION
Follow-up to #1641. The stream works after that fix but is laggy; this removes the part of the lag that is ours.

## What was buffering

The agent's capture pipeline buffered twice on a leg whose only job is to move bytes.

**`rtspsrc latency=200`.** A jitter buffer absorbs reordering and variable delay, both properties of RTP over UDP. This pipeline forces `protocols=tcp`, where the transport already guarantees ordered delivery — so the depth was delay added to every frame in exchange for nothing. `drop-on-latency` keeps its default of `false`, so a depth of zero delays rather than discards.

**`fdsink` with the inherited `GstBaseSink` default `sync=true`.** It held every buffer until its presentation time — right for a sink that renders, wrong for one that relays. It paced the byte stream to the pipeline clock, applying the pipeline's latency a second time on top of the jitter buffer's. Whatever displays these frames does its own timing; the CLI viewer already runs its sink `sync=false`.

## Measured

Reolink RLC-520A, 30 s, same camera and same sub-stream, access-unit arrival timed at the CLI:

| | before | after |
|---|---|---|
| worst gap | 763 ms | **232 ms** |
| p90 gap | 155 ms | 154 ms |
| median gap | 95 ms | 96 ms |

The median is set by the camera's frame rate and doesn't move. What goes is the tail — exactly the clock-pacing being removed.

## What this does *not* fix

Glass-to-glass latency can't be measured remotely, so this is worth being explicit about: after this change the dominant remaining term is the camera's own encoder profile, not anything the agent does. Measured on the same camera:

| | sub-stream (default) | main stream |
|---|---|---|
| frame rate | 8.4–9.1 fps | **19.1 fps** |
| keyframe interval | ~4.4 s | **2.3 s** |
| median gap | 96 ms | 36 ms |
| bitrate | ~120 kbps | 3.8 Mbps |

`ChooseStream` sends `StreamAuto` to the sub-stream, on the reasoning that it is "the smooth, low-cost feed". On this camera it is the cheap one but not the smooth one: ~9 fps with 4.4 s between keyframes reads as lag however fast the transport is, and it sets the several-second wait before the first picture, since playback cannot start until a keyframe arrives.

Two levers, neither taken here:

- `wendy device camera view --width 2560` already selects the main stream today. I did not change the default: 3.8 Mbps and 2560x1920 through single-threaded `avdec_h264` is a real CPU and bandwidth cost to impose on every viewer, and that is a product call rather than a bug fix.
- The camera's own sub-stream frame rate and I-frame interval are configurable in its web interface, and raising the frame rate / shortening the GOP there costs nothing on our side.

Worth deciding separately whether `StreamAuto` should prefer smoothness over cost.

## Testing

`TestPipelineArgsAddsNoLatencyOfItsOwn` pins both settings, asserting `sync=false` applies to `fdsink` specifically rather than appearing anywhere in the pipeline string. `go test ./internal/agent/ipcam/ ./internal/agent/services/` green; verified on the affected hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QY4gudb7z2YECibo2BLCtf