### PR TITLE
fix(agent): back off incrementally instead of restarting crash loops every 10s

### DIFF
--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -13,6 +13,56 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
+const (
+	// restartBackoffBase is the delay before the second restart of a container
+	// that keeps failing; each subsequent restart doubles it.
+	restartBackoffBase = 10 * time.Second
+	// restartBackoffCap ceilings the doubling. The monitor never gives up on a
+	// crash-looping container — unattended devices must self-heal when a
+	// dependency (network, camera, USB peripheral) comes back — so it keeps
+	// retrying at this interval indefinitely.
+	restartBackoffCap = 5 * time.Minute
+	// restartStabilityWindow is how long a container must be observed RUNNING
+	// continuously before its backoff resets. It is deliberately much longer
+	// than the tick interval: a container that starts, is seen running once,
+	// and dies is still crash-looping, and resetting on that sighting would
+	// pin the delay at the base forever.
+	restartStabilityWindow = 60 * time.Second
+)
+
+// restartDelay returns how long to wait before the next restart of a container
+// that has already been restarted level times, doubling from restartBackoffBase
+// and clamping at restartBackoffCap:
+//
+//	level: 0   1     2     3     4     5      6+
+//	delay: 0   10s   20s   40s   80s   160s   5m
+//
+// Level 0 (the first restart after a crash) is immediate and level 1 is 10s,
+// preserving the pre-backoff timing for the first two attempts so a transient
+// crash still recovers promptly.
+func restartDelay(level int) time.Duration {
+	if level <= 0 {
+		return 0
+	}
+	// Doubling by repeated multiplication with an early exit rather than
+	// `base << (level-1)`: level is unbounded (a container can loop for days),
+	// and a shift that large silently wraps — on a 64-bit int the delay would
+	// come back as 0 and restore the unthrottled every-tick restart this
+	// exists to prevent. The loop cannot run more than a handful of times
+	// because it returns the moment the cap is reached.
+	d := restartBackoffBase
+	for i := 0; i < level-1; i++ {
+		if d >= restartBackoffCap {
+			return restartBackoffCap
+		}
+		d *= 2
+	}
+	if d > restartBackoffCap {
+		return restartBackoffCap
+	}
+	return d
+}
+
 // RestartPolicy determines the container restart behavior.
 type RestartPolicy int
 
@@ -65,6 +115,15 @@ type containerState struct {
 	ExplicitStop  bool
 	RestartPolicy RestartPolicy
 	MaxRetries    int
+	// BackoffLevel is the number of restarts performed since the last reset,
+	// driving the delay before the next one (see restartDelay). It is distinct
+	// from FailureCount, which stays cumulative because it is user-visible
+	// through RestartStatuses.
+	BackoffLevel int
+	// RunningSince is when the container was first observed RUNNING since its
+	// last restart, or zero while it is not running. Once it has been running
+	// for restartStabilityWindow the backoff resets.
+	RunningSince time.Time
 }
 
 // ContainerMonitor monitors container health and implements restart policies.
@@ -87,6 +146,10 @@ type ContainerMonitor struct {
 	suppressed map[string]int
 	mu         sync.Mutex
 	interval   time.Duration
+	// now is the monitor's clock, defaulting to time.Now. Restart backoff is
+	// measured in minutes, so tests override this to drive the curve
+	// deterministically instead of sleeping.
+	now func() time.Time
 }
 
 func NewContainerMonitor(logger *zap.Logger, client services.ContainerdClient, logManager *services.ContainerLogManager, interval time.Duration) *ContainerMonitor {
@@ -101,6 +164,7 @@ func NewContainerMonitor(logger *zap.Logger, client services.ContainerdClient, l
 		groupRestarting: make(map[string]bool),
 		suppressed:      make(map[string]int),
 		interval:        interval,
+		now:             time.Now,
 	}
 }
 
@@ -520,11 +584,31 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// One clock reading for the whole pass so every container is judged
+	// against the same instant.
+	now := m.now()
 	var toRestart []string
 	for appName, state := range m.states {
 		if running[appName] {
+			// Track how long it has been up. A container that comes back and
+			// stays up is healthy, and its next failure should restart
+			// promptly rather than inherit the accumulated delay — but only
+			// sustained health counts. The monitor ticks every few seconds, so
+			// resetting on the first RUNNING sighting would hand a free reset
+			// to a container that starts, is seen once, and dies; its backoff
+			// would stay pinned at the base forever.
+			if state.RunningSince.IsZero() {
+				state.RunningSince = now
+			} else if now.Sub(state.RunningSince) >= restartStabilityWindow {
+				// FailureCount is deliberately not reset: it is user-visible
+				// through RestartStatuses as the app's cumulative failure
+				// tally.
+				state.BackoffLevel = 0
+			}
 			continue
 		}
+		// Down: any partial stability streak is void.
+		state.RunningSince = time.Time{}
 		if m.suppressed[appName] > 0 {
 			// A replace/stop operation is mid-teardown of this container; see
 			// Suppress. Skip it this tick — the caller will resume suppression
@@ -535,15 +619,23 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 		if !m.shouldRestart(state) {
 			continue
 		}
-		if time.Since(state.LastRestart) < 10*time.Second {
+		delay := restartDelay(state.BackoffLevel)
+		if now.Sub(state.LastRestart) < delay {
 			continue
 		}
 		m.logger.Info("Restarting container",
 			zap.String("app_name", appName),
 			zap.Int("failure_count", state.FailureCount),
+			zap.Duration("backoff", delay),
 		)
 		state.FailureCount++
-		state.LastRestart = time.Now()
+		state.LastRestart = now
+		// Stop counting at the ceiling: past it the delay no longer changes,
+		// and an ever-growing level on a container that loops for days is just
+		// an overflow waiting to happen.
+		if delay < restartBackoffCap {
+			state.BackoffLevel++
+		}
 		toRestart = append(toRestart, appName)
 	}
 	return toRestart

--- a/go/internal/agent/container/monitor_backoff_test.go
+++ b/go/internal/agent/container/monitor_backoff_test.go
@@ -1,0 +1,272 @@
+package container
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const backoffTestApp = "com.example.app"
+
+// newBackoffMonitor returns a monitor whose clock is driven by the returned
+// pointer, plus the stopped/running container snapshots for backoffTestApp.
+// Tests advance time by writing through the pointer instead of sleeping.
+func newBackoffMonitor(t *testing.T) (m *ContainerMonitor, clock *time.Time, stopped, running []*agentpb.AppContainer) {
+	t.Helper()
+	m = newMonitorWithClient(&fakeContainerd{})
+	// A fixed, arbitrary wall-clock origin; only deltas matter.
+	now := time.Unix(1700000000, 0)
+	clock = &now
+	m.now = func() time.Time { return *clock }
+	m.Register(backoffTestApp, RestartUnlessStopped, 0)
+
+	stopped = []*agentpb.AppContainer{{
+		AppName:      backoffTestApp,
+		RunningState: agentpb.AppRunningState_STOPPED,
+	}}
+	running = []*agentpb.AppContainer{{
+		AppName:      backoffTestApp,
+		RunningState: agentpb.AppRunningState_RUNNING,
+	}}
+	return m, clock, stopped, running
+}
+
+// backoffLevel reads the monitor's private backoff bookkeeping for the test app.
+func backoffLevel(t *testing.T, m *ContainerMonitor) int {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st, ok := m.states[backoffTestApp]
+	if !ok {
+		t.Fatalf("%s is not registered", backoffTestApp)
+	}
+	return st.BackoffLevel
+}
+
+func failureCount(t *testing.T, m *ContainerMonitor) int {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st, ok := m.states[backoffTestApp]
+	if !ok {
+		t.Fatalf("%s is not registered", backoffTestApp)
+	}
+	return st.FailureCount
+}
+
+// mustRestart asserts planRestarts schedules exactly the test app.
+func mustRestart(t *testing.T, m *ContainerMonitor, containers []*agentpb.AppContainer, msg string) {
+	t.Helper()
+	got := m.planRestarts(containers)
+	if len(got) != 1 || got[0] != backoffTestApp {
+		t.Fatalf("%s: planRestarts = %v; want [%s]", msg, got, backoffTestApp)
+	}
+}
+
+// mustNotRestart asserts planRestarts schedules nothing.
+func mustNotRestart(t *testing.T, m *ContainerMonitor, containers []*agentpb.AppContainer, msg string) {
+	t.Helper()
+	if got := m.planRestarts(containers); len(got) != 0 {
+		t.Fatalf("%s: planRestarts = %v; want no restart", msg, got)
+	}
+}
+
+// The backoff curve doubles from a 10s base and clamps at the 5m ceiling. The
+// first two restarts (levels 0 and 1) must keep the pre-backoff timing so a
+// transient crash still recovers promptly.
+func TestRestartDelay_Curve(t *testing.T) {
+	tests := []struct {
+		name  string
+		level int
+		want  time.Duration
+	}{
+		{name: "first restart is immediate", level: 0, want: 0},
+		{name: "second restart keeps the legacy 10s cooldown", level: 1, want: 10 * time.Second},
+		{name: "third doubles", level: 2, want: 20 * time.Second},
+		{name: "fourth doubles", level: 3, want: 40 * time.Second},
+		{name: "fifth doubles", level: 4, want: 80 * time.Second},
+		{name: "sixth doubles", level: 5, want: 160 * time.Second},
+		{name: "seventh would be 320s and clamps to the cap", level: 6, want: restartBackoffCap},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := restartDelay(tt.level); got != tt.want {
+				t.Errorf("restartDelay(%d) = %v; want %v", tt.level, got, tt.want)
+			}
+		})
+	}
+}
+
+// A container can loop for days. restartDelay must stay pinned at the cap for
+// any level, including ones that would overflow a naive `base << (level-1)`
+// shift (a shift of 64+ wraps to 0 on amd64/arm64, which would restore the
+// unthrottled every-tick restart this whole change exists to prevent).
+func TestRestartDelay_LargeLevelStaysAtCap(t *testing.T) {
+	for _, level := range []int{7, 20, 62, 63, 64, 65, 128, 1000, math.MaxInt32} {
+		if got := restartDelay(level); got != restartBackoffCap {
+			t.Errorf("restartDelay(%d) = %v; want %v (cap)", level, got, restartBackoffCap)
+		}
+	}
+}
+
+// Defensive: a negative level must not panic or produce a negative delay, which
+// would make the gate in planRestarts always pass.
+func TestRestartDelay_NegativeLevelIsImmediate(t *testing.T) {
+	for _, level := range []int{-1, -100, math.MinInt32} {
+		if got := restartDelay(level); got != 0 {
+			t.Errorf("restartDelay(%d) = %v; want 0", level, got)
+		}
+	}
+}
+
+// A container that never comes up must be restarted on a widening interval, and
+// must not be restarted early. Before this change the gate was a flat 10s, so
+// the 20s/40s/80s steps below all restarted a tick too soon.
+func TestPlanRestarts_BackoffWidensWhileDown(t *testing.T) {
+	m, clock, stopped, _ := newBackoffMonitor(t)
+
+	// Wait required before each successive restart.
+	for i, want := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 40 * time.Second, 80 * time.Second} {
+		if want > 0 {
+			*clock = clock.Add(want - time.Second)
+			mustNotRestart(t, m, stopped, "one second short of the backoff")
+			*clock = clock.Add(time.Second)
+		}
+		mustRestart(t, m, stopped, fmt.Sprintf("restart %d once the backoff elapsed", i+1))
+	}
+}
+
+// The delay stops doubling at the ceiling and the monitor keeps retrying there
+// forever. BackoffLevel must stop growing too, so it cannot run away.
+func TestPlanRestarts_BackoffStopsAtCap(t *testing.T) {
+	m, clock, stopped, _ := newBackoffMonitor(t)
+
+	// Drive it well past the ceiling.
+	for i := 0; i < 20; i++ {
+		*clock = clock.Add(restartBackoffCap)
+		mustRestart(t, m, stopped, fmt.Sprintf("restart %d at the ceiling", i+1))
+	}
+
+	// Still exactly the cap — no more, and no less.
+	*clock = clock.Add(restartBackoffCap - time.Second)
+	mustNotRestart(t, m, stopped, "one second short of the ceiling")
+	*clock = clock.Add(time.Second)
+	mustRestart(t, m, stopped, "once the ceiling elapsed")
+
+	// Level 6 is the first whose delay is already the cap, so incrementing
+	// stops there.
+	if got, want := backoffLevel(t, m), 6; got != want {
+		t.Errorf("BackoffLevel = %d after 20+ restarts; want it clamped at %d", got, want)
+	}
+}
+
+// A container that comes up and stays up long enough is healthy: its next
+// failure should restart promptly rather than inheriting the old long delay.
+func TestPlanRestarts_StabilityWindowResetsBackoff(t *testing.T) {
+	m, clock, stopped, running := newBackoffMonitor(t)
+
+	// Build up some backoff.
+	for _, wait := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 40 * time.Second} {
+		*clock = clock.Add(wait)
+		mustRestart(t, m, stopped, "building up backoff")
+	}
+	if got := backoffLevel(t, m); got == 0 {
+		t.Fatalf("BackoffLevel = 0 after four restarts; test cannot detect a reset")
+	}
+
+	// Healthy for the full stability window, observed across several ticks.
+	for elapsed := time.Duration(0); elapsed <= restartStabilityWindow; elapsed += 5 * time.Second {
+		mustNotRestart(t, m, running, "running container must not restart")
+		*clock = clock.Add(5 * time.Second)
+	}
+	if got := backoffLevel(t, m); got != 0 {
+		t.Fatalf("BackoffLevel = %d after %v of continuous health; want 0", got, restartStabilityWindow)
+	}
+
+	// It dies again: back to the base curve, not the accumulated one.
+	mustRestart(t, m, stopped, "first restart after recovery is immediate")
+	*clock = clock.Add(9 * time.Second)
+	mustNotRestart(t, m, stopped, "9s after recovery restart")
+	*clock = clock.Add(time.Second)
+	mustRestart(t, m, stopped, "10s after recovery restart (base delay, not the pre-reset one)")
+}
+
+// The crux: a container that survives a single tick and dies is still
+// crash-looping. If a momentary RUNNING sighting reset the backoff, the delay
+// would stay pinned at the base forever and the feature would do nothing.
+func TestPlanRestarts_BriefLivenessDoesNotResetBackoff(t *testing.T) {
+	m, clock, stopped, running := newBackoffMonitor(t)
+
+	for _, wait := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 40 * time.Second} {
+		*clock = clock.Add(wait)
+		mustRestart(t, m, stopped, "building up backoff")
+	}
+	levelBefore := backoffLevel(t, m)
+
+	// Seen running for a single 5s tick, then gone again.
+	mustNotRestart(t, m, running, "running for one tick")
+	*clock = clock.Add(5 * time.Second)
+
+	if got := backoffLevel(t, m); got != levelBefore {
+		t.Errorf("BackoffLevel = %d after one running tick; want it unchanged at %d", got, levelBefore)
+	}
+	// And the long delay still applies: 80s was next, so 79s must be too soon.
+	*clock = clock.Add(74 * time.Second)
+	mustNotRestart(t, m, stopped, "79s after the last restart, with an 80s backoff")
+}
+
+// FailureCount is user-visible through RestartStatuses (the failure column in
+// `wendy device apps` and the crash-looping flag). A stability reset clears the
+// backoff only — the reported failure tally must be untouched.
+func TestPlanRestarts_StabilityResetKeepsFailureCount(t *testing.T) {
+	m, clock, stopped, running := newBackoffMonitor(t)
+
+	for _, wait := range []time.Duration{0, 10 * time.Second, 20 * time.Second} {
+		*clock = clock.Add(wait)
+		mustRestart(t, m, stopped, "building up backoff")
+	}
+	if got, want := failureCount(t, m), 3; got != want {
+		t.Fatalf("FailureCount = %d after three restarts; want %d", got, want)
+	}
+	// Precondition: there must be backoff to reset, otherwise the assertion
+	// below that FailureCount survived a reset would hold vacuously.
+	if got := backoffLevel(t, m); got == 0 {
+		t.Fatalf("BackoffLevel = 0 after three restarts; nothing for the window to reset")
+	}
+
+	for elapsed := time.Duration(0); elapsed <= restartStabilityWindow; elapsed += 5 * time.Second {
+		mustNotRestart(t, m, running, "running container must not restart")
+		*clock = clock.Add(5 * time.Second)
+	}
+
+	if got := backoffLevel(t, m); got != 0 {
+		t.Fatalf("BackoffLevel = %d; want 0 (precondition: the reset happened)", got)
+	}
+	if got, want := failureCount(t, m), 3; got != want {
+		t.Errorf("FailureCount = %d after a stability reset; want it preserved at %d", got, want)
+	}
+}
+
+// A redeploy goes through Register, which must hand the app a clean slate
+// rather than making a freshly-deployed fix wait out the old backoff.
+func TestRegister_ResetsBackoff(t *testing.T) {
+	m, clock, stopped, _ := newBackoffMonitor(t)
+
+	for _, wait := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 40 * time.Second} {
+		*clock = clock.Add(wait)
+		mustRestart(t, m, stopped, "building up backoff")
+	}
+	if got := backoffLevel(t, m); got == 0 {
+		t.Fatalf("BackoffLevel = 0 after four restarts; test cannot detect a reset")
+	}
+
+	m.Register(backoffTestApp, RestartUnlessStopped, 0)
+
+	if got := backoffLevel(t, m); got != 0 {
+		t.Errorf("BackoffLevel = %d after Register; want 0", got)
+	}
+	mustRestart(t, m, stopped, "restart immediately after redeploy")
+}

--- a/specs/2026-08-09-container-restart-backoff-design.md
+++ b/specs/2026-08-09-container-restart-backoff-design.md
@@ -91,9 +91,16 @@ crash is unaffected. Cumulative time to reach the ceiling is ~310s. Restarts in
 the first hour of a permanent failure drop from ~360 to ~17.
 
 `BackoffLevel` stops incrementing once `restartDelay(level) >= restartBackoffCap`,
-so the shift cannot overflow no matter how long a container loops. `restartDelay`
-additionally guards its shift against large inputs rather than relying solely on
-the caller clamping.
+so it cannot run away no matter how long a container loops.
+
+`restartDelay` does not rely on that clamp for safety. It doubles by repeated
+multiplication with an early exit at the cap rather than computing
+`base << (level-1)`: a shift of 64 or more silently yields 0 on a 64-bit int,
+which would hand back a zero delay and restore the exact unthrottled every-tick
+restart this change exists to prevent. The loop exits within a handful of
+iterations because it returns as soon as the cap is reached, so even
+`math.MaxInt32` is cheap. This is covered by
+`TestRestartDelay_LargeLevelStaysAtCap`.
 
 ### Gate and reset in `planRestarts`
 

--- a/specs/2026-08-09-container-restart-backoff-design.md
+++ b/specs/2026-08-09-container-restart-backoff-design.md
@@ -1,0 +1,196 @@
+# Incremental restart backoff for crash-looping containers
+
+Date: 2026-08-09
+Status: Approved, pending implementation
+Area: `go/internal/agent/container/monitor.go`
+
+## Problem
+
+`ContainerMonitor` relaunches a stopped container on a flat cooldown. `planRestarts`
+gates every restart on a single constant:
+
+```go
+if time.Since(state.LastRestart) < 10*time.Second {
+    continue
+}
+```
+
+An app that crashes immediately on start therefore restarts every ~10 seconds,
+indefinitely. `FailureCount` climbs without bound and is never reset. Only
+`RestartOnFailure` combined with an explicit `MaxRetries` ever stops; the default
+policy (`RestartUnlessStopped`) and `RestartAlways` never do.
+
+The consequences on a device are continuous churn from a permanently-broken app:
+container create/start work, image and mount setup, log lines from both the agent
+and the app, and whatever local endpoints the app touches during startup — roughly
+360 restart cycles per hour, forever.
+
+## Goals
+
+- Slow repeated restarts of a container that keeps failing.
+- Leave the timing of the first couple of attempts unchanged, so genuinely
+  transient crashes still recover promptly.
+- Let an app that recovers on its own return to normal restart behavior without
+  operator action.
+- Keep the change contained to the agent. No proto change, no CLI change.
+
+## Non-goals
+
+- Giving up on a crash-looping app. The monitor keeps retrying forever at the
+  ceiling. Edge devices are unattended, and a dependency that comes back
+  (network, camera, USB peripheral) must self-heal.
+- Surfacing backoff state to the CLI. `wendy device apps` and the dashboard keep
+  rendering exactly what they render today.
+- Exit-code awareness. `RestartOnFailure` still behaves like
+  `RestartUnlessStopped`, as documented in `shouldRestart`.
+
+## Design
+
+### State
+
+Two fields are added to `containerState`:
+
+```go
+// BackoffLevel is the number of restarts performed since the last reset. It
+// drives the delay before the next restart (see restartDelay).
+BackoffLevel int
+
+// RunningSince is the first tick at which the container was observed RUNNING
+// since its last restart; zero while it is not running. Used to decide when a
+// container has been healthy long enough to reset BackoffLevel.
+RunningSince time.Time
+```
+
+`FailureCount` is deliberately left alone: cumulative and never reset. It is
+user-visible through `RestartStatuses` → `container_service.go`, which feeds the
+failure column in `wendy device apps` and the `crashLooping` flag. Keeping it
+untouched means this change is invisible to every consumer outside the monitor.
+
+### Delay curve
+
+```go
+const (
+    restartBackoffBase = 10 * time.Second
+    restartBackoffCap  = 5 * time.Minute
+)
+
+// restartDelay returns how long to wait before the next restart of a container
+// that has already been restarted `level` times.
+func restartDelay(level int) time.Duration
+```
+
+- `level <= 0` → `0` (first restart is immediate)
+- otherwise `restartBackoffBase << (level-1)`, clamped to `restartBackoffCap`
+
+| restart # | 1 | 2 | 3 | 4 | 5 | 6 | 7+ |
+|-----------|---|---|---|---|---|---|-----|
+| wait before it | 0 | 10s | 20s | 40s | 80s | 160s | 300s |
+
+The first two attempts match today's timing exactly, so the common transient
+crash is unaffected. Cumulative time to reach the ceiling is ~310s. Restarts in
+the first hour of a permanent failure drop from ~360 to ~17.
+
+`BackoffLevel` stops incrementing once `restartDelay(level) >= restartBackoffCap`,
+so the shift cannot overflow no matter how long a container loops. `restartDelay`
+additionally guards its shift against large inputs rather than relying solely on
+the caller clamping.
+
+### Gate and reset in `planRestarts`
+
+The existing constant gate becomes level-aware:
+
+```go
+if time.Since(state.LastRestart) < restartDelay(state.BackoffLevel) {
+    continue
+}
+```
+
+When a restart is scheduled, alongside the existing `FailureCount++` and
+`LastRestart = now`, `BackoffLevel` is incremented — but only while
+`restartDelay(BackoffLevel) < restartBackoffCap`, so it stops growing once the
+ceiling is reached rather than counting up forever. The existing "Restarting
+container" log line gains the delay that was applied, so the growing backoff is
+visible in agent logs.
+
+The `running[appName]` branch, currently a bare `continue`, records stability:
+
+- If `RunningSince` is zero, set it to now.
+- Else if `now.Sub(RunningSince) >= restartStabilityWindow`, reset
+  `BackoffLevel = 0`.
+
+The not-running path clears `RunningSince` back to zero.
+
+```go
+const restartStabilityWindow = 60 * time.Second
+```
+
+The window is the crux of the design. The monitor ticks every 5s, so a container
+that starts, is observed running once, and dies would otherwise earn a full reset
+on every cycle and the backoff would stay pinned at 10s forever — precisely the
+case this change exists to address. Requiring 60s of continuously-observed
+RUNNING means only a container that is actually healthy gets its backoff cleared.
+
+### Reset on redeploy
+
+`Register` constructs a fresh `containerState`, so a redeploy resets the backoff
+with no additional code.
+
+`ClearExplicitStop` deliberately does **not** reset the backoff. A redeploy is
+already covered by `Register`; a manual `start` of an app whose image has not
+changed is still crash-looping and should keep its accumulated backoff. This also
+avoids giving the failed-stop rollback path in `container_service.go` (which
+calls `ClearExplicitStop` to revert marks) a side effect it does not want.
+
+### Testability
+
+`ContainerMonitor` calls `time.Now()` directly, and existing tests depend on a
+zero `LastRestart` reading as "backoff already elapsed"
+(`monitor_checkcontainers_test.go:306`). An unexported field is added:
+
+```go
+now func() time.Time // defaults to time.Now; overridden in tests
+```
+
+`NewContainerMonitor` defaults it. Backoff-growth and stability-window tests set
+it to drive a fake clock instead of sleeping. Existing tests are unaffected.
+
+## Testing
+
+New tests in `go/internal/agent/container`:
+
+1. **Backoff grows** — a container that stays down across successive ticks is
+   restarted at 0, 10s, 20s, 40s, and not sooner.
+2. **Cap holds** — after enough failures the delay stops at 5 min and stays
+   there; `BackoffLevel` stops growing (guards against shift overflow).
+3. **Stability resets** — a container observed RUNNING for ≥60s returns to a 0
+   delay on its next failure.
+4. **Brief liveness does not reset** — a container seen RUNNING for one tick and
+   then down does not reset; the backoff continues to grow.
+5. **`FailureCount` is unchanged** — it keeps incrementing per restart and is
+   never reset, so `RestartStatuses` output is unaffected by a stability reset.
+6. **Redeploy resets** — `Register` on an existing name clears the backoff.
+7. **First restart is still immediate** — a freshly registered container that is
+   down restarts on the first tick, matching today.
+
+Existing `monitor_test.go` and `monitor_checkcontainers_test.go` must pass
+unmodified. This was checked against the current tests: every case that expects a
+restart uses a freshly-constructed monitor whose `LastRestart` is zero, and
+`restartDelay(0)` is `0`, so none of them are gated by the new curve. The
+suppression tests that call `planRestarts` twice (`monitor_test.go:550`, `:579`)
+are also safe — a suppressed container returns before the `LastRestart` advance,
+so the second call still sees a zero `LastRestart`.
+
+## Known limitation (pre-existing, not addressed)
+
+For shared-namespace app groups, `planRestartActions` collapses the down members
+into one group restart that stops and recreates *every* member. A member that was
+still running at plan time is therefore restarted without its own `LastRestart`
+or `BackoffLevel` advancing. This is existing behavior; backoff neither improves
+nor worsens it. Fixing it would mean advancing state for all group members at
+plan time, which is out of scope here.
+
+## Files touched
+
+- `go/internal/agent/container/monitor.go` — state fields, `restartDelay`,
+  constants, `planRestarts` gate and reset, clock field, log field.
+- `go/internal/agent/container/monitor_backoff_test.go` — new tests.


### PR DESCRIPTION
## Problem

`ContainerMonitor` gated every restart on a flat 10s cooldown:

```go
if time.Since(state.LastRestart) < 10*time.Second { continue }
```

An app that crashes on start was therefore relaunched roughly **360 times an hour, forever** — container create/start work, image and mount setup, log lines from both the agent and the app, and whatever local endpoints the app touches on startup, all repeating indefinitely. `FailureCount` climbed unbounded and was never reset. Only `on-failure` with an explicit `MaxRetries` ever stopped; the default `unless-stopped` and `always` never did.

## Change

Restarts now back off and clamp at a ceiling:

| restart | 1 | 2 | 3 | 4 | 5 | 6 | 7+ |
|---|---|---|---|---|---|---|---|
| wait | 0 | 10s | 20s | 40s | 80s | 160s | 5m |

That takes a permanently-broken app from ~360 restarts/hour to ~17.

The first two attempts keep their pre-existing timing, so a transient crash still recovers promptly. At the ceiling the monitor **keeps retrying indefinitely rather than giving up** — edge devices are unattended, so an app whose dependency comes back (network, camera, USB peripheral) must self-heal without anyone intervening.

The backoff resets only after a container has been observed `RUNNING` continuously for 60s. That window is load-bearing: the monitor ticks every 15s, so resetting on the first `RUNNING` sighting would hand a free reset to a container that starts, is seen once, and dies — the delay would stay pinned at the base and the change would do nothing.

`restartDelay` doubles by repeated multiplication rather than `base << (level-1)`: a shift of 64+ silently wraps to a **zero** delay, which would restore the exact unthrottled behaviour this fixes. `BackoffLevel` also stops incrementing once it reaches the ceiling.

## Scope

One production file, `go/internal/agent/container/monitor.go`. **No proto or CLI change.** `FailureCount` is deliberately left cumulative and unreset — it is user-visible through `RestartStatuses` as the failure column in `wendy device apps` and the crash-looping flag — so nothing outside the monitor observes a difference.

A redeploy resets the backoff for free via `Register`. `ClearExplicitStop` deliberately does *not* reset it: a manual start of an unchanged image is still crash-looping.

## Tests

New `monitor_backoff_test.go`, written test-first — each was watched failing against the old flat-10s behaviour before implementing:

- backoff widens while down, and does not fire early
- delay stops at the cap; `BackoffLevel` clamps (guards against runaway/overflow)
- curve values, including `math.MaxInt32` and negative levels
- 60s stability window resets the backoff, and the next failure returns to the 10s base rather than the accumulated delay
- **one running tick does not reset** — the case the whole design hinges on
- a stability reset preserves `FailureCount`
- `Register` (redeploy) resets

Adds an injectable clock (`now func() time.Time`, defaulted to `time.Now` in the constructor) so the curve is tested deterministically instead of by sleeping. Every construction already goes through `NewContainerMonitor`, so there is no nil-clock path.

**The 11 pre-existing monitor tests pass unmodified** — no existing test file is touched by this PR.

## Verification

- `go test ./internal/agent/...` — all pass
- `go test -race ./internal/agent/container ./internal/agent/services` — pass
- `go test -race -count=2 ./internal/agent/container` — pass
- `go build ./...` exit 0, `go vet` and `gofmt` clean

⚠️ **Hardware-unverified** — fixture-tested only; I have not watched a real crash-looping app back off on a device.

## Known limitation (pre-existing, not addressed)

For shared-namespace app groups, `planRestartActions` collapses down members into one group restart that recreates *every* member, so a member still running at plan time is restarted without its own `BackoffLevel` advancing. Existing behaviour in that function; this change neither improves nor worsens it.

Design doc: `specs/2026-08-09-container-restart-backoff-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Yca8hVvsfLMC5vGNmakK4