### PR TITLE
fix(cli): stop macOS Keychain writes from raising a blocking dialog

### DIFF
--- a/go/internal/cli/tlscache/cache_test.go
+++ b/go/internal/cli/tlscache/cache_test.go
@@ -324,7 +324,16 @@ func TestKeychainPutCommandLineSizeForSessionTicket(t *testing.T) {
 
 	var captured string
 	origRun := secretstore.RunSecurity
-	secretstore.RunSecurity = func(_ context.Context, stdin string, _ ...string) ([]byte, error) {
+	secretstore.RunSecurity = func(_ context.Context, stdin string, args ...string) ([]byte, error) {
+		// Put probes for a writable keychain before it writes (see
+		// secretstore/keychain_probe_darwin.go); answer both probes so the
+		// write this test measures is actually reached.
+		switch args[0] {
+		case "default-keychain":
+			return []byte("    \"/Users/tester/Library/Keychains/login.keychain-db\"\n"), nil
+		case "show-keychain-info":
+			return []byte("no-timeout\n"), nil
+		}
 		captured = stdin
 		return nil, nil
 	}

--- a/go/internal/cli/tlscache/store.go
+++ b/go/internal/cli/tlscache/store.go
@@ -16,9 +16,9 @@ const keychainService = "wendy-tls-session"
 // newDefaultStore picks the ticket store backend. WENDY_TLS_SESSION_STORE
 // forces one: "off" disables caching (right for CI), "file"/"keychain" force a
 // backend. Anything else gets the platform default, which is the file backend
-// on every platform — "keychain" is opt-in only, because it can raise a
-// blocking macOS modal (see newPlatformStore in store_select_darwin.go). A nil
-// return disables session caching entirely.
+// on every platform — "keychain" is opt-in only, because it costs several
+// `security` subprocesses per connection (see newPlatformStore in
+// store_select_darwin.go). A nil return disables session caching entirely.
 func newDefaultStore() secretstore.Store {
 	switch os.Getenv("WENDY_TLS_SESSION_STORE") {
 	case "off":

--- a/go/internal/cli/tlscache/store_select_darwin.go
+++ b/go/internal/cli/tlscache/store_select_darwin.go
@@ -7,17 +7,16 @@ import "github.com/wendylabsinc/wendy/go/internal/shared/secretstore"
 // The Keychain backend (secretstore.NewKeychain, still reachable via
 // WENDY_TLS_SESSION_STORE=keychain) shells out to `/usr/bin/security`, which
 // offers no way to suppress user interaction: `add-generic-password` has no
-// no-interaction flag and `security` has no global one. In any context where
-// the keychain search list does not resolve — a sandboxed process, a non-login
-// session — macOS answers the write with a blocking "A keychain cannot be
-// found to store ..." modal. Put runs on a background goroutine and discards
-// its result, so that modal appears with no CLI context and nothing to
-// correlate it to.
+// no-interaction flag and `security` has no global one. secretstore's
+// checkWritableKeychain now closes that hole from the other side — it declines
+// the write in the states macOS would answer with a modal — but the file
+// backend remains the default here on latency grounds alone: it drops three
+// (now five, counting the probes) subprocess spawns per connection from a
+// feature whose whole point is speed.
 //
 // Session resumption is a latency optimization whose fallback is a full
 // handshake, so it must never be able to interrupt the user. The file backend
-// cannot prompt. It also drops three subprocess spawns per connection from a
-// feature whose whole point is speed.
+// cannot prompt at all.
 //
 // The security delta is small enough to accept: the ticket is a 7-day bearer
 // secret derived from a client identity whose ML-DSA private key already sits

--- a/go/internal/shared/secretstore/keychain_darwin.go
+++ b/go/internal/shared/secretstore/keychain_darwin.go
@@ -45,15 +45,14 @@ func (k keychain) Get(account string) []byte {
 
 // Put carries a hazard reads do not: `security` exposes no way to suppress
 // user interaction (`add-generic-password` has no no-interaction flag and
-// `security` has no global one), so in a context where the keychain search
-// list does not resolve — a sandboxed process, a non-login session — macOS
-// answers the write with a blocking "A keychain cannot be found to store ..."
-// modal. Nothing here can prevent that, so callers that must never interrupt
-// the user cannot make this backend their default; tlscache's
-// newPlatformStore documents that reasoning for the session-ticket cache.
+// `security` has no global one), so a write macOS cannot satisfy is answered
+// with a blocking modal instead of an error. checkWritableKeychain settles
+// beforehand — using read-only probes that never draw UI — whether this
+// process is in a state where that can happen, and Put declines rather than
+// hand `security` a write it would turn into a dialog. Callers keep the
+// secret wherever it already lives (config.dehydrate leaves it inline), so a
+// refusal costs storage hardening, never the secret itself.
 func (k keychain) Put(account string, secret []byte) error {
-	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
-	defer cancel()
 	// `security -i` reads the command from stdin so the secret never appears
 	// on argv (argv is world-readable via ps). base64 and account names
 	// contain no whitespace, so no quoting is needed.
@@ -65,15 +64,29 @@ func (k keychain) Put(account string, secret []byte) error {
 	// silently storing a corrupt value. Refuse before that can happen rather
 	// than risk it. Today's payloads (a P-256 PEM key, short tokens, TLS
 	// session-ticket blobs) are all well under this, so this is a
-	// deterministic-failure guard, not a live bug.
+	// deterministic-failure guard, not a live bug. It runs before the
+	// keychain probes because it needs no process state to decide.
 	if len(cmdLine) >= 4000 {
 		return fmt.Errorf("secret too large for security(1) stdin line (%d bytes, limit ~4096): refusing truncated write", len(cmdLine))
 	}
+	if err := checkWritableKeychain(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
 	_, err := RunSecurity(ctx, cmdLine, "-i")
 	return err
 }
 
+// Delete is gated on the same probes as Put: deleting from a locked keychain
+// raises the unlock dialog, and tlscache calls Delete from a background
+// goroutine to evict a broken session — a prompt raised there would reach the
+// user with no CLI output to explain it. Skipping leaves an item that nothing
+// references, which is inert.
 func (k keychain) Delete(account string) {
+	if err := checkWritableKeychain(); err != nil {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
 	defer cancel()
 	_, _ = RunSecurity(ctx, "", "delete-generic-password", "-s", k.service, "-a", account)

--- a/go/internal/shared/secretstore/keychain_darwin_test.go
+++ b/go/internal/shared/secretstore/keychain_darwin_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 )
 
+// testKeychainPath is the path the faked `security default-keychain` reports.
+const testKeychainPath = "/Users/tester/Library/Keychains/login.keychain-db"
+
 type fakeSecurity struct {
 	calls []struct {
 		stdin string
@@ -16,6 +19,10 @@ type fakeSecurity struct {
 	}
 	out []byte
 	err error
+	// respond, when set, answers each invocation by argv and takes precedence
+	// over out/err — needed by tests that must distinguish the read-only
+	// keychain probes from the write they gate.
+	respond func(args []string) ([]byte, error)
 }
 
 func (f *fakeSecurity) run(_ context.Context, stdin string, args ...string) ([]byte, error) {
@@ -23,14 +30,50 @@ func (f *fakeSecurity) run(_ context.Context, stdin string, args ...string) ([]b
 		stdin string
 		args  []string
 	}{stdin, args})
+	if f.respond != nil {
+		return f.respond(args)
+	}
 	return f.out, f.err
+}
+
+// withProbesOK lets the two read-only keychain probes succeed and keeps
+// out/err for everything else, so tests about Put/Delete themselves do not
+// have to restate the probes.
+func (f *fakeSecurity) withProbesOK() *fakeSecurity {
+	f.respond = func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "default-keychain":
+			return []byte(`    "` + testKeychainPath + `"` + "\n"), nil
+		case "show-keychain-info":
+			return []byte("no-timeout\n"), nil
+		}
+		return f.out, f.err
+	}
+	return f
+}
+
+// writeCall returns the first mutating security(1) invocation recorded, so
+// assertions skip over the probes that now precede every write.
+func (f *fakeSecurity) writeCall(t *testing.T) (stdin string, args []string) {
+	t.Helper()
+	for _, c := range f.calls {
+		if len(c.args) > 0 && (c.args[0] == "-i" || c.args[0] == "delete-generic-password") {
+			return c.stdin, c.args
+		}
+	}
+	t.Fatalf("no mutating security(1) call recorded, got %v", f.calls)
+	return "", nil
 }
 
 func withFake(t *testing.T, f *fakeSecurity) {
 	t.Helper()
 	orig := RunSecurity
 	RunSecurity = f.run
-	t.Cleanup(func() { RunSecurity = orig })
+	resetKeychainProbeForTest()
+	t.Cleanup(func() {
+		RunSecurity = orig
+		resetKeychainProbeForTest()
+	})
 }
 
 func TestKeychainGetDecodesBase64(t *testing.T) {
@@ -63,23 +106,23 @@ func TestKeychainGetBadBase64(t *testing.T) {
 }
 
 func TestKeychainPutKeepsSecretOffArgvAndReportsError(t *testing.T) {
-	fake := &fakeSecurity{}
+	fake := (&fakeSecurity{}).withProbesOK()
 	withFake(t, fake)
 	if err := NewKeychain("svc-a").Put("acct1", []byte("secret")); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	call := fake.calls[0]
-	if strings.Join(call.args, " ") != "-i" {
-		t.Fatalf("argv = %v, want [-i]", call.args)
+	stdin, args := fake.writeCall(t)
+	if strings.Join(args, " ") != "-i" {
+		t.Fatalf("argv = %v, want [-i]", args)
 	}
 	b64 := base64.StdEncoding.EncodeToString([]byte("secret"))
 	for _, frag := range []string{"add-generic-password", "-U", "-s svc-a", "-a acct1", "-w " + b64} {
-		if !strings.Contains(call.stdin, frag) {
-			t.Errorf("stdin %q missing %q", call.stdin, frag)
+		if !strings.Contains(stdin, frag) {
+			t.Errorf("stdin %q missing %q", stdin, frag)
 		}
 	}
 
-	failing := &fakeSecurity{err: errors.New("keychain locked")}
+	failing := (&fakeSecurity{err: errors.New("write refused")}).withProbesOK()
 	withFake(t, failing)
 	if err := NewKeychain("svc-a").Put("acct1", []byte("secret")); err == nil {
 		t.Error("Put with failing security = nil error, want non-nil")
@@ -91,7 +134,7 @@ func TestKeychainPutKeepsSecretOffArgvAndReportsError(t *testing.T) {
 // be refused before RunSecurity is ever invoked, never handed to it for a
 // truncated (possibly silently "successful") write.
 func TestKeychainPutRefusesOversizedCommandLine(t *testing.T) {
-	fake := &fakeSecurity{}
+	fake := (&fakeSecurity{}).withProbesOK()
 	withFake(t, fake)
 	// base64 inflates by ~4/3, so 4000 raw bytes comfortably pushes the full
 	// "add-generic-password ..." command line past the 4000-byte guard.
@@ -109,11 +152,12 @@ func TestKeychainPutRefusesOversizedCommandLine(t *testing.T) {
 }
 
 func TestKeychainDelete(t *testing.T) {
-	fake := &fakeSecurity{}
+	fake := (&fakeSecurity{}).withProbesOK()
 	withFake(t, fake)
 	NewKeychain("svc-a").Delete("acct1")
+	_, args := fake.writeCall(t)
 	want := "delete-generic-password -s svc-a -a acct1"
-	if strings.Join(fake.calls[0].args, " ") != want {
-		t.Errorf("args = %v, want %q", fake.calls[0].args, want)
+	if strings.Join(args, " ") != want {
+		t.Errorf("args = %v, want %q", args, want)
 	}
 }

--- a/go/internal/shared/secretstore/keychain_probe_darwin.go
+++ b/go/internal/shared/secretstore/keychain_probe_darwin.go
@@ -1,0 +1,93 @@
+package secretstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// This file exists to keep `security` writes from ever becoming a macOS
+// dialog. Two states turn a write into UI instead of an error:
+//
+//  1. The user's default keychain does not resolve. `SecKeychainCopyDefault`
+//     reads ~/Library/Preferences/com.apple.security.plist and falls back to
+//     $HOME/Library/Keychains/login.keychain-db, so any invocation whose HOME
+//     has neither — `sudo wendy ...` (HOME=/var/root), a launchd job, a
+//     sandboxed or non-login session — hits it. macOS answers the write with
+//     "A keychain cannot be found to store <account>", a blocking modal whose
+//     "Reset To Defaults" button rewrites the user's keychain search list.
+//     Reproduce the underlying failure without raising the dialog:
+//     `HOME=$(mktemp -d) security default-keychain`.
+//
+//  2. The target keychain is locked, which a write answers with the unlock
+//     prompt.
+//
+// Both are detectable with commands that only read: `default-keychain` reads
+// a plist, `show-keychain-info` reports lock state and returns
+// "User interaction is not allowed." rather than prompting. Probing first and
+// declining is the only way to guarantee silence while `security(1)` remains
+// the executor — and it has to remain the executor, because items it creates
+// carry an ACL naming `security` itself, which is what lets every rebuilt
+// wendy binary keep reading them.
+
+// defaultKeychain caches `security default-keychain`'s answer for the life of
+// the process. What it depends on — HOME and the user's security preferences
+// — cannot change under a running CLI, so one subprocess covers every write.
+// Lock state is deliberately not cached: a keychain can lock mid-run, and a
+// stale "unlocked" verdict is exactly the prompt this file exists to prevent.
+var (
+	defaultKeychainMu   sync.Mutex
+	defaultKeychainPath string
+	defaultKeychainErr  error
+	defaultKeychainDone bool
+)
+
+func resetKeychainProbeForTest() {
+	defaultKeychainMu.Lock()
+	defer defaultKeychainMu.Unlock()
+	defaultKeychainPath, defaultKeychainErr, defaultKeychainDone = "", nil, false
+}
+
+func defaultKeychain() (string, error) {
+	defaultKeychainMu.Lock()
+	defer defaultKeychainMu.Unlock()
+	if !defaultKeychainDone {
+		defaultKeychainPath, defaultKeychainErr = resolveDefaultKeychain()
+		defaultKeychainDone = true
+	}
+	return defaultKeychainPath, defaultKeychainErr
+}
+
+func resolveDefaultKeychain() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	out, err := RunSecurity(ctx, "", "default-keychain", "-d", "user")
+	if err != nil {
+		return "", fmt.Errorf("no default keychain for this user: %w", err)
+	}
+	// `security` prints the path indented and double-quoted.
+	path := strings.Trim(strings.TrimSpace(string(out)), `"`)
+	if path == "" {
+		return "", fmt.Errorf("no default keychain for this user: `security default-keychain` named none")
+	}
+	return path, nil
+}
+
+// checkWritableKeychain reports nil only when a `security` write is certain
+// not to raise UI. Its error is returned verbatim to Put's caller, so it
+// names both the state and the remedy.
+func checkWritableKeychain() error {
+	path, err := defaultKeychain()
+	if err != nil {
+		return fmt.Errorf("skipping macOS Keychain write to avoid a blocking system prompt: %w"+
+			" (set WENDY_SECRET_STORE=file to silence this path permanently)", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), securityTimeout)
+	defer cancel()
+	if _, err := RunSecurity(ctx, "", "show-keychain-info", path); err != nil {
+		return fmt.Errorf("skipping macOS Keychain write to avoid a blocking unlock prompt: %s is locked or unreadable: %w"+
+			" (unlock it with `security unlock-keychain`)", path, err)
+	}
+	return nil
+}

--- a/go/internal/shared/secretstore/keychain_probe_darwin_test.go
+++ b/go/internal/shared/secretstore/keychain_probe_darwin_test.go
@@ -1,0 +1,141 @@
+package secretstore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// wroteAnything reports whether any recorded call was a mutating security(1)
+// invocation — the `-i` stdin form used by Put, or delete-generic-password.
+// Those are exactly the calls that can block on a macOS modal.
+func (f *fakeSecurity) wroteAnything() bool {
+	for _, c := range f.calls {
+		if len(c.args) == 0 {
+			continue
+		}
+		if c.args[0] == "-i" || c.args[0] == "delete-generic-password" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestKeychainPutRefusesWithoutDefaultKeychain is the regression test for the
+// reported bug: a `wendy` invocation whose HOME holds no user keychain (sudo,
+// launchd, any non-login context) makes `SecKeychainCopyDefault` fail, and a
+// write in that state pops the blocking "A keychain cannot be found to store
+// key-<hex>" modal — whose "Reset To Defaults" button rewrites the user's
+// keychain search list. Put must detect that with the read-only probe and
+// never reach the write.
+func TestKeychainPutRefusesWithoutDefaultKeychain(t *testing.T) {
+	fake := &fakeSecurity{respond: func(args []string) ([]byte, error) {
+		if args[0] == "default-keychain" {
+			return nil, errors.New("exit status 1") // SecKeychainCopyDefault failed
+		}
+		return nil, nil
+	}}
+	withFake(t, fake)
+
+	err := NewKeychain("svc-a").Put("key-5bccc0bca49d432c", []byte("secret"))
+	if err == nil {
+		t.Fatal("Put with no default keychain = nil error, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "default keychain") {
+		t.Errorf("error %q does not name the unresolvable default keychain", err)
+	}
+	if fake.wroteAnything() {
+		t.Errorf("Put reached a mutating security(1) call (%v) — the write must be short-circuited before macOS can raise a modal", fake.calls)
+	}
+}
+
+// TestKeychainPutRefusesWhenKeychainLocked covers the other prompt the write
+// path can raise: a locked keychain answers a write with the unlock dialog.
+// `show-keychain-info` reports lock state without any UI, so Put can decline
+// instead. Callers keep the secret wherever it already lives.
+func TestKeychainPutRefusesWhenKeychainLocked(t *testing.T) {
+	fake := &fakeSecurity{respond: func(args []string) ([]byte, error) {
+		switch args[0] {
+		case "default-keychain":
+			return []byte(`    "` + testKeychainPath + `"` + "\n"), nil
+		case "show-keychain-info":
+			return nil, errors.New("SecKeychainCopySettings: User interaction is not allowed.")
+		}
+		return nil, nil
+	}}
+	withFake(t, fake)
+
+	err := NewKeychain("svc-a").Put("acct1", []byte("secret"))
+	if err == nil {
+		t.Fatal("Put against a locked keychain = nil error, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "locked") {
+		t.Errorf("error %q does not explain the lock", err)
+	}
+	if fake.wroteAnything() {
+		t.Errorf("Put reached a mutating security(1) call (%v) despite the locked keychain", fake.calls)
+	}
+}
+
+// TestKeychainDeleteSkipsUnwritableKeychain guards the quietest instance of
+// the bug: tlscache evicts a broken session by calling Delete from a
+// background goroutine, so an unlock prompt raised there would appear with no
+// CLI context at all.
+func TestKeychainDeleteSkipsUnwritableKeychain(t *testing.T) {
+	fake := &fakeSecurity{respond: func(args []string) ([]byte, error) {
+		if args[0] == "default-keychain" {
+			return nil, errors.New("exit status 1")
+		}
+		return nil, nil
+	}}
+	withFake(t, fake)
+
+	NewKeychain("svc-a").Delete("acct1")
+	if fake.wroteAnything() {
+		t.Errorf("Delete reached a mutating security(1) call (%v) with no writable keychain", fake.calls)
+	}
+}
+
+// TestKeychainPutBlankDefaultKeychainIsRefused pins the parse: a successful
+// exit with empty output must not be read as "some keychain resolved".
+func TestKeychainPutBlankDefaultKeychainIsRefused(t *testing.T) {
+	fake := &fakeSecurity{respond: func(args []string) ([]byte, error) {
+		if args[0] == "default-keychain" {
+			return []byte("   \n"), nil
+		}
+		return nil, nil
+	}}
+	withFake(t, fake)
+
+	if err := NewKeychain("svc-a").Put("acct1", []byte("secret")); err == nil {
+		t.Fatal("Put with a blank default-keychain answer = nil error, want a refusal")
+	}
+	if fake.wroteAnything() {
+		t.Errorf("Put reached a mutating security(1) call (%v) on a blank keychain path", fake.calls)
+	}
+}
+
+// TestDefaultKeychainResolvedOncePerProcess keeps the guard cheap: the
+// resolution depends on HOME, which cannot change under a running CLI, so
+// repeated writes must not each pay a subprocess for it.
+func TestDefaultKeychainResolvedOncePerProcess(t *testing.T) {
+	resolves := 0
+	fake := &fakeSecurity{respond: func(args []string) ([]byte, error) {
+		if args[0] == "default-keychain" {
+			resolves++
+			return []byte(`    "` + testKeychainPath + `"` + "\n"), nil
+		}
+		return nil, nil
+	}}
+	withFake(t, fake)
+
+	store := NewKeychain("svc-a")
+	for range 3 {
+		if err := store.Put("acct1", []byte("secret")); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	if resolves != 1 {
+		t.Errorf("`security default-keychain` ran %d times across 3 Puts, want 1", resolves)
+	}
+}

--- a/specs/2026-08-08-client-secrets-keychain-design.md
+++ b/specs/2026-08-08-client-secrets-keychain-design.md
@@ -163,3 +163,51 @@ against a provisioned device post-migration.
 - Removing the buildx registry-proxy temp key file (`docker.go` writes the
   key to a `0600` temp file for the proxy); it now sources the key via the
   accessor but the temp-file mechanism itself is out of scope.
+
+## Amendment (2026-08-09): writes must never raise a system dialog
+
+Shipped behaviour missed a case: the design reasoned about *reads* being
+promptless (the item ACL trusts `/usr/bin/security`) but treated writes as
+merely fallible. They are not. `security` has no way to suppress user
+interaction — `add-generic-password` has no no-interaction flag and there is
+no global one — so a write macOS cannot satisfy becomes a blocking dialog
+rather than a non-zero exit.
+
+Two states do that:
+
+1. **The user default keychain does not resolve.** `SecKeychainCopyDefault`
+   reads `~/Library/Preferences/com.apple.security.plist` and falls back to
+   `$HOME/Library/Keychains/login.keychain-db`, so any invocation whose HOME
+   has neither — `sudo wendy …` (`HOME=/var/root`), a launchd job, a
+   sandboxed or non-login session — hits it. macOS shows *"A keychain cannot
+   be found to store `key-<hex>`"*, whose **"Reset To Defaults"** button
+   rewrites the user's keychain search list. Reproduce the underlying
+   failure without the dialog: `HOME=$(mktemp -d) security default-keychain`.
+2. **The target keychain is locked**, which a write answers with the unlock
+   prompt.
+
+Both compound badly with the surrounding design. `dehydrate` keeps a secret
+inline when `Put` fails, and `MigrateSecretsIfNeeded` retries on every
+invocation, so one bad environment yields the dialog on *every* `wendy`
+command. `tlscache` calls `Delete` from a background goroutine, so a prompt
+raised there arrives with no CLI output to explain it.
+
+**Resolution.** `secretstore.checkWritableKeychain` settles the question up
+front with commands that only read and therefore cannot draw UI —
+`default-keychain -d user` (a plist read) and `show-keychain-info` (returns
+"User interaction is not allowed." on a locked keychain) — and `Put`/`Delete`
+decline rather than hand `security` a write it would turn into a dialog. The
+default-keychain answer is memoized per process (HOME cannot change under a
+running CLI); lock state deliberately is not, since a keychain can lock
+mid-run.
+
+`security(1)` stays the executor: items it creates carry an ACL naming
+`security` itself, which is what keeps every rebuilt `wendy` binary able to
+read them. Talking to `SecItem*` directly via cgo would let us set
+`SecKeychainSetUserInteractionAllowed(false)` instead, but it would also
+re-own those ACLs against a code signature that changes on every build.
+
+A refusal costs storage hardening, never the secret: the value stays wherever
+it already lives, exactly as an ordinary `Put` failure already did.
+`WENDY_SECRET_STORE=file` remains the way to opt out of the Keychain path
+entirely.


### PR DESCRIPTION
## The bug

`wendy` pops a blocking macOS dialog — **"A keychain cannot be found to store `key-<hex>`"** — with no CLI context to explain it. Its *"Reset To Defaults"* button rewrites the user's keychain search list, so it is a hostile prompt to hand someone unprompted.

The `key-<hex16>` account name comes from `config.keyAccount` — the client private key being moved into the Keychain by `config.dehydrate`.

## Root cause

`/usr/bin/security` has **no way to suppress user interaction**: `add-generic-password` has no no-interaction flag and `security` has no global one. So a write macOS cannot satisfy becomes a *dialog* rather than a non-zero exit. Two states do that:

1. **The user default keychain does not resolve.** `SecKeychainCopyDefault` reads `~/Library/Preferences/com.apple.security.plist` and falls back to `$HOME/Library/Keychains/login.keychain-db`, so any invocation whose HOME has neither — `sudo wendy …` (`HOME=/var/root`), a launchd job, a sandboxed or non-login session — hits it. Reproduce the underlying failure *without* the dialog:
   ```
   $ HOME=$(mktemp -d) security default-keychain
   security: SecKeychainCopyDefault: A default keychain could not be found.
   ```
2. **The target keychain is locked**, which a write answers with the unlock prompt.

Both compound with the surrounding design, which is why it reads as *repeated* popups rather than one:

- `config.dehydrate` keeps a secret inline when `Put` fails, and `MigrateSecretsIfNeeded` retries on **every** invocation from the root pre-run — so one bad environment yields the dialog on every `wendy` command.
- `tlscache` calls `Delete` from a **background goroutine** to evict a broken session, so a prompt raised there arrives with no CLI output at all.

## The fix

`secretstore.checkWritableKeychain` settles the question up front using commands that only *read* and therefore cannot draw UI, and `Put`/`Delete` decline rather than hand `security` a write it would turn into a dialog:

| probe | detects | behaviour when it fails |
|---|---|---|
| `security default-keychain -d user` | no resolvable default (plist read) | exits non-zero, no UI |
| `security show-keychain-info <path>` | locked or unreadable keychain | `"User interaction is not allowed."`, no UI |

The `default-keychain` answer is memoized per process — HOME cannot change under a running CLI, so one subprocess covers every write. **Lock state deliberately is not cached**: a keychain can lock mid-run, and a stale "unlocked" verdict is exactly the prompt this is meant to prevent.

### Why not cgo + `SecKeychainSetUserInteractionAllowed(false)`

That is Apple's real "never show UI" API and it would cover every case at once, but it also means talking to `SecItem*` directly — which re-owns the item ACLs against the *wendy* binary's code signature instead of `security`'s. That signature changes on every build, so a rebuilt or updated CLI would silently lose read access to its own credentials. `security(1)` stays the executor for exactly that reason.

### Cost of a refusal

None to the secret: the value stays wherever it already lives (inline in `config.json`), exactly as an ordinary `Put` failure already did. What is lost is storage hardening on machines that can't offer it anyway. `WENDY_SECRET_STORE=file` remains the way to opt out of the Keychain path entirely.

## Verification

**Unit** — `go/internal/shared/secretstore/keychain_probe_darwin_test.go`, each confirmed red against the pre-fix code:

- Put refuses with no default keychain, and never reaches a mutating `security` call
- Put refuses on a locked keychain
- Delete skips when the keychain is unwritable (the background-goroutine case)
- a blank `default-keychain` answer is not read as "resolved"
- `default-keychain` resolves once across three Puts

**End-to-end on a real Mac**, driving the built binary with an isolated `HOME` (the real login keychain and default were verified untouched throughout):

| scenario | result |
|---|---|
| HOME with no keychain, inline secret in config | no dialog; secret stays inline |
| HOME with a healthy keychain | migrates as before — `keychain:v1:key-…` ref written, item found in the keychain |
| HOME with a locked keychain | no unlock prompt; secret stays inline |

`gofmt`/`go vet`/tests clean for `secretstore`, `tlscache`, `config`; `go vet` also clean cross-compiled for linux and windows.

## Also in this PR

- Comments in `tlscache/store_select_darwin.go` and `store.go` asserted the modal was unpreventable and that this was *why* the file backend is the darwin default. That is no longer true, so they now rest on the argument that still holds — subprocess count. **The tlscache default is unchanged**; `keychain` stays opt-in.
- An amendment section on `specs/2026-08-08-client-secrets-keychain-design.md`, whose threat model reasoned about promptless *reads* but treated writes as merely fallible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et9D3c6fVT67AhyhzwBryC
