### PR TITLE
fix(audio): read the ALSA mixer in one call, not one process per control

### DIFF
--- a/go/internal/agent/audio/alsa.go
+++ b/go/internal/agent/audio/alsa.go
@@ -23,17 +23,27 @@ import (
 
 // AplayListRun and ArecordListRun enumerate ALSA cards. Behind vars so tests
 // can supply a fixture instead of running the real tools.
+// Each of these is bounded by queryTimeout for the same reason the PipeWire
+// queries are: the RPC context they inherit carries no deadline of its own, so
+// without one here a wedged card holds the call open for as long as the caller
+// is willing to wait — which, for the CLI, is forever.
 var (
 	AplayListRun = func(ctx context.Context) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+		defer cancel()
 		return exec.CommandContext(ctx, "aplay", "-l").Output()
 	}
 	ArecordListRun = func(ctx context.Context) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+		defer cancel()
 		return exec.CommandContext(ctx, "arecord", "-l").Output()
 	}
 )
 
 // AmixerRun runs amixer for ALSA volume control. Behind a var for tests.
 var AmixerRun = func(ctx context.Context, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
 	return exec.CommandContext(ctx, "amixer", args...).CombinedOutput()
 }
 
@@ -162,14 +172,45 @@ var (
 	preferredPlaybackControls = []string{"Master", "PCM", "Speaker", "Headphone"}
 )
 
-func parseSimpleMixerControls(output string) []string {
-	var controls []string
-	scanner := bufio.NewScanner(strings.NewReader(output))
-	for scanner.Scan() {
-		if match := simpleMixerControlPattern.FindStringSubmatch(strings.TrimSpace(scanner.Text())); len(match) == 2 {
-			controls = append(controls, match[1])
+// mixerContents is one simple mixer control as `amixer scontents` reports it:
+// the name from its header line, and the indented body lines that follow
+// carrying its capabilities and current values.
+type mixerContents struct {
+	name string
+	body string
+}
+
+// maxMixerLine bounds a single scontents line. A routing mux on a Tegra APE
+// card enumerates every selectable source on one "Items:" line, so the default
+// 64 KiB scanner limit is nearer than it looks — and overrunning it would
+// silently truncate the mixer rather than report anything.
+const maxMixerLine = 1 << 20
+
+// parseMixerContents splits `amixer scontents` output into per-control blocks,
+// preserving the order amixer listed them in.
+func parseMixerContents(output string) []mixerContents {
+	var controls []mixerContents
+	var body strings.Builder
+	flush := func() {
+		if len(controls) > 0 {
+			controls[len(controls)-1].body = body.String()
 		}
+		body.Reset()
 	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxMixerLine)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if match := simpleMixerControlPattern.FindStringSubmatch(strings.TrimSpace(line)); len(match) == 2 {
+			flush()
+			controls = append(controls, mixerContents{name: match[1]})
+			continue
+		}
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+	flush()
 	return controls
 }
 
@@ -213,20 +254,37 @@ func parsePlaybackVolume(output string) (uint32, bool) {
 
 // mixerControl resolves the ALSA simple mixer control that owns playback
 // volume for a card and returns its current percentage.
+//
+// This reads the whole mixer with one `scontents` dump rather than listing the
+// controls and running `sget` per control. The per-control scan is quadratic in
+// the wrong thing: a Tegra APE card lists 2179 simple controls, nearly all of
+// them routing muxes, and the first one exposing a playback volume sits at
+// index 1872 — 1872 amixer processes, ~150s on a Jetson Thor, during which
+// `wendy device audio` shows nothing at all. scontents answers the same
+// question in a single process (~0.1s on the same card) because the values are
+// already in the listing.
 func mixerControl(ctx context.Context, card uint64) (string, uint32, error) {
 	cardArg := strconv.FormatUint(card, 10)
-	listOutput, err := AmixerRun(ctx, "-c", cardArg, "scontrols")
+	output, err := AmixerRun(ctx, "-c", cardArg, "scontents")
 	if err != nil {
-		return "", 0, fmt.Errorf("listing mixer controls: %w: %s", err, strings.TrimSpace(string(listOutput)))
+		return "", 0, fmt.Errorf("reading mixer controls: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
-	for _, control := range orderPlaybackControls(parseSimpleMixerControls(string(listOutput))) {
-		output, getErr := AmixerRun(ctx, "-c", cardArg, "sget", control)
-		if getErr != nil {
+	// Keep the first block of any repeated name: `sget <name>` used to resolve
+	// to index 0, and amixer lists the indices in order.
+	bodies := make(map[string]string)
+	names := make([]string, 0)
+	for _, control := range parseMixerContents(string(output)) {
+		if _, seen := bodies[control.name]; seen {
 			continue
 		}
-		if volume, ok := parsePlaybackVolume(string(output)); ok {
-			return control, volume, nil
+		bodies[control.name] = control.body
+		names = append(names, control.name)
+	}
+
+	for _, name := range orderPlaybackControls(names) {
+		if volume, ok := parsePlaybackVolume(bodies[name]); ok {
+			return name, volume, nil
 		}
 	}
 	return "", 0, fmt.Errorf("no playback volume control found on ALSA card %d", card)

--- a/go/internal/agent/audio/alsa_test.go
+++ b/go/internal/agent/audio/alsa_test.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -140,11 +141,58 @@ func TestAlsaIDDistinguishesDirection(t *testing.T) {
 	}
 }
 
-func TestParseSimpleMixerControls(t *testing.T) {
-	input := "Simple mixer control 'PCM',0\nSimple mixer control 'Mic',0\nignored line"
-	want := []string{"PCM", "Mic"}
-	if got := parseSimpleMixerControls(input); !reflect.DeepEqual(got, want) {
-		t.Fatalf("parseSimpleMixerControls() = %v, want %v", got, want)
+func TestParseMixerContents(t *testing.T) {
+	input := "Simple mixer control 'PCM',0\n" +
+		"  Capabilities: pvolume\n" +
+		"  Mono: Playback 51 [22%] [on]\n" +
+		"Simple mixer control 'Mic',0\n" +
+		"  Capabilities: cvolume\n"
+	got := parseMixerContents(input)
+	want := []mixerContents{
+		{name: "PCM", body: "  Capabilities: pvolume\n  Mono: Playback 51 [22%] [on]\n"},
+		{name: "Mic", body: "  Capabilities: cvolume\n"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMixerContents() = %#v, want %#v", got, want)
+	}
+}
+
+// A Tegra APE card lists ~2200 simple mixer controls and does not reveal a
+// playback volume until roughly control 1900. Resolving that with one `amixer
+// sget` process per control took ~150s on a Jetson Thor — long enough that
+// `wendy device audio` looked hung — so the whole mixer must come back in a
+// single call regardless of how deep the first playback control sits.
+func TestMixerControlReadsWholeMixerInOneCall(t *testing.T) {
+	orig := AmixerRun
+	t.Cleanup(func() { AmixerRun = orig })
+
+	var mixer strings.Builder
+	for i := 1; i <= 2000; i++ {
+		fmt.Fprintf(&mixer, "Simple mixer control 'ADMAIF%d Mux',0\n", i)
+		mixer.WriteString("  Capabilities: enum\n  Items: 'None' 'ADMAIF1' 'I2S1'\n  Item0: 'None'\n")
+	}
+	mixer.WriteString("Simple mixer control 'CVB-RT DAC1',0\n")
+	mixer.WriteString("  Capabilities: pvolume pswitch\n")
+	mixer.WriteString("  Front Left: Playback 51 [22%] [-20.04dB] [on]\n")
+
+	var calls [][]string
+	AmixerRun = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if strings.Join(args, " ") != "-c 2 scontents" {
+			return nil, errors.New("unexpected amixer call: " + strings.Join(args, " "))
+		}
+		return []byte(mixer.String()), nil
+	}
+
+	control, volume, err := mixerControl(context.Background(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control != "CVB-RT DAC1" || volume != 22 {
+		t.Fatalf("mixerControl() = %q, %d; want CVB-RT DAC1, 22", control, volume)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("amixer ran %d times, want exactly 1 (the scontents dump); calls = %v", len(calls), calls)
 	}
 }
 
@@ -179,10 +227,11 @@ func TestMixerControlPrefersPCMAndSkipsCaptureOnly(t *testing.T) {
 	AmixerRun = func(_ context.Context, args ...string) ([]byte, error) {
 		calls = append(calls, append([]string(nil), args...))
 		switch strings.Join(args, " ") {
-		case "-c 2 scontrols":
-			return []byte("Simple mixer control 'Mic',0\nSimple mixer control 'PCM',0\n"), nil
-		case "-c 2 sget PCM":
-			return []byte("Mono: Playback 51 [22%] [-20.04dB] [on]\n"), nil
+		case "-c 2 scontents":
+			return []byte("Simple mixer control 'Mic',0\n" +
+				"  Mono: Capture 12 [22%]\n" +
+				"Simple mixer control 'PCM',0\n" +
+				"  Mono: Playback 51 [22%] [-20.04dB] [on]\n"), nil
 		default:
 			return nil, errors.New("unexpected amixer call")
 		}
@@ -195,7 +244,7 @@ func TestMixerControlPrefersPCMAndSkipsCaptureOnly(t *testing.T) {
 	if control != "PCM" || volume != 22 {
 		t.Fatalf("mixerControl() = %q, %d; want PCM, 22", control, volume)
 	}
-	wantCalls := [][]string{{"-c", "2", "scontrols"}, {"-c", "2", "sget", "PCM"}}
+	wantCalls := [][]string{{"-c", "2", "scontents"}}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("calls = %v, want %v", calls, wantCalls)
 	}
@@ -209,10 +258,8 @@ func TestSetAlsaVolume(t *testing.T) {
 	AmixerRun = func(_ context.Context, args ...string) ([]byte, error) {
 		calls = append(calls, append([]string(nil), args...))
 		switch strings.Join(args, " ") {
-		case "-c 2 scontrols":
-			return []byte("Simple mixer control 'PCM',0\n"), nil
-		case "-c 2 sget PCM":
-			return []byte("Mono: Playback 51 [22%] [on]\n"), nil
+		case "-c 2 scontents":
+			return []byte("Simple mixer control 'PCM',0\n  Mono: Playback 51 [22%] [on]\n"), nil
 		case "-c 2 sset PCM 100% unmute":
 			return []byte("Mono: Playback 231 [100%] [on]\n"), nil
 		default:

--- a/go/internal/agent/audio/pipewire.go
+++ b/go/internal/agent/audio/pipewire.go
@@ -46,8 +46,9 @@ var expectedUID = func() (uint32, bool) {
 	return uint32(uid), true
 }
 
-// queryTimeout bounds a single pw-dump or wpctl invocation, so a wedged
-// PipeWire cannot hold an RPC open indefinitely.
+// queryTimeout bounds a single audio-query subprocess — pw-dump or wpctl here,
+// aplay/arecord/amixer on the ALSA fallback — so a wedged PipeWire or sound
+// card cannot hold an RPC open indefinitely.
 const queryTimeout = 5 * time.Second
 
 // Node is a PipeWire sink or source.


### PR DESCRIPTION
## Problem

`wendy device audio` on a Jetson Thor (walter) printed `Using default device …` and then sat there. Measured: **151s before the first TUI frame**.

Bare `wendy device audio` takes the interactive TUI path, the only caller of **AudioService*V2***. `wendy device audio list` uses v1 and returns instantly — that's the whole difference. V2's `ListAudioDevices` does one extra thing:

```go
volumes := s.v1.nodeVolumes(ctx, v1resp.Devices)
```

Thor has no PipeWire session, so that falls through to ALSA, where `mixerControl` listed the card's simple controls and then ran **one `amixer sget` process per control** until one reported a playback volume.

Fine on a 2-control USB card, pathological on a Tegra APE. Measured on the affected device:

| card | controls | first control with a playback volume | time |
|---|---|---|---|
| 0 (PowerConf USB) | 2 | #1 | ~0s |
| 1 (HDA/HDMI) | 1 | none | ~0s |
| **2 (Tegra APE)** | **2179** | **#1872** | **146s** |

1872 amixer processes at ~0.08s each, card 2 iterated last, nothing printed meanwhile.

## Fix

`amixer scontents` already carries every control's current values, so one dump answers the same question. On the same card: **0.115s** for the dump, **2.5ms** to parse — and it resolves the *identical* control the scan used to find (`CVB-RT DAC1`, the one at index 1872), so which control gets picked is unchanged.

Also bounded the `aplay`/`arecord`/`amixer` subprocesses with the existing `queryTimeout`, as the PipeWire queries already are. They inherit the RPC context, which carries no deadline of its own, so nothing capped how long a wedged card could hold the call open — that's why this surfaced as a silent freeze rather than an error.

`SetAudioVolume` also routes through `mixerControl`, so ←/→ in that TUI would have frozen it for another ~150s per keypress. Same fix covers it.

## Tests

- `go test -race ./internal/agent/audio ./internal/agent/services`
- `go test ./internal/cli/commands`
- New `TestMixerControlReadsWholeMixerInOneCall` drives a 2001-control mixer whose only playback control is last, and asserts exactly one amixer call — it fails against the old scan.
- `TestParseMixerContents` covers the block parser.
- Verified separately against a real 446 KB `scontents` capture from the affected Thor: 2179 controls parsed, correct control resolved, 1 call.

## Follow-up (not in this PR)

The CLI passes `cmd.Context()` with no deadline to these RPCs, so a slow device still shows as a frozen terminal rather than a timeout. Same shape as #1660. Worth a separate pass over the audio commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ay4P9xALX73iirJpUrxRn