### PR TITLE
fix(ci): support CUDA 13 GPU fixtures

### DIFF
--- a/.github/ci-tests/python-gpu/Dockerfile.cuda13
+++ b/.github/ci-tests/python-gpu/Dockerfile.cuda13
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:13.0.2-cudnn-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv libgomp1 libnuma1 \
+    libnvpl-blas0 libnvpl-lapack0 cuda-cupti-13-0 libcudss0-cuda-13 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Jetson AI Lab's CUDA-13 SBSA wheel contains kernels for Thor (sm_110) and
+# Spark (sm_121).
+# Use the immutable, hashed wheel URL so pip cannot select the CPU-only
+# aarch64 package from PyPI. Its ordinary Python dependencies still resolve
+# from PyPI.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       'https://pypi.jetson-ai-lab.io/sbsa/cu130/+f/e65/21b6628938478/torch-2.9.1-cp312-cp312-linux_aarch64.whl#sha256=e6521b662893847896ece6740a6f3bd996c8a067d7b3334aadd6e3dcef47fd64' \
+       numpy
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/lib/aarch64-linux-gnu/libcudss/13:${LD_LIBRARY_PATH}" \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY main.py .
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-onnx-gpu/Dockerfile.cuda13
+++ b/.github/ci-tests/python-onnx-gpu/Dockerfile.cuda13
@@ -1,0 +1,20 @@
+FROM nvidia/cuda:13.0.2-cudnn-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Jetson AI Lab's CUDA-13 SBSA wheel targets CUDA-13 devices including Thor
+# (sm_110) and Spark (sm_121).
+# Pin its immutable, hashed URL while allowing the wheel's ordinary Python
+# dependencies to resolve from PyPI.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       'https://pypi.jetson-ai-lab.io/sbsa/cu130/+f/012/c10bef23a39f0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl#sha256=012c10bef23a39f074730d158b72f797a7314f2695c65835a0669b57282422f6' \
+       onnx numpy
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY main.py .
+CMD ["python3", "main.py"]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -355,8 +355,16 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
+          # Wendy appends -oci to WENDY_BUILDX_BUILDER for chunk-diff exports.
+          # Remove that actual builder too; cleaning only the unsuffixed name
+          # leaked one buildkitd container per integration run until the runner
+          # exhausted memory.
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
           # DOCKER_HOST is often unset here. ssh re-joins its arguments into one
@@ -483,8 +491,14 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
+          # The CLI creates ${BUILDER}-oci for chunk-diff exports; clean both
+          # names so a buildkitd container is not leaked after every CI run.
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
           WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh "${TEST_ARGS[@]}" -h "$INPUT_HOSTNAME"

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -289,9 +289,12 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          cleanup() { docker buildx rm "$BUILDER" --force 2>/dev/null || true; }
-          trap cleanup EXIT
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           WENDY_BUILDX_BUILDER="$BUILDER" scripts/test-templates.sh "${ARGS[@]}"
 

--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -100,7 +100,7 @@ The harness skips a test rather than failing it when the host or device cannot s
 | Tests | Skipped unless |
 | --- | --- |
 | `swift-*` | the build host has a `swiftly` toolchain (checked instead of `swift`, which on macOS is an Xcode shim that exists with no usable toolchain behind it) |
-| `*-gpu` | the device reports `gpuVendor: nvidia` and either `gpuArch: sm_87` or no GPU architecture (for compatibility with older agents). The current PyTorch and ONNX fixtures use JetPack-6 / CUDA-12 images built for Orin; CUDA-13 architectures such as Thor's `sm_110` are skipped until their fixtures are hardware-verified. |
+| `*-gpu` | the device reports `gpuVendor: nvidia` and a supported architecture. Orin (`sm_87`) uses the JetPack-6 / CUDA-12 fixtures; Thor (`sm_110`) and Spark (`sm_121`) use Ubuntu-24.04 / CUDA-13 fixtures. An older agent with no architecture uses CUDA 13 when its device type is `jetson-agx-thor` and otherwise retains the CUDA-12 path for compatibility. Other reported architectures are skipped until a matching fixture is hardware-verified. |
 
 #### Stable release gate
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -121,6 +121,24 @@ run_test() {
     return $rc
 }
 
+# A per-run docker-container builder is shared by every integration fixture.
+# If buildkitd is OOM-killed or loses its gRPC socket, leaving that dead builder
+# in place turns one transient host failure into a long list of unrelated test
+# failures. This recovery is deliberately gated on WENDY_BUILDX_BUILDER, which
+# the CI workflows set to their disposable builder; local user builders are
+# never removed automatically.
+recover_ci_oci_builder() {
+    local output="$1"
+    [[ -n "${WENDY_BUILDX_BUILDER:-}" ]] || return 1
+    grep -qiE \
+        'failed to receive status:.*(EOF|Unavailable)|error reading from server: EOF|/run/buildkit/buildkitd\.sock: connect: connection refused|failed to list workers:.*Unavailable|ResourceExhausted:.*cannot allocate memory' \
+        <<<"$output" || return 1
+
+    local builder="${WENDY_BUILDX_BUILDER}-oci"
+    echo "    BuildKit daemon failed; recreating disposable CI builder $builder and retrying once"
+    docker buildx rm "$builder" --force >/dev/null 2>&1 || true
+}
+
 # ── Container verdict ────────────────────────────────────────────────
 # An attached `wendy run` exits 0 whatever the container did, so its exit code
 # only tells us the deploy worked. Every standard test asserts inside the app
@@ -193,12 +211,17 @@ run_container_test() {
     app_id=$(app_id_for_test "$test_dir")
 
     container_test_passes() {
-        local out
+        local out rc
         # --no-restart stops the agent restarting a test app that has done its
         # job and exited, which otherwise churns the recorded state (a
         # short-lived app reads back as CRASH_LOOPING).
         out=$("$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --no-restart "$@" 2>&1)
-        local rc=$?
+        rc=$?
+        if [[ $rc -ne 0 ]] && recover_ci_oci_builder "$out"; then
+            echo "$out"
+            out=$("$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --no-restart "$@" 2>&1)
+            rc=$?
+        fi
         echo "$out"
         if [[ $rc -ne 0 ]]; then
             return $rc
@@ -309,16 +332,29 @@ if [[ "$DEVICE_GPU_VENDOR" == "nvidia" ]]; then
     DEVICE_HAS_CUDA=true
 fi
 
-# The current Python GPU fixtures are JetPack-6 / CUDA-12 images built for
-# Orin's sm_87. An NVIDIA vendor bit alone is not enough: Thor is sm_110 and
-# needs a CUDA-13 userspace image, so running these fixtures there produces
-# CUDA error 801 (PyTorch) and missing libcublasLt.so.12 (ONNX) rather than a
-# meaningful GPU-entitlement verdict. Older agents did not report gpuArch, so
-# preserve their established NVIDIA behavior; every reported architecture is
-# opt-in after its fixture has been hardware-verified.
-DEVICE_SUPPORTS_GPU_FIXTURES=false
-if [[ "$DEVICE_HAS_CUDA" == "true" ]] && [[ -z "$DEVICE_GPU_ARCH" || "$DEVICE_GPU_ARCH" == "sm_87" ]]; then
-    DEVICE_SUPPORTS_GPU_FIXTURES=true
+# GPU framework wheels are architecture-specific. Pick a userspace that
+# matches the device instead of treating the NVIDIA vendor bit as sufficient:
+# Orin (sm_87) uses the existing JetPack-6 / CUDA-12 fixture, while Thor
+# (sm_110) uses the Ubuntu-24.04 / CUDA-13 fixture. Older agents did not report
+# gpuArch, so identify Thor by device type and preserve CUDA-12 behavior for
+# other older NVIDIA devices. Every other reported architecture remains opt-in
+# after its fixture is hardware-verified.
+DEVICE_GPU_FIXTURE_DOCKERFILE=""
+if [[ "$DEVICE_HAS_CUDA" == "true" ]]; then
+    case "$DEVICE_GPU_ARCH" in
+        sm_87)          DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile" ;;
+        sm_110|sm_121)  DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile.cuda13" ;;
+        "")
+            # gpuArch was added after Thor support. Device type lets those
+            # older Thor agents select CUDA 13 without regressing older Orin
+            # and generic NVIDIA agents, which retain the CUDA-12 fixture.
+            if [[ "$DEVICE_TYPE" == "jetson-agx-thor" ]]; then
+                DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile.cuda13"
+            else
+                DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile"
+            fi
+            ;;
+    esac
 fi
 echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none}, arch: ${DEVICE_GPU_ARCH:-unknown})${RESET}"
 
@@ -421,8 +457,8 @@ for test_name in "${TESTS[@]}"; do
         continue
     fi
 
-    if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_SUPPORTS_GPU_FIXTURES" != "true" ]]; then
-        skip_test "$test_name" "CI GPU fixtures support sm_87; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
+    if [[ "$test_name" == *"-gpu"* ]] && [[ -z "$DEVICE_GPU_FIXTURE_DOCKERFILE" ]]; then
+        skip_test "$test_name" "CI GPU fixtures support sm_87, sm_110, and sm_121; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
         continue
     fi
 
@@ -640,7 +676,13 @@ for test_name in "${TESTS[@]}"; do
     fi
 
     # ── Standard single-container tests ─────────────────────────────────
-    run_container_test "$test_name" "$test_dir"
+    if [[ "$test_name" == *"-gpu"* ]]; then
+        # Both GPU test directories contain architecture-specific Dockerfiles,
+        # so name the selected one explicitly and avoid an interactive picker.
+        run_container_test "$test_name" "$test_dir" --dockerfile "$DEVICE_GPU_FIXTURE_DOCKERFILE"
+    else
+        run_container_test "$test_name" "$test_dir"
+    fi
 done
 
 # ── Summary ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Add architecture-specific CUDA 13 fixtures for `python-gpu` and `python-onnx-gpu`.
- Select CUDA 12 for Orin (`sm_87`) and CUDA 13 for Thor/Spark (`sm_110`/`sm_121`), with a device-type fallback for older Thor agents that do not report `gpuArch`.
- Pin the CUDA 13 framework wheels by immutable URL and SHA-256.
- Clean up the actual `<WENDY_BUILDX_BUILDER>-oci` builders in integration and template workflows.
- Recreate and retry a disposable CI OCI builder once when BuildKit dies from EOF, connection refusal, or resource exhaustion.
- Update the integration-testing documentation.

## Why

Follow-up to #1692. That PR was deliberately merged as a release hotfix: it stopped the JetPack-6 / CUDA-12 fixtures from running on Thor, but did so by skipping CUDA 13 hardware rather than testing it.

Thor needs a CUDA 13 userspace and framework wheels carrying `sm_110` kernels. The new fixtures use NVIDIA's ARM64 CUDA 13.0.2 + cuDNN runtime and Jetson AI Lab's `sbsa/cu130` PyTorch and ONNX Runtime wheels. The existing Orin fixtures remain unchanged on CUDA 12.6.

This also fixes the unrelated stable-gate failure in [release run 31654465165](https://github.com/wendylabsinc/WendyOS/actions/runs/31654465165). The workflow passed `WENDY_BUILDX_BUILDER=$BUILDER`, the CLI created `$BUILDER-oci`, but cleanup removed only `$BUILDER`. Leaked buildkitd containers accumulated until the runner hit EOF/connection-refused failures and `cannot allocate memory`.

## Impact

- Thor and Spark now run real CUDA entitlement/compute coverage rather than skipping it.
- Orin continues using its verified CUDA 12.6 images.
- Disposable CI BuildKit daemons no longer leak after integration/template jobs, and a daemon crash no longer poisons every later fixture in the same run.

## Validation

- Live Jetson AGX Thor (`sm_110`, JetPack 7.2, host CUDA 13.2):
  - `python-gpu`: PASS (CUDA compute/matrix multiplication)
  - `python-onnx-gpu`: PASS (CUDAExecutionProvider inference)
  - Result: 2 passed, 0 failed, 0 skipped
- ARM64 PyTorch image build and smoke test:
  - PyTorch 2.9.1
  - CUDA 13.0
  - compiled architectures: `sm_110 sm_121`
- ARM64 ONNX Runtime image build and smoke test:
  - ONNX Runtime 1.24.0
  - CUDAExecutionProvider present
  - no unresolved shared libraries
- Release-run failure signatures match the new one-shot builder recovery.
- `actionlint .github/workflows/integration-tests.yml .github/workflows/test-templates.yml`
- `shellcheck -S warning go/scripts/test-ci.sh`
- `bash -n go/scripts/test-ci.sh`
- `git diff --check`