### PR TITLE
fix(discovery): stop LAN probes from re-entering discovery (1.9 GB -> 43 MB)

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/analytics"
 	"github.com/wendylabsinc/wendy/go/internal/cli/commands"
+	"github.com/wendylabsinc/wendy/go/internal/cli/memguard"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/env"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
@@ -21,6 +22,11 @@ import (
 
 func main() {
 	start := time.Now()
+	// Before anything else, so a leak during command construction or prerun is
+	// caught too. A trip kills the process outright, which means no analytics
+	// event and no error message from below — the heap profile it leaves behind
+	// is the report.
+	memguard.Start()
 	cmd := commands.NewRootCmd()
 
 	// Reject an unknown subcommand before cobra can quietly answer it with the

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1455,6 +1455,15 @@ func resolveAddrOnce(ctx context.Context, addr string) string {
 // path, which already prefers discovered IPs for the same reason. Returns "" for
 // non-".local" hosts or when no advertised device matches.
 func resolveMDNSHost(ctx context.Context, host string) string {
+	// A dial made *by* a discovery probe must never browse: the browse starts
+	// another discovery session, whose probes dial, which browse again. Each
+	// level re-reads and re-parses the CLI config, certs and pin store, so the
+	// tree cost 934 MB of live heap (83% of the process) in one long-running
+	// `wendy device logs`. The probe already has the addresses this browse would
+	// look up — discovery handed them to it. See discovery.WithinProbe.
+	if discovery.IsWithinProbe(ctx) {
+		return ""
+	}
 	normalized := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
 	if !strings.HasSuffix(normalized, ".local") {
 		return ""

--- a/go/internal/cli/commands/mdns_probe_recursion_test.go
+++ b/go/internal/cli/commands/mdns_probe_recursion_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// countingBrowse replaces lanBrowseFn for the test and reports how many times a
+// browse was started.
+func countingBrowse(t *testing.T) *atomic.Int64 {
+	t.Helper()
+	var calls atomic.Int64
+	orig := lanBrowseFn
+	t.Cleanup(func() { lanBrowseFn = orig })
+	lanBrowseFn = func(context.Context, time.Duration) ([]models.LANDevice, error) {
+		calls.Add(1)
+		return []models.LANDevice{{Hostname: "orin.local", IPAddress: "192.168.0.9"}}, nil
+	}
+	return &calls
+}
+
+// The cycle this guards: a discovery probe dials a device, the dial cannot
+// resolve its ".local" name, and the mDNS fallback starts a WHOLE NEW discovery
+// session — which probes, which dials, which browses. Branching factor
+// probeWorkers per level, bounded only by each level's timeout. One
+// `wendy device logs` reached 934 MB of live heap this way.
+func TestResolveMDNSHostRefusesToBrowseInsideAProbe(t *testing.T) {
+	calls := countingBrowse(t)
+
+	got := resolveMDNSHost(discovery.WithinProbe(context.Background()), "orin.local")
+
+	if got != "" {
+		t.Fatalf("resolveMDNSHost returned %q inside a probe; it must decline", got)
+	}
+	if n := calls.Load(); n != 0 {
+		t.Fatalf("started %d LAN browse(s) from inside a probe; the recursion is not broken", n)
+	}
+}
+
+// Outside a probe the fallback must still work — it is what keeps ".local"
+// names dialable on platforms whose resolver does not do mDNS (issue #1155).
+func TestResolveMDNSHostStillBrowsesOutsideAProbe(t *testing.T) {
+	calls := countingBrowse(t)
+
+	got := resolveMDNSHost(context.Background(), "orin.local")
+
+	if got != "192.168.0.9" {
+		t.Fatalf("resolveMDNSHost = %q, want the advertised IP 192.168.0.9", got)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("browsed %d times, want exactly 1", n)
+	}
+}
+
+// resolveHostMDNSFallback is the frame the dial path actually calls, so the
+// guard has to hold through it too — a literal IP short-circuits before any
+// browse, and an unresolvable name inside a probe must not fall through to one.
+func TestResolveHostMDNSFallbackDoesNotBrowseInsideAProbe(t *testing.T) {
+	calls := countingBrowse(t)
+	origLookup := osLookupHostFn
+	t.Cleanup(func() { osLookupHostFn = origLookup })
+	osLookupHostFn = func(context.Context, string) ([]string, error) {
+		return nil, context.DeadlineExceeded // force the mDNS fallback
+	}
+
+	got := resolveHostMDNSFallback(discovery.WithinProbe(context.Background()), "orin.local")
+
+	if got != "" {
+		t.Fatalf("resolveHostMDNSFallback returned %q inside a probe, want \"\"", got)
+	}
+	if n := calls.Load(); n != 0 {
+		t.Fatalf("started %d LAN browse(s) from inside a probe; the recursion is not broken", n)
+	}
+}

--- a/go/internal/cli/memguard/kill_unix.go
+++ b/go/internal/cli/memguard/kill_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package memguard
+
+import (
+	"os"
+	"syscall"
+)
+
+// kill terminates this process immediately with SIGKILL. The signal is
+// deliberately uncatchable: a guard that could be swallowed by a signal handler
+// or blocked behind a deferred cleanup is not a ceiling. The shell reports it as
+// 137, which is a clearer signature in a bug report than a plain nonzero exit.
+func kill() {
+	_ = syscall.Kill(os.Getpid(), syscall.SIGKILL)
+	// Not reached in practice. If the signal somehow was not delivered, exit
+	// with the code the shell would have reported for it anyway.
+	os.Exit(137)
+}

--- a/go/internal/cli/memguard/kill_windows.go
+++ b/go/internal/cli/memguard/kill_windows.go
@@ -1,0 +1,10 @@
+package memguard
+
+import "os"
+
+// kill terminates this process immediately. Windows has no SIGKILL, so this
+// exits with 137 — the code a unix shell reports for a SIGKILL — to keep the
+// signature of a memory-limit trip identical across platforms.
+func kill() {
+	os.Exit(137)
+}

--- a/go/internal/cli/memguard/memguard.go
+++ b/go/internal/cli/memguard/memguard.go
@@ -1,0 +1,183 @@
+// Package memguard enforces a hard ceiling on the Wendy CLI's own memory use.
+//
+// A leak in a long-lived command — a polling TUI, a log stream, a build that
+// retains every layer it touches — is otherwise invisible until the machine
+// starts swapping, and by then the evidence of what was retained is gone.
+// memguard samples the live heap and, once it stays above the ceiling across a
+// forced collection, writes a heap profile and kills the process outright.
+//
+// The profile is the point. A trip names the retaining call sites, which turns
+// "wendy ate my RAM again" into an actionable leak report:
+//
+//	go tool pprof -top /tmp/wendy-memguard-<pid>.pprof
+//
+// The guard reads the live heap (HeapAlloc), not process RSS. A leak grows the
+// live heap; RSS also counts pages the collector has freed but not yet returned
+// to the OS, so tripping on RSS would kill churn-heavy commands that are not
+// leaking anything.
+package memguard
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultLimit is the ceiling the CLI is expected to stay under. Nothing the
+// CLI does legitimately needs half a gigabyte of live heap: large payloads
+// (OS images, container layers) are streamed or staged through temp files
+// rather than buffered whole — see decompressLayerToTemp in the commands
+// package.
+const DefaultLimit uint64 = 512 << 20
+
+// limitEnvVar overrides DefaultLimit, in MiB. Set it to 0 to disable the guard
+// entirely, or to a larger value for a workload that genuinely needs the room.
+const limitEnvVar = "WENDY_MEM_LIMIT_MB"
+
+// sampleInterval is how often the live heap is read. A trip can overshoot the
+// ceiling by roughly one interval's worth of allocation, so this is kept short:
+// runtime.ReadMemStats stops the world only for tens of microseconds, which is
+// invisible twice a second even inside a live TUI redraw.
+const sampleInterval = 500 * time.Millisecond
+
+// config isolates every side effect of a trip so the decision logic can be
+// tested without killing the test binary.
+type config struct {
+	limit    uint64
+	interval time.Duration
+	liveHeap func() uint64
+	forceGC  func()
+	dump     func() (string, error)
+	stderr   io.Writer
+	kill     func()
+}
+
+// Start launches the watchdog and reports whether one is now running. It
+// returns immediately; the sampling goroutine lives for the rest of the
+// process. Call it as early as possible in main so that command startup is
+// covered too.
+func Start() bool {
+	limit := limitFromEnv()
+	if limit == 0 {
+		return false
+	}
+
+	// Give the collector the same ceiling as a soft target so it works harder
+	// to stay under it instead of letting the guard do all the enforcing. A
+	// process that can genuinely fit inside the limit then never trips, and one
+	// that cannot is killed by the check below rather than thrashing forever.
+	// An explicit GOMEMLIMIT from the operator wins.
+	if os.Getenv("GOMEMLIMIT") == "" {
+		debug.SetMemoryLimit(int64(limit))
+	}
+
+	cfg := &config{
+		limit:    limit,
+		interval: sampleInterval,
+		liveHeap: liveHeap,
+		forceGC:  runtime.GC,
+		dump:     writeHeapProfile,
+		stderr:   os.Stderr,
+		kill:     kill,
+	}
+	go func() {
+		ticker := time.NewTicker(cfg.interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			check(cfg)
+		}
+	}()
+	return true
+}
+
+// check reads one sample and, if the ceiling is genuinely exceeded, dumps a
+// heap profile and kills the process. It reports whether it tripped; in
+// production cfg.kill does not return.
+func check(cfg *config) bool {
+	if cfg.liveHeap() <= cfg.limit {
+		return false
+	}
+
+	// One sample over the line proves nothing: the collector is free to let
+	// dead objects pile up between cycles, so a command that churns hundreds of
+	// megabytes without retaining any of it can read high at any instant. Force
+	// a collection and re-read, and only condemn the process if the memory is
+	// genuinely still reachable.
+	cfg.forceGC()
+	live := cfg.liveHeap()
+	if live <= cfg.limit {
+		return false
+	}
+
+	fmt.Fprintf(cfg.stderr, "\nwendy: memory limit exceeded: %s of live heap, ceiling is %s.\n",
+		formatMiB(live), formatMiB(cfg.limit))
+	if path, err := cfg.dump(); err != nil {
+		fmt.Fprintf(cfg.stderr, "wendy: could not write a heap profile: %v\n", err)
+	} else {
+		fmt.Fprintf(cfg.stderr, "wendy: heap profile written to %s\n", path)
+		fmt.Fprintf(cfg.stderr, "wendy: please attach it to a bug report — inspect it with:\n")
+		fmt.Fprintf(cfg.stderr, "wendy:   go tool pprof -top %s\n", path)
+	}
+	fmt.Fprintf(cfg.stderr, "wendy: killing this process. Raise or disable the ceiling with %s=<MiB>.\n", limitEnvVar)
+
+	cfg.kill()
+	return true
+}
+
+// liveHeap returns the bytes of reachable heap objects.
+func liveHeap() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapAlloc
+}
+
+// writeHeapProfile dumps a pprof heap profile and returns its path. The name is
+// keyed by pid so concurrent CLI invocations cannot clobber each other's
+// evidence, and is stable across trips within one process.
+func writeHeapProfile() (string, error) {
+	path := fmt.Sprintf("%s/wendy-memguard-%d.pprof", strings.TrimRight(os.TempDir(), "/\\"), os.Getpid())
+	f, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	// check has already forced a collection, so the profile reflects what is
+	// actually still reachable rather than the last cycle's garbage.
+	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
+		f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// limitFromEnv resolves the ceiling in bytes from the environment, falling back
+// to DefaultLimit for anything it cannot parse. A malformed override must not
+// silently disable the guard, so it warns and uses the default.
+func limitFromEnv() uint64 {
+	v := strings.TrimSpace(os.Getenv(limitEnvVar))
+	if v == "" {
+		return DefaultLimit
+	}
+	mb, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || mb < 0 {
+		log.Printf("WARNING: invalid %s=%q, expected a whole number of MiB, using default %s",
+			limitEnvVar, v, formatMiB(DefaultLimit))
+		return DefaultLimit
+	}
+	return uint64(mb) << 20
+}
+
+// formatMiB renders bytes as whole MiB, truncating so a reported figure never
+// reads as if it had crossed a ceiling it has not.
+func formatMiB(b uint64) string {
+	return fmt.Sprintf("%d MiB", b>>20)
+}

--- a/go/internal/cli/memguard/memguard_test.go
+++ b/go/internal/cli/memguard/memguard_test.go
@@ -1,0 +1,196 @@
+package memguard
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testConfig returns a config whose every side effect is captured, with the
+// live-heap reading driven by a caller-supplied sequence of samples.
+func testConfig(samples ...uint64) (*config, *[]string, *bytes.Buffer, *bool) {
+	var log []string
+	var stderr bytes.Buffer
+	killed := false
+	i := 0
+	cfg := &config{
+		limit:    512 << 20,
+		interval: time.Millisecond,
+		liveHeap: func() uint64 {
+			v := samples[i]
+			if i < len(samples)-1 {
+				i++
+			}
+			return v
+		},
+		forceGC: func() { log = append(log, "gc") },
+		dump: func() (string, error) {
+			log = append(log, "dump")
+			return "/tmp/heap.pprof", nil
+		},
+		stderr: &stderr,
+		kill:   func() { log = append(log, "kill"); killed = true },
+	}
+	return cfg, &log, &stderr, &killed
+}
+
+func TestCheckDoesNothingBelowLimit(t *testing.T) {
+	cfg, log, stderr, killed := testConfig(100 << 20)
+	if check(cfg) {
+		t.Fatal("check tripped below the limit")
+	}
+	if *killed {
+		t.Fatal("process killed below the limit")
+	}
+	if len(*log) != 0 {
+		t.Fatalf("expected no side effects below the limit, got %v", *log)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no output below the limit, got %q", stderr.String())
+	}
+}
+
+// A single sample over the ceiling can be uncollected garbage rather than a
+// leak: the Go GC is free to let dead objects pile up between cycles. A
+// churn-heavy but leak-free command must survive that, so the guard forces a
+// collection and re-reads before condemning the process.
+func TestCheckForcesGCBeforeKillingAndSparesCollectableGarbage(t *testing.T) {
+	cfg, log, stderr, killed := testConfig(600<<20, 100<<20)
+	if check(cfg) {
+		t.Fatal("check tripped on garbage that a GC reclaimed")
+	}
+	if *killed {
+		t.Fatal("process killed on garbage that a GC reclaimed")
+	}
+	if len(*log) != 1 || (*log)[0] != "gc" {
+		t.Fatalf("expected exactly one forced GC and nothing else, got %v", *log)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no output when the GC reclaimed the overage, got %q", stderr.String())
+	}
+}
+
+func TestCheckDumpsThenKillsWhenLiveHeapStaysOverLimit(t *testing.T) {
+	cfg, log, stderr, killed := testConfig(600 << 20)
+	if !check(cfg) {
+		t.Fatal("check did not trip on a live heap over the limit")
+	}
+	if !*killed {
+		t.Fatal("process not killed on a live heap over the limit")
+	}
+	// Order matters: the profile is the whole point of the trip, so it must be
+	// written before the process dies.
+	want := []string{"gc", "dump", "kill"}
+	if len(*log) != len(want) {
+		t.Fatalf("expected %v, got %v", want, *log)
+	}
+	for i := range want {
+		if (*log)[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, *log)
+		}
+	}
+	out := stderr.String()
+	for _, want := range []string{"600 MiB", "512 MiB", "/tmp/heap.pprof", "go tool pprof"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A failed dump must not stop the kill: the ceiling is the contract, the
+// profile is best-effort.
+func TestCheckKillsEvenWhenTheDumpFails(t *testing.T) {
+	cfg, log, stderr, killed := testConfig(600 << 20)
+	cfg.dump = func() (string, error) { return "", os.ErrPermission }
+	if !check(cfg) {
+		t.Fatal("check did not trip when the dump failed")
+	}
+	if !*killed {
+		t.Fatal("process not killed when the dump failed")
+	}
+	if (*log)[len(*log)-1] != "kill" {
+		t.Fatalf("kill did not happen last, got %v", *log)
+	}
+	if !strings.Contains(stderr.String(), "could not write a heap profile") {
+		t.Fatalf("dump failure not reported:\n%s", stderr.String())
+	}
+}
+
+func TestLimitFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  string
+		want uint64
+	}{
+		{name: "unset uses the default ceiling", set: "", want: DefaultLimit},
+		{name: "override in megabytes", set: "1024", want: 1024 << 20},
+		{name: "zero disables the guard", set: "0", want: 0},
+		{name: "surrounding whitespace tolerated", set: " 64 ", want: 64 << 20},
+		{name: "garbage falls back to the default", set: "lots", want: DefaultLimit},
+		{name: "negative falls back to the default", set: "-1", want: DefaultLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(limitEnvVar, tc.set)
+			if got := limitFromEnv(); got != tc.want {
+				t.Fatalf("limitFromEnv() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// Start must be a no-op when the guard is disabled, so an operator who needs
+// the ceiling out of the way gets no sampling goroutine either.
+func TestStartDisabledByZeroLimit(t *testing.T) {
+	t.Setenv(limitEnvVar, "0")
+	if Start() {
+		t.Fatal("Start reported a running guard with the limit disabled")
+	}
+}
+
+func TestStartRunsWithADefaultLimit(t *testing.T) {
+	t.Setenv(limitEnvVar, "4096")
+	if !Start() {
+		t.Fatal("Start did not report a running guard")
+	}
+}
+
+// The real dump path must produce a parseable, non-empty profile — a guard
+// that kills the process and leaves a zero-byte file behind is worthless.
+func TestWriteHeapProfileProducesANonEmptyFile(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	path, err := writeHeapProfile()
+	if err != nil {
+		t.Fatalf("writeHeapProfile: %v", err)
+	}
+	if filepath.Ext(path) != ".pprof" {
+		t.Fatalf("profile path %q does not end in .pprof", path)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat profile: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("heap profile is empty")
+	}
+}
+
+func TestFormatMiB(t *testing.T) {
+	for _, tc := range []struct {
+		in   uint64
+		want string
+	}{
+		{in: 0, want: "0 MiB"},
+		{in: 512 << 20, want: "512 MiB"},
+		{in: 1 << 20, want: "1 MiB"},
+		// Truncating, not rounding: a reported figure must never read as if it
+		// had already crossed a ceiling it has not.
+		{in: (1 << 20) - 1, want: "0 MiB"},
+	} {
+		if got := formatMiB(tc.in); got != tc.want {
+			t.Fatalf("formatMiB(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/go/internal/shared/discovery/probectx.go
+++ b/go/internal/shared/discovery/probectx.go
@@ -1,0 +1,38 @@
+package discovery
+
+import "context"
+
+// probeContextKey marks a context as running underneath a LAN discovery probe.
+type probeContextKey struct{}
+
+// WithinProbe marks ctx as belonging to a discovery probe, so code further down
+// the call chain can refuse to re-enter discovery.
+//
+// This exists to break a recursive cycle. A discovery session probes each
+// candidate device to confirm its agent answers; in the CLI that probe dials the
+// device, and the dial path falls back to an mDNS browse when it cannot resolve
+// a ".local" name. That browse is another discovery session, which probes its
+// own candidates, which dial, which browse — a tree with a branching factor of
+// probeWorkers per level and no bound on depth beyond each level's timeout. It
+// cost 934 MB of live heap in one `wendy device logs`, 83% of the process, most
+// of it thousands of duplicate parsed copies of the CLI config that each level
+// re-read from disk.
+//
+// The mark rides the context rather than a parameter because the cycle closes
+// seven frames below the probe, through a seam that exists for tests; threading
+// a flag through all of them would put the knowledge of this cycle in every
+// intermediate signature instead of at the two ends that care.
+//
+// A probe never needs the browse it would trigger: the session already resolved
+// the device's addresses from the mDNS record it is probing and hands them to
+// the prober. Re-browsing to find what discovery just found is the bug, not a
+// capability being given up.
+func WithinProbe(ctx context.Context) context.Context {
+	return context.WithValue(ctx, probeContextKey{}, true)
+}
+
+// IsWithinProbe reports whether ctx descends from a discovery probe.
+func IsWithinProbe(ctx context.Context) bool {
+	v, _ := ctx.Value(probeContextKey{}).(bool)
+	return v
+}

--- a/go/internal/shared/discovery/probectx_test.go
+++ b/go/internal/shared/discovery/probectx_test.go
@@ -1,0 +1,72 @@
+package discovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+func TestIsWithinProbeFalseForAPlainContext(t *testing.T) {
+	if IsWithinProbe(context.Background()) {
+		t.Fatal("a plain context reported as being inside a probe")
+	}
+}
+
+func TestWithinProbeMarksAContextAndSurvivesDerivation(t *testing.T) {
+	ctx := WithinProbe(context.Background())
+	if !IsWithinProbe(ctx) {
+		t.Fatal("WithinProbe did not mark the context")
+	}
+	// The mark has to survive the derivations the dial path makes below it —
+	// that whole path is why the mark exists.
+	derived, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	if !IsWithinProbe(derived) {
+		t.Fatal("mark lost across context.WithTimeout")
+	}
+}
+
+// The mark must reach the prober itself: a prober that cannot tell it is
+// running inside discovery would re-enter discovery, which is the recursion
+// this exists to stop.
+func TestProberReceivesAProbeMarkedContext(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/devices.json"
+	seedCache(t, path, discoverycache.Entry{
+		ID:          "urn:wendy:org:1:asset:1",
+		DisplayName: "probe-marker",
+		Hostname:    "probe-marker.local",
+		IP:          "192.168.0.2",
+		Port:        50051,
+	})
+	// Emits nothing — the cached row is what drives the probe. It must still
+	// honour cancellation, or the session's wg.Wait never returns and the test
+	// hangs instead of failing.
+	useStreamSeams(t, func(ctx context.Context, _ string, _ func(MDNSService)) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}, cacheLoaderFor(path))
+
+	marked := make(chan bool, 1)
+	prober := func(ctx context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		select {
+		case marked <- IsWithinProbe(ctx):
+		default:
+		}
+		return dev, nil
+	}
+
+	startStream(t, StreamOptions{UseCache: true, Prober: prober})
+
+	select {
+	case got := <-marked:
+		if !got {
+			t.Fatal("prober received a context that was NOT marked as inside a probe")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("prober was never called")
+	}
+}

--- a/go/internal/shared/discovery/stream.go
+++ b/go/internal/shared/discovery/stream.go
@@ -675,7 +675,10 @@ func (s *lanStream) scheduleProbe(key string, st *lanDeviceState) {
 		}
 		defer func() { <-s.sem }()
 
-		probeCtx, cancel := context.WithTimeout(s.ctx, probeTimeout)
+		// Marked so the prober's dial path cannot fall back to another mDNS
+		// browse, which would start a fresh discovery session and probe from
+		// there — see WithinProbe.
+		probeCtx, cancel := context.WithTimeout(WithinProbe(s.ctx), probeTimeout)
 		defer cancel()
 		probed, err := prober(probeCtx, dev)
 


### PR DESCRIPTION
## The bug

Probing a device re-entered full LAN discovery, which spawned more probes:

```
lanStream.scheduleProbe -> lanProber -> resolveLANAgentVersion
  -> getAgentVersionAtAddress -> connectWithAutoTLS
    -> resolveHostMDNSFallback -> resolveMDNSHost
      -> lanBrowseFn -> discovery.CollectLAN     <- a WHOLE NEW session
        -> new probes -> lanProber -> ...
```

Branching factor is `probeWorkers` (4) per level, and nothing bounded the **depth** — only each level's `probeTimeout` (1.5s). Every level also re-read and re-parsed `~/.wendy/config.json`, the cert list and the device-pin store from disk, so the tree became gigabytes of duplicate parsed JSON.

From a heap dump of a long-running `wendy device logs`:

| | share of 1.12 GB live heap |
|---|---|
| `lanProber` (under probe goroutines) | **934 MB — 83.7%** |
| `json.Unmarshal` (cum) | 769 MB — 68.9% |
| ↳ via `config.Load` | 428 MB |
| ↳ via `devicepin.Open` | 389 MB |
| `context.withCancel` | 7.5 MB — tens of thousands of live contexts |

The cycle only fires when the OS resolver **fails** on a `.local` name, which is why a healthy device never shows it and a flaky one takes an hour to blow up.

`helpers.go:1386` already documented this exact chain — but only as a *variable-initialization* cycle, worked around with `init()`. The runtime call cycle survived.

## The fix

Probe contexts are marked (`discovery.WithinProbe`), and `resolveMDNSHost` declines to browse when it sees the mark. 13 lines of production code.

A probe never needed that browse: the session already resolved the device's addresses from the mDNS record it is probing and handed them to the prober. Re-browsing to find what discovery just found was the bug, not a capability being given up. Outside a probe the fallback is unchanged, so `.local` names stay dialable on platforms whose resolver does not do mDNS (#1155).

The mark rides the context because the cycle closes **seven frames** below the probe, through a seam that only exists for tests. Threading a flag would put knowledge of this cycle into every intermediate signature instead of at the two ends that care.

## Repro — deterministic, ~20s

```
wendy device logs --device ghost-device-xyz.local
```

| | peak RSS | outcome |
|---|---|---|
| before | **1,886 MB** | OOM-killed at 21s |
| after | **43 MB** | runs to its ~92s timeout, exits cleanly |

## Second commit: a 512 MiB ceiling

`memguard` samples the live heap and, once it stays over the ceiling across a forced GC, writes a pprof heap profile and SIGKILLs. **This is what found the bug above** — without it this was an unreproducible "wendy sometimes eats my RAM".

- Trips on live heap (`HeapAlloc`), not RSS — RSS counts pages the GC freed but has not returned, so an RSS ceiling would kill churn-heavy non-leaking commands.
- Forces a GC and re-reads before killing, so uncollected garbage never triggers a kill.
- Sets `debug.SetMemoryLimit` to the same ceiling unless `GOMEMLIMIT` is set.
- `WENDY_MEM_LIMIT_MB` overrides; `0` disables.

Reviewers: this commit is separable. Happy to split it into its own PR if you would rather land the fix alone — it is a behaviour change for every user, and a trip kills before `trackCommand`, so a memory kill emits **no analytics event**.

## Tests run

- `go test ./internal/cli/commands ./internal/cli/memguard ./cmd/wendy` — pass
- `go test ./internal/shared/discovery` — one **pre-existing** failure, `TestMDNSStreamBackend`. Verified identical on clean `stream.go` by reverting my edit; it is in `mdns_darwin_test.go` so it does not run in Linux CI.
- `gofmt` clean; builds verified for darwin/arm64 and windows/amd64.

New tests: refuses to browse inside a probe, still browses outside one, the guard holds through `resolveHostMDNSFallback`, the mark survives `context.WithTimeout` derivation, the mark reaches the prober; plus memguard's ceiling decisions, GC-reclaimable-overage sparing, failed-dump-still-kills, env parsing, and a real non-empty profile write.

## Not in this PR

`config.Load` still re-reads and re-parses on every call, and `loadAllCLICerts`/`openPinStore` still call it per dial. Much smaller now that the recursion is gone, but real waste. Sharing one parsed copy needs a mutex on `devicepin.Store` first — it currently has none and mutates its map in `CheckAndUpdate`, which would also fix a latent last-writer-wins race where N independent stores each hold a stale snapshot of `known_devices.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4JpbQ7PDaPGGKzua2MHS6