### PR TITLE
fix(mcp): serve before connecting to default device

### DIFF
--- a/go/internal/cli/commands/mcp.go
+++ b/go/internal/cli/commands/mcp.go
@@ -50,16 +50,21 @@ func newMCPServeCmd() *cobra.Command {
 				// agent socket regardless of any configured device. connectFn
 				// (connectWithAutoTLS) honors WENDY_AGENT_SOCKET, so the address
 				// passed here is ignored.
-				if err := srv.ConnectTo(ctx, ""); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: could not connect to agent socket: %v\n", err)
-				}
+				srv.SetStartupConnect(func(connectCtx context.Context) {
+					if err := srv.ConnectToOnStartup(connectCtx, ""); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: could not connect to agent socket: %v\n", err)
+					}
+				})
 			case address != "":
 				if _, _, err := net.SplitHostPort(address); err != nil {
 					address = hostPort(address, defaultAgentPort)
 				}
-				if err := srv.ConnectTo(ctx, address); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: could not connect to %s: %v\n", address, err)
-				}
+				startupAddress := address
+				srv.SetStartupConnect(func(connectCtx context.Context) {
+					if err := srv.ConnectToOnStartup(connectCtx, startupAddress); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: could not connect to %s: %v\n", startupAddress, err)
+					}
+				})
 			}
 			return srv.Start(ctx)
 		},

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -25,14 +25,26 @@ import (
 type ConnectFunc func(ctx context.Context, address string) (*grpcclient.AgentConnection, error)
 
 type mcpServer struct {
-	cfg           *config.Config
-	connectFn     ConnectFunc
-	conn          *grpcclient.AgentConnection
-	connType      string
-	cloudTunnels  map[string]*mcpCloudTunnel
-	discoverLANFn func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error)
-	mu            sync.RWMutex
-	proxyDiag     []proxyDiagEntry
+	cfg              *config.Config
+	connectFn        ConnectFunc
+	startupConnectFn func(context.Context)
+	conn             *grpcclient.AgentConnection
+	connRevision     uint64
+	connType         string
+	cloudTunnels     map[string]*mcpCloudTunnel
+	discoverLANFn    func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error)
+	mu               sync.RWMutex
+	proxyDiag        []proxyDiagEntry
+}
+
+// SetStartupConnect configures the optional device connection attempted after
+// the MCP stdio server starts accepting requests. Keeping this work off the
+// protocol startup path prevents an offline default device from delaying the
+// initialize handshake until the MCP host times out.
+func (s *mcpServer) SetStartupConnect(fn func(context.Context)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startupConnectFn = fn
 }
 
 func New(cfg *config.Config, connectFn ConnectFunc) *mcpServer {
@@ -58,6 +70,7 @@ func (s *mcpServer) SetConn(conn *grpcclient.AgentConnection) {
 		_ = s.conn.Close()
 	}
 	s.conn = conn
+	s.connRevision++
 	if conn == nil {
 		s.connType = ""
 	}
@@ -101,6 +114,44 @@ func (s *mcpServer) ConnectTo(ctx context.Context, address string) error {
 	return nil
 }
 
+// ConnectToOnStartup connects only if no explicit connection change occurred
+// while the attempt was in flight. Once stdio is serving, a device_connect,
+// cloud_connect, or device_disconnect request must take precedence over the
+// automatic default-device connection.
+func (s *mcpServer) ConnectToOnStartup(ctx context.Context, address string) error {
+	if s.connectFn == nil {
+		return fmt.Errorf("no connect function configured")
+	}
+
+	s.mu.RLock()
+	revision := s.connRevision
+	alreadyConnected := s.conn != nil
+	s.mu.RUnlock()
+	if alreadyConnected {
+		return nil
+	}
+
+	conn, err := s.connectFn(ctx, address)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	s.mu.Lock()
+	if s.connRevision != revision || s.conn != nil {
+		s.mu.Unlock()
+		_ = conn.Close()
+		return nil
+	}
+	s.conn = conn
+	s.connRevision++
+	s.mu.Unlock()
+	return nil
+}
+
 // Start registers all tools and begins serving MCP over stdio. Blocks until
 // the client closes the connection.
 func (s *mcpServer) Start(ctx context.Context) error {
@@ -122,13 +173,43 @@ func (s *mcpServer) Start(ctx context.Context) error {
 	s.registerProvisioningTools(srv)
 	s.registerOSTools(srv)
 	s.registerCloudTools(srv)
+
+	startupCtx, cancelStartup := context.WithCancel(ctx)
+	defer cancelStartup()
+	go s.runStartupConnect(startupCtx, srv)
+
+	return serveStdio(srv)
+}
+
+// serveStdio is replaceable in tests so startup ordering can be verified
+// without taking over the test process's stdin and stdout.
+var serveStdio = func(srv *server.MCPServer) error {
+	return server.ServeStdio(srv)
+}
+
+func (s *mcpServer) runStartupConnect(ctx context.Context, srv *server.MCPServer) {
+	s.mu.RLock()
+	connect := s.startupConnectFn
+	s.mu.RUnlock()
+	if connect == nil {
+		return
+	}
+
+	connect(ctx)
+	if ctx.Err() != nil {
+		return
+	}
+
+	// MCPServer.AddTool is concurrency-safe and sends tools/list_changed to
+	// initialized clients, so container tools may be discovered after the host
+	// has completed its handshake with Wendy.
 	cleanups := s.registerContainerMCPTools(ctx, srv)
 	defer func() {
-		for _, c := range cleanups {
-			c()
+		for _, cleanup := range cleanups {
+			cleanup()
 		}
 	}()
-	return server.ServeStdio(srv)
+	<-ctx.Done()
 }
 
 func errNotConnected() *mcpgo.CallToolResult {

--- a/go/internal/cli/mcp/server_test.go
+++ b/go/internal/cli/mcp/server_test.go
@@ -4,11 +4,96 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
+
+func TestStart_ServesWhileStartupConnectIsBlocked(t *testing.T) {
+	originalServeStdio := serveStdio
+	t.Cleanup(func() { serveStdio = originalServeStdio })
+
+	serveStarted := make(chan map[string]*server.ServerTool, 1)
+	allowServeReturn := make(chan struct{})
+	serveStdio = func(srv *server.MCPServer) error {
+		serveStarted <- srv.ListTools()
+		<-allowServeReturn
+		return nil
+	}
+
+	connectStarted := make(chan struct{})
+	connectCanceled := make(chan struct{})
+	s := New(&config.Config{}, nil)
+	s.SetStartupConnect(func(ctx context.Context) {
+		close(connectStarted)
+		<-ctx.Done()
+		close(connectCanceled)
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.Start(context.Background()) }()
+
+	select {
+	case tools := <-serveStarted:
+		if _, ok := tools["wendy_status"]; !ok {
+			t.Fatal("stdio server started without built-in Wendy tools")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stdio server did not start while startup connection was blocked")
+	}
+
+	select {
+	case <-connectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("startup connection did not begin")
+	}
+
+	close(allowServeReturn)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after stdio server stopped")
+	}
+
+	select {
+	case <-connectCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("startup connection context was not canceled when stdio stopped")
+	}
+}
+
+func TestConnectToOnStartup_DoesNotOverwriteExplicitConnection(t *testing.T) {
+	connectStarted := make(chan struct{})
+	allowConnect := make(chan struct{})
+	startupConn := &grpcclient.AgentConnection{}
+	explicitConn := &grpcclient.AgentConnection{}
+	s := New(&config.Config{}, func(context.Context, string) (*grpcclient.AgentConnection, error) {
+		close(connectStarted)
+		<-allowConnect
+		return startupConn, nil
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.ConnectToOnStartup(context.Background(), "default.local:50051") }()
+	<-connectStarted
+
+	// This models device_connect/cloud_connect winning while the automatic
+	// default-device attempt is still pending.
+	s.SetConn(explicitConn)
+	close(allowConnect)
+	if err := <-done; err != nil {
+		t.Fatalf("ConnectToOnStartup returned error: %v", err)
+	}
+	if got := s.GetConn(); got != explicitConn {
+		t.Fatalf("startup connection overwrote explicit connection: got %p, want %p", got, explicitConn)
+	}
+}
 
 func TestNew_NotNil(t *testing.T) {
 	srv := New(&config.Config{}, nil)


### PR DESCRIPTION
## Summary

- start serving MCP stdio before attempting the optional default-device connection
- perform startup connection and container-tool discovery in the background
- prevent a slow automatic connection from overwriting a later explicit device or cloud connection
- add regression coverage for startup ordering, cancellation, and connection precedence

## Root cause

`wendy mcp serve` attempted to connect to the configured default device before calling `ServeStdio`. When that device was offline or unreachable, connection retries delayed the MCP initialize response beyond the host's startup timeout, so the server appeared not to load.

## Impact

MCP hosts can initialize Wendy immediately even when the saved default device is unavailable. Device-backed tools continue to connect and appear asynchronously, while explicit connection requests always take precedence over the startup attempt.

In the reproduced failure case, initialize latency dropped from about 38 seconds to 0.21 seconds.

## Validation

- `go test ./go/internal/cli/mcp ./go/internal/cli/commands -count=1`
- `go test -race ./go/internal/cli/mcp -count=1`
- `go vet ./go/internal/cli/mcp ./go/internal/cli/commands`
- `git diff --check`
- end-to-end MCP initialize handshake with an unreachable configured default device