### PR TITLE
Fail fast instead of hanging when a prompt has no terminal

### DIFF
--- a/go/internal/cli/commands/device_shell.go
+++ b/go/internal/cli/commands/device_shell.go
@@ -49,8 +49,15 @@ func newDeviceShellCmd() *cobra.Command {
 
 func runDeviceShell(cmd *cobra.Command, shellCmd []string) error {
 	fd := int(os.Stdin.Fd())
-	if !term.IsTerminal(fd) {
-		return fmt.Errorf("device shell requires an interactive terminal")
+	interactive := term.IsTerminal(fd)
+
+	// A login shell genuinely needs a terminal — there is nothing to drive it
+	// otherwise. A one-off `-- command` does not: it is the natural way to run
+	// something on the device from a script, from CI, or from an AI agent, and
+	// refusing it forces every such caller to shell out to a human. Only the
+	// no-command form still requires a TTY.
+	if !interactive && len(shellCmd) == 0 {
+		return fmt.Errorf("device shell requires an interactive terminal (pass `-- command...` to run a single command non-interactively)")
 	}
 
 	ctx := cmd.Context()
@@ -74,29 +81,44 @@ func runDeviceShell(cmd *cobra.Command, shellCmd []string) error {
 		return stream.Send(req)
 	}
 
-	rows, cols := termSize(fd)
+	var rows, cols uint32 = 24, 80
+	if interactive {
+		rows, cols = termSize(fd)
+	}
 	if err := send(buildShellStart(shellCmd, rows, cols)); err != nil {
 		return fmt.Errorf("sending shell start: %w", err)
 	}
 
-	oldState, rawErr := term.MakeRaw(fd)
-	if rawErr == nil {
-		defer func() { _ = term.Restore(fd, oldState) }()
+	if interactive {
+		oldState, rawErr := term.MakeRaw(fd)
+		if rawErr == nil {
+			defer func() { _ = term.Restore(fd, oldState) }()
+		}
+
+		// Terminal resize -> resize frames (SIGWINCH on Unix; no-op on Windows).
+		winch := make(chan os.Signal, 1)
+		stopResize := notifyTerminalResize(winch)
+		defer stopResize()
+		go func() {
+			for range winch {
+				r, c := termSize(fd)
+				_ = send(shellWinSizeFrame(r, c))
+			}
+		}()
 	}
 
-	// Terminal resize -> resize frames (SIGWINCH on Unix; no-op on Windows).
-	winch := make(chan os.Signal, 1)
-	stopResize := notifyTerminalResize(winch)
-	defer stopResize()
+	// stdin -> stream. With no terminal there is nothing to forward, and
+	// leaving the send side open makes the remote command wait forever on
+	// input that will never arrive — so close it straight away.
+	if !interactive {
+		sendMu.Lock()
+		_ = stream.CloseSend()
+		sendMu.Unlock()
+	}
 	go func() {
-		for range winch {
-			r, c := termSize(fd)
-			_ = send(shellWinSizeFrame(r, c))
+		if !interactive {
+			return
 		}
-	}()
-
-	// stdin -> stream.
-	go func() {
 		buf := make([]byte, 4096)
 		for {
 			n, rerr := os.Stdin.Read(buf)

--- a/go/internal/cli/tui/confirm.go
+++ b/go/internal/cli/tui/confirm.go
@@ -3,9 +3,11 @@ package tui
 import (
 	"fmt"
 	"io"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 )
 
 // ConfirmModel is a Bubble Tea model for styled yes/no prompts.
@@ -142,7 +144,23 @@ func (m ConfirmModel) Cancelled() bool {
 	return m.quitting
 }
 
+// stdinIsTerminal reports whether stdin is a real terminal.
+//
+// This deliberately uses term.IsTerminal rather than checking
+// os.ModeCharDevice: /dev/null IS a character device, so the mode check reports
+// "terminal" for the single most common non-interactive stdin there is — which
+// is how `go test` runs, and how many CI runners invoke commands.
+func stdinIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
 func runConfirm(m ConfirmModel, programOpts []tea.ProgramOption) (bool, error) {
+	// Only guard the default path. Callers that supply their own program
+	// options (ConfirmWithIO, tests) have deliberately provided an input
+	// source and must keep working with no terminal attached.
+	if len(programOpts) == 0 && !stdinIsTerminal() {
+		return false, ErrNotInteractive
+	}
 	p := tea.NewProgram(m, programOpts...)
 	result, err := p.Run()
 	if err != nil {

--- a/go/internal/cli/tui/confirm_test.go
+++ b/go/internal/cli/tui/confirm_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -79,5 +81,39 @@ func TestConfirmNoDefault_CtrlCCancels(t *testing.T) {
 	}
 	if cm.answered {
 		t.Error("Ctrl+C should not mark the prompt answered")
+	}
+}
+
+// A prompt with no terminal must fail fast rather than hang. Under `go test`
+// stdin is not a character device, so the default (no program options) path is
+// exactly the non-interactive case an agent or CI job hits.
+func TestConfirmWithoutTerminalReturnsErrNotInteractive(t *testing.T) {
+	for name, fn := range map[string]func(string, ...tea.ProgramOption) (bool, error){
+		"Confirm":                Confirm,
+		"ConfirmDefaultYes":      ConfirmDefaultYes,
+		"ConfirmNoDefault":       ConfirmNoDefault,
+		"ConfirmNoDefaultDanger": ConfirmNoDefaultDanger,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ok, err := fn("proceed?")
+			if !errors.Is(err, ErrNotInteractive) {
+				t.Fatalf("expected ErrNotInteractive, got ok=%v err=%v", ok, err)
+			}
+			if ok {
+				t.Fatal("a prompt that could not be shown must never report confirmation")
+			}
+		})
+	}
+}
+
+// Callers that supply their own input keep working with no terminal attached —
+// the guard must not break ConfirmWithIO or the existing tests.
+func TestConfirmWithIOStillWorksWithoutTerminal(t *testing.T) {
+	ok, err := ConfirmWithIO("proceed?", strings.NewReader("y"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected confirmation from supplied input")
 	}
 }

--- a/go/internal/cli/tui/errors.go
+++ b/go/internal/cli/tui/errors.go
@@ -4,3 +4,14 @@ import "errors"
 
 // ErrCancelled is returned when the user cancels an interactive prompt (e.g. Ctrl+C or q).
 var ErrCancelled = errors.New("cancelled")
+
+// ErrNotInteractive is returned instead of drawing a prompt when stdin is not a
+// terminal — CI, a script, or an AI agent driving the CLI.
+//
+// The alternative is worse than an error: a Bubble Tea prompt with no terminal
+// to read from produces no output and never resolves, so the command appears to
+// hang forever with an idle CPU and nothing in its log. That is
+// indistinguishable from a slow build, and it cost a full debugging session
+// before the cause was found. Failing loudly, naming the flag that fixes it, is
+// always better than blocking a caller that can never answer.
+var ErrNotInteractive = errors.New("cannot prompt: stdin is not a terminal (pass --yes to accept prompts non-interactively)")


### PR DESCRIPTION
> **Draft, and not my design.** This was uncommitted work sitting in the main working tree on `jo/stagefile-variant-picker`. That branch is PR #1654 (the build-file picker) and this change is unrelated to it, so committing it there would have contaminated an open PR — it is on a fresh branch off `main` instead, where it applies cleanly. The original working tree was left untouched: this is a copy, not a move, so whoever is editing there still has their files.
>
> Two real defects are open. I found them auditing the change rather than by running it, and deliberately did not fix them, because the fix for each is a design call the author should make.

## What it does

Two independent changes, both about the CLI being driven by something that is not a human.

**`tui.Confirm*` fails fast without a terminal.** It now returns a new `ErrNotInteractive` instead of starting a Bubble Tea program that has nothing to read from. That program emits no output and never resolves, so the command looks like a hang with an idle CPU and an empty log — indistinguishable from a slow build. The check is `term.IsTerminal`, not `os.ModeCharDevice`, because `/dev/null` is a character device and would be misread as a terminal, which is exactly how `go test` and many CI runners supply stdin.

**`wendy device shell -- command` no longer requires a TTY.** A login shell needs one and still demands it; a one-off command does not, and refusing it forced every script, CI job and agent to go find a human. With no terminal the send side is closed immediately, since leaving it open makes the remote command wait forever on input that never arrives.

This is a real problem, not a hypothetical one: earlier today `wendy device apps remove` failed for me with `confirm prompt: could not open a new TTY: open /dev/tty: device not configured`, and the only way through was `--force`.

## Defect 1 — the error message names a flag that mostly does not exist

`ErrNotInteractive` says *"pass `--yes` to accept prompts non-interactively"*. `--yes` exists on exactly four commands: `wendy run` (`run.go:577`), `wendy cloud run` (`cloud_run.go:39`), `wendy device unenroll` (`device.go:1050`), `wendy device update` (`device.go:2509`). There is no persistent `--yes` on root (`root.go:116-117`).

None of those four is a command that will reach this error. The callers that actually abort on it spell the flag differently:

| Command | Confirm call | Actual flag |
|---|---|---|
| `device apps remove` | `apps.go:640` | `--force` |
| `device volumes remove` | `volumes.go:171` | `--force` |
| `os install` (×6 sites) | `os_install.go:201,711`, `os_install_orin.go:95,439`, `os_install_thor_shared.go:133`, `os_install_thor_brief.go:99` | `--force` |
| `os download` | `os_download.go:85` | `--overwrite` |
| `wendy init` | `init_cmd.go:950` | `--git-init no` |

So the message sends users to a flag cobra will reject with `unknown flag: --yes`. Either make it flag-agnostic, or have each command wrap the error with its own flag name.

## Defect 2 — the guard is skipped on the most-used path

`runConfirm` only returns `ErrNotInteractive` when `len(programOpts) == 0` (`confirm.go:161`). The stated reason is sound — `ConfirmWithIO` and tests deliberately supply their own input source. But the exemption keys on *any* program option, and `confirmFn` / `confirmDefaultNoFn` (`helpers.go:342,351`) pass `tea.WithOutput(os.Stderr)` — an **output** option, not an input one.

Those two wrappers back **17 call sites** (`docker.go:1080,1115,2161`, `device.go:667,790,998,2094,2155`, `helpers.go:373,379,2277,2766`, `helpers_cloudauth.go:116`, `init_cmd.go:1841`, `wifi.go:389`, `camera_gst.go:66`), and they are the most common confirmation path in the CLI. All of them still get a Bubble Tea program on a non-TTY stdin — the exact hang the comment in `errors.go` says this prevents. Narrowing the exemption to options that actually supply input would close it.

## Verification

`go build ./...`, `go vet ./go/internal/cli/...` and `go test ./go/internal/cli/...` are clean; the new `TestConfirmWithoutTerminalReturnsErrNotInteractive` covers all four `Confirm*` entry points. The `device_shell.go` half has **no test coverage** — the non-interactive path is not exercised anywhere, and I did not deploy against a device to try it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A18yL9ChqTvpqXEci18cZ9
