### PR TITLE
docs: move shipped work onto the roadmap, and correct three stale gates

### DIFF
--- a/go/internal/cli/assets/docs/roadmap.md
+++ b/go/internal/cli/assets/docs/roadmap.md
@@ -2,33 +2,40 @@
 
 This page mirrors the current public roadmap language for engineering and docs references.
 
-## Imminent
-
-- **Jetson AGX Orin support**: WendyOS support for production robotics, vision, and physical AI workloads is imminent.
-- **Cloud fleet management**: fleet deploy, manage, and debug workflows are being worked on and are imminent.
-- **PKI / cloud release** — _planned, target **2026-06-19**, not yet shipped_ ([WDY-1226](https://linear.app/wendylabsinc/issue/WDY-1226)): public-key infrastructure backing device-to-cloud auth is tested locally; remaining work is the GCP deployment, supporting marketing assets, and cloud documentation. The logging/telemetry demo ([WDY-1231](https://linear.app/wendylabsinc/issue/WDY-1231)) is sequenced against the same date.
-
 ## In Progress
 
-- **Jetson AGX Thor support**: WendyOS support for AGX Thor-class physical AI workloads.
-- **MLX Swift support**: MLX Swift integration for unified-memory AI workloads.
-- **Companion SDK** — _planned release **2026-07-03**, not yet shipped_ ([WDY-1235](https://linear.app/wendylabsinc/issue/WDY-1235)): the companion SDK and its associated applications are demoable today but still need polish for an official release. The launch is sequenced one week after the Pipecat Agent template refresh ([WDY-1228](https://linear.app/wendylabsinc/issue/WDY-1228)) to avoid overlapping marketing pushes.
-- **MLX LLM in a local container** — _planned, not yet shipped_ ([WDY-1229](https://linear.app/wendylabsinc/issue/WDY-1229)): MLX currently compiles as a Swift package; remaining work is Wendy-ecosystem integration plus Dockerfiles for Linux compilation, building toward a containerised demo of MLX LLM.
+- **MLX Swift support**: MLX Swift integration for unified-memory AI workloads. The containerised MLX LLM demo has landed (see Shipped); the remaining work is first-class MLX Swift integration in the Wendy ecosystem.
+- **Companion SDK** — _not yet shipped_ ([WDY-1235](https://linear.app/wendylabsinc/issue/WDY-1235)): the companion SDK and its associated applications are demoable today but still need polish for an official release. The original 2026-07-03 target and its sequencing behind the Pipecat Agent template refresh have both lapsed — the Pipecat refresh ([WDY-1228](https://linear.app/wendylabsinc/issue/WDY-1228)) shipped, so the launch is no longer gated on it and needs a new date.
 
 ## Available Beta
 
-- **Headless Mac**: deploy native macOS apps to Apple Silicon Mac targets with [Headless Mac](/docs/installation/wendy-agent-macos). Beta limitations are documented in the macOS install guide.
+- **Wendy Cloud** — _beta_: fleet management over the internet. Devices enroll once, dial home to the cloud broker over mutual TLS, and are reachable by name from anywhere via `wendy cloud` and `wendy fleet` — enroll, discover, deploy, tunnel, stream telemetry. See [Cloud](/docs/cloud).
+- **Headless Mac** — _beta_: deploy native macOS apps to Apple Silicon Mac targets with [Headless Mac](/docs/installation/wendy-agent-macos). Apple Silicon only. Since the initial beta it has gained remote agent self-update, a LAN registry served over mTLS, app supervision and restart parity across agent restarts, and native gamepad entitlements. Beta limitations are documented in the macOS install guide.
+
+## Available Preview
+
+- **Jetson AGX Thor** — _preview_: WendyOS support for AGX Thor-class physical AI workloads, including the dedicated USB-recovery flash path that writes QSPI and internal NVMe directly. Install, deploy, GPU, and camera all work; see the [AGX Thor install guide](/docs/installation/wendyos-nvidia-jetson-agx-thor).
+- **Wendy Lite** — _preview_: WASM runtime for microcontrollers. Deploy Swift, Rust, C, or Zig apps to ESP32-C6 and ESP32-C5 with the same CLI workflow. Host APIs cover GPIO, I2C, SPI, UART, RMT, NeoPixel, timers, storage, BLE, WiFi, sockets, TLS, USB, and OTel. Camera and display peripherals are not exposed to WASM guests. See [Wendy Lite](/docs/advanced/wendy-lite).
 
 ## Shipped
 
+- **Jetson AGX Orin support**: stable — install, deploy, GPU, and camera.
+- **Jetson Orin Nano support**: stable.
+- **Raspberry Pi 3, 4, and 5 support** (8GB Pi 5 recommended).
 - **Windows support** for the Wendy CLI and VS Code deployment flow.
-- **Jetson Orin Nano support**.
-- **Raspberry Pi 3, 4, and 5 support**. Continuous-integration coverage for the Raspberry Pi 3 and Pi 4 boards is currently being re-instrumented — physical hardware needs to be sourced and brought back online before automated regression coverage resumes. See [WDY-1230](https://linear.app/wendylabsinc/issue/WDY-1230) for the CI re-onboarding work.
+- **Zero-trust PKI, deployed to GCP** ([WDY-1226](https://linear.app/wendylabsinc/issue/WDY-1226)): the public-key infrastructure backing device-to-cloud auth is deployed, with CI auto-deploy from main. Every cloud connection is mutually authenticated. See [PKI](/docs/advanced/pki).
+- **Stagefile build descriptors**: `build.stagefile.yaml` is now a first-class build input alongside Dockerfiles and compose files, with parallel compilation, CUDA stages resolved from the device's GPU architecture, pinned source installs, and cache scoping. The bundled example apps have been converted to it.
+- **ROS 2 support**: standard upstream ROS 2 in stock containers with a selectable middleware (CycloneDDS, Fast DDS, RTI Connext, GurumDDS), plus `wendy device ros2` for remote nodes, topics, services, parameters, actions, lifecycle nodes, and rosbags. See [Robotics](/docs/integrations) and the [Foxglove integration](/docs/integrations/foxglove).
+- **Swift on the device**: Swift app templates, tutorials, cross-compilation, and remote Swift debugging, plus native Swift apps on macOS targets.
+- **Unitree G1 support**: agent install and reflash guides for the G1.
+- **Network (IP) cameras**: a third camera transport alongside USB and CSI, with camera discovery, a credential store, and a picker.
 - **Python debugging** from the VS Code extension.
 - **Local OS updates** without requiring a full system flash.
+- **MLX LLM in a local container** ([WDY-1229](https://linear.app/wendylabsinc/issue/WDY-1229)): a working containerised MLX LLM demo, backed by an upstream MLX segfault fix. The demo container is not size-optimised — it ships Ubuntu 24, the CUDA toolkit, and the Swift toolchain, because MLX compiles CUDA just-in-time.
 
 ## Planned
 
 - **RISC-V support**.
 - **3D geospatial digital twin** targeted for Q3.
-- **Wendy Swift initiative** — _planned, separate release track, not yet shipped_: Swift support is being developed as a separate initiative from the primary release cycle so that its launch is not diluted by adjacent releases. Target window is approximately one week after the Pipecat Agent template refresh ([WDY-1228](https://linear.app/wendylabsinc/issue/WDY-1228)).
+- **Logging and telemetry demo** — _planned, not yet started_ ([WDY-1231](https://linear.app/wendylabsinc/issue/WDY-1231)): a demo showcasing remote hardware debugging through logging and telemetry. It was originally sequenced against the PKI release, which has since shipped; the demo is still in the backlog.
+- **Wendy Swift initiative** — _separate release track_: the Swift toolchain, templates, and debugging support have shipped (see Shipped). The remaining work is the coordinated launch, which is deliberately kept on its own track so it is not diluted by adjacent releases. The original sequencing behind the Pipecat Agent template refresh no longer applies — that work shipped.


### PR DESCRIPTION
## Why

`docs/roadmap.md` was last updated on 2026-06-28 and had drifted from both the docs site and Linear. Several things listed as "imminent" or "not yet shipped" have shipped; a few things listed as in-flight were closed or canceled.

Every change below is backed by a source — the README platform table, a docs page, or the Linear issue the roadmap itself cites — rather than inferred from commit history.

## Moved to Shipped

| Item | Was | Evidence |
|---|---|---|
| Jetson AGX Orin | Imminent | README platform table: Stable across install/deploy/GPU/camera |
| Zero-trust PKI on GCP | Imminent, target 2026-06-19, "not yet shipped" | [WDY-1226](https://linear.app/wendylabsinc/issue/WDY-1226) **Done** — deployed, CI auto-deploy from main; `docs/pki/` exists |
| MLX LLM in a local container | In Progress, "not yet shipped" | [WDY-1229](https://linear.app/wendylabsinc/issue/WDY-1229) **Done** — working demo, upstream MLX segfault fix merged |

Also added, none of which the roadmap tracked at all: Stagefile build descriptors, ROS 2 + Foxglove, Swift on device, Unitree G1, and network (IP) cameras.

For MLX I kept Gabriele's caveat from the issue — the demo container is not size-optimised, since MLX compiles CUDA just-in-time and the toolchain cannot be stripped.

## Status changes

- **Wendy Cloud** — "cloud fleet management … imminent" becomes an Available Beta entry, matching the Beta badge on the docs overview. `wendy cloud` and `wendy fleet` both ship.
- **New Available Preview section** for **Jetson AGX Thor** (was In Progress) and **Wendy Lite** (absent entirely), matching the README's `Preview` status and the docs overview badge.
- **Logging/telemetry demo** ([WDY-1231](https://linear.app/wendylabsinc/issue/WDY-1231)) pulled out of the PKI bullet into its own Planned entry — it is still Backlog, and its sequencing against the PKI date is moot now that PKI shipped.

## Corrected rather than shipped

Two entries looked shippable but are not, so I flagged them instead:

- **Raspberry Pi** — the bullet cited [WDY-1230](https://linear.app/wendylabsinc/issue/WDY-1230) for in-flight Pi 3/4 CI re-instrumentation. That issue is **Canceled**, so the sentence is dropped. The docs hardware showcase still lists Pi 3/4/5, so the support claim stands.
- **Companion SDK** — [WDY-1235](https://linear.app/wendylabsinc/issue/WDY-1235) is **Done**, but that issue only covers *establishing a release timeline*, and there is no Companion SDK in the tree. It stays In Progress, noting that both its 2026-07-03 target and its gate on the Pipecat refresh ([WDY-1228](https://linear.app/wendylabsinc/issue/WDY-1228), now Done) have lapsed.
- **Wendy Swift initiative** — same treatment. The toolchain, templates, and debugging moved to Shipped; the coordinated launch stayed Planned, with the stale Pipecat gate removed.

**Both the Companion SDK and the Swift launch need new dates from whoever owns them** — I did not invent one.

## Scope

Only the tracked flat source `go/internal/cli/assets/docs/roadmap.md` is edited. `content/` is gitignored and regenerated by `scripts/prepare-content.mjs`.

## Validation

- `go build ./internal/cli/assets/... ./internal/cli/commands/` — passes (docs are embedded in the binary)
- `go test ./internal/cli/commands/ -run Docs` — passes
- Ran `scripts/prepare-content.mjs` and confirmed all 7 relative links in the generated page resolve to real routes (`cloud`, `installation/wendy-agent-macos`, `installation/wendyos-nvidia-jetson-agx-thor`, `advanced/wendy-lite`, `advanced/pki`, `integrations`, `integrations/foxglove`)

Prose-only change — no runtime behaviour is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9RwYq8Hvz99UzbpbMmody