### PR TITLE
Append --user-args to the image command instead of replacing it

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1158,21 +1158,9 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		return fmt.Errorf("reading image config for %q (image is incomplete or corrupt): %w", imageName, err)
 	}
 
-	// Build the container command: explicit request > image config > /bin/sh.
-	var args []string
-	cmd := req.GetCmd()
-	if cmd != "" {
-		args = strings.Fields(cmd)
-	}
-	if len(req.GetUserArgs()) > 0 {
-		args = append(args, req.GetUserArgs()...)
-	}
-	if len(args) == 0 {
-		args = append(imageSpec.Config.Entrypoint, imageSpec.Config.Cmd...)
-	}
-	if len(args) == 0 {
-		args = []string{"/bin/sh"}
-	}
+	// Build the container command: explicit request Cmd > image config >
+	// /bin/sh, with UserArgs appended to whichever base won.
+	args := containerArgs(req.GetCmd(), req.GetUserArgs(), imageSpec.Config)
 
 	// Wrap Python commands with debugpy for remote debugging (only in debug mode).
 	if appCfg.Debug && appCfg.Language == "python" {

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -235,6 +236,31 @@ func isLocalRegistryImage(imageName string) bool {
 		strings.HasPrefix(imageName, "localhost:5555/") ||
 		strings.HasPrefix(imageName, "127.0.0.1:5555/") ||
 		strings.HasPrefix(imageName, "[::1]:5555/")
+}
+
+// containerArgs resolves a container's argv from the create request and the
+// image's OCI config. An explicit request Cmd replaces the image's
+// entrypoint/cmd; UserArgs are then *appended* to whichever base won.
+//
+// Appending rather than replacing is what makes `wendy run --user-args ...`
+// (and wendy.json `run.args`) usable against an image that already declares its
+// own ENTRYPOINT/CMD: replacing the base would exec the first user argument as
+// the binary, which fails with "executable file not found" or — worse, for an
+// arg that happens to name a real binary — silently runs the wrong program.
+func containerArgs(cmd string, userArgs []string, cfg ocispec.ImageConfig) []string {
+	var args []string
+	if cmd != "" {
+		args = strings.Fields(cmd)
+	}
+	if len(args) == 0 {
+		// Fresh slice: never append into the image config's backing arrays.
+		args = append(args, cfg.Entrypoint...)
+		args = append(args, cfg.Cmd...)
+	}
+	if len(args) == 0 {
+		args = []string{"/bin/sh"}
+	}
+	return append(args, userArgs...)
 }
 
 func gcTimestamp() string {

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -634,5 +636,101 @@ func TestSafeJoin(t *testing.T) {
 	// Reject traversal via filepath.Join normalisation.
 	if _, err := safeJoin(base, "sub/../../../etc/passwd"); err == nil {
 		t.Error("safeJoin: traversal via .. should be rejected")
+	}
+}
+
+func TestContainerArgs(t *testing.T) {
+	entrypointOnly := ocispec.ImageConfig{Entrypoint: []string{"/app/server"}}
+	cmdOnly := ocispec.ImageConfig{Cmd: []string{"python3", "main.py"}}
+	both := ocispec.ImageConfig{Entrypoint: []string{"/usr/bin/entry"}, Cmd: []string{"--serve"}}
+
+	cases := []struct {
+		name     string
+		cmd      string
+		userArgs []string
+		cfg      ocispec.ImageConfig
+		want     []string
+	}{
+		{
+			// The bug this guards: --user-args used to replace the image
+			// entrypoint entirely, so the container exec'd "--port".
+			name:     "user args append to image entrypoint",
+			userArgs: []string{"--port", "8080"},
+			cfg:      entrypointOnly,
+			want:     []string{"/app/server", "--port", "8080"},
+		},
+		{
+			name:     "user args append to image cmd",
+			userArgs: []string{"--verbose"},
+			cfg:      cmdOnly,
+			want:     []string{"python3", "main.py", "--verbose"},
+		},
+		{
+			name:     "user args append after entrypoint and cmd",
+			userArgs: []string{"--extra"},
+			cfg:      both,
+			want:     []string{"/usr/bin/entry", "--serve", "--extra"},
+		},
+		{
+			name: "no user args keeps image config",
+			cfg:  both,
+			want: []string{"/usr/bin/entry", "--serve"},
+		},
+		{
+			// Explicit Cmd still overrides the image, with user args after it.
+			name:     "explicit cmd replaces image config",
+			cmd:      "/bin/custom",
+			userArgs: []string{"--flag"},
+			cfg:      both,
+			want:     []string{"/bin/custom", "--flag"},
+		},
+		{
+			name: "explicit cmd is field-split",
+			cmd:  "sh -c",
+			cfg:  both,
+			want: []string{"sh", "-c"},
+		},
+		{
+			name:     "empty image config falls back to /bin/sh",
+			userArgs: []string{"-c", "echo hi"},
+			want:     []string{"/bin/sh", "-c", "echo hi"},
+		},
+		{
+			name: "empty everything falls back to /bin/sh",
+			want: []string{"/bin/sh"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containerArgs(tc.cmd, tc.userArgs, tc.cfg)
+			if len(got) != len(tc.want) {
+				t.Fatalf("containerArgs() = %q; want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("containerArgs() = %q; want %q", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// The image's Entrypoint/Cmd slices come straight out of the shared image spec,
+// so containerArgs must never append into their backing arrays.
+func TestContainerArgs_DoesNotMutateImageConfig(t *testing.T) {
+	entrypoint := make([]string, 1, 4)
+	entrypoint[0] = "/app/server"
+	cfg := ocispec.ImageConfig{Entrypoint: entrypoint}
+
+	if got := containerArgs("", []string{"--first"}, cfg); got[1] != "--first" {
+		t.Fatalf("containerArgs() = %q", got)
+	}
+	got := containerArgs("", []string{"--second"}, cfg)
+	if len(got) != 2 || got[0] != "/app/server" || got[1] != "--second" {
+		t.Fatalf("containerArgs() = %q; want [/app/server --second]", got)
+	}
+	if len(cfg.Entrypoint) != 1 || cfg.Entrypoint[0] != "/app/server" {
+		t.Fatalf("image config entrypoint mutated: %q", cfg.Entrypoint)
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -157,7 +157,7 @@ On a **Windows host**, `wendy run` returns an actionable error for Swift project
 | `--service <name>` | Build and run only the named service and its transitive dependencies (multi-service `wendy.json` projects only). Returns an error if the name does not match any key in the `services` map. |
 | `--keep-going` | Deploy services that build successfully instead of aborting the whole group on the first build/push failure (multi-service projects only). |
 | `--max-concurrency <n>` | Max service images to build+push at once in multi-service projects. 0 = auto-throttle large groups (default). |
-| `--user-args <args>` | Extra arguments to pass to the container at runtime. |
+| `--user-args <args>` | Extra arguments to append to the image's own entrypoint/`CMD` at runtime. Repeatable, and also accepts a comma-separated list. |
 | `--env <KEY=VALUE>` | Set an environment variable in the container. Repeatable. Overrides a `wendy.json` `env` entry of the same key. See [Environment variables](#environment-variables). |
 | `--chunking <mode>` | Controls the content-based chunking (CBC) chunk-diff deploy path: `auto` (default), `force`, or `off`. See [Deploy path: `--chunking`](#deploy-path---chunking). |
 | `--watch` | Watch the project directory and redeploy on every change. Runs detached and non-interactive. See [Watch mode](#watch-mode). |

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1141,9 +1141,10 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	restartPolicy := resolveRestartPolicy(opts)
 
 	// wendy.json run.args are the default arguments; explicit `wendy run -- ...`
-	// args take precedence. The agent replaces the image entrypoint whenever
-	// Cmd/UserArgs are set, so pass the product binary as Cmd alongside them —
-	// swift-container-plugin images use /<product> as their entrypoint.
+	// args take precedence. Current agents append UserArgs to the image's own
+	// entrypoint, but agents older than this change replace it, so keep passing
+	// the product binary as Cmd — swift-container-plugin images use /<product>
+	// as their entrypoint, so both agent versions produce the same argv.
 	userArgs := opts.userArgs
 	if len(userArgs) == 0 && appCfg.Run != nil {
 		userArgs = appCfg.Run.Args

--- a/plugins/wendy-agentic-coding/skills/wendy-app-lifecycle/SKILL.md
+++ b/plugins/wendy-agentic-coding/skills/wendy-app-lifecycle/SKILL.md
@@ -93,7 +93,7 @@ Attached `wendy run` starts the container and streams output. Ctrl+C stops the c
 
 `--deploy` creates the container but does not start it. To start that existing app later, use `wendy device apps start <app-id>`, knowing that the current agent-backed start path attaches to the app stream. There is no `wendy device apps start --detach` flag.
 
-`--user-args` is repeatable and also accepts comma-separated values. Prefer repeated flags when values could contain commas.
+`--user-args` is repeatable and also accepts comma-separated values. Prefer repeated flags when values could contain commas. The values are appended to the image's own entrypoint/`CMD`, not substituted for it, so `--user-args --port,8080` runs `<image entrypoint> --port 8080`.
 
 ## Stream logs
 


### PR DESCRIPTION
## Problem

`--user-args` (and `wendy.json` `run.args`) replaced the container's command instead of adding to it.

The agent built argv as `Cmd + UserArgs`, and only fell back to the image's `ENTRYPOINT`/`CMD` when that result was empty (`containerd/client.go`). Two deploy paths send no explicit `Cmd`:

- the Dockerfile/registry path (`run.go:1714`)
- the chunk-diff fast path (`run.go:2485`)

On those, `wendy run --user-args --port,8080` made `["--port", "8080"]` the *entire* argv. The container exec'd `--port` and exited immediately — and for a user arg that happens to name a real binary, it would silently run the wrong program instead.

## Fix

Argv now resolves through one helper, `containerArgs(cmd, userArgs, imageConfig)`:

1. base = `strings.Fields(req.Cmd)` when set, else image `Entrypoint` + `Cmd`, else `/bin/sh`
2. `UserArgs` appended to whichever base won

So `--user-args --port,8080` against an image with `ENTRYPOINT ["/app/server"]` now runs `/app/server --port 8080`.

The old fallback also did `append(imageSpec.Config.Entrypoint, ...Cmd...)`, which could write into the image config's backing array. The helper builds a fresh slice, with a test pinning that.

## Notes

- Explicit `Cmd` still overrides the image entirely — compose (`composeArgv`) and the macOS native file-sync path always set `Cmd` alongside `UserArgs`, so they are unaffected.
- The SwiftPM path keeps passing `/<product>` as `Cmd`. It was a workaround for the replace behavior, but removing it would break a new CLI against a pre-fix agent, and it yields the same argv either way. Comment updated.
- Flag docs in `run.md` and the `wendy-app-lifecycle` skill said only "extra arguments to pass to the container"; both now say the values are appended.

## Testing

- `go build ./...`
- `go test ./internal/agent/containerd/... ./internal/agent/services/... ./internal/cli/commands` — all pass
- New table test covers append-to-entrypoint, append-to-cmd, append-after-both, explicit `Cmd` override, field-splitting, and both `/bin/sh` fallbacks

**Not verified on hardware.** This is agent-side, so confirming end-to-end needs a device running a freshly built agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcY3yCBskfKSHeVzrcpwvV