### PR TITLE
fix(ci): gate GPU fixtures by architecture

### DIFF
--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -100,7 +100,7 @@ The harness skips a test rather than failing it when the host or device cannot s
 | Tests | Skipped unless |
 | --- | --- |
 | `swift-*` | the build host has a `swiftly` toolchain (checked instead of `swift`, which on macOS is an Xcode shim that exists with no usable toolchain behind it) |
-| `*-gpu` | the device reports `gpuVendor: nvidia` — these are CUDA tests, and `hasGpu` is also true for a non-NVIDIA GPU with a `/dev/dri` node |
+| `*-gpu` | the device reports `gpuVendor: nvidia` and either `gpuArch: sm_87` or no GPU architecture (for compatibility with older agents). The current PyTorch and ONNX fixtures use JetPack-6 / CUDA-12 images built for Orin; CUDA-13 architectures such as Thor's `sm_110` are skipped until their fixtures are hardware-verified. |
 
 #### Stable release gate
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -291,9 +291,12 @@ device_field() {
 if [[ -z "$VERSION_JSON" ]]; then
     echo -e "${YELLOW}==> WARNING: 'wendy device info' returned nothing — the agent under test cannot be identified${RESET}"
 fi
+DEVICE_TYPE=$(device_field deviceType '')
+DEVICE_GPU_ARCH=$(device_field gpuArch '')
+
 echo -e "${BOLD}==> Agent version: $(device_field version 'unknown')${RESET}"
 echo -e "${BOLD}==> Device OS: $(device_field os 'unknown') $(device_field osVersion 'unknown')${RESET}"
-echo -e "${BOLD}==> Device type: $(device_field deviceType 'none reported') ($(device_field cpuArchitecture 'unknown'))${RESET}"
+echo -e "${BOLD}==> Device type: ${DEVICE_TYPE:-none reported} ($(device_field cpuArchitecture 'unknown'))${RESET}"
 
 # ── Device capability detection ──────────────────────────────────────
 
@@ -305,7 +308,19 @@ DEVICE_HAS_CUDA=false
 if [[ "$DEVICE_GPU_VENDOR" == "nvidia" ]]; then
     DEVICE_HAS_CUDA=true
 fi
-echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none})${RESET}"
+
+# The current Python GPU fixtures are JetPack-6 / CUDA-12 images built for
+# Orin's sm_87. An NVIDIA vendor bit alone is not enough: Thor is sm_110 and
+# needs a CUDA-13 userspace image, so running these fixtures there produces
+# CUDA error 801 (PyTorch) and missing libcublasLt.so.12 (ONNX) rather than a
+# meaningful GPU-entitlement verdict. Older agents did not report gpuArch, so
+# preserve their established NVIDIA behavior; every reported architecture is
+# opt-in after its fixture has been hardware-verified.
+DEVICE_SUPPORTS_GPU_FIXTURES=false
+if [[ "$DEVICE_HAS_CUDA" == "true" ]] && [[ -z "$DEVICE_GPU_ARCH" || "$DEVICE_GPU_ARCH" == "sm_87" ]]; then
+    DEVICE_SUPPORTS_GPU_FIXTURES=true
+fi
+echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none}, arch: ${DEVICE_GPU_ARCH:-unknown})${RESET}"
 
 # The Swift tests build their image with swift-container-plugin, so this host
 # needs a Swift toolchain — which the CLI provisions through swiftly, and
@@ -403,6 +418,11 @@ for test_name in "${TESTS[@]}"; do
 
     if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_HAS_CUDA" != "true" ]]; then
         skip_test "$test_name" "no NVIDIA GPU (vendor: ${DEVICE_GPU_VENDOR:-none})"
+        continue
+    fi
+
+    if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_SUPPORTS_GPU_FIXTURES" != "true" ]]; then
+        skip_test "$test_name" "CI GPU fixtures support sm_87; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
         continue
     fi
 


### PR DESCRIPTION
## What changed

- Read and report `gpuArch` in the integration harness.
- Run the existing Python GPU fixtures only for NVIDIA `sm_87` devices (or older NVIDIA agents that do not report an architecture).
- Skip unverified CUDA architectures with an explicit reason.
- Document the architecture boundary in the integration-testing guide.

## Why

[Release run 31650765375](https://github.com/wendylabsinc/WendyOS/actions/runs/31650765375) discovered the Thor as `wendyos-thor.local`, then failed its integration job in `python-gpu` and `python-onnx-gpu`.

The harness treated `gpuVendor: nvidia` as sufficient to select both tests. Their images are not architecture-neutral: they carry JetPack-6 / CUDA-12 userspace built for Orin `sm_87`, while Thor is `sm_110` and needs a CUDA-13 userspace. On Thor, PyTorch failed CUDA initialization with error 801 and ONNX Runtime could not load `libcublasLt.so.12`. Those results test an incompatible fixture, not the GPU entitlement.

The repository's Stagefile CUDA profiles use the same proven boundary: only `sm_87` is enabled until another architecture has been hardware-verified.

## Impact

Thor remains in the stable integration matrix and continues running the other applicable entitlement and deployment tests. The two Orin-specific GPU fixtures now skip explicitly on Thor instead of blocking releases with a false-negative compatibility failure. Orin coverage remains enabled.

## Validation

- `bash -n go/scripts/test-ci.sh`
- `git diff --check`
- `shellcheck go/scripts/test-ci.sh` (only pre-existing informational findings)
- Mocked device metadata:
  - Thor `nvidia` / `sm_110`: GPU fixture skips with the architecture reason.
  - Orin `nvidia` / `sm_87`: GPU fixture is attempted.
  - AMD / `gfx1100`: retains the existing non-NVIDIA skip.