### PR TITLE
Make Stagefile Swift builds incremental, and stop the derived ignore file from disabling the project's own

### DIFF
--- a/go/internal/cli/commands/buildprofile_test.go
+++ b/go/internal/cli/commands/buildprofile_test.go
@@ -44,7 +44,7 @@ func TestCompileStagefileDebugBuildsSwiftUnoptimized(t *testing.T) {
 	if _, err := compileStagefile(dir, "", debugStagefileOptions(true)...); err != nil {
 		t.Fatalf("compileStagefile: %v", err)
 	}
-	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "swift build -c debug") {
+	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "-c debug") {
 		t.Fatalf("want a debug build:\n%s", got)
 	}
 }
@@ -54,7 +54,7 @@ func TestCompileStagefileDefaultsToReleaseWithoutDebug(t *testing.T) {
 	if _, err := compileStagefile(dir, "", debugStagefileOptions(false)...); err != nil {
 		t.Fatalf("compileStagefile: %v", err)
 	}
-	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "swift build -c release") {
+	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "-c release") {
 		t.Fatalf("want a release build:\n%s", got)
 	}
 }
@@ -78,7 +78,7 @@ func TestResolveDockerfileForwardsDebugProfileToStagefile(t *testing.T) {
 	if name != generatedDockerfileName {
 		t.Fatalf("resolved %q, want %q", name, generatedDockerfileName)
 	}
-	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "swift build -c debug") {
+	if got := generatedDockerfileText(t, dir); !strings.Contains(got, "-c debug") {
 		t.Fatalf("want a debug build:\n%s", got)
 	}
 }

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -661,7 +661,18 @@ func compileStagefile(dir, gpuArch string, sfOpts ...stagefile.Option) (string, 
 	// BuildKit prefers <dockerfile>.dockerignore over .dockerignore for the
 	// file passed via -f, so the derived allowlist rides along without ever
 	// touching (or destroying) a user-authored .dockerignore in the project.
-	if err := writeGeneratedFile(filepath.Join(dir, generatedDockerignoreName), []byte(dockerignoreText)); err != nil {
+	//
+	// That precedence is also why an empty derivation must leave no file behind
+	// rather than write one: winning the precedence with a file that ignores
+	// nothing would disable the project's own .dockerignore. An earlier build of
+	// the same project may have written one, so remove it rather than assume
+	// absence.
+	ignorePath := filepath.Join(dir, generatedDockerignoreName)
+	if dockerignoreText == "" {
+		if err := os.Remove(ignorePath); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("removing stale %s: %w", generatedDockerignoreName, err)
+		}
+	} else if err := writeGeneratedFile(ignorePath, []byte(dockerignoreText)); err != nil {
 		return "", fmt.Errorf("writing %s: %w", generatedDockerignoreName, err)
 	}
 	return generatedDockerfileName, nil

--- a/go/internal/cli/commands/docker_test.go
+++ b/go/internal/cli/commands/docker_test.go
@@ -3022,3 +3022,65 @@ func TestWriteGeneratedFile_SkipsUnchangedWrites(t *testing.T) {
 		t.Fatalf("temp files left behind: %v", leftovers)
 	}
 }
+
+// A Stagefile that copies the whole context yields no derivable allowlist, and
+// the generated ignore file wins BuildKit's precedence over the project's own
+// .dockerignore. Writing a vacuous one there would therefore disable the
+// project's excludes — shipping, for a Swift project, a multi-gigabyte .build
+// directory into the build context and then into the image.
+func TestCompileStagefile_NoIgnoreFileWhenContextRootIsCopied(t *testing.T) {
+	dir := t.TempDir()
+	source := "version: 1\nstages:\n  - name: app\n    from: debian:12\n    workdir: /app\n" +
+		"    copy:\n      - from: local\n        paths: [.]\n        dest: /app/\n"
+	mustWrite(t, filepath.Join(dir, "build.stagefile.yaml"), source)
+	mustWrite(t, filepath.Join(dir, "build.stagefile.lock.yaml"),
+		"version: 1\nsourceHash: sha256:irrelevant\nimages:\n  debian:12: sha256:fakepindigest\n")
+	// The project's own excludes, which must remain the ones in effect.
+	mustWrite(t, filepath.Join(dir, ".dockerignore"), ".build/\n")
+
+	// A sidecar left by an earlier build must not survive: absence is what puts
+	// the project's .dockerignore back in charge, so a stale file is as bad as
+	// writing a new one.
+	stale := filepath.Join(dir, generatedDockerignoreName)
+	mustWrite(t, stale, "*\n!.\n!./\n!./**\n")
+
+	if _, err := compileStagefile(dir, ""); err != nil {
+		t.Fatalf("compileStagefile: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		b, _ := os.ReadFile(stale)
+		t.Fatalf("%s should not exist for a whole-context copy; stat err = %v, content:\n%s",
+			generatedDockerignoreName, err, b)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, ".dockerignore")); err != nil || string(b) != ".build/\n" {
+		t.Fatalf("the project .dockerignore must be left alone: %q, err = %v", b, err)
+	}
+}
+
+// The narrow case still gets its allowlist: only a whole-context copy suppresses it.
+func TestCompileStagefile_WritesIgnoreFileForNamedPaths(t *testing.T) {
+	dir := t.TempDir()
+	source := "version: 1\nstages:\n  - name: app\n    from: debian:12\n" +
+		"    copy:\n      - from: local\n        paths: [main.py]\n"
+	mustWrite(t, filepath.Join(dir, "build.stagefile.yaml"), source)
+	mustWrite(t, filepath.Join(dir, "build.stagefile.lock.yaml"),
+		"version: 1\nsourceHash: sha256:irrelevant\nimages:\n  debian:12: sha256:fakepindigest\n")
+
+	if _, err := compileStagefile(dir, ""); err != nil {
+		t.Fatalf("compileStagefile: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, generatedDockerignoreName))
+	if err != nil {
+		t.Fatalf("expected an allowlist for a named path: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "*\n") || !strings.Contains(string(b), "!main.py") {
+		t.Fatalf("unexpected allowlist:\n%s", b)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/internal/stagefile/buildprofile_test.go
+++ b/go/internal/stagefile/buildprofile_test.go
@@ -38,10 +38,12 @@ stages:
 	if err != nil {
 		t.Fatalf("compileFile: %v", err)
 	}
-	if !strings.Contains(dockerfile, "swift build -c debug") {
+	// Matched on the profile flag alone: a Swift build carries --scratch-path
+	// and --cache-path between the command and its configuration.
+	if !strings.Contains(dockerfile, "-c debug") {
 		t.Errorf("swift stage not switched to debug:\n%s", dockerfile)
 	}
-	if strings.Contains(dockerfile, "swift build -c release") {
+	if strings.Contains(dockerfile, "-c release") {
 		t.Errorf("swift stage still builds release:\n%s", dockerfile)
 	}
 	if strings.Contains(dockerfile, "cargo build --release") {
@@ -63,7 +65,7 @@ stages:
 	if err != nil {
 		t.Fatalf("compileFile: %v", err)
 	}
-	if !strings.Contains(dockerfile, "swift build -c release") {
+	if !strings.Contains(dockerfile, "-c release") {
 		t.Fatalf("want a release build by default:\n%s", dockerfile)
 	}
 }

--- a/go/internal/stagefile/codegen/cachescope_test.go
+++ b/go/internal/stagefile/codegen/cachescope_test.go
@@ -104,6 +104,99 @@ func TestPipCacheIDSharesWhenContentCanBeShared(t *testing.T) {
 	}
 }
 
+// swiftStage is a Swift build stage at the given toolchain and profile.
+func swiftStage(from, profile string) spec.Stage {
+	return spec.Stage{Name: "app", From: from, Workdir: "/app",
+		Build: &spec.Build{Lang: "swift", Profile: profile}}
+}
+
+// genScoped is gen with a cache scope, standing in for CompileFile passing the
+// project directory.
+func genScoped(t *testing.T, scope, platform string, s spec.Stage) string {
+	t.Helper()
+	out, err := Generate(&spec.File{Version: 1, Stages: []spec.Stage{s}},
+		map[string]string{s.From: "sha256:abc123"}, nil, platform, nil, WithCacheScope(scope))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	return out
+}
+
+// scratchID returns the id of the mount targeting the Swift build tree.
+func scratchID(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "target="+swiftScratchPath) {
+			continue
+		}
+		_, after, _ := strings.Cut(line, "id=")
+		id, _, _ := strings.Cut(after, ",")
+		return id
+	}
+	t.Fatalf("no scratch mount in:\n%s", out)
+	return ""
+}
+
+// The Swift build tree is the one compiler cache here holding object files
+// rather than self-describing downloads, so two projects sharing it would take
+// turns invalidating each other — and, being sharing=locked, queue to do it.
+func TestSwiftScratchCacheIDSeparatesProjects(t *testing.T) {
+	s := swiftStage("swift:6.1", "")
+	a := scratchID(t, genScoped(t, "/home/dev/alpha", "linux/arm64", s))
+	b := scratchID(t, genScoped(t, "/home/dev/beta", "linux/arm64", s))
+	if a == b {
+		t.Fatalf("two projects share one Swift build tree (id %q)", a)
+	}
+}
+
+// The same project rebuilding must land on the same tree, or the cache buys
+// nothing at all — this is the case the mount exists for.
+func TestSwiftScratchCacheIDIsStableAcrossRebuilds(t *testing.T) {
+	s := swiftStage("swift:6.1", "")
+	a := scratchID(t, genScoped(t, "/home/dev/alpha", "linux/arm64", s))
+	b := scratchID(t, genScoped(t, "/home/dev/alpha", "linux/arm64", s))
+	if a != b {
+		t.Fatalf("same project got two build trees: %q vs %q", a, b)
+	}
+}
+
+// Object files are per-architecture, per-toolchain and per-profile. Mixing any
+// of the three in one tree means SwiftPM discards it and rebuilds.
+func TestSwiftScratchCacheIDSeparatesBuildInputs(t *testing.T) {
+	const scope = "/home/dev/alpha"
+	base := scratchID(t, genScoped(t, scope, "linux/arm64", swiftStage("swift:6.1", "release")))
+	for _, c := range []struct {
+		name string
+		id   string
+	}{
+		{"platform", scratchID(t, genScoped(t, scope, "linux/amd64", swiftStage("swift:6.1", "release")))},
+		{"toolchain", scratchID(t, genScoped(t, scope, "linux/arm64", swiftStage("swift:6.2", "release")))},
+		{"profile", scratchID(t, genScoped(t, scope, "linux/arm64", swiftStage("swift:6.1", "debug")))},
+	} {
+		if c.id == base {
+			t.Errorf("a different %s shares the build tree (id %q)", c.name, base)
+		}
+	}
+}
+
+// SwiftPM's shared cache is scoped the other way on purpose: it holds bare
+// clones keyed by repository URL, so two projects depending on swift-nio should
+// share the one clone rather than each fetching it.
+func TestSwiftPMCacheIsSharedAcrossProjects(t *testing.T) {
+	s := swiftStage("swift:6.1", "")
+	ids := func(scope string) []string {
+		return mountIDs(t, genScoped(t, scope, "linux/arm64", s))
+	}
+	a, b := ids("/home/dev/alpha"), ids("/home/dev/beta")
+	if len(a) != 2 || len(b) != 2 {
+		t.Fatalf("want a scratch mount and a SwiftPM cache mount, got %v / %v", a, b)
+	}
+	// mountIDs returns them in emission order: scratch first, then the cache.
+	if a[1] != b[1] {
+		t.Fatalf("two projects cannot share SwiftPM's download cache: %q vs %q", a[1], b[1])
+	}
+}
+
 // uv resolves wheels the same way pip does and has the same platform split.
 func TestUvCacheIDSeparatesPlatforms(t *testing.T) {
 	s := spec.Stage{Name: "app", From: "python:3.12-slim", Install: &spec.Install{Uv: &spec.UvInstall{}}}

--- a/go/internal/stagefile/codegen/codegen.go
+++ b/go/internal/stagefile/codegen/codegen.go
@@ -24,6 +24,27 @@ import (
 // /etc/passwd entry, so it works on any base image.
 const defaultUser = "65532"
 
+// Option configures a Generate call.
+type Option func(*options)
+
+type options struct {
+	cacheScope string
+}
+
+// WithCacheScope names the project being built, for the cache-mount ids that
+// must not be shared between projects — currently the Swift build tree, which
+// is the only compiler cache here that holds object files rather than
+// self-describing downloaded artifacts.
+//
+// It is an option rather than a parameter because it is not needed to produce
+// a correct Dockerfile, only an efficient one: without it, projects whose
+// stages agree on toolchain, platform and profile take turns invalidating one
+// build tree. Callers pass something stable and unique per project;
+// CompileFile passes the project directory.
+func WithCacheScope(scope string) Option {
+	return func(o *options) { o.cacheScope = scope }
+}
+
 // Generate compiles f into Dockerfile text. images maps every pinned from:
 // value in f to its resolved "sha256:..." digest, and downloads maps every
 // download url that declared no sha256 of its own to the one resolved for it
@@ -36,7 +57,11 @@ const defaultUser = "65532"
 // for, and is required if any stage declares cuda:. It is passed in rather
 // than looked up here because it is pinned in the lockfile: the compiler must
 // emit what was recorded, not what this binary's table says today.
-func Generate(f *spec.File, images, downloads map[string]string, platform string, cudaProfile *gpu.Profile) (string, error) {
+func Generate(f *spec.File, images, downloads map[string]string, platform string, cudaProfile *gpu.Profile, opts ...Option) (string, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
 	var blocks []string
 	lastIdx := len(f.Stages) - 1
 
@@ -118,7 +143,7 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 		}
 
 		if s.Build != nil {
-			bl, err := buildLines(s.Build)
+			bl, err := buildLines(s.Build, s.From, stagePlatform, o.cacheScope)
 			if err != nil {
 				return "", fmt.Errorf("stage %q: %w", s.Name, err)
 			}
@@ -264,11 +289,39 @@ func cacheRun(dir, cmd string) string {
 // object files that must never meet. An id lets the caller say exactly what
 // may share.
 func cacheRunID(id, dir, cmd string) string {
+	return "RUN " + mountFlag(cacheMount{id: id, target: dir}) + " " + cmd
+}
+
+// cacheMount is one BuildKit cache mount: a target path, and the id that
+// decides which other builds may share it (empty means "scoped by target
+// path", BuildKit's default).
+type cacheMount struct {
+	id     string
+	target string
+}
+
+// mountFlag renders one cache mount's --mount= flag. Every cache mount in the
+// generated Dockerfile is rendered here, so none can be emitted without a
+// sharing mode — see cacheRun for why sharing=locked rather than BuildKit's
+// default.
+func mountFlag(m cacheMount) string {
 	mount := "type=cache,sharing=locked"
-	if id != "" {
-		mount += ",id=" + id
+	if m.id != "" {
+		mount += ",id=" + m.id
 	}
-	return fmt.Sprintf("RUN --mount=%s,target=%s %s", mount, dir, cmd)
+	return fmt.Sprintf("--mount=%s,target=%s", mount, m.target)
+}
+
+// cacheRunMounts is cacheRunID for a step that needs more than one cache
+// mount, which a compiled build usually does: one cache for the dependencies
+// it downloads and a separate one for the object files it produces, because
+// the two are invalidated by completely different things.
+func cacheRunMounts(mounts []cacheMount, cmd string) string {
+	parts := make([]string, 0, len(mounts)+1)
+	for _, m := range mounts {
+		parts = append(parts, mountFlag(m))
+	}
+	return "RUN " + strings.Join(append(parts, cmd), " \\\n    ")
 }
 
 // scopedCacheID hashes the parts that decide whether two builds can share a
@@ -720,7 +773,104 @@ func copyLines(entries []spec.CopyEntry) []string {
 	return lines
 }
 
-func buildLines(b *spec.Build) ([]string, error) {
+// buildLines compiles a stage's build: step. from, platform and scope are not
+// used by every language — they are the inputs that scope a compiler's cache
+// mounts, and only a language whose object files are cached needs them.
+// swiftScratchPath and swiftCachePath are where a Swift stage's build tree and
+// SwiftPM's shared cache live while the stage builds. Both are cache mounts,
+// and neither is the package's own .build — deliberately.
+//
+// Mounting over .build would be the obvious thing and is wrong: a cache mount
+// is not part of any layer, so the product binary would vanish the moment the
+// RUN finished, and every Swift entrypoint naming .build/release/<product>
+// (which is where SwiftPM puts it, and what a hand-written Swift Dockerfile
+// therefore copies from) would point at nothing. Building into a scratch path
+// off to the side leaves .build an ordinary directory that the binary can be
+// installed into, so the cache is invisible to the rest of the Stagefile.
+const (
+	swiftScratchPath = "/var/cache/stagefile/swift/scratch"
+	swiftCachePath   = "/var/cache/stagefile/swift/pm"
+)
+
+// swiftScratchID scopes a Swift build tree to everything that decides which
+// object files belong in it: the toolchain image, the target platform, the
+// compile profile, and the project itself.
+//
+// The project is in the scope even though sharing a tree across projects would
+// not produce a wrong binary — SwiftPM rebuilds what it does not recognise.
+// It would produce the one thing this mount exists to prevent: two projects
+// alternately invalidating each other's tree, and, because the mount stays
+// sharing=locked, queueing to do it. scope is empty when the caller did not
+// name a project, which falls back to sharing per (toolchain, platform,
+// profile) — no worse than having no id at all.
+func swiftScratchID(scope, from, platform, profile string) string {
+	return scopedCacheID("swift-scratch", scope, from, platform, profile)
+}
+
+// swiftCacheID scopes SwiftPM's shared cache to the toolchain and platform,
+// and deliberately not to the project. It holds bare dependency clones keyed
+// by repository URL and compiled manifests keyed by their own contents, so two
+// projects depending on swift-nio genuinely share one clone instead of each
+// fetching it — the same reason the pip cache is scoped by index rather than
+// by project.
+func swiftCacheID(from, platform string) string {
+	return scopedCacheID("swiftpm", from, platform)
+}
+
+// swiftBuildLines compiles a Swift build stage.
+//
+// Two things are cached, because two different things are slow and they are
+// invalidated by different events. The scratch tree holds every object file in
+// the build including all of its dependencies', and is the entire reason a
+// second build is incremental: without it a one-line edit to app code
+// recompiles SwiftNIO from source. The shared cache holds SwiftPM's dependency
+// clones and compiled manifests, so a rebuild also stops re-cloning every
+// package in the graph over the network before it can start compiling.
+//
+// The binary is then installed from the scratch tree into .build/<profile>/,
+// which is what SwiftPM would have written had it built in place. That keeps
+// the cache an implementation detail: an entrypoint written against the
+// conventional path keeps working, and nothing in the Stagefile has to know
+// the build tree moved.
+func swiftBuildLines(b *spec.Build, profile, from, platform, scope string) []string {
+	// Always spell the configuration out. Bare `swift build` already means
+	// debug, so an implicit debug build is indistinguishable from someone
+	// having forgotten the flag — both in the generated Dockerfile and to the
+	// optimizer check that scans for it.
+	flags := "--scratch-path " + swiftScratchPath +
+		" --cache-path " + swiftCachePath +
+		" -c " + profile
+	build := "swift build " + flags
+	if b.Product != "" {
+		build += " --product " + shellQuote(b.Product)
+	}
+
+	dest := ".build/" + profile
+	commands := []string{
+		build,
+		// The bin path is asked of SwiftPM rather than assembled from profile:
+		// the real directory carries the target triple, so composing it here
+		// would mean hardcoding a per-architecture guess that breaks quietly
+		// the first time it is wrong. --product is omitted because the path is
+		// the same for every product in the package.
+		`BIN="$(swift build ` + flags + ` --show-bin-path)"`,
+		"mkdir -p " + dest,
+		// Only the top level, and only files and resource bundles. The
+		// per-target *.build/ directories sitting beside them hold the object
+		// files, which belong in the cache mount and would otherwise be copied
+		// into the image — several hundred megabytes of build intermediates in
+		// a layer, for nothing.
+		`find "$BIN" -mindepth 1 -maxdepth 1 \( -type f -o -name '*.bundle' \) ` +
+			`-exec cp -a '{}' ` + dest + `/ ';'`,
+	}
+	mounts := []cacheMount{
+		{id: swiftScratchID(scope, from, platform, profile), target: swiftScratchPath},
+		{id: swiftCacheID(from, platform), target: swiftCachePath},
+	}
+	return []string{cacheRunMounts(mounts, strings.Join(commands, " \\\n    && "))}
+}
+
+func buildLines(b *spec.Build, from, platform, scope string) ([]string, error) {
 	profile := b.Profile
 	if profile == "" {
 		profile = "release"
@@ -744,15 +894,7 @@ func buildLines(b *spec.Build) ([]string, error) {
 		}
 		return []string{cacheRun("/root/.cache/go-build", "go build ./...")}, nil
 	case "swift":
-		// Always spell the configuration out. Bare `swift build` already means
-		// debug, so an implicit debug build is indistinguishable from someone
-		// having forgotten the flag — both in the generated Dockerfile and to the
-		// optimizer check that scans for it.
-		cmd := "swift build -c " + profile
-		if b.Product != "" {
-			cmd += " --product " + shellQuote(b.Product)
-		}
-		return []string{cacheRun("/root/.swiftpm", cmd)}, nil
+		return swiftBuildLines(b, profile, from, platform, scope), nil
 	case "npm", "yarn", "pnpm":
 		script := b.Script
 		if script == "" {

--- a/go/internal/stagefile/codegen/codegen_newfields_test.go
+++ b/go/internal/stagefile/codegen/codegen_newfields_test.go
@@ -180,7 +180,7 @@ func TestGenerateBuildProducts(t *testing.T) {
 		build *spec.Build
 		want  string
 	}{
-		{&spec.Build{Lang: "swift", Product: "camserver"}, "swift build -c release --product 'camserver'"},
+		{&spec.Build{Lang: "swift", Product: "camserver"}, "-c release --product 'camserver'"},
 		{&spec.Build{Lang: "rust", Product: "serve"}, "cargo build --release --bin 'serve'"},
 		{&spec.Build{Lang: "go", Product: "./cmd/serve"}, "go build -o /usr/local/bin/ './cmd/serve'"},
 		{&spec.Build{Lang: "npm"}, "RUN --mount=type=cache,sharing=locked,target=/root/.npm npm run 'build'"},

--- a/go/internal/stagefile/codegen/codegen_test.go
+++ b/go/internal/stagefile/codegen/codegen_test.go
@@ -394,11 +394,24 @@ func TestGenerateBuildSwiftReleaseByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	want := "FROM swift:6.0@sha256:abc123 AS app\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.swiftpm swift build -c release\n" +
-		"USER 65532\n"
-	if out != want {
-		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
+	// The build runs against a scratch path on a cache mount and then installs
+	// the product into .build/release, which is where SwiftPM would have put it
+	// had it built in place — so an entrypoint naming that path still resolves
+	// even though the tree it was compiled in never enters the image.
+	for _, want := range []string{
+		"swift build --scratch-path " + swiftScratchPath + " --cache-path " + swiftCachePath + " -c release",
+		"target=" + swiftScratchPath,
+		"target=" + swiftCachePath,
+		"mkdir -p .build/release",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// The old cache location. It held SwiftPM's *configuration*, not its build
+	// tree or its shared cache, so caching it sped up nothing at all.
+	if strings.Contains(out, "/root/.swiftpm") {
+		t.Errorf("still caching /root/.swiftpm, which holds no build output:\n%s", out)
 	}
 }
 
@@ -415,11 +428,16 @@ func TestGenerateBuildSwiftDebugIsExplicit(t *testing.T) {
 	// -c debug is spelled out rather than left implicit: bare `swift build`
 	// already means debug, so omitting the flag is indistinguishable from
 	// having forgotten it.
-	want := "FROM swift:6.0@sha256:abc123 AS app\n" +
-		"RUN --mount=type=cache,sharing=locked,target=/root/.swiftpm swift build -c debug\n" +
-		"USER 65532\n"
-	if out != want {
-		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
+	if !strings.Contains(out, " -c debug") {
+		t.Errorf("missing an explicit -c debug in:\n%s", out)
+	}
+	if strings.Contains(out, "-c release") {
+		t.Errorf("debug profile still compiled -c release:\n%s", out)
+	}
+	// The install destination follows the profile, or a debug build would
+	// deposit its binary where a release entrypoint looks for it.
+	if !strings.Contains(out, "mkdir -p .build/debug") {
+		t.Errorf("debug build does not install into .build/debug:\n%s", out)
 	}
 }
 
@@ -511,17 +529,27 @@ func TestGenerateLocksEveryCacheMount(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 
-	mounts := 0
 	for _, line := range strings.Split(out, "\n") {
 		if !strings.Contains(line, "type=cache") {
 			continue
 		}
-		mounts++
 		if !strings.Contains(line, "sharing=locked") {
 			t.Errorf("cache mount without an explicit sharing mode (defaults to shared):\n%s", line)
 		}
 	}
-	if mounts != len(f.Stages) {
-		t.Fatalf("found %d cache mounts, want one per stage (%d)", mounts, len(f.Stages))
+
+	// Every stage above declares something cache-mounted, so a stage with no
+	// mount at all means a primitive lost its cache rather than its sharing
+	// mode. Counted per stage rather than in total because a single stage may
+	// legitimately declare several — a Swift build mounts its object tree and
+	// SwiftPM's download cache separately.
+	blocks := strings.Split(strings.TrimSpace(out), "\n\n")
+	if len(blocks) != len(f.Stages) {
+		t.Fatalf("got %d stage blocks, want %d", len(blocks), len(f.Stages))
+	}
+	for i, block := range blocks {
+		if !strings.Contains(block, "type=cache") {
+			t.Errorf("stage %q emits no cache mount:\n%s", f.Stages[i].Name, block)
+		}
 	}
 }

--- a/go/internal/stagefile/dockerignore/dockerignore.go
+++ b/go/internal/stagefile/dockerignore/dockerignore.go
@@ -5,6 +5,7 @@
 package dockerignore
 
 import (
+	"path"
 	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
@@ -37,9 +38,40 @@ func LocalPaths(f *spec.File) []string {
 	return paths
 }
 
-// Derive returns .dockerignore content that denies everything except the
-// given paths.
+// isContextRoot reports whether a declared copy path is the build context
+// itself — `.`, `./`, `/`, or any spelling that cleans to one of those.
+//
+// Such a path defeats the allowlist rather than narrowing it. `copy: {paths:
+// [.]}` would compile to `*` followed by `!.` and `!./**`, and BuildKit cleans
+// `./**` to `**`, so the deny-all is undone on the next line and nothing is
+// ignored at all. A repo whose .dockerignore excludes a 4 GB .build directory
+// would ship it anyway, and COPY it into the image.
+//
+// There is also nothing to derive here: a stage that copies the whole context
+// has already said "everything", so the only ignore rules that can be right are
+// the project's own.
+func isContextRoot(raw string) bool {
+	switch path.Clean(raw) {
+	case ".", "/", "..":
+		return true
+	}
+	return false
+}
+
+// Derive returns .dockerignore content that denies everything except the given
+// paths, or "" when no allowlist can be expressed — see isContextRoot.
+//
+// "" means "write no ignore file", not "ignore nothing". The distinction
+// matters because BuildKit prefers <dockerfile>.dockerignore over
+// .dockerignore: a generated file always wins, so emitting one that ignores
+// nothing silently disables the project's own .dockerignore, while emitting
+// none leaves it in charge.
 func Derive(paths []string) string {
+	for _, raw := range paths {
+		if isContextRoot(raw) {
+			return ""
+		}
+	}
 	lines := []string{"*"}
 	seen := map[string]bool{}
 	add := func(p string) {

--- a/go/internal/stagefile/dockerignore/dockerignore.go
+++ b/go/internal/stagefile/dockerignore/dockerignore.go
@@ -52,7 +52,7 @@ func LocalPaths(f *spec.File) []string {
 // the project's own.
 func isContextRoot(raw string) bool {
 	switch path.Clean(raw) {
-	case ".", "/", "..":
+	case ".", "/":
 		return true
 	}
 	return false

--- a/go/internal/stagefile/dockerignore/dockerignore_test.go
+++ b/go/internal/stagefile/dockerignore/dockerignore_test.go
@@ -139,3 +139,33 @@ func TestLocalPathsIncludesYarnLockForYarnManager(t *testing.T) {
 		t.Fatalf("got %+v, want %+v", got, want)
 	}
 }
+
+// A stage that copies the whole context cannot be narrowed by an allowlist, and
+// the naive attempt is actively harmful: `*` then `!./**` cleans to `*` then
+// `!**`, which ignores nothing. Because BuildKit prefers
+// <dockerfile>.dockerignore over .dockerignore, emitting that would silently
+// override the project's own denylist — so a repo excluding a multi-gigabyte
+// .build directory would ship it. "" means "write no file", leaving the
+// project's .dockerignore in charge.
+func TestDeriveWritesNothingForTheContextRoot(t *testing.T) {
+	for _, p := range []string{".", "./", "/", "././."} {
+		if got := Derive([]string{p}); got != "" {
+			t.Errorf("Derive([%q]) = %q, want \"\" (no ignore file)", p, got)
+		}
+	}
+}
+
+// The root poisons the whole allowlist, not just its own entry: once everything
+// is re-included, the narrower entries alongside it cannot take anything back.
+func TestDeriveContextRootPoisonsOtherPaths(t *testing.T) {
+	if got := Derive([]string{"requirements.txt", "."}); got != "" {
+		t.Errorf("Derive with a root path among others = %q, want \"\"", got)
+	}
+}
+
+// The ordinary case must keep denying everything it did before.
+func TestDeriveStillAllowlistsNormalPaths(t *testing.T) {
+	if got := Derive([]string{"Sources"}); got != "*\n!Sources\n!Sources/\n!Sources/**\n" {
+		t.Errorf("normal allowlist regressed: %q", got)
+	}
+}

--- a/go/internal/stagefile/spec/validate.go
+++ b/go/internal/stagefile/spec/validate.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
 	"unicode"
@@ -60,6 +61,9 @@ func (f *File) Validate() error {
 			return fmt.Errorf("stage %q: %w", s.Name, err)
 		}
 		if err := validateBuild(s.Build); err != nil {
+			return fmt.Errorf("stage %q: %w", s.Name, err)
+		}
+		if err := validateBuildWorkdir(&s); err != nil {
 			return fmt.Errorf("stage %q: %w", s.Name, err)
 		}
 		if err := validateHealthcheck(s.Healthcheck); err != nil {
@@ -510,6 +514,54 @@ func validateCopy(entries []CopyEntry, priorNames map[string]bool) error {
 		}
 	}
 	return nil
+}
+
+// validateBuildWorkdir rejects a build stage that copies its source somewhere
+// the build will not run.
+//
+// The compiler emits no cd of its own: a build stage's RUN executes in the
+// stage's workdir, and a stage without one has no WORKDIR at all, so the build
+// runs in /. `copy: {dest: /app/}` with no `workdir:` therefore compiles to a
+// build launched in an empty directory, which fails inside the container with
+// the build tool's own "no manifest here" message — several minutes into a
+// build, naming a path nothing in the Stagefile mentions.
+//
+// The rule is deliberately narrow: only a stage where *every* local copy lands
+// at an absolute path other than / is rejected. Building at / is legal, and a
+// stage that means it puts something there (a copy with no dest lands in the
+// workdir, whatever it is), so a stage doing that on purpose has at least one
+// copy this accepts.
+func validateBuildWorkdir(s *Stage) error {
+	if s.Build == nil || s.Workdir != "" || len(s.Copy) == 0 {
+		return nil
+	}
+	var dests []string
+	for _, e := range s.Copy {
+		if e.From != "local" {
+			continue
+		}
+		dest := e.Dest
+		if dest == "" {
+			// No dest means the path keeps its own name, relative to the
+			// workdir — so the source does land where the build will run.
+			return nil
+		}
+		if !strings.HasPrefix(dest, "/") {
+			// Likewise relative to the workdir.
+			return nil
+		}
+		if path.Clean(dest) == "/" {
+			return nil
+		}
+		dests = append(dests, dest)
+	}
+	if len(dests) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"build runs in the stage's workdir, but this stage declares no workdir (so the build runs in /) "+
+			"while its source is copied to %s — add `workdir: %s`",
+		strings.Join(dests, ", "), path.Clean(dests[0]))
 }
 
 func validateBuild(b *Build) error {

--- a/go/internal/stagefile/spec/validate_newfields_test.go
+++ b/go/internal/stagefile/spec/validate_newfields_test.go
@@ -106,3 +106,45 @@ func TestValidateEntrypointSourceNoNewline(t *testing.T) {
 		Exec: []string{"ros2"}, Source: "/opt\n/evil",
 	}}), "newline")
 }
+
+// A build stage runs its RUN in the stage's workdir, and a stage without one
+// has no WORKDIR at all — so source copied to /app with no `workdir: /app`
+// compiles to a build launched in an empty /. That failed inside the container,
+// minutes in, with the build tool's own "no manifest here" error.
+func TestValidateBuildWithoutWorkdirWhereSourceLands(t *testing.T) {
+	build := &Build{Lang: "swift", Product: "app"}
+	copyTo := func(dest string) []CopyEntry {
+		return []CopyEntry{{From: "local", Paths: []string{"."}, Dest: dest}}
+	}
+
+	err := oneStage(Stage{Name: "app", From: "swift:6.1", Build: build, Copy: copyTo("/app/")}).Validate()
+	if err == nil {
+		t.Fatal("a build stage with source at /app and no workdir must not validate")
+	}
+	// The message has to name the fix: the failure it replaces gave no hint
+	// that a missing workdir was the cause.
+	for _, want := range []string{"workdir: /app", "/app/"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+
+	// With the workdir declared, the same stage is fine.
+	if err := oneStage(Stage{Name: "app", From: "swift:6.1", Workdir: "/app",
+		Build: build, Copy: copyTo("/app/")}).Validate(); err != nil {
+		t.Fatalf("workdir matching the copy dest must validate: %v", err)
+	}
+
+	// Building at / is legal, and a stage that means it lands source there.
+	for _, dest := range []string{"/", ""} {
+		if err := oneStage(Stage{Name: "app", From: "swift:6.1",
+			Build: build, Copy: copyTo(dest)}).Validate(); err != nil {
+			t.Errorf("copy dest %q with no workdir must validate: %v", dest, err)
+		}
+	}
+
+	// A stage with no build: has nothing to run in the wrong place.
+	if err := oneStage(Stage{Name: "app", From: "swift:6.1", Copy: copyTo("/app/")}).Validate(); err != nil {
+		t.Fatalf("a stage without build: must validate: %v", err)
+	}
+}

--- a/go/internal/stagefile/stagefile.go
+++ b/go/internal/stagefile/stagefile.go
@@ -213,7 +213,18 @@ func compileFile(dir, platform, gpuArch, buildProfile string, resolver lock.Reso
 		return "", "", err
 	}
 
-	dockerfile, err = codegen.Generate(f, updated.Images, updated.Downloads, platform, cudaProfile)
+	// The project directory is the cache scope: it is what makes two different
+	// projects' compiler caches distinct, and it is stable across the rebuilds
+	// of one project that the caches exist to speed up. An absolute path means
+	// moving a checkout starts from a cold cache, which is the right trade —
+	// the alternative keys are either not unique per project or not stable
+	// across an edit.
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = dir
+	}
+	dockerfile, err = codegen.Generate(f, updated.Images, updated.Downloads, platform, cudaProfile,
+		codegen.WithCacheScope(absDir))
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
The Stagefile Swift path had never been run end to end — there are no Swift stagefiles in `Examples/`, so nothing covered it. Trying to deploy a real Swift project through it surfaced three defects.

## 1. The build cached the wrong directory

`build: lang: swift` mounted a cache at `/root/.swiftpm`. That holds SwiftPM *configuration*, and it does not even exist in `swift:6.3-noble` — so nothing that makes a build incremental was cached, and every container build recompiled the entire dependency graph. Go got this right (`/root/.cache/go-build`); Swift didn't.

Now two mounts, scoped separately because they are invalidated by different things: the scratch tree (every object file, dependencies included) and SwiftPM's shared cache (dependency clones, compiled manifests).

The scratch tree is deliberately **not** mounted over the package's `.build`. That would be the obvious thing and it is wrong: a cache mount never enters a layer, so the product binary would vanish when the `RUN` finished, breaking every entrypoint that names `.build/<profile>/<product>` — which is where SwiftPM puts it, and therefore what a hand-written Swift Dockerfile copies from. It builds into a path off to the side and installs the binary back to the conventional location, so the cache stays invisible to the rest of the Stagefile.

Measured on a real project (`swift-mujoco`, product `go2-observe`, warm cache, one-line source edit):

| | cold build step | one-line-edit rebuild |
|---|---|---|
| before | 45.8s | 48.9s |
| after | 54.0s | **12.6s** |

Before this, incremental builds did not exist — a one-line edit cost the same as a cold build. Cold builds pay ~8s more to populate the mounts, the standard trade cargo and go builds already make here.

## 2. A build stage with no `workdir` failed minutes in

A stage's `RUN` executes in its workdir, and a stage declaring none gets no `WORKDIR` at all. So `copy: {dest: /app/}` without `workdir: /app` compiled to a build launched in an empty `/`, dying with:

```
error: Could not find Package.swift in this directory or any of its parent directories.
```

— several minutes into a build, naming a path nothing in the Stagefile mentions. Now a compile-time error that names the fix. The rule is narrow: only a stage where *every* local copy lands at an absolute path other than `/` is rejected, so building at `/` on purpose still validates.

## 3. The derived `.dockerignore` silently replaced the project's

BuildKit prefers `<dockerfile>.dockerignore` over `.dockerignore`, so the generated file always wins. `Derive(["."])` emitted:

```
*
!.
!./
!./**
```

BuildKit cleans `./**` to `**`, so the deny-all is undone on the very next line and **nothing is ignored**. The project's `.dockerignore` was not deleted — it was simply never consulted, replaced by one that excludes nothing. A Swift project whose `.dockerignore` excludes a multi-gigabyte `.build` directory shipped it anyway, into the context and then into an image layer.

Verified on a controlled 120 MB context:

| | context transferred | in image |
|---|---|---|
| project `.dockerignore` alone | 270 B | 16 KB |
| + derived sidecar | 125.86 MB | 120 MB |
| after fix | **161 B** | **16 KB** |

`paths: [.]` has no allowlist to derive — it already says "everything" — so `Derive` returns `""` for any path that cleans to the context root, and the writer *removes* the sidecar rather than writing a vacuous one, leaving the project's `.dockerignore` in charge. Absence is what restores it, so a stale sidecar from an earlier build is removed too. Named-path allowlists are unchanged.

## Testing

- `internal/stagefile/...` and `internal/cli/...` pass; `gofmt` and `go vet` clean.
- New coverage: Swift cache-mount scoping (per project / toolchain / platform / profile, and that SwiftPM's download cache is deliberately *shared* across projects), the workdir validation, and both ignore-file behaviours including stale-sidecar removal.
- End to end: the compiled Dockerfile builds and the binary it produces starts under the slim runtime image on `linux/arm64`.
- **Not** verified on hardware.

## Note for reviewers

`codegen.Generate` gained a variadic `Option` so existing call sites are untouched; `WithCacheScope` carries the project directory from `CompileFile`. It matters for correctness of *sharing*, not of output: without it, projects agreeing on stage name, product and base image would take turns invalidating one build tree, and — being `sharing=locked` — queue to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoWP9HgAQfu42jmVFPQuqp
