### PR TITLE
ci: keep CI credentials inline, the runner keychain cannot be read

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,15 @@ on:
 permissions:
   contents: read
 
+# The self-hosted macOS runners execute as a LaunchAgent, whose session cannot
+# authorize the login Keychain: security(1) exits 152 ("Unable to obtain
+# authorization for this operation") for every read, so a dehydrated credential
+# is unreadable here. Keep this runner's credentials inline in config.json
+# instead. Covers steps that run the CLI directly; commands sent through
+# `ssh localhost` start a fresh session and export it again themselves.
+env:
+  WENDY_SECRET_STORE: file
+
 jobs:
   discover:
     name: Discover (${{ matrix.runner.name }})
@@ -365,6 +374,9 @@ jobs:
           export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/bin:$PATH"
           export DOCKER_HOST="$DOCKER_HOST_VALUE"
           export WENDY_BUILDX_BUILDER="$BUILDER"
+          # ssh starts a fresh session, so the workflow-level env does not reach
+          # here — see the note on WENDY_SECRET_STORE at the top of this file.
+          export WENDY_SECRET_STORE=file
           cd "$WORKDIR"
           exec go/scripts/test-ci.sh "$@" -h "$HOSTNAME"
           REMOTE


### PR DESCRIPTION
The self-hosted macOS runners execute as a LaunchAgent, and that session cannot authorize the login Keychain. Since credentials were dehydrated into it, the four `python-multiservice` integration tests have failed on every run, which blocks the stable agent release.

## What the runner actually does

Instrumented `keychain.Get` on the runner. Every read fails the same way:

```
get#1 svc=wendy-credentials acct=key-97f62c0565666ad3 FAIL in 34ms
      err=*exec.ExitError:exit status 152  exit=152  ctxErr=<nil>  stderr=""
get#1 RETRY also failed in 55ms  exit=152
get#1 show-keychain-info: stderr="security: SecKeychainCopySettings <NULL>:
                                  Unable to obtain authorization for this operation."
```

- **Not a timeout** — `ctxErr` is nil and the call returns in ~40ms against a 5s budget.
- **Not transient** — an immediate sequential retry fails identically.
- **Not concurrency** — serialising the reads changes nothing.

Across the whole job: **27 failed reads, 0 successful ones.**

## Why only four tests failed

The failing call path is the mTLS rung of the connection ladder:

```
PrivateKeyPEM <- newAgentTLSConfig <- ConnectWithTLSExpecting
              <- dialAgentLadderWithCerts <- dialAgentLadder <- connectWithAutoTLS
```

When that rung fails the CLI falls back to plaintext, which works against a dev agent — so single-service tests pass *without ever reading the key*. The multiservice build calls `loadCLICert()` directly for the registry proxy and has no fallback, so those four are the only tests where the failure is fatal.

## Fix

`WENDY_SECRET_STORE=file`, so `Save` keeps credentials inline instead of pushing them into a store this session cannot read back. Set in two places:

- **workflow-level**, for steps that run the CLI directly — `discover` browses over mTLS and can write a pin, which would re-dehydrate the key.
- **inside the ssh heredoc**, because `ssh localhost` starts a fresh session that the workflow env does not reach.

Linux is unaffected: `secretsPlatformDefault` is already `false` there.

## This also removes a hazard beyond the failing tests

Repeatedly hammering an unauthorizable keychain can wedge `securityd`. Once it stops answering, keychain reads **block** rather than fail — which hangs `wendy discover`, and takes down anything else on the machine that keeps state there. With credentials inline these jobs stop invoking `security(1)` altogether, so that failure mode is off the table.

## Prerequisite

The env var governs **writes**. An existing `keychain:v1:` reference stays unresolvable until the runner's config is rewritten, and `inlineSecrets` cannot help because it only rewrites references it can successfully resolve. The runner needs:

```
WENDY_SECRET_STORE=file wendy auth login
```

as the user that `ssh localhost` lands in.

## Not addressed here

- **The product-level question.** Keychain storage is macOS-CLI-only (`secretsPlatformDefault`; nothing under `internal/agent/` imports it). Any headless macOS session — CI, LaunchAgent, plain `ssh` — hits this. Whether to keep it on by default is a separate decision.
- **`keychain.Get` swallows the reason.** Not-found, denied, timed-out and non-zero-exit all collapse to a bare `return nil`, which is why this took a full instrumented run to characterise. Worth surfacing the cause to callers.
- **The integration suite never runs on `go/**` PRs.** `build.yml` has no `pull_request` trigger, and `pr-integration-tests.yml` filters on `paths: ['.github/**']` — so the PR that introduced the Keychain migration got no integration coverage. This PR touches `.github/**`, so it does run here.
