### PR TITLE
fix(cli): point the OS-update hint at the command that exists

### DIFF
--- a/go/internal/cli/commands/device_osupdate.go
+++ b/go/internal/cli/commands/device_osupdate.go
@@ -58,7 +58,7 @@ func formatOSUpdateInfo(resp *agentpb.GetOSUpdateStatusResponse) string {
 		}
 		b.WriteString(line + "\n")
 		if resp.GetOutcome() != agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED {
-			b.WriteString("  " + tui.Dim("Details:") + " " + tui.Command("wendy device os update-status") + "\n")
+			b.WriteString("  " + tui.Dim("Details:") + " " + tui.Command("wendy os update-status") + "\n")
 		}
 	}
 
@@ -111,7 +111,7 @@ func styledOSUpdateOutcome(o agentpb.GetOSUpdateStatusResponse_Outcome) string {
 }
 
 // osUpdateOutcomeLabel is the compact outcome wording used in `device info`;
-// the full record stays with `wendy device os update-status`.
+// the full record stays with `wendy os update-status`.
 func osUpdateOutcomeLabel(o agentpb.GetOSUpdateStatusResponse_Outcome) string {
 	switch o {
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED:

--- a/go/internal/cli/commands/device_osupdate_test.go
+++ b/go/internal/cli/commands/device_osupdate_test.go
@@ -62,7 +62,7 @@ func TestFormatOSUpdateInfoFailureShowsHint(t *testing.T) {
 	if !strings.Contains(got, "Last update: rolled back") {
 		t.Errorf("missing rolled-back line:\n%s", got)
 	}
-	if !strings.Contains(got, "wendy device os update-status") {
+	if !strings.Contains(got, "wendy os update-status") {
 		t.Errorf("failure outcome should point at the detailed command:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Problem

After a rolled-back or failed OS update, `wendy device info` prints:

```
OS Update:
  Slot A: booted, rootfs normal, WendyOS 0.17.0
  Last update: rolled back (0.16.0 → 0.17.0)
  Details: wendy device os update-status
```

`wendy device os update-status` does not exist. There is no `os` subcommand under `device` — running the suggested command just errors out. So the one hint we give a user whose update went wrong sends them nowhere.

The real command is `wendy os update-status` (the top-level, hidden `os` group in `os_cmd.go`), which is what the docs under `assets/docs/.../os/update.md` and `device/info.md` already tell users to run.

## Fix

Corrects the three mentions of the non-existent command:

- `device_osupdate.go:61` — the user-facing `Details:` hint
- `device_osupdate.go:114` — doc comment repeating it
- `device_osupdate_test.go:65` — the assertion that pinned the wrong string

No behaviour change beyond the printed text; the output now matches what `device/info.md:72` documents.

## Testing

`go test ./internal/cli/commands/ -run TestFormatOSUpdateInfo` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tspn47X9oPgTa1ia7SmmhX