### PR TITLE
fix(agent): address ALSA endpoints by direction, and say why PipeWire was skipped

### DIFF
--- a/go/internal/agent/audio/alsa.go
+++ b/go/internal/agent/audio/alsa.go
@@ -37,17 +37,45 @@ var AmixerRun = func(ctx context.Context, args ...string) ([]byte, error) {
 	return exec.CommandContext(ctx, "amixer", args...).CombinedOutput()
 }
 
-// EncodeAlsaID and DecodeAlsaID convert between an ALSA card/device pair and
-// the Node.ID used to address it, so 0 remains the "unspecified" sentinel
-// callers already use for PipeWire node IDs.
-func EncodeAlsaID(card, device uint64) uint32 { return uint32(((card << 8) | device) + 1) }
+// Layout of the Node.ID an ALSA endpoint encodes to: device in the low 8 bits,
+// card in the next 16, direction in the bit above.
+//
+// Direction has to be part of the ID because a card/device pair does not
+// identify one endpoint. A duplex device — a USB speakerphone, say — is
+// reported as the same card and device by both aplay -l and arecord -l, so an
+// ID built from card and device alone names its playback and capture halves at
+// once, and FindNode resolves it to whichever one the sort happened to place
+// first.
+const (
+	alsaDeviceBits = 8
+	alsaCardBits   = 16
+	alsaDeviceMask = 1<<alsaDeviceBits - 1
+	alsaCardMask   = 1<<alsaCardBits - 1
+	// alsaSourceFlag marks a capture endpoint; sinks leave it clear.
+	alsaSourceFlag = uint64(1) << (alsaDeviceBits + alsaCardBits)
+)
 
-func DecodeAlsaID(id uint32) (card, device uint64) {
+// EncodeAlsaID and DecodeAlsaID convert between an ALSA card/device/direction
+// triple and the Node.ID used to address it, so 0 remains the "unspecified"
+// sentinel callers already use for PipeWire node IDs.
+func EncodeAlsaID(card, device uint64, isSink bool) uint32 {
+	encoded := ((card & alsaCardMask) << alsaDeviceBits) | (device & alsaDeviceMask)
+	if !isSink {
+		encoded |= alsaSourceFlag
+	}
+	return uint32(encoded + 1)
+}
+
+// DecodeAlsaID reverses EncodeAlsaID. The zero sentinel decodes to card 0,
+// device 0; its direction is meaningless and callers must not read it.
+func DecodeAlsaID(id uint32) (card, device uint64, isSink bool) {
 	if id == 0 {
-		return 0, 0
+		return 0, 0, false
 	}
 	encoded := uint64(id) - 1
-	return encoded >> 8, encoded & 0xFF
+	card = (encoded >> alsaDeviceBits) & alsaCardMask
+	device = encoded & alsaDeviceMask
+	return card, device, encoded&alsaSourceFlag == 0
 }
 
 // parseAlsaList parses the output of "aplay -l" or "arecord -l": lines of the
@@ -79,7 +107,7 @@ func parseAlsaList(output string, isSink bool) []Node {
 			}
 		}
 		nodes = append(nodes, Node{
-			ID: EncodeAlsaID(card, device),
+			ID: EncodeAlsaID(card, device, isSink),
 			// plughw, not hw: the plug layer handles format conversion a
 			// card's native rate/format may not support directly.
 			Name:        fmt.Sprintf("plughw:%d,%d", card, device),
@@ -115,7 +143,12 @@ func ListAlsaNodes(ctx context.Context) ([]Node, error) {
 	if len(nodes) == 0 && firstErr != nil {
 		return nil, fmt.Errorf("querying ALSA: %w", firstErr)
 	}
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	// SliceStable, not Slice: an unstable sort leaves the order of any two
+	// nodes that compare equal up to the algorithm, which is how a duplicate ID
+	// used to resolve to an arbitrary one of the two nodes carrying it. IDs are
+	// unique now, so this is belt and braces — but it costs nothing and keeps a
+	// listing reproducible if a future card ever collides again.
+	sort.SliceStable(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
 	return nodes, nil
 }
 

--- a/go/internal/agent/audio/alsa_test.go
+++ b/go/internal/agent/audio/alsa_test.go
@@ -39,7 +39,7 @@ func TestListAlsaNodes(t *testing.T) {
 		t.Fatalf("got %d nodes, want 3 (two HDMI outputs, one USB input); got %+v", len(nodes), nodes)
 	}
 
-	hdmi0, ok := FindNode(nodes, EncodeAlsaID(0, 0))
+	hdmi0, ok := FindNode(nodes, EncodeAlsaID(0, 0, true))
 	if !ok {
 		t.Fatal("card 0 device 0 missing")
 	}
@@ -47,7 +47,7 @@ func TestListAlsaNodes(t *testing.T) {
 		t.Errorf("hdmi0 = %+v, want a sink named plughw:0,0", hdmi0)
 	}
 
-	mic, ok := FindNode(nodes, EncodeAlsaID(2, 0))
+	mic, ok := FindNode(nodes, EncodeAlsaID(2, 0, false))
 	if !ok {
 		t.Fatal("card 2 device 0 missing")
 	}
@@ -76,20 +76,67 @@ func TestListAlsaNodesNoCards(t *testing.T) {
 }
 
 func TestEncodeDecodeAlsaID(t *testing.T) {
-	for _, tc := range []struct{ card, device uint64 }{
-		{0, 0}, {0, 1}, {2, 0}, {255, 255},
+	for _, tc := range []struct {
+		card, device uint64
+		isSink       bool
+	}{
+		{0, 0, true}, {0, 0, false}, {0, 1, true}, {2, 0, false},
+		{255, 255, true}, {255, 255, false}, {65535, 255, false},
 	} {
-		id := EncodeAlsaID(tc.card, tc.device)
+		id := EncodeAlsaID(tc.card, tc.device, tc.isSink)
 		if id == 0 {
-			t.Fatalf("EncodeAlsaID(%d, %d) = 0, which collides with the unspecified sentinel", tc.card, tc.device)
+			t.Fatalf("EncodeAlsaID(%d, %d, %v) = 0, which collides with the unspecified sentinel", tc.card, tc.device, tc.isSink)
 		}
-		gotCard, gotDevice := DecodeAlsaID(id)
-		if gotCard != tc.card || gotDevice != tc.device {
-			t.Errorf("DecodeAlsaID(EncodeAlsaID(%d, %d)) = (%d, %d)", tc.card, tc.device, gotCard, gotDevice)
+		gotCard, gotDevice, gotIsSink := DecodeAlsaID(id)
+		if gotCard != tc.card || gotDevice != tc.device || gotIsSink != tc.isSink {
+			t.Errorf("DecodeAlsaID(EncodeAlsaID(%d, %d, %v)) = (%d, %d, %v)",
+				tc.card, tc.device, tc.isSink, gotCard, gotDevice, gotIsSink)
 		}
 	}
-	if card, device := DecodeAlsaID(0); card != 0 || device != 0 {
+	if card, device, _ := DecodeAlsaID(0); card != 0 || device != 0 {
 		t.Errorf("DecodeAlsaID(0) = (%d, %d), want (0, 0)", card, device)
+	}
+}
+
+// A duplex device — one card exposing the same card/device number for both
+// playback and capture — must get two distinct IDs. A USB speakerphone is the
+// common case: aplay -l and arecord -l both report it as card 0, device 0, so
+// an ID derived from card and device alone addresses two nodes at once and
+// FindNode returns whichever the sort happened to place first.
+func TestAlsaIDDistinguishesDirection(t *testing.T) {
+	const duplex = "card 0: PowerConf [PowerConf], device 0: USB Audio [USB Audio]\n"
+
+	origAplay, origArecord := AplayListRun, ArecordListRun
+	t.Cleanup(func() { AplayListRun, ArecordListRun = origAplay, origArecord })
+	AplayListRun = func(context.Context) ([]byte, error) { return []byte(duplex), nil }
+	ArecordListRun = func(context.Context) ([]byte, error) { return []byte(duplex), nil }
+
+	nodes, err := ListAlsaNodes(context.Background())
+	if err != nil {
+		t.Fatalf("ListAlsaNodes() error = %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2 (one playback, one capture); got %+v", len(nodes), nodes)
+	}
+	if nodes[0].ID == nodes[1].ID {
+		t.Fatalf("playback and capture share ID %d; FindNode(%d) is ambiguous", nodes[0].ID, nodes[0].ID)
+	}
+
+	sink, ok := FindNode(nodes, EncodeAlsaID(0, 0, true))
+	if !ok || !sink.IsSink {
+		t.Errorf("playback node not addressable by its own ID: %+v, ok=%v", sink, ok)
+	}
+	source, ok := FindNode(nodes, EncodeAlsaID(0, 0, false))
+	if !ok || source.IsSink {
+		t.Errorf("capture node not addressable by its own ID: %+v, ok=%v", source, ok)
+	}
+
+	// Both resolve back to the same underlying ALSA card and device.
+	for _, n := range nodes {
+		card, device, _ := DecodeAlsaID(n.ID)
+		if card != 0 || device != 0 {
+			t.Errorf("node %+v decodes to card %d device %d, want 0/0", n, card, device)
+		}
 	}
 }
 

--- a/go/internal/agent/audio/pipewire.go
+++ b/go/internal/agent/audio/pipewire.go
@@ -79,31 +79,78 @@ func (d Defaults) IsDefault(n Node) bool {
 	return n.Name != "" && n.Name == d.SourceName
 }
 
-// RuntimeDir returns the directory holding the user session's PipeWire socket,
-// or "" when no session is up. Only the socket owned by the "wendy" user is
-// trusted: on a multi-user host, any local UID can create a session under
-// /run/user/<uid>, and root blindly following the first glob match would let
-// that UID influence the agent's audio graph operations.
-func RuntimeDir() string {
+// session locates the user session's PipeWire socket directory. It returns
+// either a directory and an empty reason, or an empty directory and a reason
+// naming the precondition that failed.
+//
+// The reason exists because "no session" is three different situations — no
+// "wendy" account, no socket, or a socket owned by someone else — and a caller
+// that sees only "" reports the same thing for all three. Each is a distinct
+// misconfiguration, and an operator can only act on the one that applies.
+//
+// Only the socket owned by the "wendy" user is trusted: on a multi-user host,
+// any local UID can create a session under /run/user/<uid>, and root blindly
+// following the first glob match would let that UID influence the agent's
+// audio graph operations.
+func session() (dir, reason string) {
 	uid, ok := expectedUID()
 	if !ok {
-		return ""
+		return "", `no local user "wendy" (PipeWire runs in that user's session)`
 	}
 	matches, _ := filepath.Glob(SocketGlob)
+	// Tracked so a candidate that exists but is unusable can be reported for
+	// what it is: a socket owned by the wrong UID is a very different fault
+	// from no socket at all, and conflating them sends an operator looking in
+	// the wrong place.
+	var rejected string
 	for _, m := range matches {
 		// Lstat, not Stat: a symlink swapped in after the glob must not be
 		// followed to a socket outside the expected session.
 		fi, err := os.Lstat(m)
-		if err != nil || fi.Mode()&os.ModeSocket == 0 {
+		if err != nil {
+			if rejected == "" {
+				rejected = fmt.Sprintf("%s could not be read: %v", m, err)
+			}
+			continue
+		}
+		if fi.Mode()&os.ModeSocket == 0 {
+			if rejected == "" {
+				rejected = fmt.Sprintf("%s is not a socket", m)
+			}
 			continue
 		}
 		st, ok := fi.Sys().(*syscall.Stat_t)
-		if !ok || st.Uid != uid {
+		if !ok {
 			continue
 		}
-		return filepath.Dir(m)
+		if st.Uid != uid {
+			if rejected == "" {
+				rejected = fmt.Sprintf("%s is owned by uid %d, expected the \"wendy\" user (uid %d)", m, st.Uid, uid)
+			}
+			continue
+		}
+		return filepath.Dir(m), ""
 	}
-	return ""
+	if rejected != "" {
+		return "", rejected
+	}
+	return "", fmt.Sprintf("no socket matching %s (is pipewire-user-setup.service running?)", SocketGlob)
+}
+
+// RuntimeDir returns the directory holding the user session's PipeWire socket,
+// or "" when no session is up. Use UnavailableReason to find out why.
+func RuntimeDir() string {
+	dir, _ := session()
+	return dir
+}
+
+// UnavailableReason explains why no PipeWire session was usable, or "" when one
+// is. Callers put it in log lines and error messages so a fallback to ALSA
+// states its cause rather than asserting, unprovably, that nothing is running.
+// Behind a var so tests can pair it with a stubbed Available.
+var UnavailableReason = func() string {
+	_, reason := session()
+	return reason
 }
 
 // Available reports whether a PipeWire user session is up. Callers use this

--- a/go/internal/agent/audio/pipewire_test.go
+++ b/go/internal/agent/audio/pipewire_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -278,6 +279,60 @@ func TestRuntimeDir(t *testing.T) {
 	expectedUID = func() (uint32, bool) { return 0, false }
 	if got := RuntimeDir(); got != "" {
 		t.Errorf("unresolvable expected UID should yield \"\", got %q", got)
+	}
+}
+
+// RuntimeDir can fail for three unrelated reasons, and collapsing them into a
+// bare "" leaves both the operator and the agent's own logs with no way to tell
+// a missing "wendy" account from a session that simply is not up. Each reason
+// must name the specific precondition that failed.
+func TestUnavailableReason(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	origGlob, origUID := SocketGlob, expectedUID
+	t.Cleanup(func() { SocketGlob, expectedUID = origGlob, origUID })
+
+	ownUID := uint32(os.Getuid())
+	SocketGlob = filepath.Join(dir, "user-*", "pipewire-0")
+
+	// No "wendy" account: the reason must say so, not blame a missing socket.
+	expectedUID = func() (uint32, bool) { return 0, false }
+	reason := UnavailableReason()
+	if !strings.Contains(reason, "wendy") {
+		t.Errorf("unresolvable user reason = %q, want it to name the \"wendy\" user", reason)
+	}
+
+	// No socket: the reason must name where the agent looked, so an operator
+	// can check that exact path.
+	expectedUID = func() (uint32, bool) { return ownUID, true }
+	reason = UnavailableReason()
+	if !strings.Contains(reason, SocketGlob) {
+		t.Errorf("missing socket reason = %q, want it to name the glob %q", reason, SocketGlob)
+	}
+
+	// Socket present but owned by someone else: the reason must say that,
+	// rather than claiming no session is running when one plainly is.
+	sessionDir := filepath.Join(dir, "user-1000")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	listenUnix(t, filepath.Join(sessionDir, "pipewire-0"))
+	expectedUID = func() (uint32, bool) { return ownUID + 1, true }
+	reason = UnavailableReason()
+	if !strings.Contains(reason, "owned by") {
+		t.Errorf("owner-mismatch reason = %q, want it to report the owning uid", reason)
+	}
+	if strings.Contains(reason, "no PipeWire session") {
+		t.Errorf("owner-mismatch reason = %q, must not claim no session is running", reason)
+	}
+
+	// A usable session has no reason to report.
+	expectedUID = func() (uint32, bool) { return ownUID, true }
+	if reason = UnavailableReason(); reason != "" {
+		t.Errorf("UnavailableReason() = %q with a valid session, want \"\"", reason)
 	}
 }
 

--- a/go/internal/agent/services/audio_service.go
+++ b/go/internal/agent/services/audio_service.go
@@ -58,6 +58,10 @@ func (s *AudioService) pipewireUnavailable(op string) (bool, string) {
 		return false, ""
 	}
 	reason := audio.UnavailableReason()
+	if reason == "" {
+		// Session became available between checks; avoid falling back with no reason.
+		return false, ""
+	}
 	s.logger.Warn("PipeWire session unavailable; falling back to ALSA",
 		zap.String("operation", op),
 		zap.String("reason", reason))

--- a/go/internal/agent/services/audio_service.go
+++ b/go/internal/agent/services/audio_service.go
@@ -25,10 +25,13 @@ import (
 // Device IDs are PipeWire node IDs, which wpctl accepts directly and which name
 // Bluetooth endpoints as well as sound cards.
 //
-// When no PipeWire user session is running (audio.Available() is false),
+// When no PipeWire user session is reachable (audio.Available() is false),
 // every method here falls back to raw ALSA (aplay/arecord/amixer) instead of
 // failing outright, so a board with a sound card but no desktop session still
-// has basic playback and capture. The two paths never mix within one call:
+// has basic playback and capture. Every such fallback logs the specific reason
+// from audio.UnavailableReason: the backend swap is invisible in the responses,
+// so without that line a misconfigured session is indistinguishable from a
+// board that never had one. The two paths never mix within one call:
 // falling back means enumerating ALSA cards *instead of* the PipeWire graph,
 // not alongside it, which is what caused a Bluetooth device to appear on some
 // surfaces and not others before this service moved to PipeWire exclusively.
@@ -40,6 +43,25 @@ type AudioService struct {
 // NewAudioService creates a new AudioService.
 func NewAudioService(logger *zap.Logger) *AudioService {
 	return &AudioService{logger: logger}
+}
+
+// pipewireUnavailable reports whether this call must use the ALSA fallback, and
+// logs the specific reason when it must.
+//
+// Falling back silently is what made this hard to diagnose in the field: every
+// audio RPC quietly changed backend, the device listing came back full of
+// plausible plughw entries, and nothing said the graph had been swapped out or
+// which precondition failed. Warn, not Debug: on a device whose image ships
+// PipeWire this is a misconfiguration, not a supported steady state.
+func (s *AudioService) pipewireUnavailable(op string) (bool, string) {
+	if audio.Available() {
+		return false, ""
+	}
+	reason := audio.UnavailableReason()
+	s.logger.Warn("PipeWire session unavailable; falling back to ALSA",
+		zap.String("operation", op),
+		zap.String("reason", reason))
+	return true, reason
 }
 
 // audioDeviceType maps a node's direction onto the proto enum.
@@ -56,15 +78,15 @@ func audioDeviceType(n audio.Node) agentpb.AudioDeviceType {
 func (s *AudioService) ListAudioDevices(ctx context.Context, req *agentpb.ListAudioDevicesRequest) (*agentpb.ListAudioDevicesResponse, error) {
 	var nodes []audio.Node
 	var defaults audio.Defaults
-	if audio.Available() {
+	if unavailable, _ := s.pipewireUnavailable("ListAudioDevices"); unavailable {
 		var err error
-		nodes, defaults, err = audio.ListNodes(ctx)
+		nodes, err = audio.ListAlsaNodes(ctx)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to enumerate audio devices: %v", err)
 		}
 	} else {
 		var err error
-		nodes, err = audio.ListAlsaNodes(ctx)
+		nodes, defaults, err = audio.ListNodes(ctx)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to enumerate audio devices: %v", err)
 		}
@@ -142,7 +164,7 @@ func (s *AudioService) alsaVolumes(ctx context.Context, devices []*agentpb.Audio
 		if device.GetType() != agentpb.AudioDeviceType_AUDIO_DEVICE_TYPE_OUTPUT {
 			continue
 		}
-		card, _ := audio.DecodeAlsaID(device.GetId())
+		card, _, _ := audio.DecodeAlsaID(device.GetId())
 		result, cached := cache[card]
 		if !cached {
 			volume, ok := audio.AlsaVolume(ctx, card)
@@ -168,7 +190,7 @@ func (s *AudioService) setAudioVolume(ctx context.Context, deviceID, volumePerce
 		return 0, status.Errorf(codes.InvalidArgument, "volume must be between 0 and 100, got %d", volumePercent)
 	}
 
-	if !audio.Available() {
+	if unavailable, _ := s.pipewireUnavailable("SetAudioVolume"); unavailable {
 		return s.setAlsaVolume(ctx, deviceID, volumePercent)
 	}
 
@@ -214,7 +236,7 @@ func (s *AudioService) setAlsaVolume(ctx context.Context, deviceID, volumePercen
 		return 0, status.Errorf(codes.InvalidArgument, "device %d (%s) is an input; it has no playback volume", deviceID, node.Name)
 	}
 
-	card, _ := audio.DecodeAlsaID(deviceID)
+	card, _, _ := audio.DecodeAlsaID(deviceID)
 	actual, err := audio.SetAlsaVolume(ctx, card, volumePercent)
 	if err != nil {
 		return 0, err
@@ -234,11 +256,15 @@ func (s *AudioService) SetDefaultAudioDevice(ctx context.Context, req *agentpb.S
 		return nil, status.Errorf(codes.InvalidArgument, "device ID 0 is not a valid audio device")
 	}
 
-	if !audio.Available() {
+	if unavailable, reason := s.pipewireUnavailable("SetDefaultAudioDevice"); unavailable {
 		// "Default sink/source" is PipeWire/WirePlumber metadata; raw ALSA has
-		// no equivalent to set. Saying so beats reporting success for a
-		// setting that does not exist.
-		errMsg := fmt.Sprintf("cannot set a default audio device: no PipeWire session is running (device %d)", req.GetDeviceId())
+		// no equivalent to set. Saying so beats reporting success for a setting
+		// that does not exist.
+		//
+		// The reason is included rather than a flat "no PipeWire session is
+		// running", which claims more than the agent knows: all it established
+		// is that it found no session it would trust at the path it checked.
+		errMsg := fmt.Sprintf("cannot set a default audio device: %s (device %d)", reason, req.GetDeviceId())
 		return &agentpb.SetDefaultAudioDeviceResponse{Success: false, ErrorMessage: &errMsg}, nil
 	}
 
@@ -444,6 +470,8 @@ func (s *AudioService) StreamAudioLevels(req *agentpb.StreamAudioLevelsRequest, 
 		rateHz = 60
 	}
 
+	s.pipewireUnavailable("StreamAudioLevels")
+
 	target, err := captureTarget(ctx, req.GetDeviceId())
 	if err != nil {
 		return err
@@ -509,6 +537,8 @@ func (s *AudioService) StreamAudio(req *agentpb.StreamAudioRequest, stream grpc.
 	}
 	// Bounds on sampleRate/channels are enforced by startCapture, not here, so
 	// every caller of startCapture is protected uniformly.
+
+	s.pipewireUnavailable("StreamAudio")
 
 	target, err := captureTarget(ctx, req.GetDeviceId())
 	if err != nil {

--- a/go/internal/agent/services/audio_service_test.go
+++ b/go/internal/agent/services/audio_service_test.go
@@ -215,6 +215,36 @@ func TestListAudioDevicesFallsBackToALSAWithNoSession(t *testing.T) {
 	}
 }
 
+// Without a session the agent cannot set a default, but the refusal has to say
+// which precondition failed. The old message asserted "no PipeWire session is
+// running", which is more than the agent established — it only knows it found
+// no session it would trust where it looked — and it left an operator with
+// nothing to check.
+func TestSetDefaultAudioDeviceReportsWhyPipeWireIsUnavailable(t *testing.T) {
+	origAvailable, origReason := audio.Available, audio.UnavailableReason
+	t.Cleanup(func() { audio.Available, audio.UnavailableReason = origAvailable, origReason })
+	audio.Available = func() bool { return false }
+	audio.UnavailableReason = func() string {
+		return `/run/user/1000/pipewire-0 is owned by uid 0, expected the "wendy" user (uid 1000)`
+	}
+
+	resp, err := testAudioService().SetDefaultAudioDevice(context.Background(),
+		&agentpb.SetDefaultAudioDeviceRequest{DeviceId: 1})
+	if err != nil {
+		t.Fatalf("SetDefaultAudioDevice() error = %v", err)
+	}
+	if resp.GetSuccess() {
+		t.Fatal("success = true with no PipeWire session")
+	}
+	msg := resp.GetErrorMessage()
+	if !strings.Contains(msg, "owned by uid 0") {
+		t.Errorf("error = %q, want it to carry the specific reason", msg)
+	}
+	if strings.Contains(msg, "no PipeWire session is running") {
+		t.Errorf("error = %q, must not assert that no session is running", msg)
+	}
+}
+
 func TestSetDefaultAudioDevice(t *testing.T) {
 	calls := stubGraph(t, graphFixture, nil)
 


### PR DESCRIPTION
## What went wrong

`wendy device audio set-default --device wendystudio-walter --id 1` failed with:

```
✗ failed: cannot set a default audio device: no PipeWire session is running (device 1)
```

Investigating that turned up two separate faults.

### 1. ALSA endpoint IDs collided across directions

`EncodeAlsaID` derived the node ID from the card and device numbers alone. A duplex device is reported as the *same* card and device by both `aplay -l` and `arecord -l`, so its playback and capture halves encoded to the same ID. On the Thor, an Anker PowerConf speakerphone showed up twice, both as `id: 1`:

```
{ "id": 1, "name": "plughw:0,0", "description": "PowerConf ...", "type": 2 }   # output
{ "id": 1, "name": "plughw:0,0", "description": "PowerConf ...", "type": 1 }   # input
```

`FindNode` returns the first match, and `ListAlsaNodes` sorted with `sort.Slice` — which is **unstable** — so which of the two `--id 1` resolved to was arbitrary. This also reached `SetAudioVolume`, which can reject a perfectly valid speaker with "device 1 is an input; it has no playback volume", and the capture-target path.

Direction now occupies a bit above the card, so each endpoint is separately addressable, and the sort is `SliceStable` so any future collision degrades to a reproducible order instead of an arbitrary one.

Sink IDs are unchanged; only source IDs move. They are re-enumerated on every call and never persisted, so nothing carries an old value across.

### 2. The PipeWire fallback was silent and the message overclaimed

`RuntimeDir` collapsed three unrelated causes — no `wendy` account, no socket, a socket owned by another UID — into a bare `""`. Every audio RPC then swapped to the ALSA backend with **no log line at all**: the listing comes back full of plausible `plughw:` entries and nothing anywhere says the graph was swapped out.

The resulting message asserted "no PipeWire session is running", which is more than the agent established — all it knows is that it found no session it would trust at the path it checked. Two of the three causes are misconfigurations on a device whose image *does* ship PipeWire (`meta-wendyos` `audio-config` runs pipewire + wireplumber as `wendy`), and none of them was distinguishable from the outside.

Each cause is now reported specifically, logged at `Warn` on every fallback, and carried into the error the CLI prints.

## Verified on hardware

Cross-compiled and deployed to a Jetson AGX Thor (WendyOS 0.17.0).

IDs are now unique per direction — the PowerConf's two halves separate cleanly:

```
id=1        type=2 (OUTPUT)  plughw:0,0
id=16777217 type=1 (INPUT )  plughw:0,0
```

And the same failing command now names the actual root cause:

```
✗ failed: cannot set a default audio device: no socket matching /run/user/*/pipewire-0
  (is pipewire-user-setup.service running?) (device 1)
```

That answers the original question: PipeWire genuinely is **not** running on that device — not an owner mismatch, not a missing user. The agent's fallback was correct; it just could not say so.

## Follow-up, not in this PR

Why `pipewire-user-setup.service` left no session on that Thor is an OS-side issue. One candidate worth checking first: `wendyos-builder/recipes-multimedia/audio-config/files/pipewire-user-setup.sh:19-22` does `exit 0` when `/home/wendy` is missing — a *silent success* that leaves no session and no failed unit, which would produce exactly this symptom. Filing separately against the builder.

## Testing

- New: `TestAlsaIDDistinguishesDirection` — duplex card gets two distinct, separately addressable IDs.
- New: `TestUnavailableReason` — each of the three preconditions reports its own cause; a usable session reports none.
- New: `TestSetDefaultAudioDeviceReportsWhyPipeWireIsUnavailable` — the refusal carries the reason and no longer claims no session is running.
- Updated: `TestEncodeDecodeAlsaID` round-trips direction, including the 16-bit card range.
- `go test ./...` green; `go vet ./internal/agent/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ens6UtXELudWvEMFAZraUU