### PR TITLE
fix(cli): make `wendy auth status --json` actually print JSON

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -668,6 +669,64 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 	return nil
 }
 
+// certExpiryWindow is how far ahead of NotAfter `auth status` starts warning
+// that a certificate is about to expire.
+const certExpiryWindow = 7 * 24 * time.Hour
+
+// authStatusCert is the certificate half of one `auth status` session in JSON.
+type authStatusCert struct {
+	ExpiresAt    time.Time `json:"expiresAt"`
+	Expired      bool      `json:"expired"`
+	ExpiringSoon bool      `json:"expiringSoon"`
+}
+
+// authStatusSession is one stored cloud session in `auth status --json`. It
+// carries the same facts as the human rendering below; keep the two in step.
+type authStatusSession struct {
+	Cloud          string          `json:"cloud"`
+	CloudGRPC      string          `json:"cloudGrpc,omitempty"`
+	UserID         string          `json:"userId,omitempty"`
+	OrganizationID int             `json:"organizationId,omitempty"`
+	Certificate    *authStatusCert `json:"certificate,omitempty"`
+}
+
+type authStatusJSON struct {
+	LoggedIn bool                `json:"loggedIn"`
+	Sessions []authStatusSession `json:"sessions"`
+}
+
+// authStatusCertInfo summarizes a stored PEM certificate's expiry. It returns
+// nil when the certificate is absent or unparseable, matching the human
+// rendering, which simply omits the line in that case.
+func authStatusCertInfo(pemCert string, now time.Time) *authStatusCert {
+	if pemCert == "" {
+		return nil
+	}
+	block, _ := pem.Decode([]byte(pemCert))
+	if block == nil {
+		return nil
+	}
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil
+	}
+	expiry := x509Cert.NotAfter
+	return &authStatusCert{
+		ExpiresAt:    expiry,
+		Expired:      now.After(expiry),
+		ExpiringSoon: !now.After(expiry) && expiry.Sub(now) < certExpiryWindow,
+	}
+}
+
+// authStatusEndpoint is the address `auth status` labels "Cloud:" — the
+// dashboard URL when stored, else the gRPC endpoint.
+func authStatusEndpoint(auth config.AuthConfig) string {
+	if auth.CloudDashboard != "" {
+		return auth.CloudDashboard
+	}
+	return auth.CloudGRPC
+}
+
 func newAuthStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
@@ -678,50 +737,50 @@ func newAuthStatusCmd() *cobra.Command {
 				return fmt.Errorf("loading config: %w", err)
 			}
 
+			// --json is a root persistent flag, and the root PersistentPreRunE
+			// also turns it on for non-interactive stdout, so every scripted
+			// invocation lands here. Emit JSON only — no banner, no warning
+			// lines — so the output stays pipeable into jq.
+			out := cmd.OutOrStdout()
+			if jsonOutput {
+				return writeAuthStatusJSON(out, cfg, time.Now())
+			}
+
 			if len(cfg.Auth) == 0 {
-				fmt.Println(tui.WarningMessage("Not logged in. Run 'wendy auth login' to authenticate."))
+				fmt.Fprintln(out, tui.WarningMessage("Not logged in. Run 'wendy auth login' to authenticate."))
 				return nil
 			}
 
 			for _, auth := range cfg.Auth {
-				endpoint := auth.CloudDashboard
-				if endpoint == "" {
-					endpoint = auth.CloudGRPC
-				}
-				fmt.Printf("Cloud:  %s\n", endpoint)
+				endpoint := authStatusEndpoint(auth)
+				fmt.Fprintf(out, "Cloud:  %s\n", endpoint)
 				if auth.CloudGRPC != "" && auth.CloudGRPC != endpoint {
-					fmt.Printf("  gRPC: %s\n", auth.CloudGRPC)
+					fmt.Fprintf(out, "  gRPC: %s\n", auth.CloudGRPC)
 				}
 
 				if len(auth.Certificates) == 0 {
-					fmt.Println(tui.WarningMessage("  No certificates stored."))
+					fmt.Fprintln(out, tui.WarningMessage("  No certificates stored."))
 					continue
 				}
 
 				cert := auth.Certificates[0]
 				if cert.UserID != "" {
-					fmt.Printf("  User: %s\n", cert.UserID)
+					fmt.Fprintf(out, "  User: %s\n", cert.UserID)
 				}
 				if cert.OrganizationID != 0 {
-					fmt.Printf("  Org:  %d\n", cert.OrganizationID)
+					fmt.Fprintf(out, "  Org:  %d\n", cert.OrganizationID)
 				}
 
-				if cert.PemCertificate != "" {
-					block, _ := pem.Decode([]byte(cert.PemCertificate))
-					if block != nil {
-						if x509Cert, parseErr := x509.ParseCertificate(block.Bytes); parseErr == nil {
-							expiry := x509Cert.NotAfter
-							remaining := time.Until(expiry).Round(time.Hour)
-							expiryStr := expiry.Format("2006-01-02 15:04 UTC")
-							switch {
-							case time.Now().After(expiry):
-								fmt.Println(tui.ErrorMessage(fmt.Sprintf("  Certificate expired on %s", expiryStr)))
-							case remaining < 7*24*time.Hour:
-								fmt.Println(tui.WarningMessage(fmt.Sprintf("  Certificate expires %s (in %s)", expiryStr, remaining)))
-							default:
-								fmt.Println(tui.SuccessMessage(fmt.Sprintf("  Certificate valid until %s", expiryStr)))
-							}
-						}
+				if info := authStatusCertInfo(cert.PemCertificate, time.Now()); info != nil {
+					expiryStr := info.ExpiresAt.Format("2006-01-02 15:04 UTC")
+					switch {
+					case info.Expired:
+						fmt.Fprintln(out, tui.ErrorMessage(fmt.Sprintf("  Certificate expired on %s", expiryStr)))
+					case info.ExpiringSoon:
+						remaining := time.Until(info.ExpiresAt).Round(time.Hour)
+						fmt.Fprintln(out, tui.WarningMessage(fmt.Sprintf("  Certificate expires %s (in %s)", expiryStr, remaining)))
+					default:
+						fmt.Fprintln(out, tui.SuccessMessage(fmt.Sprintf("  Certificate valid until %s", expiryStr)))
 					}
 				}
 			}
@@ -729,6 +788,35 @@ func newAuthStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// writeAuthStatusJSON renders auth status as JSON. Sessions is always a list
+// (never null) so `.sessions | length` works on a logged-out config too.
+func writeAuthStatusJSON(w io.Writer, cfg *config.Config, now time.Time) error {
+	status := authStatusJSON{
+		LoggedIn: len(cfg.Auth) > 0,
+		Sessions: make([]authStatusSession, 0, len(cfg.Auth)),
+	}
+	for _, auth := range cfg.Auth {
+		session := authStatusSession{
+			Cloud:     authStatusEndpoint(auth),
+			CloudGRPC: auth.CloudGRPC,
+		}
+		if len(auth.Certificates) > 0 {
+			cert := auth.Certificates[0]
+			session.UserID = cert.UserID
+			session.OrganizationID = cert.OrganizationID
+			session.Certificate = authStatusCertInfo(cert.PemCertificate, now)
+		}
+		status.Sessions = append(status.Sessions, session)
+	}
+
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding auth status: %w", err)
+	}
+	fmt.Fprintln(w, string(data))
+	return nil
 }
 
 // openBrowser opens the given URL in the default browser.

--- a/go/internal/cli/commands/auth_status_json_test.go
+++ b/go/internal/cli/commands/auth_status_json_test.go
@@ -1,0 +1,216 @@
+//go:build darwin || linux || windows
+
+package commands
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// testCertPEM is selfSignedCertPEM with a caller-chosen expiry, so the expiry
+// classification (valid / expiring soon / expired) can be exercised.
+func testCertPEM(t *testing.T, notAfter time.Time) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// runAuthStatus executes `auth status` with the given global --json setting and
+// returns everything the command wrote to its out writer.
+func runAuthStatus(t *testing.T, wantJSON bool) string {
+	t.Helper()
+	prev := jsonOutput
+	jsonOutput = wantJSON
+	t.Cleanup(func() { jsonOutput = prev })
+
+	var buf bytes.Buffer
+	cmd := newAuthStatusCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth status: %v", err)
+	}
+	return buf.String()
+}
+
+// statusConfig is a logged-in config with one long-lived certificate.
+func statusConfig(t *testing.T, notAfter time.Time) *config.Config {
+	t.Helper()
+	return &config.Config{Auth: []config.AuthConfig{{
+		CloudDashboard: "https://cloud.wendy.dev",
+		CloudGRPC:      "prod.example.com:443",
+		Certificates: []config.CertificateInfo{{
+			OrganizationID: 7,
+			UserID:         "user-abc",
+			PemCertificate: testCertPEM(t, notAfter),
+		}},
+	}}}
+}
+
+// Regression for `wendy auth status --json`: it ignored the global --json flag
+// and printed the human summary, so piping it into jq always failed. Note the
+// root command also turns --json on implicitly for non-interactive stdout, so
+// this hit every scripted invocation, not just explicit `--json`.
+func TestAuthStatusJSONEmitsJSON(t *testing.T) {
+	seedConfig(t, statusConfig(t, time.Now().Add(365*24*time.Hour)))
+
+	out := runAuthStatus(t, true)
+
+	var got struct {
+		LoggedIn bool `json:"loggedIn"`
+		Sessions []struct {
+			Cloud          string `json:"cloud"`
+			CloudGRPC      string `json:"cloudGrpc"`
+			UserID         string `json:"userId"`
+			OrganizationID int    `json:"organizationId"`
+			Certificate    *struct {
+				ExpiresAt    string `json:"expiresAt"`
+				Expired      bool   `json:"expired"`
+				ExpiringSoon bool   `json:"expiringSoon"`
+			} `json:"certificate"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+
+	if !got.LoggedIn {
+		t.Errorf("loggedIn = false, want true")
+	}
+	if len(got.Sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(got.Sessions))
+	}
+	s := got.Sessions[0]
+	if s.Cloud != "https://cloud.wendy.dev" {
+		t.Errorf("cloud = %q", s.Cloud)
+	}
+	if s.CloudGRPC != "prod.example.com:443" {
+		t.Errorf("cloudGrpc = %q", s.CloudGRPC)
+	}
+	if s.UserID != "user-abc" {
+		t.Errorf("userId = %q", s.UserID)
+	}
+	if s.OrganizationID != 7 {
+		t.Errorf("organizationId = %d, want 7", s.OrganizationID)
+	}
+	if s.Certificate == nil {
+		t.Fatal("certificate missing")
+	}
+	if s.Certificate.Expired || s.Certificate.ExpiringSoon {
+		t.Errorf("a year-out cert reported expired=%v expiringSoon=%v", s.Certificate.Expired, s.Certificate.ExpiringSoon)
+	}
+	if _, err := time.Parse(time.RFC3339, s.Certificate.ExpiresAt); err != nil {
+		t.Errorf("expiresAt %q is not RFC3339: %v", s.Certificate.ExpiresAt, err)
+	}
+}
+
+// The logged-out path printed a human warning to stdout, which also broke jq.
+func TestAuthStatusJSONWhenLoggedOut(t *testing.T) {
+	seedConfig(t, &config.Config{})
+
+	out := runAuthStatus(t, true)
+
+	var got struct {
+		LoggedIn bool  `json:"loggedIn"`
+		Sessions []any `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("logged-out output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if got.LoggedIn {
+		t.Errorf("loggedIn = true, want false")
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("got %d sessions, want 0", len(got.Sessions))
+	}
+	// sessions must be [] rather than null so `.sessions | length` works.
+	if !strings.Contains(out, `"sessions": []`) {
+		t.Errorf("want an empty array for sessions, got:\n%s", out)
+	}
+}
+
+// An expired certificate must be flagged, not silently reported as fine.
+func TestAuthStatusJSONFlagsExpiredCert(t *testing.T) {
+	seedConfig(t, statusConfig(t, time.Now().Add(-24*time.Hour)))
+
+	out := runAuthStatus(t, true)
+
+	var got struct {
+		Sessions []struct {
+			Certificate struct {
+				Expired bool `json:"expired"`
+			} `json:"certificate"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if len(got.Sessions) != 1 || !got.Sessions[0].Certificate.Expired {
+		t.Errorf("expired cert not flagged, got:\n%s", out)
+	}
+}
+
+// A cert inside the 7-day window keeps the human warning's meaning in JSON.
+func TestAuthStatusJSONFlagsExpiringSoonCert(t *testing.T) {
+	seedConfig(t, statusConfig(t, time.Now().Add(48*time.Hour)))
+
+	out := runAuthStatus(t, true)
+
+	var got struct {
+		Sessions []struct {
+			Certificate struct {
+				Expired      bool `json:"expired"`
+				ExpiringSoon bool `json:"expiringSoon"`
+			} `json:"certificate"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if len(got.Sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(got.Sessions))
+	}
+	if got.Sessions[0].Certificate.Expired || !got.Sessions[0].Certificate.ExpiringSoon {
+		t.Errorf("48h-out cert should be expiringSoon and not expired, got:\n%s", out)
+	}
+}
+
+// Guard the human path: fixing --json must not change the default rendering.
+func TestAuthStatusHumanOutputUnchanged(t *testing.T) {
+	seedConfig(t, statusConfig(t, time.Now().Add(365*24*time.Hour)))
+
+	out := runAuthStatus(t, false)
+
+	if json.Valid([]byte(strings.TrimSpace(out))) {
+		t.Errorf("human output should not be JSON, got:\n%s", out)
+	}
+	for _, want := range []string{"https://cloud.wendy.dev", "prod.example.com:443", "user-abc", "Org:  7"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("human output missing %q, got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`wendy auth status` never read the global `--json` flag. It printed its human summary regardless, so piping into `jq` always failed:

```console
$ wendy auth status --json | jq .
parse error: Invalid numeric literal at line 1, column 6
```

## Why it's worse than an explicit-flag bug

`--json` is a root persistent flag, and `root.go`'s `PersistentPreRunE` also flips `jsonOutput` on whenever stdout is not a terminal:

https://github.com/wendylabsinc/WendyOS/blob/main/go/internal/cli/commands/root.go#L42-L44

So **every scripted `wendy auth status` was affected**, flag or not.

The logged-out path was the sharpest edge: it wrote `Not logged in. Run 'wendy auth login' to authenticate.` to *stdout*, so a script had no way to tell "no sessions" apart from malformed output.

## The fix

Emit JSON carrying the same facts as the human rendering — cloud endpoint, gRPC endpoint, user and org from the first stored certificate, and certificate expiry with the expired / expiring-soon classification the human output already encoded through its colored lines.

```console
$ wendy auth status --json | jq -c '.sessions[0]'
{"cloud":"https://cloud.wendy.dev","cloudGrpc":"…:443","userId":"22zj…","organizationId":2,"certificate":{"expiresAt":"2027-08-10T00:30:51Z","expired":false,"expiringSoon":false}}

$ wendy auth status --json          # logged out
{"loggedIn":false,"sessions":[]}
```

`sessions` is always an array, never `null`, so `.sessions | length` works when logged out.

Both paths now write through `cmd.OutOrStdout()` rather than package-level `fmt.Print`, matching the plumbing `wendy docs` already uses (and which `TestNewDocsCmd_RespectsSetOut` guards) — that is what makes the human rendering testable at all.

The three-way expiry classification is now shared between the two renderings via `authStatusCertInfo`, so they cannot drift apart.

## Testing

New `auth_status_json_test.go`, all failing before the change:

- `--json` emits parseable JSON with the expected fields
- logged-out emits valid JSON with `"sessions": []`, not the human warning
- expired certificate is flagged
- certificate inside the 7-day window is `expiringSoon` and not `expired`
- **human output is unchanged** (regression guard on the default path)

Verified against a real build for all three cases: explicit `--json`, implicit JSON when piped, and `--json=false` human output (byte-identical to before).

`go vet` clean; full `./internal/cli/commands/` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfvBGbi5tFhp93tr3vzUzV