### PR TITLE
fix(agent): never run ROS 2 discovery over WiFi

### DIFF
--- a/go/internal/agent/hoststats/rosbattery/config.go
+++ b/go/internal/agent/hoststats/rosbattery/config.go
@@ -25,7 +25,8 @@ type fileConfig struct {
 }
 
 // DefaultConfig is the behaviour with no config file present: discover
-// automatically on the ROS 2 default domain across every candidate interface.
+// automatically on the ROS 2 default domain across every wired candidate
+// interface. Setting "interfaces" is what opts a wireless link back in.
 func DefaultConfig() Config {
 	return Config{Enabled: true}
 }

--- a/go/internal/agent/hoststats/rosbattery/monitor.go
+++ b/go/internal/agent/hoststats/rosbattery/monitor.go
@@ -49,39 +49,81 @@ var virtualIfacePrefixes = []string{
 	"docker", "br-", "veth", "cni", "flannel", "virbr", "kube", "nerdctl", "tap", "tun",
 }
 
-// candidateInterfaces lists interfaces worth trying for DDS discovery: up,
-// non-loopback, multicast-capable, with an IPv4 address, and not obviously
-// virtual.
+// candidateIface is the part of a net.Interface that eligibility depends on,
+// split out so the filter can be tested without a host's real interface list.
+type candidateIface struct {
+	Name    string
+	Flags   net.Flags
+	HasIPv4 bool
+}
+
+// candidateInterfaces lists the host's interfaces worth trying for DDS
+// discovery. See eligibleInterfaces for the criteria.
 func candidateInterfaces() []string {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil
 	}
-	var out []string
+	out := make([]candidateIface, 0, len(ifaces))
 	for _, iface := range ifaces {
-		f := iface.Flags
-		if f&net.FlagUp == 0 || f&net.FlagLoopback != 0 || f&net.FlagMulticast == 0 {
-			continue
-		}
-		if isVirtualInterface(iface.Name) {
-			continue
-		}
+		c := candidateIface{Name: iface.Name, Flags: iface.Flags}
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue
 		}
 		for _, a := range addrs {
 			if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() != nil {
-				out = append(out, iface.Name)
+				c.HasIPv4 = true
 				break
 			}
 		}
+		out = append(out, c)
+	}
+	return eligibleInterfaces(out)
+}
+
+// eligibleInterfaces narrows a host's interfaces to those worth trying for DDS
+// discovery: up, non-loopback, multicast-capable, with an IPv4 address, and
+// neither virtual nor wireless.
+func eligibleInterfaces(ifaces []candidateIface) []string {
+	var out []string
+	for _, iface := range ifaces {
+		f := iface.Flags
+		if f&net.FlagUp == 0 || f&net.FlagLoopback != 0 || f&net.FlagMulticast == 0 {
+			continue
+		}
+		if !iface.HasIPv4 {
+			continue
+		}
+		if isVirtualInterface(iface.Name) || isWireless(iface.Name) {
+			continue
+		}
+		out = append(out, iface.Name)
 	}
 	return out
 }
 
 func isVirtualInterface(name string) bool {
 	for _, p := range virtualIfacePrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWireless reports whether a name looks like a wireless interface. Linux
+// predictable names use a "wl" prefix; the legacy names are wlanN and wifiN,
+// and some out-of-tree drivers use athN and raN. Mirrors the helper in
+// internal/agent/ipcam.
+//
+// A robot's DDS bus is a wired network. Announcing SPDP over WiFi puts
+// multicast discovery traffic onto whatever office or home network the device
+// happens to be associated with, where it can only find strangers' robots, so
+// auto-discovery skips wireless outright rather than merely deprioritising it.
+func isWireless(name string) bool {
+	name = strings.ToLower(name)
+	for _, p := range []string{"wl", "wifi", "ath", "ra"} {
 		if strings.HasPrefix(name, p) {
 			return true
 		}
@@ -111,9 +153,10 @@ func moveToFront(names []string, want string) []string {
 type Config struct {
 	// Enabled false disables the monitor entirely.
 	Enabled bool
-	// Interfaces pins discovery to named network interfaces. Empty means
-	// auto-select. Only the first is used today; the field is plural so the
-	// config format does not have to change to support more.
+	// Interfaces pins discovery to named network interfaces, tried in order
+	// until one yields a battery topic. Empty means auto-select, which skips
+	// virtual and wireless interfaces; naming one here bypasses that filter and
+	// is how a host whose robot link is WiFi opts back in.
 	Interfaces []string
 	// DomainID is the DDS domain. Zero is the ROS 2 default.
 	DomainID int
@@ -171,14 +214,20 @@ func (m *Monitor) Run(ctx context.Context) {
 // on a device running containers, a handful of bridge interfaces. Picking the
 // first multicast-capable interface finds the battery only by luck.
 func (m *Monitor) scanAndSubscribe(ctx context.Context) bool {
+	// A configured list is taken verbatim: naming an interface is how an
+	// operator overrides the filter below, including to force a wireless one on
+	// hardware whose robot link really is WiFi.
 	ifaces := m.cfg.Interfaces
 	if len(ifaces) == 0 {
 		ifaces = candidateInterfaces()
 	}
-	// A last resort of "" lets the rtps package auto-select, so a host whose
-	// interfaces all look virtual still gets one attempt.
+	// There is deliberately no "let rtps auto-select" fallback here. Auto-select
+	// takes the first multicast-capable interface, which on a host with nothing
+	// eligible means WiFi or a container bridge — exactly what the filter just
+	// excluded, and traffic we would rather not emit at all.
 	if len(ifaces) == 0 {
-		ifaces = []string{""}
+		m.logf("ros2 battery: no wired multicast interface; set interfaces in %s to override", ConfigFile)
+		return false
 	}
 
 	// Start from whichever interface last worked, so a steady-state rescan does

--- a/go/internal/agent/hoststats/rosbattery/monitor_test.go
+++ b/go/internal/agent/hoststats/rosbattery/monitor_test.go
@@ -1,0 +1,112 @@
+package rosbattery
+
+import (
+	"net"
+	"slices"
+	"testing"
+)
+
+func TestEligibleInterfaces(t *testing.T) {
+	const up = net.FlagUp | net.FlagMulticast
+
+	tests := []struct {
+		name   string
+		ifaces []candidateIface
+		want   []string
+	}{
+		{
+			name: "wired interface is eligible",
+			ifaces: []candidateIface{
+				{Name: "eth0", Flags: up, HasIPv4: true},
+			},
+			want: []string{"eth0"},
+		},
+		{
+			// The motivating case: a Jetson whose only routable interface is
+			// WiFi must yield nothing, so the monitor never announces SPDP onto
+			// somebody's office network.
+			name: "wireless-only host has no candidates",
+			ifaces: []candidateIface{
+				{Name: "wlan0", Flags: up, HasIPv4: true},
+			},
+			want: nil,
+		},
+		{
+			name: "wireless is dropped alongside wired",
+			ifaces: []candidateIface{
+				{Name: "wlan0", Flags: up, HasIPv4: true},
+				{Name: "eth0", Flags: up, HasIPv4: true},
+				{Name: "wlp2s0", Flags: up, HasIPv4: true},
+				{Name: "wifi0", Flags: up, HasIPv4: true},
+			},
+			want: []string{"eth0"},
+		},
+		{
+			name: "virtual interfaces are dropped",
+			ifaces: []candidateIface{
+				{Name: "docker0", Flags: up, HasIPv4: true},
+				{Name: "veth1a2b", Flags: up, HasIPv4: true},
+				{Name: "br-abc123", Flags: up, HasIPv4: true},
+				{Name: "enp3s0", Flags: up, HasIPv4: true},
+			},
+			want: []string{"enp3s0"},
+		},
+		{
+			name: "down, loopback, non-multicast and IPv6-only are dropped",
+			ifaces: []candidateIface{
+				{Name: "eth0", Flags: net.FlagMulticast, HasIPv4: true},
+				{Name: "lo", Flags: up | net.FlagLoopback, HasIPv4: true},
+				{Name: "eth1", Flags: net.FlagUp, HasIPv4: true},
+				{Name: "eth2", Flags: up, HasIPv4: false},
+				{Name: "eth3", Flags: up, HasIPv4: true},
+			},
+			want: []string{"eth3"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := eligibleInterfaces(tc.ifaces)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("eligibleInterfaces() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsWireless(t *testing.T) {
+	wireless := []string{"wlan0", "wlp2s0", "wl0", "wifi0", "ath0", "ra0", "WLAN0"}
+	for _, name := range wireless {
+		if !isWireless(name) {
+			t.Errorf("isWireless(%q) = false, want true", name)
+		}
+	}
+	// "eno1" and "enp3s0" both start with "en", which must not be confused with
+	// the "ra" and "wl" wireless prefixes.
+	wired := []string{"eth0", "eno1", "enp3s0", "end0", "usb0", "rndis0"}
+	for _, name := range wired {
+		if isWireless(name) {
+			t.Errorf("isWireless(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestMoveToFront(t *testing.T) {
+	tests := []struct {
+		name  string
+		names []string
+		want  string
+		out   []string
+	}{
+		{"present", []string{"eth0", "eth1", "eth2"}, "eth1", []string{"eth1", "eth0", "eth2"}},
+		{"already first", []string{"eth0", "eth1"}, "eth0", []string{"eth0", "eth1"}},
+		{"absent leaves order", []string{"eth0", "eth1"}, "eth9", []string{"eth0", "eth1"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := moveToFront(tc.names, tc.want); !slices.Equal(got, tc.out) {
+				t.Errorf("moveToFront(%v, %q) = %v, want %v", tc.names, tc.want, got, tc.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

An agent on a Jetson was announcing DDS discovery onto the office WiFi:

```
21:19:52  participant 010f4d18… on domain 0, unicast 192.168.0.104:54172, multicast 239.255.0.1:7400
21:21:52  ros2 battery: no battery topic among 0 writers on "wlan0"
21:26:52  multicast egress pinned to wlan0
21:28:52  ros2 battery: no battery topic among 0 writers on "wlan0"
```

A robot's DDS bus is a wired network. Announcing SPDP over WiFi (TTL 4, so it is routable off-link) puts multicast discovery traffic onto whatever network the device happens to be associated with, where it can only ever find strangers' robots.

`candidateInterfaces()` filtered virtual interfaces (`docker`/`br-`/`veth`/…) but never wireless ones. On this device that left `wlan0` as the only candidate — the 5-minute `idleRescan` gap after the failure proves it, since `scanAndSubscribe` walks candidates back-to-back and only sleeps once the whole list is exhausted.

## Change

- Add `isWireless()` (`wl`/`wifi`/`ath`/`ra` prefixes), mirroring the helper already in `internal/agent/ipcam/link.go`, and drop wireless alongside virtual in auto-discovery.
- **Remove the `[]string{""}` last-resort entry** in `scanAndSubscribe`. This is the part that made the fix real: `""` let `rtps.resolveInterface()` auto-select, which takes the first up/multicast/IPv4 interface — exactly the WiFi or bridge the filter had just excluded. No candidates now means no scan plus a log line pointing at the config.
- Split the filter into a pure `eligibleInterfaces([]candidateIface)` so it is testable without the host's real interface list.
- Fix the `Config.Interfaces` doc, which claimed "only the first is used today" — `scanAndSubscribe` has always tried all of them in order.

## Escape hatch

Naming interfaces in `/etc/wendy-agent/ros2-battery.json` bypasses the filter entirely, so hardware whose robot link genuinely is wireless opts back in without a code change:

```json
{ "interfaces": ["wlan0"] }
```

## Behaviour change

A device with no wired multicast interface now runs no DDS discovery at all and logs:

```
ros2 battery: no wired multicast interface; set interfaces in ros2-battery.json to override
```

Previously it scanned WiFi. Since such a scan could only find a robot on the wrong network, nothing that worked before stops working — but it does mean a wireless-linked robot needs the config above.

## Tests

New `monitor_test.go`: table tests for `eligibleInterfaces` (wireless-only host yields nothing; wireless dropped alongside wired; virtual dropped; down/loopback/non-multicast/IPv6-only dropped), `isWireless` (checks `eno1`/`enp3s0`/`rndis0` are not caught by the `en`/`ra` prefix overlap), and `moveToFront`.

```
gofmt -l ./internal/agent/hoststats/rosbattery/   # clean
go vet ./internal/agent/hoststats/...             # clean
go test ./internal/agent/hoststats/... ./internal/rtps/...   # ok
```

Not verified on hardware — the affected Jetson has no wired link up, which is the condition this changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJNiycZP87UXaVFYKWRqji