### PR TITLE
fix(ci): allow current Thor integration host

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -152,6 +152,7 @@ jobs:
           EXPECTED=(
             "wendy-SER9.local"
             "wendyos-jetson-thor-ci.local"
+            "wendyos-thor.local"
             "wendyos-dynamic-channel.local"
           )
 


### PR DESCRIPTION
## What changed

- Add `wendyos-thor.local` to the hardware integration allowlist.
- Preserve the existing CI target hostnames for compatibility.

## Why

Release run 31650452743 discovered the Thor device as `wendyos-thor.local`, while the workflow only allowed `wendyos-jetson-thor-ci.local`. Discovery therefore selected zero devices and failed the stable release gate.

## Impact

The release integration gate can select the currently advertised Thor device and run the macOS integration suite instead of failing discovery.

## Validation

- `actionlint .github/workflows/integration-tests.yml`
- Extracted workflow Bash block parsed with `bash -n`
- `git diff --check`