### PR TITLE
Fall back to a cached time proof so a stale device can be rescued (WDY-2389)

### DIFF
--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -11,6 +11,7 @@ import (
 	circlSign "github.com/cloudflare/circl/sign"
 	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
 	"github.com/cloudflare/circl/sign/mldsa/mldsa87"
+	"github.com/wendylabsinc/wendy/go/internal/shared/timefmt"
 	"go.uber.org/zap"
 )
 
@@ -208,7 +209,7 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 			// The floor is irrelevant once the cert is expired against the real
 			// clock: pass realNow so the rejection log reflects the actual clock
 			// and never mistakes an expired cert for a clock-skew case.
-			logCertRejection(logger, leaf, expiredErr, realNow)
+			logCertRejection(logger, leaf, expiredErr, realNow, realNow)
 			return expiredErr
 		}
 
@@ -236,16 +237,16 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 			// signature algorithm; for all other failures return the standard error.
 			sigOID, oidErr := certSigAlgOID(leaf)
 			if oidErr != nil {
-				logCertRejection(logger, leaf, stdErr, effectiveNow)
+				logCertRejection(logger, leaf, stdErr, realNow, effectiveNow)
 				return stdErr
 			}
 			if _, schemeErr := mldsaScheme(sigOID); schemeErr != nil {
-				logCertRejection(logger, leaf, stdErr, effectiveNow)
+				logCertRejection(logger, leaf, stdErr, realNow, effectiveNow)
 				return stdErr
 			}
 			mldsaErr := verifyMLDSAClientCert(leaf, caCerts, realNow, effectiveNow)
 			if mldsaErr != nil {
-				logCertRejection(logger, leaf, mldsaErr, effectiveNow)
+				logCertRejection(logger, leaf, mldsaErr, realNow, effectiveNow)
 				return mldsaErr
 			}
 		}
@@ -254,7 +255,7 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 		// checkRevocation only inspects the leaf's validity window, so it needs no
 		// CA list and cannot be bypassed by either the standard or ML-DSA branch.
 		if revErr := checkRevocation(leaf); revErr != nil {
-			logCertRejection(logger, leaf, revErr, effectiveNow)
+			logCertRejection(logger, leaf, revErr, realNow, effectiveNow)
 			return revErr
 		}
 		return nil
@@ -262,8 +263,10 @@ func buildVerifyPeerCertificate(caPool *x509.CertPool, caCerts []*x509.Certifica
 }
 
 // logCertRejection logs a WARN when a client cert is rejected, with a clock
-// skew hint when the error indicates the cert is not yet valid.
-func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error, effectiveNow time.Time) {
+// skew hint when the error indicates the cert is not yet valid. realNow is the
+// device clock; effectiveNow is the floored clock verification actually used, and
+// the two differ by however far the floor carried the device.
+func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error, realNow, effectiveNow time.Time) {
 	if logger == nil {
 		return
 	}
@@ -271,18 +274,26 @@ func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error, eff
 		zap.String("subject", leaf.Subject.CommonName),
 		zap.Time("notBefore", leaf.NotBefore),
 		zap.Time("notAfter", leaf.NotAfter),
+		zap.Time("clock", realNow),
 		zap.Error(err),
 	}
 	msg := "mTLS client certificate rejected"
-	// Only hint at clock skew when the device clock is behind the cert's NotBefore.
-	// String-matching on the error text would also fire for expired certs, pointing
-	// operators at the wrong remediation (NTP sync won't help an expired cert).
+	// Only hint at clock skew when the verification clock is behind the cert's
+	// NotBefore. String-matching on the error text would also fire for expired
+	// certs, pointing operators at the wrong remediation (NTP sync won't help an
+	// expired cert).
 	if effectiveNow.Before(leaf.NotBefore) {
-		msg += ": certificate not yet valid — this device's clock reads " +
-			leaf.NotBefore.Sub(effectiveNow).Round(time.Second).String() +
-			" before the certificate was issued. Check the clock (timedatectl status);" +
+		// Report the device clock's own lag, which is what the operator has to fix.
+		// effectiveNow may already have been carried forward by the floor, so the
+		// gap verification failed on understates how far back the clock is.
+		clockLag := leaf.NotBefore.Sub(realNow)
+		msg += ": certificate not yet valid — this device's clock is " +
+			timefmt.Skew(clockLag) +
+			" behind the time the certificate was issued. Check the clock (timedatectl status);" +
 			" push a verified time from a host on this network with: wendy device sync-time"
-		fields = append(fields, zap.Duration("clockLag", leaf.NotBefore.Sub(effectiveNow)))
+		fields = append(fields,
+			zap.Duration("clockLag", clockLag),
+			zap.Duration("verifyLag", leaf.NotBefore.Sub(effectiveNow)))
 	}
 	logger.Warn(msg, fields...)
 }

--- a/go/internal/agent/mtls/mldsa_verify.go
+++ b/go/internal/agent/mtls/mldsa_verify.go
@@ -278,7 +278,11 @@ func logCertRejection(logger *zap.Logger, leaf *x509.Certificate, err error, eff
 	// String-matching on the error text would also fire for expired certs, pointing
 	// operators at the wrong remediation (NTP sync won't help an expired cert).
 	if effectiveNow.Before(leaf.NotBefore) {
-		msg += ": certificate not yet valid — device clock may be skewed; check NTP sync with: timedatectl status"
+		msg += ": certificate not yet valid — this device's clock reads " +
+			leaf.NotBefore.Sub(effectiveNow).Round(time.Second).String() +
+			" before the certificate was issued. Check the clock (timedatectl status);" +
+			" push a verified time from a host on this network with: wendy device sync-time"
+		fields = append(fields, zap.Duration("clockLag", leaf.NotBefore.Sub(effectiveNow)))
 	}
 	logger.Warn(msg, fields...)
 }

--- a/go/internal/agent/timesync/floor.go
+++ b/go/internal/agent/timesync/floor.go
@@ -20,21 +20,23 @@ var (
 	floorMax = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
 )
 
-// readFloor reads the Unix-seconds timestamp from configPath/clock_floor.
-// Returns zero time if the file doesn't exist, cannot be read, or holds a value
-// outside the plausible window; rejected reports which of those it was, so the
-// caller can log an implausible value rather than treat it as an absent file.
-func readFloor(configPath string) (t time.Time, rejected bool) {
+// readFloor reads the Unix-seconds timestamp from configPath/clock_floor. floor
+// is the value to apply and is zero when there is nothing to apply — an absent or
+// short file, the normal pre-feature case, or a value outside the plausible
+// window. Such a value comes back as refused instead, which is non-zero only in
+// that case, so it can be logged (an all-zero write, a 1970 host clock and a
+// year-2200 value need different remedies) without any path applying it.
+func readFloor(configPath string) (floor, refused time.Time) {
 	data, err := os.ReadFile(filepath.Join(configPath, clockFloorFile))
 	if err != nil || len(data) < 8 {
-		return time.Time{}, false
+		return time.Time{}, time.Time{}
 	}
 	sec := int64(binary.BigEndian.Uint64(data[:8])) //nolint:gosec — range-checked below
-	t = time.Unix(sec, 0)
+	t := time.Unix(sec, 0)
 	if t.Before(floorMin) || t.After(floorMax) {
-		return time.Time{}, true
+		return time.Time{}, t
 	}
-	return t, false
+	return t, time.Time{}
 }
 
 // FloorBytes encodes t as the 8-byte big-endian clock_floor payload.

--- a/go/internal/agent/timesync/floor.go
+++ b/go/internal/agent/timesync/floor.go
@@ -9,15 +9,32 @@ import (
 
 const clockFloorFile = "clock_floor"
 
+// A floor outside this window is treated as absent. It catches a torn or zeroed
+// write, not a wrong-but-plausible one: the CLI writes this file from the
+// flashing host's own clock (cli/commands/os_provision.go), so a host that is
+// merely months or years out still produces a value inside the window. Since
+// AdvanceTo never moves the clock backward, a future floor parks the device there
+// until it is reflashed, and only the grossly-wrong cases are caught here.
+var (
+	floorMin = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	floorMax = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
 // readFloor reads the Unix-seconds timestamp from configPath/clock_floor.
-// Returns zero time if the file doesn't exist or cannot be read.
-func readFloor(configPath string) time.Time {
+// Returns zero time if the file doesn't exist, cannot be read, or holds a value
+// outside the plausible window; rejected reports which of those it was, so the
+// caller can log an implausible value rather than treat it as an absent file.
+func readFloor(configPath string) (t time.Time, rejected bool) {
 	data, err := os.ReadFile(filepath.Join(configPath, clockFloorFile))
 	if err != nil || len(data) < 8 {
-		return time.Time{}
+		return time.Time{}, false
 	}
-	sec := int64(binary.BigEndian.Uint64(data[:8]))
-	return time.Unix(sec, 0)
+	sec := int64(binary.BigEndian.Uint64(data[:8])) //nolint:gosec — range-checked below
+	t = time.Unix(sec, 0)
+	if t.Before(floorMin) || t.After(floorMax) {
+		return time.Time{}, true
+	}
+	return t, false
 }
 
 // FloorBytes encodes t as the 8-byte big-endian clock_floor payload.

--- a/go/internal/agent/timesync/floor_bounds_test.go
+++ b/go/internal/agent/timesync/floor_bounds_test.go
@@ -1,0 +1,63 @@
+package timesync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// /config/clock_floor is eight bytes on a FAT partition that anyone flashing a
+// card can write. Since AdvanceTo only moves the clock forward, a value in the
+// future parks the device there and every certificate reads as expired until it
+// is reflashed.
+func TestReadFloor_RejectsImplausibleValues(t *testing.T) {
+	cases := map[string][]byte{
+		"all zero":    {0, 0, 0, 0, 0, 0, 0, 0},
+		"all ones":    {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		"far future":  FloorBytes(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)),
+		"before 2024": FloorBytes(time.Date(2019, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, clockFloorFile), payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, rejected := readFloor(dir)
+			if !got.IsZero() {
+				t.Errorf("readFloor = %v, want zero time", got)
+			}
+			if !rejected {
+				t.Error("an implausible value must report rejected so it can be logged")
+			}
+		})
+	}
+}
+
+// A short or absent file is the normal pre-feature case, not an anomaly, and must
+// not be reported as a rejected value.
+func TestReadFloor_AbsentOrShortIsNotRejected(t *testing.T) {
+	dir := t.TempDir()
+	if got, rejected := readFloor(dir); !got.IsZero() || rejected {
+		t.Errorf("absent file: got %v rejected=%v, want zero/false", got, rejected)
+	}
+	if err := os.WriteFile(filepath.Join(dir, clockFloorFile), []byte{0, 0, 0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, rejected := readFloor(dir); !got.IsZero() || rejected {
+		t.Errorf("short file: got %v rejected=%v, want zero/false", got, rejected)
+	}
+}
+
+func TestReadFloor_AcceptsPlausibleValue(t *testing.T) {
+	dir := t.TempDir()
+	want := time.Date(2026, 8, 7, 0, 33, 2, 0, time.UTC)
+	if err := os.WriteFile(filepath.Join(dir, clockFloorFile), FloorBytes(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, rejected := readFloor(dir)
+	if !got.Equal(want) || rejected {
+		t.Errorf("readFloor = %v rejected=%v, want %v/false", got, rejected, want)
+	}
+}

--- a/go/internal/agent/timesync/floor_bounds_test.go
+++ b/go/internal/agent/timesync/floor_bounds_test.go
@@ -5,13 +5,16 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // /config/clock_floor is eight bytes on a FAT partition that anyone flashing a
 // card can write. Since AdvanceTo only moves the clock forward, a value in the
 // future parks the device there and every certificate reads as expired until it
 // is reflashed.
-func TestReadFloor_RejectsImplausibleValues(t *testing.T) {
+func TestReadFloor_RefusesImplausibleValues(t *testing.T) {
 	cases := map[string][]byte{
 		"all zero":    {0, 0, 0, 0, 0, 0, 0, 0},
 		"all ones":    {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
@@ -24,29 +27,29 @@ func TestReadFloor_RejectsImplausibleValues(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, clockFloorFile), payload, 0o600); err != nil {
 				t.Fatal(err)
 			}
-			got, rejected := readFloor(dir)
-			if !got.IsZero() {
-				t.Errorf("readFloor = %v, want zero time", got)
+			floor, refused := readFloor(dir)
+			if !floor.IsZero() {
+				t.Errorf("floor = %v, want zero so no caller can apply it", floor)
 			}
-			if !rejected {
-				t.Error("an implausible value must report rejected so it can be logged")
+			if refused.IsZero() {
+				t.Error("the refused value must be returned so it can be logged")
 			}
 		})
 	}
 }
 
 // A short or absent file is the normal pre-feature case, not an anomaly, and must
-// not be reported as a rejected value.
-func TestReadFloor_AbsentOrShortIsNotRejected(t *testing.T) {
+// not be reported as a refused value.
+func TestReadFloor_AbsentOrShortIsNotRefused(t *testing.T) {
 	dir := t.TempDir()
-	if got, rejected := readFloor(dir); !got.IsZero() || rejected {
-		t.Errorf("absent file: got %v rejected=%v, want zero/false", got, rejected)
+	if floor, refused := readFloor(dir); !floor.IsZero() || !refused.IsZero() {
+		t.Errorf("absent file: got %v / %v, want both zero", floor, refused)
 	}
 	if err := os.WriteFile(filepath.Join(dir, clockFloorFile), []byte{0, 0, 0}, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got, rejected := readFloor(dir); !got.IsZero() || rejected {
-		t.Errorf("short file: got %v rejected=%v, want zero/false", got, rejected)
+	if floor, refused := readFloor(dir); !floor.IsZero() || !refused.IsZero() {
+		t.Errorf("short file: got %v / %v, want both zero", floor, refused)
 	}
 }
 
@@ -56,8 +59,29 @@ func TestReadFloor_AcceptsPlausibleValue(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, clockFloorFile), FloorBytes(want), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	got, rejected := readFloor(dir)
-	if !got.Equal(want) || rejected {
-		t.Errorf("readFloor = %v rejected=%v, want %v/false", got, rejected, want)
+	floor, refused := readFloor(dir)
+	if !floor.Equal(want) || !refused.IsZero() {
+		t.Errorf("readFloor = %v / %v, want %v / zero", floor, refused, want)
+	}
+}
+
+// An operator seeing only "ignoring implausible clock floor" cannot tell a zeroed
+// write from a year-2200 value, which need different remedies.
+func TestApplyFloor_LogsTheRefusedValue(t *testing.T) {
+	dir := t.TempDir()
+	bad := time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.WriteFile(filepath.Join(dir, clockFloorFile), FloorBytes(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	core, logs := observer.New(zap.WarnLevel)
+	NewManager(zap.New(core), dir).ApplyFloor()
+
+	entries := logs.FilterMessageSnippet("implausible clock floor").All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(entries))
+	}
+	got, ok := entries[0].ContextMap()["floor"].(time.Time)
+	if !ok || !got.Equal(bad) {
+		t.Errorf("logged floor = %v, want the refused value %v", got, bad)
 	}
 }

--- a/go/internal/agent/timesync/manager.go
+++ b/go/internal/agent/timesync/manager.go
@@ -22,7 +22,11 @@ func NewManager(logger *zap.Logger, configPath string) *Manager {
 // ApplyFloor reads the config-partition floor and advances the clock if it
 // is ahead of the current time. Called once at agent startup.
 func (m *Manager) ApplyFloor() {
-	floor := readFloor(m.configPath)
+	floor, rejected := readFloor(m.configPath)
+	if rejected && m.logger != nil {
+		m.logger.Warn("timesync: ignoring implausible clock floor",
+			zap.Time("min", floorMin), zap.Time("max", floorMax))
+	}
 	if floor.IsZero() {
 		return
 	}

--- a/go/internal/agent/timesync/manager.go
+++ b/go/internal/agent/timesync/manager.go
@@ -22,9 +22,10 @@ func NewManager(logger *zap.Logger, configPath string) *Manager {
 // ApplyFloor reads the config-partition floor and advances the clock if it
 // is ahead of the current time. Called once at agent startup.
 func (m *Manager) ApplyFloor() {
-	floor, rejected := readFloor(m.configPath)
-	if rejected && m.logger != nil {
+	floor, refused := readFloor(m.configPath)
+	if !refused.IsZero() && m.logger != nil {
 		m.logger.Warn("timesync: ignoring implausible clock floor",
+			zap.Time("floor", refused),
 			zap.Time("min", floorMin), zap.Time("max", floorMax))
 	}
 	if floor.IsZero() {

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -16,6 +16,7 @@ import (
 
 	qrcode "github.com/skip2/go-qrcode"
 	"github.com/spf13/cobra"
+	clitimesync "github.com/wendylabsinc/wendy/go/internal/cli/timesync"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/browseropen"
 	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
@@ -285,6 +286,11 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	}
 
 	fmt.Println(tui.SuccessMessage("Authentication successful. Certificates saved."))
+	// The certificate is only usable on a device whose clock has reached its
+	// NotBefore. Grab a Roughtime proof now, while the network is known good, so
+	// a later run can hand it to a device that is behind and offline. Paired with
+	// the cert just issued, so it asserts a time at or after its NotBefore.
+	clitimesync.CacheProof(ctx)
 
 	if len(issueResp.GetWarnings()) > 0 {
 		fmt.Println(tui.WarningMessage("Warnings:"))
@@ -407,6 +413,12 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 
 	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Local authentication successful (org=%d, device=%s). Certificates saved.",
 		issueResp.GetOrganizationId(), deviceID)))
+	// The certificate is only usable on a device whose clock has reached its
+	// NotBefore. Grab a Roughtime proof now, while the network is known good, so
+	// a later run can hand it to a device that is behind and offline. Paired with
+	// the cert just issued, so it asserts a time at or after its NotBefore.
+	clitimesync.CacheProof(ctx)
+
 	return nil
 }
 

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -286,10 +286,6 @@ func performLogin(ctx context.Context, cloudDashboard, cloudGRPC string) error {
 	}
 
 	fmt.Println(tui.SuccessMessage("Authentication successful. Certificates saved."))
-	// The certificate is only usable on a device whose clock has reached its
-	// NotBefore. Grab a Roughtime proof now, while the network is known good, so
-	// a later run can hand it to a device that is behind and offline. Paired with
-	// the cert just issued, so it asserts a time at or after its NotBefore.
 	clitimesync.CacheProof(ctx)
 
 	if len(issueResp.GetWarnings()) > 0 {
@@ -413,10 +409,6 @@ func performLocalLogin(ctx context.Context, cloudGRPC, apiKey string, orgID int3
 
 	fmt.Println(tui.SuccessMessage(fmt.Sprintf("Local authentication successful (org=%d, device=%s). Certificates saved.",
 		issueResp.GetOrganizationId(), deviceID)))
-	// The certificate is only usable on a device whose clock has reached its
-	// NotBefore. Grab a Roughtime proof now, while the network is known good, so
-	// a later run can hand it to a device that is behind and offline. Paired with
-	// the cert just issued, so it asserts a time at or after its NotBefore.
 	clitimesync.CacheProof(ctx)
 
 	return nil
@@ -677,6 +669,10 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 			UserID:              existingCert.UserID,
 		},
 	}
+
+	// This cert has a later NotBefore than the one it replaces, so the proof kept
+	// for offline use has to move with it.
+	clitimesync.CacheProof(ctx)
 
 	return nil
 }

--- a/go/internal/cli/commands/device_clock.go
+++ b/go/internal/cli/commands/device_clock.go
@@ -76,4 +76,3 @@ func debugClock(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, "[clock] "+format+"\n", args...)
 	}
 }
-

--- a/go/internal/cli/commands/device_clock.go
+++ b/go/internal/cli/commands/device_clock.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	clitimesync "github.com/wendylabsinc/wendy/go/internal/cli/timesync"
+	"github.com/wendylabsinc/wendy/go/internal/shared/timefmt"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 )
 
@@ -65,7 +66,7 @@ func maybeFixClock(ctx context.Context, conn *grpcclient.AgentConnection) {
 		return
 	}
 	if syncResp.GetApplied() && !jsonOutput {
-		fmt.Fprintf(os.Stderr, "⏱  Device clock was %s behind — synchronized via Roughtime.\n", formatClockSkew(skew))
+		fmt.Fprintf(os.Stderr, "⏱  Device clock was %s behind — synchronized via Roughtime.\n", timefmt.Skew(skew))
 	}
 }
 
@@ -76,18 +77,3 @@ func debugClock(format string, args ...any) {
 	}
 }
 
-// formatClockSkew renders a coarse, human-friendly magnitude (e.g. "56y", "3h", "5m").
-func formatClockSkew(d time.Duration) string {
-	switch {
-	case d >= 365*24*time.Hour:
-		return fmt.Sprintf("%dy", int(d/(365*24*time.Hour)))
-	case d >= 24*time.Hour:
-		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
-	case d >= time.Hour:
-		return fmt.Sprintf("%dh", int(d/time.Hour))
-	case d >= time.Minute:
-		return fmt.Sprintf("%dm", int(d/time.Minute))
-	default:
-		return d.Round(time.Minute).String()
-	}
-}

--- a/go/internal/cli/commands/device_sync_time.go
+++ b/go/internal/cli/commands/device_sync_time.go
@@ -10,9 +10,8 @@ import (
 
 func newDeviceSyncTimeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "sync-time",
-		Hidden: true,
-		Short:  "Sync the clock on nearby WendyOS devices via Roughtime multicast",
+		Use:   "sync-time",
+		Short: "Sync the clock on nearby WendyOS devices via Roughtime multicast",
 		Long: `Queries a Roughtime server for a cryptographically signed timestamp,
 then multicasts the signed proof to all WendyOS devices on the local network.
 Devices verify the Roughtime signature themselves — the Mac is an untrusted relay.`,
@@ -21,10 +20,14 @@ Devices verify the Roughtime signature themselves — the Mac is an untrusted re
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Synced: %s ± %s  (via %s)\n",
+			source := "live query"
+			if clitimesync.ProofFromCache() {
+				source = "cached proof — no route to a Roughtime server"
+			}
+			fmt.Printf("Broadcast: %s ± %s  (via %s, %s)\n",
 				result.Midpoint.UTC().Format("2006-01-02T15:04:05Z"),
 				result.Radius.Round(time.Millisecond),
-				result.Server)
+				result.Server, source)
 			return nil
 		},
 	}

--- a/go/internal/cli/commands/device_sync_time.go
+++ b/go/internal/cli/commands/device_sync_time.go
@@ -21,8 +21,9 @@ Devices verify the Roughtime signature themselves — the Mac is an untrusted re
 				return err
 			}
 			source := "live query"
-			if clitimesync.ProofFromCache() {
-				source = "cached proof — no route to a Roughtime server"
+			if cached, age := clitimesync.ProofFromCache(); cached {
+				source = fmt.Sprintf("proof cached %s ago — no route to a Roughtime server",
+					age.Round(time.Minute))
 			}
 			fmt.Printf("Broadcast: %s ± %s  (via %s, %s)\n",
 				result.Midpoint.UTC().Format("2006-01-02T15:04:05Z"),

--- a/go/internal/cli/timesync/main_test.go
+++ b/go/internal/cli/timesync/main_test.go
@@ -1,0 +1,21 @@
+package clitimesync
+
+import (
+	"os"
+	"testing"
+)
+
+// FetchProofPacket writes the proof it obtains under $HOME, so every test in this
+// package runs against a throwaway home. Without this a test that stubs the
+// Roughtime query overwrites the developer's own cached proof with a fake one.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "wendy-timesync-test")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", dir)             //nolint:errcheck
+	os.Setenv("USERPROFILE", dir)      //nolint:errcheck — config.ConfigDir on Windows
+	code := m.Run()
+	os.RemoveAll(dir) //nolint:errcheck
+	os.Exit(code)
+}

--- a/go/internal/cli/timesync/main_test.go
+++ b/go/internal/cli/timesync/main_test.go
@@ -13,8 +13,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	os.Setenv("HOME", dir)             //nolint:errcheck
-	os.Setenv("USERPROFILE", dir)      //nolint:errcheck — config.ConfigDir on Windows
+	os.Setenv("HOME", dir)        //nolint:errcheck
+	os.Setenv("USERPROFILE", dir) //nolint:errcheck — config.ConfigDir on Windows
 	code := m.Run()
 	os.RemoveAll(dir) //nolint:errcheck
 	os.Exit(code)

--- a/go/internal/cli/timesync/proofcache.go
+++ b/go/internal/cli/timesync/proofcache.go
@@ -1,0 +1,93 @@
+package clitimesync
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// proofCacheFile holds the most recent Roughtime proof this host obtained, so a
+// device can still be given a verified time when the host has no route to a
+// Roughtime server — the case that matters, because a device whose clock is too
+// far behind to accept our certificate is usually offline and so are we.
+//
+// Replaying an old proof cannot harm the device: the agent's AdvanceTo only ever
+// moves the clock forward, so a stale proof either advances it (good) or does
+// nothing. Moving a clock backward, or forward past the true time, would require
+// the Roughtime server's Ed25519 key.
+//
+// A cached proof only has to be as fresh as the certificate it is used with. Both
+// are obtained at login, so the proof asserts a time at or after the cert's
+// NotBefore — exactly the advance needed for that cert to satisfy a strict
+// NotBefore check on the device.
+const proofCacheFile = "timeproof.json"
+
+type cachedProof struct {
+	// Packet is the encoded WendyDatagram the agent verifies, base64 for JSON.
+	Packet string `json:"packet"`
+	// MidpointUnix and Server describe the proof for display only; the device
+	// re-derives both from Packet and verifies the signature itself.
+	MidpointUnix int64  `json:"midpointUnix"`
+	Server       string `json:"server"`
+	FetchedUnix  int64  `json:"fetchedUnix"`
+}
+
+func proofCachePath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, proofCacheFile), nil
+}
+
+// storeProof persists pkt so a later run without network can still broadcast it.
+// Best-effort: a cache we cannot write costs nothing today.
+func storeProof(pkt []byte, midpoint time.Time, server string) error {
+	path, err := proofCachePath()
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(cachedProof{
+		Packet:       base64.StdEncoding.EncodeToString(pkt),
+		MidpointUnix: midpoint.Unix(),
+		Server:       server,
+		FetchedUnix:  time.Now().Unix(),
+	})
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// loadProof returns the cached proof packet and the time it asserts.
+func loadProof() (pkt []byte, midpoint time.Time, server string, err error) {
+	path, err := proofCachePath()
+	if err != nil {
+		return nil, time.Time{}, "", err
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, time.Time{}, "", err
+	}
+	var c cachedProof
+	if err := json.Unmarshal(body, &c); err != nil {
+		return nil, time.Time{}, "", fmt.Errorf("parsing cached time proof: %w", err)
+	}
+	pkt, err = base64.StdEncoding.DecodeString(c.Packet)
+	if err != nil {
+		return nil, time.Time{}, "", fmt.Errorf("decoding cached time proof: %w", err)
+	}
+	if len(pkt) == 0 {
+		return nil, time.Time{}, "", fmt.Errorf("cached time proof is empty")
+	}
+	return pkt, time.Unix(c.MidpointUnix, 0), c.Server, nil
+}

--- a/go/internal/cli/timesync/proofcache.go
+++ b/go/internal/cli/timesync/proofcache.go
@@ -9,32 +9,29 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
 )
 
-// proofCacheFile holds the most recent Roughtime proof this host obtained, so a
-// device can still be given a verified time when the host has no route to a
-// Roughtime server — the case that matters, because a device whose clock is too
-// far behind to accept our certificate is usually offline and so are we.
+// proofCacheFile holds the most recent Roughtime proof this host obtained, for
+// hosts with no route to a Roughtime server. Replaying it cannot harm a device:
+// the agent only ever advances its clock, and moving a clock backward or past the
+// true time would require the server's Ed25519 key.
 //
-// Replaying an old proof cannot harm the device: the agent's AdvanceTo only ever
-// moves the clock forward, so a stale proof either advances it (good) or does
-// nothing. Moving a clock backward, or forward past the true time, would require
-// the Roughtime server's Ed25519 key.
-//
-// A cached proof only has to be as fresh as the certificate it is used with. Both
-// are obtained at login, so the proof asserts a time at or after the cert's
-// NotBefore — exactly the advance needed for that cert to satisfy a strict
-// NotBefore check on the device.
+// The proof only has to be as fresh as the certificate it is used with. Both are
+// obtained at login, so the proof asserts a time at or after the cert's
+// NotBefore — the advance that cert needs to pass a strict NotBefore check.
 const proofCacheFile = "timeproof.json"
 
+// The server's own fields are cached, not the encoded datagram: the wire format
+// identifies the server by its index in timesync.Servers, so a cached packet
+// would name the wrong verification key after that list is reordered.
 type cachedProof struct {
-	// Packet is the encoded WendyDatagram the agent verifies, base64 for JSON.
-	Packet string `json:"packet"`
-	// MidpointUnix and Server describe the proof for display only; the device
-	// re-derives both from Packet and verifies the signature itself.
-	MidpointUnix int64  `json:"midpointUnix"`
-	Server       string `json:"server"`
-	FetchedUnix  int64  `json:"fetchedUnix"`
+	Server      string `json:"server"`
+	Nonce       string `json:"nonce"`       // base64
+	RawResponse string `json:"rawResponse"` // base64
+	MidpointMS  int64  `json:"midpointMs"`
+	RadiusMS    int64  `json:"radiusMs"`
+	FetchedUnix int64  `json:"fetchedUnix"`
 }
 
 func proofCachePath() (string, error) {
@@ -45,49 +42,75 @@ func proofCachePath() (string, error) {
 	return filepath.Join(dir, proofCacheFile), nil
 }
 
-// storeProof persists pkt so a later run without network can still broadcast it.
-// Best-effort: a cache we cannot write costs nothing today.
-func storeProof(pkt []byte, midpoint time.Time, server string) error {
+// storeProof persists result so a later run without network can still broadcast
+// it. Best-effort: a cache we cannot write costs nothing today.
+func storeProof(result roughtime.Result, now time.Time) error {
 	path, err := proofCachePath()
 	if err != nil {
 		return err
 	}
 	body, err := json.Marshal(cachedProof{
-		Packet:       base64.StdEncoding.EncodeToString(pkt),
-		MidpointUnix: midpoint.Unix(),
-		Server:       server,
-		FetchedUnix:  time.Now().Unix(),
+		Server:      result.Server,
+		Nonce:       base64.StdEncoding.EncodeToString(result.Nonce),
+		RawResponse: base64.StdEncoding.EncodeToString(result.RawResponse),
+		MidpointMS:  result.Midpoint.UnixMilli(),
+		RadiusMS:    result.Radius.Milliseconds(),
+		FetchedUnix: now.Unix(),
 	})
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".timeproof-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	defer os.Remove(tmp.Name()) // no-op once the rename below succeeds
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
 }
 
-// loadProof returns the cached proof packet and the time it asserts.
-func loadProof() (pkt []byte, midpoint time.Time, server string, err error) {
+// loadProof returns the cached proof and when it was obtained. A proof missing
+// the fields needed to rebuild the datagram is reported as an error rather than
+// relayed as an unverifiable packet.
+func loadProof() (result roughtime.Result, fetchedAt time.Time, err error) {
 	path, err := proofCachePath()
 	if err != nil {
-		return nil, time.Time{}, "", err
+		return roughtime.Result{}, time.Time{}, err
 	}
 	body, err := os.ReadFile(path)
 	if err != nil {
-		return nil, time.Time{}, "", err
+		return roughtime.Result{}, time.Time{}, err
 	}
 	var c cachedProof
 	if err := json.Unmarshal(body, &c); err != nil {
-		return nil, time.Time{}, "", fmt.Errorf("parsing cached time proof: %w", err)
+		return roughtime.Result{}, time.Time{}, fmt.Errorf("parsing cached time proof: %w", err)
 	}
-	pkt, err = base64.StdEncoding.DecodeString(c.Packet)
+	nonce, err := base64.StdEncoding.DecodeString(c.Nonce)
 	if err != nil {
-		return nil, time.Time{}, "", fmt.Errorf("decoding cached time proof: %w", err)
+		return roughtime.Result{}, time.Time{}, fmt.Errorf("decoding cached nonce: %w", err)
 	}
-	if len(pkt) == 0 {
-		return nil, time.Time{}, "", fmt.Errorf("cached time proof is empty")
+	response, err := base64.StdEncoding.DecodeString(c.RawResponse)
+	if err != nil {
+		return roughtime.Result{}, time.Time{}, fmt.Errorf("decoding cached response: %w", err)
 	}
-	return pkt, time.Unix(c.MidpointUnix, 0), c.Server, nil
+	if len(nonce) == 0 || len(response) == 0 || c.Server == "" {
+		return roughtime.Result{}, time.Time{}, fmt.Errorf("cached time proof is incomplete")
+	}
+	return roughtime.Result{
+		Server:      c.Server,
+		Nonce:       nonce,
+		RawResponse: response,
+		Midpoint:    time.UnixMilli(c.MidpointMS),
+		Radius:      time.Duration(c.RadiusMS) * time.Millisecond,
+	}, time.Unix(c.FetchedUnix, 0), nil
 }

--- a/go/internal/cli/timesync/proofcache_test.go
+++ b/go/internal/cli/timesync/proofcache_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
 )
 
-// stubQuery replaces the Roughtime query for the duration of a test and clears
-// both the in-process memo and the on-disk cache around it.
+// stubQuery replaces the Roughtime query for the duration of a test, in a home
+// directory of its own so the on-disk cache starts empty.
 func stubQuery(t *testing.T, fn func() (roughtime.Result, error)) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 	orig := roughtimeQueryFn
 	roughtimeQueryFn = func(_ context.Context, _ []roughtime.Server) (roughtime.Result, error) {
 		return fn()
@@ -25,20 +26,27 @@ func stubQuery(t *testing.T, fn func() (roughtime.Result, error)) {
 	resetProofCache()
 }
 
+func liveResult() roughtime.Result {
+	return roughtime.Result{
+		Server:      "cloudflare",
+		Nonce:       []byte("nonce"),
+		RawResponse: []byte("resp"),
+		Midpoint:    time.Date(2026, 8, 11, 3, 0, 0, 0, time.UTC),
+		Radius:      2 * time.Second,
+	}
+}
+
 // WDY-2389: the rescue path exists for a device too far behind to accept our
 // certificate, which is usually offline — and so is the host. A proof kept from a
 // run that did have a route is what makes the path work then.
 func TestFetchProofPacket_FallsBackToCachedProof(t *testing.T) {
-	midpoint := time.Date(2026, 8, 11, 3, 0, 0, 0, time.UTC)
-	stubQuery(t, func() (roughtime.Result, error) {
-		return roughtime.Result{Server: "cloudflare", Nonce: []byte("nonce"), RawResponse: []byte("resp"), Midpoint: midpoint}, nil
-	})
+	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
 
 	fresh, _, err := FetchProofPacket(context.Background())
 	if err != nil {
 		t.Fatalf("first fetch: %v", err)
 	}
-	if ProofFromCache() {
+	if cached, _ := ProofFromCache(); cached {
 		t.Error("a live query must not report as cached")
 	}
 
@@ -48,18 +56,27 @@ func TestFetchProofPacket_FallsBackToCachedProof(t *testing.T) {
 		return roughtime.Result{}, errors.New("network is unreachable")
 	}
 
-	cached, result, err := FetchProofPacket(context.Background())
+	pkt, result, err := FetchProofPacket(context.Background())
 	if err != nil {
 		t.Fatalf("expected the cached proof to be used, got: %v", err)
 	}
-	if !bytes.Equal(cached, fresh) {
-		t.Error("cached packet differs from the one stored")
+	// The datagram is rebuilt from the cached fields rather than stored verbatim,
+	// so this also pins that the round trip reproduces it byte for byte.
+	if !bytes.Equal(pkt, fresh) {
+		t.Error("packet rebuilt from cache differs from the live one")
 	}
-	if !ProofFromCache() {
+	cached, age := ProofFromCache()
+	if !cached {
 		t.Error("ProofFromCache() must report true so the caller can say so")
 	}
-	if !result.Midpoint.Equal(midpoint) {
-		t.Errorf("midpoint = %v, want %v", result.Midpoint, midpoint)
+	if age < 0 || age > time.Minute {
+		t.Errorf("age = %v, want the time since it was stored", age)
+	}
+	// Radius has to survive: the CLI prints it, and a zero would advertise a
+	// months-old proof as accurate to the millisecond.
+	if want := liveResult(); !result.Midpoint.Equal(want.Midpoint) || result.Radius != want.Radius {
+		t.Errorf("result = %v ± %v, want %v ± %v",
+			result.Midpoint, result.Radius, want.Midpoint, want.Radius)
 	}
 }
 
@@ -72,10 +89,45 @@ func TestFetchProofPacket_NoCacheAndNoNetworkStillErrors(t *testing.T) {
 	}
 }
 
-func TestCacheProof_WritesForALaterRun(t *testing.T) {
+// Our own deadline expiring is not evidence that the host has no route, and
+// substituting an older proof there would report success while leaving the device
+// short of the time it needed.
+func TestFetchProofPacket_DoesNotFallBackOnCancelledContext(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
+	if _, _, err := FetchProofPacket(context.Background()); err != nil {
+		t.Fatalf("seeding the cache: %v", err)
+	}
+
+	resetProofCache()
+	roughtimeQueryFn = func(ctx context.Context, _ []roughtime.Server) (roughtime.Result, error) {
+		return roughtime.Result{}, ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := FetchProofPacket(ctx); err == nil {
+		t.Fatal("a cancelled query must not silently fall back to the cached proof")
+	}
+}
+
+// The wire format names the server by index into timesync.Servers, so a cached
+// proof naming a server this build does not know cannot be re-encoded — sending
+// index 0 would have the device verify against the wrong key.
+func TestFetchProofPacket_RejectsCachedProofFromUnknownServer(t *testing.T) {
 	stubQuery(t, func() (roughtime.Result, error) {
-		return roughtime.Result{Server: "int08h", Nonce: []byte("n"), RawResponse: []byte("r"), Midpoint: time.Now()}, nil
+		return roughtime.Result{}, errors.New("network is unreachable")
 	})
+	r := liveResult()
+	r.Server = "retired.example.com"
+	if err := storeProof(r, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := FetchProofPacket(context.Background()); err == nil {
+		t.Fatal("expected a cached proof from an unknown server to be refused")
+	}
+}
+
+func TestCacheProof_WritesForALaterRun(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
 
 	CacheProof(context.Background())
 
@@ -91,16 +143,24 @@ func TestCacheProof_WritesForALaterRun(t *testing.T) {
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Errorf("cache mode = %o, want 0600", perm)
 	}
-	if _, _, _, err := loadProof(); err != nil {
+	if _, _, err := loadProof(); err != nil {
 		t.Errorf("loadProof after CacheProof: %v", err)
+	}
+	// A failed rename must not leave scratch files next to it.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != proofCacheFile {
+			t.Errorf("unexpected leftover file %q in the config dir", e.Name())
+		}
 	}
 }
 
 // A cache we cannot read must not stop a live query from working.
 func TestFetchProofPacket_IgnoresCorruptCache(t *testing.T) {
-	stubQuery(t, func() (roughtime.Result, error) {
-		return roughtime.Result{Server: "test", Nonce: []byte("n"), RawResponse: []byte("r")}, nil
-	})
+	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
 	path, err := proofCachePath()
 	if err != nil {
 		t.Fatal(err)
@@ -113,16 +173,27 @@ func TestFetchProofPacket_IgnoresCorruptCache(t *testing.T) {
 	}
 }
 
-func TestLoadProof_RejectsEmptyPacket(t *testing.T) {
+// A proof missing the fields needed to rebuild the datagram must be an error, not
+// an empty packet relayed as if it were a time.
+func TestLoadProof_RejectsIncompleteProof(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 	path, err := proofCachePath()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(`{"packet":"","midpointUnix":1,"server":"x"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, _, err := loadProof(); err == nil {
-		t.Fatal("expected an error for an empty cached packet")
+	for name, body := range map[string]string{
+		"no nonce":    `{"server":"cloudflare","rawResponse":"cmVzcA==","midpointMs":1}`,
+		"no response": `{"server":"cloudflare","nonce":"bm9uY2U=","midpointMs":1}`,
+		"no server":   `{"nonce":"bm9uY2U=","rawResponse":"cmVzcA==","midpointMs":1}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := loadProof(); err == nil {
+				t.Fatal("expected an error for an incomplete cached proof")
+			}
+		})
 	}
 }

--- a/go/internal/cli/timesync/proofcache_test.go
+++ b/go/internal/cli/timesync/proofcache_test.go
@@ -89,10 +89,9 @@ func TestFetchProofPacket_NoCacheAndNoNetworkStillErrors(t *testing.T) {
 	}
 }
 
-// Our own deadline expiring is not evidence that the host has no route, and
-// substituting an older proof there would report success while leaving the device
-// short of the time it needed.
-func TestFetchProofPacket_DoesNotFallBackOnCancelledContext(t *testing.T) {
+// A caller that abandoned the operation does not want an older time relayed on
+// its behalf.
+func TestFetchProofPacket_DoesNotFallBackWhenCallerCancels(t *testing.T) {
 	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
 	if _, _, err := FetchProofPacket(context.Background()); err != nil {
 		t.Fatalf("seeding the cache: %v", err)
@@ -106,6 +105,33 @@ func TestFetchProofPacket_DoesNotFallBackOnCancelledContext(t *testing.T) {
 	cancel()
 	if _, _, err := FetchProofPacket(ctx); err == nil {
 		t.Fatal("a cancelled query must not silently fall back to the cached proof")
+	}
+}
+
+// The rescue runs under autoSyncTimeAndRetry's 5s budget against servers that do
+// not answer, so "no route" presents as that budget running out. Refusing the
+// cache then disables the fallback in the one scenario it exists for — which is
+// what happened on hardware before this case was pinned.
+func TestFetchProofPacket_FallsBackWhenOurOwnDeadlineExpires(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) { return liveResult(), nil })
+	if _, _, err := FetchProofPacket(context.Background()); err != nil {
+		t.Fatalf("seeding the cache: %v", err)
+	}
+
+	resetProofCache()
+	roughtimeQueryFn = func(ctx context.Context, _ []roughtime.Server) (roughtime.Result, error) {
+		<-ctx.Done()
+		return roughtime.Result{}, ctx.Err()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, result, err := FetchProofPacket(ctx)
+	if err != nil {
+		t.Fatalf("expected the cached proof to be used, got: %v", err)
+	}
+	if !result.Midpoint.Equal(liveResult().Midpoint) {
+		t.Errorf("midpoint = %v, want the cached one", result.Midpoint)
 	}
 }
 

--- a/go/internal/cli/timesync/proofcache_test.go
+++ b/go/internal/cli/timesync/proofcache_test.go
@@ -1,0 +1,128 @@
+package clitimesync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
+)
+
+// stubQuery replaces the Roughtime query for the duration of a test and clears
+// both the in-process memo and the on-disk cache around it.
+func stubQuery(t *testing.T, fn func() (roughtime.Result, error)) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	orig := roughtimeQueryFn
+	roughtimeQueryFn = func(_ context.Context, _ []roughtime.Server) (roughtime.Result, error) {
+		return fn()
+	}
+	t.Cleanup(func() { roughtimeQueryFn = orig; resetProofCache() })
+	resetProofCache()
+}
+
+// WDY-2389: the rescue path exists for a device too far behind to accept our
+// certificate, which is usually offline — and so is the host. A proof kept from a
+// run that did have a route is what makes the path work then.
+func TestFetchProofPacket_FallsBackToCachedProof(t *testing.T) {
+	midpoint := time.Date(2026, 8, 11, 3, 0, 0, 0, time.UTC)
+	stubQuery(t, func() (roughtime.Result, error) {
+		return roughtime.Result{Server: "cloudflare", Nonce: []byte("nonce"), RawResponse: []byte("resp"), Midpoint: midpoint}, nil
+	})
+
+	fresh, _, err := FetchProofPacket(context.Background())
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if ProofFromCache() {
+		t.Error("a live query must not report as cached")
+	}
+
+	// New process, no route to any server.
+	resetProofCache()
+	roughtimeQueryFn = func(_ context.Context, _ []roughtime.Server) (roughtime.Result, error) {
+		return roughtime.Result{}, errors.New("network is unreachable")
+	}
+
+	cached, result, err := FetchProofPacket(context.Background())
+	if err != nil {
+		t.Fatalf("expected the cached proof to be used, got: %v", err)
+	}
+	if !bytes.Equal(cached, fresh) {
+		t.Error("cached packet differs from the one stored")
+	}
+	if !ProofFromCache() {
+		t.Error("ProofFromCache() must report true so the caller can say so")
+	}
+	if !result.Midpoint.Equal(midpoint) {
+		t.Errorf("midpoint = %v, want %v", result.Midpoint, midpoint)
+	}
+}
+
+func TestFetchProofPacket_NoCacheAndNoNetworkStillErrors(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) {
+		return roughtime.Result{}, errors.New("network is unreachable")
+	})
+	if _, _, err := FetchProofPacket(context.Background()); err == nil {
+		t.Fatal("expected an error when there is neither a route nor a cached proof")
+	}
+}
+
+func TestCacheProof_WritesForALaterRun(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) {
+		return roughtime.Result{Server: "int08h", Nonce: []byte("n"), RawResponse: []byte("r"), Midpoint: time.Now()}, nil
+	})
+
+	CacheProof(context.Background())
+
+	path, err := proofCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("CacheProof did not write %s: %v", filepath.Base(path), err)
+	}
+	// The proof is not a secret, but it sits in ~/.wendy alongside credentials.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("cache mode = %o, want 0600", perm)
+	}
+	if _, _, _, err := loadProof(); err != nil {
+		t.Errorf("loadProof after CacheProof: %v", err)
+	}
+}
+
+// A cache we cannot read must not stop a live query from working.
+func TestFetchProofPacket_IgnoresCorruptCache(t *testing.T) {
+	stubQuery(t, func() (roughtime.Result, error) {
+		return roughtime.Result{Server: "test", Nonce: []byte("n"), RawResponse: []byte("r")}, nil
+	})
+	path, err := proofCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := FetchProofPacket(context.Background()); err != nil {
+		t.Fatalf("a corrupt cache must not break a live query: %v", err)
+	}
+}
+
+func TestLoadProof_RejectsEmptyPacket(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path, err := proofCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"packet":"","midpointUnix":1,"server":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := loadProof(); err == nil {
+		t.Fatal("expected an error for an empty cached packet")
+	}
+}

--- a/go/internal/cli/timesync/sender.go
+++ b/go/internal/cli/timesync/sender.go
@@ -24,13 +24,24 @@ var (
 	proofPkt    []byte
 	proofResult roughtime.Result
 	proofCached bool
+	// proofFromDisk records that the proof in use came from the on-disk cache
+	// rather than a live query, so callers can say so.
+	proofFromDisk bool
 )
+
+// ProofFromCache reports whether the proof this run broadcast came from the
+// on-disk cache instead of a live Roughtime query.
+func ProofFromCache() bool {
+	proofMu.Lock()
+	defer proofMu.Unlock()
+	return proofFromDisk
+}
 
 // resetProofCache clears the per-process proof cache (test helper).
 func resetProofCache() {
 	proofMu.Lock()
 	defer proofMu.Unlock()
-	proofPkt, proofResult, proofCached = nil, roughtime.Result{}, false
+	proofPkt, proofResult, proofCached, proofFromDisk = nil, roughtime.Result{}, false, false
 }
 
 // FetchProofPacket queries a Roughtime server and returns the encoded
@@ -45,12 +56,31 @@ func FetchProofPacket(ctx context.Context) ([]byte, roughtime.Result, error) {
 	}
 	result, err := roughtimeQueryFn(ctx, timesync.Servers)
 	if err != nil {
+		// No route to a Roughtime server. Fall back to the proof kept from a run
+		// that did have one: it is signed by the same servers, and the agent only
+		// ever advances its clock, so an out-of-date proof cannot make things
+		// worse than having none.
+		if pkt, midpoint, server, cacheErr := loadProof(); cacheErr == nil {
+			proofPkt = pkt
+			proofResult = roughtime.Result{Midpoint: midpoint, Server: server}
+			proofCached, proofFromDisk = true, true
+			return proofPkt, proofResult, nil
+		}
 		return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w", err)
 	}
 	proofPkt = encodeProofPacket(result)
 	proofResult = result
 	proofCached = true
+	// Best-effort: keep it for a future run that cannot reach a server.
+	_ = storeProof(proofPkt, result.Midpoint, result.Server)
 	return proofPkt, proofResult, nil
+}
+
+// CacheProof fetches a proof and stores it for later offline use, discarding any
+// error. Called where the host is known to have working cloud access — notably
+// straight after login, which pairs the proof with the certificate just issued.
+func CacheProof(ctx context.Context) {
+	_, _, _ = FetchProofPacket(ctx)
 }
 
 // encodeProofPacket builds the WendyDatagram packet the agent verifies.

--- a/go/internal/cli/timesync/sender.go
+++ b/go/internal/cli/timesync/sender.go
@@ -2,6 +2,7 @@ package clitimesync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -64,10 +65,12 @@ func FetchProofPacket(ctx context.Context) ([]byte, roughtime.Result, error) {
 		// ever advances its clock, so an out-of-date proof cannot make things
 		// worse than having none.
 		//
-		// Not when our own deadline expired, though: the query may have been about
-		// to succeed, and silently relaying an older time in its place would report
-		// success while leaving the device short of the time it needed.
-		if ctx.Err() != nil {
+		// Not when the caller abandoned the operation: relaying a time nobody asked
+		// for any more is not a rescue. A deadline expiring is the opposite case —
+		// servers that do not answer consume the whole budget, so this is how "no
+		// route" usually presents, and refusing the cache here would disable the
+		// fallback exactly where it is needed.
+		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w", err)
 		}
 		cached, fetchedAt, cacheErr := loadProof()

--- a/go/internal/cli/timesync/sender.go
+++ b/go/internal/cli/timesync/sender.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
@@ -25,23 +26,25 @@ var (
 	proofResult roughtime.Result
 	proofCached bool
 	// proofFromDisk records that the proof in use came from the on-disk cache
-	// rather than a live query, so callers can say so.
+	// rather than a live query, and proofAge how old it was when read, so callers
+	// can report both.
 	proofFromDisk bool
+	proofAge      time.Duration
 )
 
 // ProofFromCache reports whether the proof this run broadcast came from the
-// on-disk cache instead of a live Roughtime query.
-func ProofFromCache() bool {
+// on-disk cache instead of a live Roughtime query, and how old it was when read.
+func ProofFromCache() (bool, time.Duration) {
 	proofMu.Lock()
 	defer proofMu.Unlock()
-	return proofFromDisk
+	return proofFromDisk, proofAge
 }
 
 // resetProofCache clears the per-process proof cache (test helper).
 func resetProofCache() {
 	proofMu.Lock()
 	defer proofMu.Unlock()
-	proofPkt, proofResult, proofCached, proofFromDisk = nil, roughtime.Result{}, false, false
+	proofPkt, proofResult, proofCached, proofFromDisk, proofAge = nil, roughtime.Result{}, false, false, 0
 }
 
 // FetchProofPacket queries a Roughtime server and returns the encoded
@@ -60,47 +63,75 @@ func FetchProofPacket(ctx context.Context) ([]byte, roughtime.Result, error) {
 		// that did have one: it is signed by the same servers, and the agent only
 		// ever advances its clock, so an out-of-date proof cannot make things
 		// worse than having none.
-		if pkt, midpoint, server, cacheErr := loadProof(); cacheErr == nil {
-			proofPkt = pkt
-			proofResult = roughtime.Result{Midpoint: midpoint, Server: server}
-			proofCached, proofFromDisk = true, true
-			return proofPkt, proofResult, nil
+		//
+		// Not when our own deadline expired, though: the query may have been about
+		// to succeed, and silently relaying an older time in its place would report
+		// success while leaving the device short of the time it needed.
+		if ctx.Err() != nil {
+			return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w", err)
 		}
-		return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w", err)
+		cached, fetchedAt, cacheErr := loadProof()
+		if cacheErr != nil {
+			return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w", err)
+		}
+		pkt, encErr := encodeProofPacket(cached)
+		if encErr != nil {
+			return nil, roughtime.Result{}, fmt.Errorf("roughtime query: %w (cached proof unusable: %v)", err, encErr)
+		}
+		proofPkt, proofResult, proofCached = pkt, cached, true
+		proofFromDisk, proofAge = true, time.Since(fetchedAt)
+		return proofPkt, proofResult, nil
 	}
-	proofPkt = encodeProofPacket(result)
-	proofResult = result
-	proofCached = true
+	pkt, err := encodeProofPacket(result)
+	if err != nil {
+		return nil, roughtime.Result{}, err
+	}
+	proofPkt, proofResult, proofCached = pkt, result, true
 	// Best-effort: keep it for a future run that cannot reach a server.
-	_ = storeProof(proofPkt, result.Midpoint, result.Server)
+	_ = storeProof(result, time.Now())
 	return proofPkt, proofResult, nil
 }
 
+// cacheProofTimeout bounds the post-login proof fetch. Nothing waits on the
+// result, so a host that cannot reach a Roughtime server must not hold up the
+// command that triggered it.
+const cacheProofTimeout = 5 * time.Second
+
 // CacheProof fetches a proof and stores it for later offline use, discarding any
 // error. Called where the host is known to have working cloud access — notably
-// straight after login, which pairs the proof with the certificate just issued.
+// straight after issuing a certificate, which pairs the proof with that cert: it
+// asserts a time at or after the cert's NotBefore, which is the advance a device
+// behind that cert needs.
 func CacheProof(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, cacheProofTimeout)
+	defer cancel()
 	_, _, _ = FetchProofPacket(ctx)
 }
 
-// encodeProofPacket builds the WendyDatagram packet the agent verifies.
-func encodeProofPacket(result roughtime.Result) []byte {
-	serverIdx := uint8(0)
+// encodeProofPacket builds the WendyDatagram packet the agent verifies. The wire
+// format names the server by its index in timesync.Servers, so a result naming a
+// server this build does not know cannot be encoded — silently sending index 0
+// would have the device verify against the wrong key.
+func encodeProofPacket(result roughtime.Result) ([]byte, error) {
+	serverIdx := -1
 	for i, s := range timesync.Servers {
 		if s.Name == result.Server {
-			serverIdx = uint8(i)
+			serverIdx = i
 			break
 		}
 	}
+	if serverIdx < 0 {
+		return nil, fmt.Errorf("unknown roughtime server %q", result.Server)
+	}
 	payload := roughtime.EncodeRoughtimePayload(roughtime.RoughtimePayload{
-		ServerIndex: serverIdx,
+		ServerIndex: uint8(serverIdx), //nolint:gosec — bounded by len(timesync.Servers)
 		Nonce:       result.Nonce,
 		Response:    result.RawResponse,
 	})
 	return roughtime.Encode(roughtime.Datagram{
 		MsgType: roughtime.MsgTypeRoughtime,
 		Payload: payload,
-	})
+	}), nil
 }
 
 // BroadcastTime fetches a Roughtime proof and multicasts it as a WendyDatagram

--- a/go/internal/cli/timesync/sender_test.go
+++ b/go/internal/cli/timesync/sender_test.go
@@ -12,7 +12,7 @@ func TestFetchProofPacketMemoizes(t *testing.T) {
 	orig := roughtimeQueryFn
 	roughtimeQueryFn = func(_ context.Context, _ []roughtime.Server) (roughtime.Result, error) {
 		calls++
-		return roughtime.Result{Server: "test", Nonce: []byte("nonce"), RawResponse: []byte("resp")}, nil
+		return roughtime.Result{Server: "cloudflare", Nonce: []byte("nonce"), RawResponse: []byte("resp")}, nil
 	}
 	t.Cleanup(func() { roughtimeQueryFn = orig; resetProofCache() })
 	resetProofCache()

--- a/go/internal/shared/timefmt/timefmt.go
+++ b/go/internal/shared/timefmt/timefmt.go
@@ -1,0 +1,29 @@
+// Package timefmt renders durations for operators. Clock skew on an RTC-less
+// device is measured in years, which time.Duration.String renders as a six-digit
+// hour count.
+package timefmt
+
+import (
+	"fmt"
+	"time"
+)
+
+// Skew renders d at the coarsest unit that still describes it: "56y", "146d",
+// "3h", "20m".
+func Skew(d time.Duration) string {
+	if d < 0 {
+		return "-" + Skew(-d)
+	}
+	switch {
+	case d >= 365*24*time.Hour:
+		return fmt.Sprintf("%dy", int(d/(365*24*time.Hour)))
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	default:
+		return d.Round(time.Second).String()
+	}
+}


### PR DESCRIPTION
Closes WDY-1878.
Closes WDY-2389.
Pairs with [WendyOS-Builder#228](https://github.com/wendylabsinc/WendyOS-Builder/pull/228).

## What breaks for the user

An owner logs in with `wendy auth login`, or their certificate quietly refreshes, then tries to reach a device that has been switched off or offline—for example, they flashed an SD card for a Raspberry Pi and put it aside for a couple of days. The device's clock is behind the moment that credential was issued, so it reads as "not yet valid" and the device refuses it on every channel. The error talks about certificates, so the natural response is to reflash — which works, and therefore hides the real cause.

The documented escape hatch, `wendy device sync-time`, fetches a fresh proof from the internet before broadcasting. So it is unavailable in exactly the situation that produces the lockout: the device is offline, the operator is standing on the same LAN looking at it, and there is nothing they can do.

## What we have to work with

The agent accepts a signed Roughtime proof over plain UDP multicast, outside mTLS — the right shape for a rescue, since the Ed25519 signature makes the CLI an untrusted relay. That also means a proof cannot be synthesised locally; it has to come from a server. And `AdvanceTo` only ever moves the clock forward, so an out-of-date proof is inert rather than harmful.

We already hold a proof at the one moment the network is known to work: when we mint the certificate.

## Changes

- Cache the Roughtime result at login and at cert refresh, and fall back to it when a live query fails. The verifier is untouched, so `NotBefore` stays strict — the device still refuses the cert until it holds a verified time, it just now has a way to get one.
- Cache the server's fields rather than the encoded datagram. The wire format names the server by its index in `timesync.Servers`, so a stored packet would name the wrong verification key once that list is reordered. An incomplete proof, or one from a server this build does not know, is refused instead of relayed as an unverifiable blob.
- Report cached-vs-live and the proof's age; un-hide `wendy device sync-time`.
- The rejection log now names the device's own clock, the lag, and the remedy.
- Plausibility bound on `/config/clock_floor`, returned separately from the value to apply so no path can apply a future-dated one — that would park the clock there permanently, since advances are one-way.

## Validation (Pi 4, `wendyos-tom-rpi4`)

The real lockout, not an approximation: `wendy auth refresh-certs` issued an operator cert with `NotBefore = 2026-08-11T05:52:29Z`, the device clock was wound back to Aug 8 and its default route deleted, and all four Roughtime servers were black-holed on the host so the operator was offline too.

| | result |
|---|---|
| no cached proof | agent: `current time 2026-08-08T12:00:01Z is before 2026-08-11T05:52:29Z`; CLI: `all Roughtime servers failed` |
| cached proof restored, nothing else changed | `timesync: clock advanced ... offset 237049s` to the proof's midpoint, mTLS restored |

The automatic path carries it: a plain `wendy device info` rescues the device, not only an explicit `sync-time`. Unreachable servers consume the retry budget rather than failing fast, so "no route" reaches the fallback as a deadline — pinned by `TestFetchProofPacket_FallsBackWhenOurOwnDeadlineExpires`.

`refresh-certs` caches a proof whose midpoint is the same second as the new cert's `NotBefore`, which is the invariant the approach rests on.

Rejection message, from the branch agent deployed to the Pi:

```
certificate not yet valid — this device's clock is 1d behind the time the
certificate was issued. Check the clock (timedatectl status); push a verified
time from a host on this network with: wendy device sync-time
clock=2026-08-09T06:00:23Z clockLag=172325s verifyLag=172325s
```

## Residual gaps

- An operator on a CLI without this change, off the device's LAN, facing a stale offline device, is still locked out. Accepted deliberately in preference to weakening `NotBefore`.
- No cached proof and no route: still stuck. The cache is only seeded by a successful query.
- Multicast is TTL 1, so the host must be on the device's segment.

## Version skew

The CLI change is self-contained: an older agent accepts the same multicast packet, and the cache is only read by the CLI that wrote it. The agent changes (log wording, floor bound) do not depend on the OS version, so a new agent on an older OS behaves as before.
