### PR TITLE
fix(cli): stop the Keychain migration from stranding headless macOS hosts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,18 @@ on:
 permissions:
   contents: read
 
+# These runners authenticate from a config.json that lives on the machine, so
+# the CLI must never move those credentials somewhere the machine cannot read
+# back. On macOS the default store is the login Keychain, readable only while
+# it is unlocked — an interactive act no CI job can perform. Pinning the file
+# store keeps credentials in config.json and, from the CLI version that added
+# RestoreSecretsIfNeeded onward, pulls already-migrated ones back inline on the
+# first run that can read them. Without this the runner's only client key sat
+# in a locked keychain and every mTLS call failed "Unauthorized", which blocked
+# every release.
+env:
+  WENDY_SECRET_STORE: file
+
 jobs:
   discover:
     name: Discover (${{ matrix.runner.name }})
@@ -304,6 +316,32 @@ jobs:
           fi
           echo "docker_ready=$DOCKER_READY" >> "$GITHUB_OUTPUT"
 
+      # Says why a credential read would fail. The CLI cannot tell these apart:
+      # security(1) answers "locked", "no such item" and "user interaction is
+      # not allowed" with the same miss, so a run that fails "Unauthorized"
+      # leaves no way to choose between unlocking the keychain and logging in
+      # again — which is what made the outage this guards against hard to read
+      # from the logs. Reports state only; prints no secret material, unlocks
+      # nothing (that needs a password no CI job should hold), and never fails
+      # the job.
+      - name: Report macOS Keychain state
+        if: steps.prepare-docker.outputs.docker_ready == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          KEYCHAIN="$(security default-keychain -d user 2>/dev/null | tr -d ' "')"
+          echo "default keychain: ${KEYCHAIN:-<none>}"
+          if [ -z "$KEYCHAIN" ]; then
+            echo "::warning::no default keychain for this user"
+            exit 0
+          fi
+          if security show-keychain-info "$KEYCHAIN" 2>&1; then
+            echo "keychain state: unlocked"
+          else
+            echo "keychain state: locked or unreadable"
+            echo "::warning::The login keychain is locked. Any wendy credential migrated into it is unreadable from this job, and mTLS will fail Unauthorized. Recover on the runner with 'WENDY_SECRET_STORE=file wendy auth login', which puts credentials back in config.json where CI can read them."
+          fi
+
       - name: Run integration tests
         if: steps.prepare-docker.outputs.docker_ready == 'true'
         run: |
@@ -364,6 +402,11 @@ jobs:
           HOSTNAME="$1"; shift
           export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"
           export DOCKER_HOST="$DOCKER_HOST_VALUE"
+          # ssh forwards no environment, so the workflow-level setting does not
+          # reach the shell that actually runs the CLI. Restating it here is
+          # what keeps the tests off the Keychain; a constant, so the quoted
+          # heredoc leaving it unexpanded is correct.
+          export WENDY_SECRET_STORE=file
           export WENDY_BUILDX_BUILDER="$BUILDER"
           cd "$WORKDIR"
           exec go/scripts/test-ci.sh "$@" -h "$HOSTNAME"

--- a/.github/workflows/nightly-os-update.yml
+++ b/.github/workflows/nightly-os-update.yml
@@ -38,7 +38,10 @@ jobs:
         run: |
           SSH="ssh -o StrictHostKeyChecking=no localhost"
           WORKDIR="$(pwd)"
-          SSH_ENV="export PATH='$PATH'"
+          # WENDY_SECRET_STORE=file: this runner authenticates from its own
+          # config.json, and the macOS default store is a login Keychain no CI
+          # job can unlock. See integration-tests.yml.
+          SSH_ENV="export PATH='$PATH' WENDY_SECRET_STORE=file"
 
           $SSH "$SSH_ENV && cd '$WORKDIR' && ./go/bin/wendy os cache clear"
 
@@ -89,7 +92,10 @@ jobs:
         run: |
           SSH="ssh -o StrictHostKeyChecking=no localhost"
           WORKDIR="$(pwd)"
-          SSH_ENV="export PATH='$PATH'"
+          # WENDY_SECRET_STORE=file: this runner authenticates from its own
+          # config.json, and the macOS default store is a login Keychain no CI
+          # job can unlock. See integration-tests.yml.
+          SSH_ENV="export PATH='$PATH' WENDY_SECRET_STORE=file"
 
           INFO=$($SSH "$SSH_ENV && cd '$WORKDIR' && ./go/bin/wendy device info --json --device '$DEVICE_HOSTNAME'" || true)
           echo "$INFO" | jq '{osVersion, agentVersion: .version, deviceType}' || true
@@ -104,7 +110,10 @@ jobs:
         run: |
           SSH="ssh -o StrictHostKeyChecking=no localhost"
           WORKDIR="$(pwd)"
-          SSH_ENV="export PATH='$PATH'"
+          # WENDY_SECRET_STORE=file: this runner authenticates from its own
+          # config.json, and the macOS default store is a login Keychain no CI
+          # job can unlock. See integration-tests.yml.
+          SSH_ENV="export PATH='$PATH' WENDY_SECRET_STORE=file"
 
           # wendy os update blocks until the device reboots and comes back
           # online, with a 5-minute internal timeout.

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -52,6 +52,12 @@ on:
 permissions:
   contents: read
 
+# The deploy job authenticates from the runner's own config.json, and the
+# macOS default secret store is a login Keychain no CI job can unlock. See
+# integration-tests.yml for what that cost.
+env:
+  WENDY_SECRET_STORE: file
+
 concurrency:
   group: template-tests-${{ github.ref }}
   cancel-in-progress: false
@@ -180,6 +186,9 @@ jobs:
           set -euo pipefail
           WORKDIR="$1"
           export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"
+          # ssh forwards no environment, so the workflow-level setting does not
+          # reach this shell. A constant, so the quoted heredoc is correct.
+          export WENDY_SECRET_STORE=file
           cd "$WORKDIR"
           ./go/bin/wendy discover --json --type lan --timeout 10s
           REMOTE

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -87,6 +87,14 @@ func NewRootCmd() *cobra.Command {
 			if config.MigrateSecretsIfNeeded(cfg) {
 				cmd.PrintErrln("Moved wendy credentials into the macOS Keychain (older wendy versions will need 'wendy auth login' again).")
 			}
+			// The mirror: a host that migrated while someone was logged in, and
+			// now runs headless (CI runner, launchd, ssh) or with
+			// WENDY_SECRET_STORE=file, gets its credentials written back to
+			// config.json the first time the Keychain is readable — so it stops
+			// depending on a keychain nothing here can unlock.
+			if config.RestoreSecretsIfNeeded(cfg) {
+				cmd.PrintErrln("Restored wendy credentials to config.json (this host cannot unlock the macOS Keychain non-interactively).")
+			}
 
 			if dueCLIUpdateCheck(cfg) {
 				scheduleCLIUpdateCheck(cfg)

--- a/go/internal/shared/config/secrets.go
+++ b/go/internal/shared/config/secrets.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/term"
+
 	"github.com/wendylabsinc/wendy/go/internal/shared/secretstore"
 )
 
@@ -67,23 +69,32 @@ func resolveSecret(ref string) (string, error) {
 
 	account, ok := strings.CutPrefix(ref, refPrefixV1)
 	if !ok {
-		return "", resolveError(fmt.Errorf("unrecognized credential reference %q (written by a newer wendy?)", ref))
+		return "", resolveError("", fmt.Errorf("unrecognized credential reference %q (written by a newer wendy?)", ref))
 	}
 	store := newCredentialStore()
 	if store == nil {
-		return "", resolveError(fmt.Errorf("no credential store on this platform (config migrated on macOS?)"))
+		return "", resolveError(account, fmt.Errorf("no credential store on this platform (config migrated on macOS?)"))
 	}
 	secret := store.Get(account)
 	if secret == nil {
-		return "", resolveError(fmt.Errorf("keychain item %s/%s not readable", credentialService, account))
+		return "", resolveError(account, fmt.Errorf("keychain item %s/%s not readable", credentialService, account))
 	}
 	cacheSecret(ref, string(secret))
 	return string(secret), nil
 }
 
-func resolveError(cause error) error {
+// resolveError wraps a failed lookup with the remedies. It names the probe
+// command as well: security(1) reports "locked", "not found" and "user
+// interaction is not allowed" as the same miss here, and which one it is
+// decides between unlocking and logging in again.
+func resolveError(account string, cause error) error {
+	probe := "security find-generic-password -s " + credentialService
+	if account != "" {
+		probe += " -a " + account
+	}
 	return fmt.Errorf("credential is stored in the macOS Keychain but could not be read (keychain locked?): %w\n"+
-		"Unlock with 'security unlock-keychain', or re-run 'wendy auth login' with WENDY_SECRET_STORE=file to keep credentials in config.json.", cause)
+		"Diagnose with '%s -w'.\n"+
+		"Unlock with 'security unlock-keychain', or re-run 'wendy auth login' with WENDY_SECRET_STORE=file to keep credentials in config.json.", cause, probe)
 }
 
 // keyAccount derives the deterministic Keychain account for a client
@@ -139,13 +150,47 @@ func (a AuthConfig) BearerToken() (string, error) {
 }
 
 // dehydrateEnabled reports whether Save should move inline secrets into the
-// platform store. WENDY_SECRET_STORE=file forces inline writes (and
-// de-migration); everything else uses the platform default.
+// platform store.
+//
+// WENDY_SECRET_STORE pins the answer either way: "file" forces inline writes
+// (and de-migration), "keychain" forces the store on even where the default
+// below declines.
+//
+// Otherwise the Keychain is used only for invocations a person is sitting in
+// front of. A Keychain item is readable only while the login keychain is
+// unlocked, and unlocking it is an interactive act — so migrating a headless
+// macOS host (a CI runner, a launchd job, `ssh host wendy ...`) swaps a
+// config.json that always works for one that stops working the moment that
+// keychain locks, with no copy left on disk to fall back to and no way to
+// answer the unlock prompt. That is not hypothetical: it took the macOS
+// integration-test runner offline, and with it every release, because the
+// runner's only client key had moved into a keychain no non-interactive
+// session could open.
 func dehydrateEnabled() bool {
-	if os.Getenv("WENDY_SECRET_STORE") == "file" {
+	switch os.Getenv("WENDY_SECRET_STORE") {
+	case "file":
+		return false
+	case "keychain":
+		return secretsPlatformDefault
+	}
+	return secretsPlatformDefault && interactiveSession()
+}
+
+// interactiveSession reports whether someone could answer a Keychain prompt
+// for this process. Package variable so tests pin it rather than inheriting
+// whatever `go test` was launched from.
+//
+// stdin and stderr are the streams that matter: stdout is redirected by
+// ordinary interactive use (`wendy device list | less`, `--json > file`),
+// while a piped stdin means nobody is there to type. CI is checked too, but
+// only as a belt-and-braces signal — it does not survive an `ssh host wendy
+// ...` hop, which is exactly how the integration-test runner invokes the CLI,
+// so the terminal check is what actually carries that case.
+var interactiveSession = func() bool {
+	if os.Getenv("CI") != "" {
 		return false
 	}
-	return secretsPlatformDefault
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // clone deep-copies a Config via JSON round-trip so Save can rewrite secret
@@ -241,6 +286,55 @@ func MigrateSecretsIfNeeded(cfg *Config) bool {
 		return false
 	}
 	return countInlineSecrets(reloaded) < countInlineSecrets(cfg)
+}
+
+// RestoreSecretsIfNeeded is MigrateSecretsIfNeeded's mirror: it pulls
+// Keychain-referenced secrets back inline once the store is no longer in use
+// here — WENDY_SECRET_STORE=file, or a host that dehydrateEnabled now
+// declines to migrate (headless, non-interactive). Without it a machine that
+// migrated while someone was logged in stays pinned to the Keychain forever,
+// because nothing else on a read-only command path calls Save.
+//
+// Returns true only when references were actually resolved and written back.
+func RestoreSecretsIfNeeded(cfg *Config) bool {
+	if dehydrateEnabled() {
+		return false
+	}
+	before := countSecretRefs(cfg)
+	if before == 0 {
+		return false
+	}
+	// Resolve against a throwaway copy first. On a locked or emptied keychain
+	// every reference is a miss and Save would rewrite the same bytes on every
+	// command forever; this keeps the rewrite to runs that recover something.
+	// The lookups it performs are memoized, so Save's own pass is free.
+	probe, err := cfg.clone()
+	if err != nil {
+		return false
+	}
+	inlineSecrets(probe)
+	if countSecretRefs(probe) == before {
+		return false
+	}
+	if err := Save(cfg); err != nil {
+		return false
+	}
+	return true
+}
+
+func countSecretRefs(cfg *Config) int {
+	n := 0
+	for _, a := range cfg.Auth {
+		if isRef(a.APIKey) {
+			n++
+		}
+		for _, c := range a.Certificates {
+			if isRef(c.PemPrivateKey) {
+				n++
+			}
+		}
+	}
+	return n
 }
 
 func countInlineSecrets(cfg *Config) int {

--- a/go/internal/shared/config/secrets_integration_test.go
+++ b/go/internal/shared/config/secrets_integration_test.go
@@ -15,9 +15,7 @@ func TestLoginFlowEndToEnd(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg, err := Load()
 	if err != nil {

--- a/go/internal/shared/config/secrets_test.go
+++ b/go/internal/shared/config/secrets_test.go
@@ -56,6 +56,22 @@ func useFakeStore(t *testing.T, s *fakeStore) {
 	})
 }
 
+// useKeychainDefault puts the process in the state dehydration requires: a
+// platform with a store, and a session someone could answer a Keychain prompt
+// from. `go test` has neither a terminal nor (in CI) an unset CI variable, so
+// pinning both is what keeps these tests exercising the dehydration path
+// rather than silently taking the inline branch.
+func useKeychainDefault(t *testing.T) {
+	t.Helper()
+	origDefault, origInteractive := secretsPlatformDefault, interactiveSession
+	secretsPlatformDefault = true
+	interactiveSession = func() bool { return true }
+	t.Cleanup(func() {
+		secretsPlatformDefault = origDefault
+		interactiveSession = origInteractive
+	})
+}
+
 func TestAccessorsInlineValues(t *testing.T) {
 	useFakeStore(t, newFakeStore())
 	c := CertificateInfo{PemPrivateKey: "-----BEGIN PRIVATE KEY-----\nabc"}
@@ -190,9 +206,7 @@ func TestSaveDehydratesAndLoadResolves(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{{
 		CloudGRPC: "grpc.wendy.com:443",
@@ -250,9 +264,7 @@ func TestSavePutFailureKeepsSecretInline(t *testing.T) {
 	store := newFakeStore()
 	store.putErr = errors.New("keychain locked")
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: "tok-123"}}}
 	if err := Save(cfg); err != nil {
@@ -269,9 +281,7 @@ func TestSaveFileModeSkipsAndDeMigrates(t *testing.T) {
 	store := newFakeStore()
 	store.m["token-cafebabe0000dead"] = []byte("tok-999") // seeded ref target
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	t.Setenv("WENDY_SECRET_STORE", "file")
 	cfg := &Config{Auth: []AuthConfig{{
@@ -296,9 +306,7 @@ func TestSaveFileModeSkipsAndDeMigrates(t *testing.T) {
 func TestSaveFileModeKeepsRefOnFailedRead(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	useFakeStore(t, newFakeStore()) // empty store → ref unresolvable
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	t.Setenv("WENDY_SECRET_STORE", "file")
 	ref := refPrefixV1 + "token-0123456789abcdef"
@@ -324,9 +332,7 @@ func TestSaveTokenAccountPerOrgOnSharedEndpoint(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{
 		{
@@ -383,9 +389,7 @@ func TestSaveTokenAccountPerDashboardOnSharedEndpoint(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{
 		{
@@ -440,9 +444,7 @@ func TestSaveKeyAccountPerAssetOnEmptyUserID(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{
 		{
@@ -510,9 +512,7 @@ func TestMigrateSecretsIfNeeded(t *testing.T) {
 	t.Setenv("WENDY_SECRET_STORE", "")
 	store := newFakeStore()
 	useFakeStore(t, store)
-	origDefault := secretsPlatformDefault
-	secretsPlatformDefault = true
-	t.Cleanup(func() { secretsPlatformDefault = origDefault })
+	useKeychainDefault(t)
 
 	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: "tok-123"}}}
 	if err := Save(cfg); err != nil { // simulate a pre-existing config...
@@ -547,7 +547,13 @@ func TestMigrateSecretsNoOpOffPlatformAndFileMode(t *testing.T) {
 	useFakeStore(t, newFakeStore())
 	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: "tok"}}}
 
-	origDefault := secretsPlatformDefault
+	origDefault, origInteractive := secretsPlatformDefault, interactiveSession
+	t.Cleanup(func() {
+		secretsPlatformDefault = origDefault
+		interactiveSession = origInteractive
+	})
+	interactiveSession = func() bool { return true }
+
 	secretsPlatformDefault = false // non-darwin
 	if MigrateSecretsIfNeeded(cfg) {
 		t.Error("migrated on a platform without a store")
@@ -557,7 +563,87 @@ func TestMigrateSecretsNoOpOffPlatformAndFileMode(t *testing.T) {
 	if MigrateSecretsIfNeeded(cfg) {
 		t.Error("migrated despite WENDY_SECRET_STORE=file")
 	}
-	secretsPlatformDefault = origDefault
+}
+
+// A headless macOS host must not migrate: it can never answer the unlock
+// prompt that reading the item back would raise, and migrating removes the
+// inline copy that was working. This is the case that took the macOS
+// integration-test runner — and every release with it — offline.
+func TestMigrateSecretsNoOpWhenNonInteractive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_SECRET_STORE", "")
+	useFakeStore(t, newFakeStore())
+	origDefault, origInteractive := secretsPlatformDefault, interactiveSession
+	t.Cleanup(func() {
+		secretsPlatformDefault = origDefault
+		interactiveSession = origInteractive
+	})
+	secretsPlatformDefault = true
+	interactiveSession = func() bool { return false }
+
+	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: "tok"}}}
+	if MigrateSecretsIfNeeded(cfg) {
+		t.Error("migrated from a session that cannot answer a Keychain prompt")
+	}
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if isRef(loaded.Auth[0].APIKey) {
+		t.Errorf("Save dehydrated non-interactively: APIKey = %q", loaded.Auth[0].APIKey)
+	}
+
+	// WENDY_SECRET_STORE=keychain is the escape hatch for anyone who wants the
+	// store anyway on such a host.
+	t.Setenv("WENDY_SECRET_STORE", "keychain")
+	if !MigrateSecretsIfNeeded(cfg) {
+		t.Error("WENDY_SECRET_STORE=keychain did not force migration")
+	}
+}
+
+// The mirror: once the store is out of use here, references come back inline
+// so the host stops depending on a keychain it cannot unlock.
+func TestRestoreSecretsIfNeeded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_SECRET_STORE", "file")
+	store := newFakeStore()
+	store.m["token-aaaa"] = []byte("tok-123")
+	useFakeStore(t, store)
+
+	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: refPrefixV1 + "token-aaaa"}}}
+	if !RestoreSecretsIfNeeded(cfg) {
+		t.Fatal("RestoreSecretsIfNeeded = false, want true (reference was resolvable)")
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Auth[0].APIKey != "tok-123" {
+		t.Errorf("APIKey on disk = %q, want the resolved secret inline", loaded.Auth[0].APIKey)
+	}
+	if RestoreSecretsIfNeeded(loaded) {
+		t.Error("second RestoreSecretsIfNeeded = true, want false (nothing left to restore)")
+	}
+}
+
+// A locked or emptied keychain resolves nothing. Rewriting config.json on
+// every command in that state buys nothing, so the restore must decline —
+// and must never drop the references it could not resolve.
+func TestRestoreSecretsKeepsUnresolvableRefs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WENDY_SECRET_STORE", "file")
+	useFakeStore(t, newFakeStore()) // empty: every lookup misses
+
+	cfg := &Config{Auth: []AuthConfig{{CloudGRPC: "g", APIKey: refPrefixV1 + "token-aaaa"}}}
+	if RestoreSecretsIfNeeded(cfg) {
+		t.Error("RestoreSecretsIfNeeded = true with nothing resolvable")
+	}
+	if cfg.Auth[0].APIKey != refPrefixV1+"token-aaaa" {
+		t.Errorf("unresolvable reference was altered: %q", cfg.Auth[0].APIKey)
+	}
 }
 
 func TestDeleteStoredSecrets(t *testing.T) {

--- a/specs/2026-08-08-client-secrets-keychain-design.md
+++ b/specs/2026-08-08-client-secrets-keychain-design.md
@@ -211,3 +211,45 @@ A refusal costs storage hardening, never the secret: the value stays wherever
 it already lives, exactly as an ordinary `Put` failure already did.
 `WENDY_SECRET_STORE=file` remains the way to opt out of the Keychain path
 entirely.
+
+## Amendment (2026-08-09): only migrate where a person can unlock
+
+The previous amendment made *writes* safe. It left the symmetric hole on the
+other side: a migration that succeeds is only as durable as the reader's
+ability to unlock the keychain later, and `dehydrate` removes the inline copy
+once `Put` returns nil. A host that was unlocked at migration time and
+headless afterwards ends up with credentials it cannot reach and no fallback
+on disk — recoverable only by `wendy auth login`.
+
+That is what happened. The macOS integration-test runner migrated its client
+key into the login keychain; the keychain later locked; the workflow's
+`ssh localhost` sessions could no longer read the item. Every mTLS call failed
+*"Unauthorized"*, 22 of 24 integration tests failed, and because `release` in
+`build.yml` gates on that job, every release was blocked.
+`checkWritableKeychain` never fired — nothing was being written.
+
+**Resolution.** `dehydrateEnabled` now migrates only from a session that could
+answer an unlock prompt: `interactiveSession()` requires stdin *and* stderr to
+be terminals (stdout is redirected by ordinary interactive use) and `CI` to be
+unset. The terminal check is the load-bearing one — `CI` does not survive the
+`ssh host wendy …` hop the runners use.
+
+`WENDY_SECRET_STORE` now pins the decision in both directions: `keychain`
+forces migration on such a host anyway, `file` keeps everything inline. The
+device-facing CI workflows set `file` explicitly rather than relying on the
+heuristic.
+
+`RestoreSecretsIfNeeded` is the recovery path, and the mirror of
+`MigrateSecretsIfNeeded`: where the store is no longer in use, references are
+resolved back inline the first time they *can* be read, so a host that
+migrated under a login session heals itself instead of staying pinned to a
+keychain nothing there can open. It declines when nothing resolves, so a
+locked keychain does not mean rewriting `config.json` on every command, and
+unresolvable references are never dropped.
+
+**Still open.** `keychain.Get` reports "locked", "no such item" and "user
+interaction is not allowed" as one undifferentiated miss, which is why the
+outage's logs could not distinguish *unlock the keychain* from *log in again*.
+The integration workflow now prints the keychain's lock state alongside the
+failure, and `resolveError` names the probe command; surfacing `security(1)`'s
+own error through `Store.Get` would be the better fix.


### PR DESCRIPTION
## Why

The macOS integration-test job has been failing every mTLS call with `Unauthorized`, and `release` in `build.yml` gates on it — so **every release is blocked**. [Failing run](https://github.com/wendylabsinc/WendyOS/actions/runs/31345732953/job/93327230208): 22 failed / 2 passed / 9 skipped, all with the same error.

```
Last mTLS error: 192.168.100.190:50052: loading client key:
  credential is stored in the macOS Keychain but could not be read (keychain locked?):
  keychain item wendy-credentials/key-97f62c0565666ad3 not readable
```

Regression from the credential-Keychain work that landed 2026-08-08 (`50007145c`…`01c10fc70`).

`dehydrate` moves the client private key into the login Keychain and **drops the inline copy from config.json**. The write path was already careful never to raise a dialog (`checkWritableKeychain`), but nothing checked that the *reader* would be able to unlock the keychain later. The runner migrated while a login session had it unlocked; the keychain then locked, and the workflow's `ssh localhost` sessions could no longer read the item back. With no copy left on disk, the CLI is permanently unauthorized there — recoverable only by `wendy auth login`.

## What changed

**Don't migrate where nobody can unlock.** `dehydrateEnabled` now requires a session that could answer an unlock prompt: stdin *and* stderr terminals, `CI` unset. The terminal check is the load-bearing one — `CI` does not survive the `ssh host wendy …` hop the runners use. `WENDY_SECRET_STORE` now pins the decision both ways (`keychain` forces it on, `file` keeps everything inline).

**`RestoreSecretsIfNeeded`** — the mirror of `MigrateSecretsIfNeeded`. Where the store is out of use, references resolve back inline the first time they *can* be read, so an already-migrated host heals itself instead of staying pinned to a keychain nothing there can open. It declines when nothing resolves (a locked keychain must not mean rewriting `config.json` on every command) and never drops an unresolvable reference.

**CI**: `WENDY_SECRET_STORE=file` pinned in `integration-tests.yml`, `test-templates.yml` and `nightly-os-update.yml`, restated inside the ssh heredocs since ssh forwards no environment. Plus a step that reports the runner's keychain lock state next to the failure — `security(1)` reports *locked*, *missing* and *user interaction is not allowed* as one undifferentiated miss, and telling them apart is the difference between unlocking and logging in again.

## Does this unblock the runner?

Partly, and only from the next run onward. CI builds the CLI from the checkout, so the fix is live in the job that uses it. The runner's `config.json` currently holds only a `keychain:v1:` reference:

- If the login keychain is **unlocked** at that point, `RestoreSecretsIfNeeded` pulls the key back inline and the runner is permanently fixed.
- If it is **locked**, the new diagnostic step says so in the log, and someone has to run this once on the Mac mini:
  ```sh
  WENDY_SECRET_STORE=file wendy auth login
  ```

I could not check which case it is — SSH to the runner is blocked from my sandbox.

## Not done

`keychain.Get` still swallows `security(1)`'s real error, which is why the outage's logs were ambiguous. `resolveError` now names the probe command as a stopgap; threading the error through `Store.Get` (2 impls, 2 callers incl. `tlscache`) is the proper fix and is noted in the design spec as still open.

## Testing

`go test ./internal/shared/config/... ./internal/shared/secretstore/... ./internal/cli/tlscache/... ./internal/cli/commands/...` — pass. New tests cover the non-interactive no-op, the `WENDY_SECRET_STORE=keychain` escape hatch, restore-on-read, and restore declining without dropping unresolvable refs. The CI behaviour itself is unverified until this runs on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YR9JW6ZHL91gYsna8kt4UP
