### PR TITLE
Stop reporting a restarting agent as an authentication failure

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -291,6 +291,70 @@ func (e provisionedAgentUnauthorizedError) Error() string {
 	return msg
 }
 
+// agentNotListeningError reports that the mTLS port refused the TCP connection:
+// the host answered, but no wendy-agent was bound to the port.
+//
+// This is deliberately NOT a provisionedAgentUnauthorizedError. The two arrive
+// at the same place — every mTLS rung failed, the plaintext probe failed, and
+// mDNS still advertises an mTLS agent — but a refused connection carries no
+// authentication verdict at all: the agent never got far enough to look at our
+// certificate. Reporting it as "Unauthorized. Run 'wendy auth login'" sends the
+// user to re-authenticate credentials that were never in question, and the most
+// common way to hit it is the few-second window after `wendy device update`
+// restarts the very agent we are dialling.
+type agentNotListeningError struct {
+	addr  string // mTLS address that refused, "" when the cause did not name one
+	cause error
+}
+
+func (e agentNotListeningError) Error() string {
+	where := "the device's mTLS port"
+	if e.addr != "" {
+		where = e.addr
+	}
+	// Deliberately free of the raw "rpc error: code = ..." text. formatError in
+	// cmd/wendy rewrites everything from that marker onwards into "Could not
+	// connect to device. Is it powered on and connected to the network?", which
+	// contradicts this diagnosis — the device answered, its agent just isn't
+	// bound. The cause stays reachable through Unwrap for callers and for
+	// WENDY_TLS_DEBUG=1, which already logs every rung verbatim.
+	return fmt.Sprintf(
+		"No wendy-agent is listening on %s (connection refused).\n"+
+			"The device advertises an mTLS agent, so this is not an authentication problem — the agent is most likely restarting, which is expected for a few seconds after 'wendy device update'. Retry shortly.\n"+
+			"If it persists, check the agent on the device: ssh wendy@<host> 'systemctl status wendy-agent'\n"+
+			"For full TLS details rerun with WENDY_TLS_DEBUG=1",
+		where)
+}
+
+func (e agentNotListeningError) Unwrap() error { return e.cause }
+
+// isConnectionRefusedError reports whether an mTLS failure is a refused TCP
+// connection. Matched on the message rather than errors.Is(syscall.ECONNREFUSED)
+// because gRPC flattens the dial error into a status description long before it
+// reaches us, which is also why every sibling predicate here
+// (isCertRefreshableError, isReachabilityTimeoutError) matches on text.
+func isConnectionRefusedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused")
+}
+
+// provisionedAgentConnectError picks the error for "a provisioned, mTLS-only
+// agent would not talk to us": a refused mTLS port means the agent is down, and
+// anything else (cert rejection, timeout, no certs at all) means we were not
+// authorized. mtlsErr is the dial ladder's last mTLS error and is nil when the
+// CLI holds no certificates — the original "you are not logged in" case, which
+// correctly falls through to the unauthorized error.
+func provisionedAgentConnectError(mtlsErr error) error {
+	if isConnectionRefusedError(mtlsErr) {
+		var attempt mtlsAttemptError
+		addr := ""
+		if errors.As(mtlsErr, &attempt) {
+			addr = attempt.addr
+		}
+		return agentNotListeningError{addr: addr, cause: mtlsErr}
+	}
+	return newProvisionedAgentUnauthorizedError(mtlsErr)
+}
+
 // isReachabilityTimeoutError reports whether an error is a connection timeout
 // against an mTLS-enrolled device's plaintext port. This indicates the device
 // is up and enrolled (only the mTLS port is open), which may mean the CLI is
@@ -975,7 +1039,7 @@ func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, 
 			// unprovisioned device apart from a provisioned one rejecting
 			// plaintext, rather than launching a second, later browse.
 			if provisionedMTLS() {
-				return nil, newProvisionedAgentUnauthorizedError(mtlsErr)
+				return nil, provisionedAgentConnectError(mtlsErr)
 			}
 			return nil, probeErr
 		}
@@ -1877,6 +1941,20 @@ func cacheHostnameForStorage(host string) string {
 	return host
 }
 
+// mtlsAttemptError tags a failed mTLS rung with the address it was dialled at.
+// It renders exactly as the "<addr>: <err>" wrapping it replaces, so the
+// diagnostics that quote the last mTLS error are unchanged; the point is that
+// the address survives as data, letting provisionedAgentConnectError name the
+// port that refused instead of re-parsing it out of the message.
+type mtlsAttemptError struct {
+	addr string
+	err  error
+}
+
+func (e mtlsAttemptError) Error() string { return e.addr + ": " + e.err.Error() }
+
+func (e mtlsAttemptError) Unwrap() error { return e.err }
+
 // dialAgentLadder tries every stored org cert's mTLS connection in turn
 // (plaintextAddr's port, then port+1 — see the mtlsAddrs comment below),
 // falling back to a plaintext connection when none succeed. addr must already
@@ -1896,7 +1974,7 @@ func dialAgentLadderWithCerts(ctx context.Context, target dialTarget, allCerts [
 	var lastMTLSErr error
 	recordMTLSErr := func(addr string, err error) {
 		if err != nil {
-			lastMTLSErr = fmt.Errorf("%s: %w", addr, err)
+			lastMTLSErr = mtlsAttemptError{addr: addr, err: err}
 		}
 	}
 	if len(allCerts) > 0 {

--- a/go/internal/cli/commands/helpers_agent_down_test.go
+++ b/go/internal/cli/commands/helpers_agent_down_test.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// refusedMTLSDial is the error the dial ladder records when nothing is bound to
+// the mTLS port — the shape gRPC produces for ECONNREFUSED, tagged with the
+// address the rung was dialled at.
+func refusedMTLSDial(addr string) error {
+	return mtlsAttemptError{
+		addr: addr,
+		err: status.Error(codes.Unavailable,
+			`connection error: desc = "transport: Error while dialing: dial tcp `+addr+`: connect: connection refused"`),
+	}
+}
+
+func TestIsConnectionRefusedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"refused mTLS dial", refusedMTLSDial("192.168.0.107:50052"), true},
+		{"nil", nil, false},
+		{
+			name: "cert rejection",
+			err: mtlsAttemptError{addr: "192.168.0.107:50052", err: status.Error(codes.Unavailable,
+				`connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate"`)},
+		},
+		{
+			name: "handshake timeout",
+			err: mtlsAttemptError{addr: "192.168.0.107:50052", err: status.Error(codes.Unavailable,
+				`connection error: desc = "transport: Error while dialing: dial tcp 192.168.0.107:50052: i/o timeout"`)},
+		},
+		{"unrelated", errors.New("loading TLS cert: bad key"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isConnectionRefusedError(tc.err); got != tc.want {
+				t.Errorf("isConnectionRefusedError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// A refused mTLS port means the agent is not running — most often because
+// `wendy device update` just restarted it. Reporting that as "Unauthorized. Run
+// 'wendy auth login'" blamed credentials that were never examined, since the
+// connection died before any certificate was presented.
+func TestProvisionedAgentConnectError_RefusedPortIsNotAnAuthFailure(t *testing.T) {
+	err := provisionedAgentConnectError(refusedMTLSDial("192.168.0.107:50052"))
+
+	if errors.Is(err, errProvisionedAgentUnauthorized) {
+		t.Fatalf("a refused mTLS port must not be reported as unauthorized, got %v", err)
+	}
+	msg := err.Error()
+	for _, forbidden := range []string{"Unauthorized", "wendy auth login", "refresh-certs"} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("message must not suggest %q, got %q", forbidden, msg)
+		}
+	}
+	if !strings.Contains(msg, "192.168.0.107:50052") {
+		t.Errorf("message should name the port that refused, got %q", msg)
+	}
+	if !strings.Contains(msg, "device update") {
+		t.Errorf("message should point at the restart window as the likely cause, got %q", msg)
+	}
+	var notListening agentNotListeningError
+	if !errors.As(err, &notListening) {
+		t.Fatalf("want agentNotListeningError, got %T", err)
+	}
+	if notListening.Unwrap() == nil {
+		t.Error("the underlying mTLS error should stay reachable through Unwrap")
+	}
+}
+
+// formatError in cmd/wendy rewrites everything from "rpc error: code = "
+// onwards into "Could not connect to device. Is it powered on and connected to
+// the network?" — which contradicts this diagnosis, because the host answered
+// and only the agent is missing. Keeping the marker out of the message is what
+// makes formatError pass it through untouched.
+func TestAgentNotListeningError_CarriesNoGRPCMarkerForFormatError(t *testing.T) {
+	msg := provisionedAgentConnectError(refusedMTLSDial("192.168.0.107:50052")).Error()
+	if strings.Contains(msg, "rpc error: code = ") {
+		t.Fatalf("message would be rewritten by cmd/wendy formatError, got %q", msg)
+	}
+}
+
+// Everything that is not a refused connection keeps the original unauthorized
+// diagnosis — including a nil cause, which is the "no certificates loaded at
+// all" case and genuinely does mean the user must log in.
+func TestProvisionedAgentConnectError_NonRefusedStaysUnauthorized(t *testing.T) {
+	tests := []struct {
+		name  string
+		cause error
+	}{
+		{"no certs loaded", nil},
+		{
+			name: "cert rejected",
+			cause: mtlsAttemptError{addr: "192.168.0.107:50052", err: status.Error(codes.Unavailable,
+				`connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate"`)},
+		},
+		{
+			name: "handshake timeout",
+			cause: mtlsAttemptError{addr: "192.168.0.107:50052", err: status.Error(codes.Unavailable,
+				`connection error: desc = "transport: Error while dialing: dial tcp 192.168.0.107:50052: i/o timeout"`)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := provisionedAgentConnectError(tc.cause)
+			if !errors.Is(err, errProvisionedAgentUnauthorized) {
+				t.Fatalf("provisionedAgentConnectError(%v) = %v, want unauthorized", tc.cause, err)
+			}
+		})
+	}
+}
+
+// The ladder's address tagging is what lets the not-listening message name a
+// port, so it has to keep rendering exactly like the "<addr>: <err>" wrapping
+// it replaced — several diagnostics quote that string verbatim.
+func TestMTLSAttemptError_RendersAddressPrefixedCause(t *testing.T) {
+	cause := errors.New("connect: connection refused")
+	err := mtlsAttemptError{addr: "192.168.0.107:50052", err: cause}
+
+	if got, want := err.Error(), "192.168.0.107:50052: connect: connection refused"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(err, cause) {
+		t.Error("the wrapped cause should stay matchable with errors.Is")
+	}
+}


### PR DESCRIPTION
## The bug

Running `wendy device update --binary ...` against a device whose agent had just restarted printed:

```
✗ Unauthorized. Run 'wendy auth login' with an account that can access this provisioned wendy-agent.
Last mTLS error: 192.168.0.107:50052: Could not connect to device. Is it powered on and connected to the network?
```

Nothing was wrong with the credentials. `wendy auth status` showed three valid org certs, and `wendy device info --device 192.168.0.107` connected over mTLS moments later.

The real failure was `connection refused` on the mTLS port — the agent process wasn't bound. The connection died before any certificate was presented, so there was no authentication verdict to report.

## Why it happened

`connectAgentAtAddressWithProvisionedHint` reaches the unauthorized message whenever three things hold: every mTLS rung failed, the plaintext probe failed, and mDNS still advertises an mTLS agent. It never inspected **why** mTLS failed.

```go
if provisionedMTLS() {
    return nil, newProvisionedAgentUnauthorizedError(mtlsErr)  // regardless of mtlsErr
}
```

The easiest way to hit this is the few-second window right after `wendy device update` restarts the very agent the next command dials. On a device that only serves 50052, the plaintext rung can never rescue it either — 50051 is permanently refused.

The second line was doubly misleading: `formatError` in `cmd/wendy` rewrites the raw `rpc error: ... connection refused` into "Could not connect to device. Is it powered on and connected to the network?", so a device that was up, pingable, and serving mTLS read as both unauthorized *and* offline.

## The fix

Split the refused case into its own `agentNotListeningError`:

```
✗ No wendy-agent is listening on 192.168.0.107:50052 (connection refused).
The device advertises an mTLS agent, so this is not an authentication problem — the agent is most likely restarting, which is expected for a few seconds after 'wendy device update'. Retry shortly.
If it persists, check the agent on the device: ssh wendy@<host> 'systemctl status wendy-agent'
For full TLS details rerun with WENDY_TLS_DEBUG=1
```

Everything else keeps today's behaviour: cert rejection, handshake timeout, and a nil cause (no certificates loaded at all — the original "you are not logged in" case) still produce the unauthorized error with its existing hints.

Two supporting changes:

- The message deliberately contains no `rpc error: code = ` text, because `formatError` would rewrite everything from that marker into the "is it powered on" line that contradicts this diagnosis. The cause stays reachable through `Unwrap`, and `WENDY_TLS_DEBUG=1` already logs every rung verbatim.
- The dial ladder records its last mTLS error as an `mtlsAttemptError` carrying the address as data rather than only in the message text, so the diagnosis can name the port that refused without re-parsing a string. It renders identically to the `"<addr>: <err>"` wrapping it replaces.

## Behaviour change worth a look

Because the refused case no longer satisfies `errors.Is(err, errProvisionedAgentUnauthorized)`, a **default** device that is down now falls through to the existing unreachable-default-device recovery (USB fallback, then the device picker) instead of returning early. That path already exists for exactly this condition, and the device is genuinely unreachable — but it is a flow change, not just a string change.

Deliberately **not** included: an automatic retry across the restart window. That would paper over genuinely-down devices, and the reported problem was the diagnosis, not the absence of a retry.

## Testing

`go test ./internal/cli/... ./cmd/wendy/...` passes.

New tests in `helpers_agent_down_test.go` cover the refused/not-refused split, the absence of the gRPC marker (the invariant `formatError` keys on), and the address-prefixed rendering of `mtlsAttemptError`. Verified they fail against the pre-fix behaviour:

```
--- FAIL: TestProvisionedAgentConnectError_RefusedPortIsNotAnAuthFailure
    a refused mTLS port must not be reported as unauthorized, got Unauthorized. Run 'wendy auth login' ...
--- FAIL: TestAgentNotListeningError_CarriesNoGRPCMarkerForFormatError
    message would be rewritten by cmd/wendy formatError ...
```

Not exercised against real hardware in the restarting-agent window — the reproduction is unit-level, driven by the exact gRPC error string the failure produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9vzw1ePzKtu381qr4urLo